### PR TITLE
docs: E2E test notlarını ekle (test:e2e + CI gate)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,10 +28,16 @@ npm run lint         # next lint
 npx prisma generate  # regenerate client (also runs on postinstall)
 npx prisma db push   # sync schema to DB (this project uses db push, NOT migrations)
 npx prisma db seed   # create first ADMIN (see seed env vars below)
+
+npm run test:e2e         # Playwright smoke tests (starts the app itself)
+npm run test:e2e:headed  # same, with a visible browser
 ```
 
-There is **no test script** in `package.json` yet. E2E tests (Playwright) are a planned
-backlog item — see Epic #11 / issue #34.
+**E2E tests** (Playwright) live in `e2e/` and run as a CI quality gate on every PR
+(`.github/workflows/e2e.yml`, isolated MySQL service). Locally `test:e2e` boots the dev
+server; set `BASE_URL=https://crm-preview.ersah.in` to run against a deployed env instead.
+After switching branches, run `npx prisma generate` so the client matches the schema —
+a stale client causes schema-drift 500s (the smoke test will catch these).
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -91,8 +91,23 @@ See [`.env.example`](.env.example) for the full list.
 | `npm run build` | Production build |
 | `npm run start` | Serve production build |
 | `npm run lint` | Lint (`next lint`) |
+| `npm run test:e2e` | Playwright smoke tests (add `:headed` to watch) |
 | `npx prisma db push` | Sync schema to DB |
 | `npx prisma db seed` | Seed first admin |
+
+## Testing
+
+End-to-end smoke tests live in [`e2e/`](e2e/) (Playwright). They cover the home page,
+sign-in, admin login, and that the admin pages render without server errors.
+
+```bash
+npm run test:e2e            # starts the app and runs headless
+npm run test:e2e:headed     # visible browser
+BASE_URL=https://crm-preview.ersah.in npm run test:e2e   # against a deployed env
+```
+
+CI runs these on every PR ([`.github/workflows/e2e.yml`](.github/workflows/e2e.yml)) against
+an isolated MySQL service, so a regression fails the check before merge.
 
 ## Deployment
 


### PR DESCRIPTION
README ve CLAUDE.md'yi #41'de eklenen Playwright E2E suite + CI gate'i yansıtacak şekilde günceller (eskiden 'henüz test yok' diyordu). Sadece dokümantasyon.