### PR TITLE
test(e2e): Playwright smoke testleri + CI quality gate (#41)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,77 @@
+name: E2E Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Cancel superseded runs on the same ref so the gate stays fast.
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    name: Playwright smoke
+    runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: internship_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -proot"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=15
+
+    env:
+      DATABASE_URL: "mysql://root:root@127.0.0.1:3306/internship_test"
+      NEXTAUTH_SECRET: "ci-test-secret-not-for-production"
+      NEXTAUTH_URL: "http://localhost:3000"
+      # Seeded admin used by the smoke tests
+      SEED_ADMIN_EMAIL: "admin@example.com"
+      SEED_ADMIN_PASSWORD: "ChangeMe123!"
+      ADMIN_EMAIL: "admin@example.com"
+      ADMIN_PASSWORD: "ChangeMe123!"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Apply DB schema
+        run: npx prisma db push
+
+      - name: Seed admin user
+        run: npx prisma db seed
+
+      - name: Build app
+        run: npm run build
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E smoke tests
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,9 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Playwright
+/playwright-report/
+/test-results/
+/blob-report/
+/playwright/.cache/

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * Smoke tests — fast quality gate. Verify the app boots, auth works, and the
+ * core admin pages render without server errors or console errors.
+ *
+ * Credentials come from the seeded admin (CI seeds these; preview uses the same).
+ */
+const ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@example.com';
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'ChangeMe123!';
+
+function attachDiagnostics(page: Page, sink: string[]) {
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') sink.push(`[console.error] ${msg.text()}`);
+  });
+  page.on('pageerror', (err) => sink.push(`[pageerror] ${err.message}`));
+  page.on('response', (res) => {
+    if (res.status() >= 500) sink.push(`[HTTP ${res.status()}] ${res.url()}`);
+  });
+}
+
+async function login(page: Page) {
+  await page.goto('/auth/signin');
+  await page.fill('input[type="email"], input[name="email"]', ADMIN_EMAIL);
+  await page.fill('input[type="password"]', ADMIN_PASSWORD);
+  await page.click('button[type="submit"]');
+  await page.waitForURL((u) => !u.pathname.includes('/auth/signin'), { timeout: 20_000 });
+}
+
+test('home page loads with favicon and no console errors', async ({ page }) => {
+  const diag: string[] = [];
+  attachDiagnostics(page, diag);
+  const res = await page.goto('/');
+  expect(res?.status() ?? 0).toBeLessThan(400);
+  await page.waitForTimeout(800);
+  const iconHref = await page.locator('link[rel="icon"]').first().getAttribute('href').catch(() => null);
+  expect(iconHref, 'an <link rel="icon"> should be present').toBeTruthy();
+  expect(diag, `unexpected diagnostics: ${diag.join(' | ')}`).toEqual([]);
+});
+
+test('signin page renders the credentials form', async ({ page }) => {
+  await page.goto('/auth/signin');
+  await expect(page.locator('input[type="email"], input[name="email"]')).toBeVisible();
+  await expect(page.locator('input[type="password"]')).toBeVisible();
+  await expect(page.locator('button[type="submit"]')).toBeVisible();
+});
+
+test('admin can log in and lands off the signin page', async ({ page }) => {
+  await login(page);
+  expect(page.url()).not.toContain('/auth/signin');
+});
+
+test('admin pages load without server errors', async ({ page }) => {
+  await login(page);
+  const paths = ['/admin', '/admin/candidates', '/admin/mentorship', '/admin/companies', '/admin/invite'];
+  for (const path of paths) {
+    const diag: string[] = [];
+    attachDiagnostics(page, diag);
+    const res = await page.goto(path);
+    await page.waitForTimeout(700);
+    const status = res?.status() ?? 0;
+    const bodyText = await page.locator('body').innerText().catch(() => '');
+    const looksError = /application error|something went wrong|internal server error|unhandled/i.test(bodyText);
+    expect(status, `${path} HTTP status`).toBeLessThan(400);
+    expect(looksError, `${path} shows an error page`).toBeFalsy();
+    expect(diag, `${path} diagnostics: ${diag.join(' | ')}`).toEqual([]);
+  }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "@types/bcryptjs": "^2.4.6",
         "@types/node": "^20",
         "@types/node-cron": "^3.0.11",
@@ -952,6 +953,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@prisma/client": {
@@ -5081,6 +5098,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
     "postinstall": "prisma generate"
   },
   "dependencies": {
@@ -29,6 +31,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@types/bcryptjs": "^2.4.6",
     "@types/node": "^20",
     "@types/node-cron": "^3.0.11",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * E2E config.
+ *
+ * - Local default: starts the dev server and tests http://localhost:3000.
+ *   Run headed to watch: `npm run test:e2e -- --headed`.
+ * - CI: builds + `next start`, runs headless against localhost.
+ * - Against a deployed env: set BASE_URL (e.g. BASE_URL=https://crm-preview.ersah.in),
+ *   which skips the local webServer and tests the remote URL.
+ */
+const externalBase = process.env.BASE_URL;
+const PORT = 3000;
+const localURL = `http://localhost:${PORT}`;
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 60_000,
+  expect: { timeout: 15_000 },
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  forbidOnly: !!process.env.CI,
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : [['list']],
+  use: {
+    baseURL: externalBase || localURL,
+    actionTimeout: 15_000,
+    navigationTimeout: 30_000,
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  // Only spin up the app locally; when BASE_URL targets a deployed env, skip it.
+  webServer: externalBase
+    ? undefined
+    : {
+        command: process.env.CI ? 'npm run start' : 'npm run dev',
+        url: localURL,
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+      },
+});


### PR DESCRIPTION
## Özet
Playwright E2E testlerini repoya alır ve her PR'da çalışan bir **CI kalite kapısı** ekler. Takım büyüdükçe regresyonları erken yakalar.

## İçerik
- `@playwright/test` + kök `playwright.config.ts` (lokal `dev`, CI `start`, `BASE_URL` ile deploy'a karşı koşma).
- `e2e/smoke.spec.ts`: ana sayfa+favicon, signin formu, admin girişi, admin alt sayfaları 500 vermeden yükleniyor mu.
- `npm run test:e2e` / `test:e2e:headed`.
- `.github/workflows/e2e.yml`: **izole MySQL service** + `prisma db push` + seed + build + headless Playwright; HTML rapor artifact. Paylaşımlı DB'ye dokunmaz.

## Doğrulama
- [x] Lokalde 4/4 geçti.
- [x] Test gerçek bir schema-drift 500'ünü yakaladı (gate çalışıyor).
- [ ] CI'da `e2e.yml` yeşil (bu PR'da koşacak).

Closes #41 · Refs #11 #32

> Not: Bu PR ayrıca mevcut "Deploy to Plesk Server" preview workflow'unu da tetikler (kod değişikliği yok ama preview yeniden deploy olur).