### PR TITLE
feat(prisma): PipelineStatus enum + pipelineStatus alanı (English key’ler) (#12)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,19 +27,19 @@ enum InteractionType {
 
 // Mentee'nin staj/işe alım sürecindeki granular aşaması (Excel status kolonunun karşılığı)
 enum PipelineStatus {
-  BASVURU_100 // 100 ilk temas
-  ONAY_220 // 220 staj için onay bekliyor
-  GORUSME_250 // 250 görüşülecek
-  TANISTIRMA_270 // 270 tanıştırılacak
-  STAJ_BASLAYACAK_300 // 300 staj başlayacak
-  STAJ_DEVAM_450 // 450 staj devam ediyor
-  YARIM_BIRAKTI_460 // 460 staj yarım bıraktı
-  STAJ_BITTI_490 // 490 staj bitti
-  IS_ARIYOR_500 // 500 iş arıyor
-  ISE_ALINABILIR_600 // 600 işe alınabilir
-  ISE_ALINDI_660 // 660 işe alındı
-  IS_BULDU_700 // 700 iş buldu
-  BASKA_YERDE_STAJ_800 // 800 başka yerde staj buldu
+  APPLICATION_100 // 100 tr: ilk temas
+  APPROVAL_PENDING_220 // 220 tr: staj için onay bekliyor
+  INTERVIEW_PENDING_250 // 250 tr: görüşülecek
+  INTRODUCTION_PENDING_270 // 270 tr: tanıştırılacak
+  INTERNSHIP_STARTING_300 // 300 tr: staj başlayacak
+  INTERNSHIP_IN_PROGRESS_450 // 450 tr: staj devam ediyor
+  INTERNSHIP_DROPPED_460 // 460 tr: staj yarım bıraktı
+  INTERNSHIP_COMPLETED_490 // 490 tr: staj bitti
+  JOB_SEEKING_500 // 500 tr: iş arıyor
+  HIREABLE_600 // 600 tr: işe alınabilir
+  HIRED_660 // 660 tr: işe alındı
+  EMPLOYED_700 // 700 tr: iş buldu
+  INTERNSHIP_FOUND_ELSEWHERE_800 // 800 tr: başka yerde staj buldu
 }
 
 model User {
@@ -91,7 +91,7 @@ model MentorshipRelation {
   companyId      String?
   startDate      DateTime         @default(now())
   status         MentorshipStatus @default(ACTIVE)
-  pipelineStatus PipelineStatus   @default(BASVURU_100)
+  pipelineStatus PipelineStatus   @default(APPLICATION_100)
 
   mentor       User             @relation("MentorRelations", fields: [mentorId], references: [id])
   mentee       User             @relation("MenteeRelations", fields: [menteeId], references: [id])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,6 +25,23 @@ enum InteractionType {
   Email
 }
 
+// Mentee'nin staj/işe alım sürecindeki granular aşaması (Excel status kolonunun karşılığı)
+enum PipelineStatus {
+  BASVURU_100 // 100 ilk temas
+  ONAY_220 // 220 staj için onay bekliyor
+  GORUSME_250 // 250 görüşülecek
+  TANISTIRMA_270 // 270 tanıştırılacak
+  STAJ_BASLAYACAK_300 // 300 staj başlayacak
+  STAJ_DEVAM_450 // 450 staj devam ediyor
+  YARIM_BIRAKTI_460 // 460 staj yarım bıraktı
+  STAJ_BITTI_490 // 490 staj bitti
+  IS_ARIYOR_500 // 500 iş arıyor
+  ISE_ALINABILIR_600 // 600 işe alınabilir
+  ISE_ALINDI_660 // 660 işe alındı
+  IS_BULDU_700 // 700 iş buldu
+  BASKA_YERDE_STAJ_800 // 800 başka yerde staj buldu
+}
+
 model User {
   id             String   @id @default(cuid())
   email          String   @unique
@@ -68,16 +85,17 @@ model CompanyNeed {
 }
 
 model MentorshipRelation {
-  id        String           @id @default(cuid())
-  mentorId  String
-  menteeId  String
-  companyId String?
-  startDate DateTime         @default(now())
-  status    MentorshipStatus @default(ACTIVE)
+  id             String           @id @default(cuid())
+  mentorId       String
+  menteeId       String
+  companyId      String?
+  startDate      DateTime         @default(now())
+  status         MentorshipStatus @default(ACTIVE)
+  pipelineStatus PipelineStatus   @default(BASVURU_100)
 
-  mentor       User              @relation("MentorRelations", fields: [mentorId], references: [id])
-  mentee       User              @relation("MenteeRelations", fields: [menteeId], references: [id])
-  company      Company?          @relation(fields: [companyId], references: [id])
+  mentor       User             @relation("MentorRelations", fields: [mentorId], references: [id])
+  mentee       User             @relation("MenteeRelations", fields: [menteeId], references: [id])
+  company      Company?         @relation(fields: [companyId], references: [id])
   interactions InteractionLog[]
 }
 


### PR DESCRIPTION
## Özet
`MentorshipRelation`'a granular **pipeline aşaması** ekler — Excel'deki status kolonunun (220 → 450 → 660 → 700 …) veri modelindeki karşılığı.  
Geri bildirim doğrultusunda enum key’leri İngilizceye çevrildi ve çoklu dil uyumu için Türkçe karşılıklar yorumlarda korundu.

## Değişiklikler
- Yeni `PipelineStatus` enum'u (13 aşama: `APPLICATION_100` … `INTERNSHIP_FOUND_ELSEWHERE_800`), her değerde Excel kodu + `tr:` açıklama yorum olarak.
- `MentorshipRelation.pipelineStatus` alanı, default `APPLICATION_100`.
- `prisma format` + `prisma validate` + `prisma generate` çalıştırıldı.

## Kabul kriterleri
- [x] Enum ve alan şemada.
- [x] Her yeni mentorship varsayılan aşamayla (`APPLICATION_100`) oluşuyor (default sayesinde).
- [ ] Şemanın paylaşımlı DB'ye uygulanması (aşağıya bak).

## DB'ye uygulama (gözden geçiren yapacak)
Proje `prisma db push` akışını kullanıyor (migrations klasörü yok). Değişiklik **additive** (yeni enum + default'lu yeni kolon), mevcut satırları bozmaz:

```bash
npx prisma db push
```

> ⚠️ `DATABASE_URL` paylaşımlı preview DB'ye (`crm-preview.ersah.in`) bakıyor; bu yüzden push'u bilerek PR dışında bıraktım.

## Sonraki adım
Bu alanı kullanan UI/API → #13 (status değiştirme), görselleştirme → #15 (kanban).