### PR TITLE
test(e2e): auth guard + mentee/mentor lifecycle testleri

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,6 +79,11 @@ jobs:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
           NEXTAUTH_URL: ${{ secrets.NEXTAUTH_URL }}
+          SMTP_HOST: ${{ secrets.SMTP_HOST }}
+          SMTP_PORT: ${{ secrets.SMTP_PORT }}
+          SMTP_USER: ${{ secrets.SMTP_USER }}
+          SMTP_PASS: ${{ secrets.SMTP_PASS }}
+          SMTP_FROM: ${{ secrets.SMTP_FROM }}
           ACTOR: ${{ github.actor }}
         run: |
           # Base64-encode secrets so special characters survive the SSH transport
@@ -86,6 +91,11 @@ jobs:
           B64_DB=$(printf '%s'  "$DATABASE_URL"    | base64 -w0)
           B64_SEC=$(printf '%s' "$NEXTAUTH_SECRET" | base64 -w0)
           B64_URL=$(printf '%s' "$NEXTAUTH_URL"    | base64 -w0)
+          B64_SMTP_HOST=$(printf '%s' "$SMTP_HOST" | base64 -w0)
+          B64_SMTP_PORT=$(printf '%s' "$SMTP_PORT" | base64 -w0)
+          B64_SMTP_USER=$(printf '%s' "$SMTP_USER" | base64 -w0)
+          B64_SMTP_PASS=$(printf '%s' "$SMTP_PASS" | base64 -w0)
+          B64_SMTP_FROM=$(printf '%s' "$SMTP_FROM" | base64 -w0)
 
           ssh -i ~/.ssh/deploy_key \
             -p "${SSH_PORT:-22}" \
@@ -96,6 +106,11 @@ jobs:
           DATABASE_URL=\$(printf '%s' '$B64_DB'  | base64 -d)
           NEXTAUTH_SECRET=\$(printf '%s' '$B64_SEC' | base64 -d)
           NEXTAUTH_URL=\$(printf '%s' '$B64_URL' | base64 -d)
+          SMTP_HOST=\$(printf '%s' '$B64_SMTP_HOST' | base64 -d)
+          SMTP_PORT=\$(printf '%s' '$B64_SMTP_PORT' | base64 -d)
+          SMTP_USER=\$(printf '%s' '$B64_SMTP_USER' | base64 -d)
+          SMTP_PASS=\$(printf '%s' '$B64_SMTP_PASS' | base64 -d)
+          SMTP_FROM=\$(printf '%s' '$B64_SMTP_FROM' | base64 -d)
           IMAGE='$IMAGE'
           ACTOR='$ACTOR'
 
@@ -123,6 +138,12 @@ jobs:
             -e DATABASE_URL="\$DATABASE_URL" \
             -e NEXTAUTH_SECRET="\$NEXTAUTH_SECRET" \
             -e NEXTAUTH_URL="\$NEXTAUTH_URL" \
+            -e NEXT_PUBLIC_APP_URL="\$NEXTAUTH_URL" \
+            -e SMTP_HOST="\$SMTP_HOST" \
+            -e SMTP_PORT="\$SMTP_PORT" \
+            -e SMTP_USER="\$SMTP_USER" \
+            -e SMTP_PASS="\$SMTP_PASS" \
+            -e SMTP_FROM="\$SMTP_FROM" \
             "\$IMAGE"
 
           docker image prune -f
@@ -140,12 +161,22 @@ jobs:
           DATABASE_URL: ${{ secrets.DATABASE_URL_PREVIEW }}
           NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
           PREVIEW_URL: ${{ secrets.PREVIEW_URL }}
+          SMTP_HOST: ${{ secrets.SMTP_HOST }}
+          SMTP_PORT: ${{ secrets.SMTP_PORT }}
+          SMTP_USER: ${{ secrets.SMTP_USER }}
+          SMTP_PASS: ${{ secrets.SMTP_PASS }}
+          SMTP_FROM: ${{ secrets.SMTP_FROM }}
           ACTOR: ${{ github.actor }}
         run: |
           B64_TOKEN=$(printf '%s' "$GH_TOKEN"        | base64 -w0)
           B64_DB=$(printf '%s'  "$DATABASE_URL"    | base64 -w0)
           B64_SEC=$(printf '%s' "$NEXTAUTH_SECRET" | base64 -w0)
           B64_URL=$(printf '%s' "$PREVIEW_URL"     | base64 -w0)
+          B64_SMTP_HOST=$(printf '%s' "$SMTP_HOST" | base64 -w0)
+          B64_SMTP_PORT=$(printf '%s' "$SMTP_PORT" | base64 -w0)
+          B64_SMTP_USER=$(printf '%s' "$SMTP_USER" | base64 -w0)
+          B64_SMTP_PASS=$(printf '%s' "$SMTP_PASS" | base64 -w0)
+          B64_SMTP_FROM=$(printf '%s' "$SMTP_FROM" | base64 -w0)
 
           ssh -i ~/.ssh/deploy_key \
             -p "${SSH_PORT:-22}" \
@@ -156,6 +187,11 @@ jobs:
           DATABASE_URL=\$(printf '%s' '$B64_DB'  | base64 -d)
           NEXTAUTH_SECRET=\$(printf '%s' '$B64_SEC' | base64 -d)
           PREVIEW_URL=\$(printf '%s' '$B64_URL' | base64 -d)
+          SMTP_HOST=\$(printf '%s' '$B64_SMTP_HOST' | base64 -d)
+          SMTP_PORT=\$(printf '%s' '$B64_SMTP_PORT' | base64 -d)
+          SMTP_USER=\$(printf '%s' '$B64_SMTP_USER' | base64 -d)
+          SMTP_PASS=\$(printf '%s' '$B64_SMTP_PASS' | base64 -d)
+          SMTP_FROM=\$(printf '%s' '$B64_SMTP_FROM' | base64 -d)
           IMAGE='$IMAGE'
           ACTOR='$ACTOR'
 
@@ -183,6 +219,12 @@ jobs:
             -e DATABASE_URL="\$CONTAINER_DB" \
             -e NEXTAUTH_SECRET="\$NEXTAUTH_SECRET" \
             -e NEXTAUTH_URL="\$PREVIEW_URL" \
+            -e NEXT_PUBLIC_APP_URL="\$PREVIEW_URL" \
+            -e SMTP_HOST="\$SMTP_HOST" \
+            -e SMTP_PORT="\$SMTP_PORT" \
+            -e SMTP_USER="\$SMTP_USER" \
+            -e SMTP_PASS="\$SMTP_PASS" \
+            -e SMTP_FROM="\$SMTP_FROM" \
             "\$IMAGE"
 
           docker image prune -f

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test';
+
+const ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@example.com';
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'ChangeMe123!';
+
+test('unauthenticated access to /admin redirects to sign in', async ({ page }) => {
+  await page.goto('/admin');
+  await page.waitForURL((u) => u.pathname.includes('/auth/signin'), { timeout: 15_000 });
+  await expect(page.locator('input[type="password"]')).toBeVisible();
+});
+
+test('wrong credentials keep the user on the sign-in page', async ({ page }) => {
+  await page.goto('/auth/signin');
+  await page.fill('input[type="email"], input[name="email"]', 'nobody@e2e.local');
+  await page.fill('input[type="password"]', 'wrong-password-123');
+  await page.click('button[type="submit"]');
+  await page.waitForTimeout(3000);
+  expect(page.url()).toContain('/auth/signin');
+});
+
+test('authenticated admin sees a Sign Out control', async ({ page }) => {
+  await page.goto('/auth/signin');
+  await page.fill('input[type="email"], input[name="email"]', ADMIN_EMAIL);
+  await page.fill('input[type="password"]', ADMIN_PASSWORD);
+  await page.click('button[type="submit"]');
+  await page.waitForURL((u) => !u.pathname.includes('/auth/signin'), { timeout: 20_000 });
+  await page.goto('/admin');
+  await expect(page.getByRole('link', { name: /sign out/i })).toBeVisible();
+});

--- a/e2e/helpers/db.ts
+++ b/e2e/helpers/db.ts
@@ -1,0 +1,45 @@
+import { PrismaClient } from '@prisma/client';
+import bcrypt from 'bcryptjs';
+import crypto from 'crypto';
+
+/**
+ * Direct DB access for E2E setup/teardown. Lets tests seed invitation tokens and
+ * users without going through the email-sending invite flow, so the suite is
+ * self-contained and never sends real mail (works in CI and against any env).
+ */
+export const prisma = new PrismaClient();
+
+export function uniqueEmail(prefix: string) {
+  return `${prefix}-${Date.now()}-${crypto.randomBytes(3).toString('hex')}@e2e.local`;
+}
+
+export async function seedInvite(email: string, role: 'ADMIN' | 'MENTOR' | 'MENTEE') {
+  const token = crypto.randomBytes(32).toString('hex');
+  const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+  await prisma.invitationToken.create({ data: { token, email, role, expiresAt } });
+  return token;
+}
+
+export async function seedUser(
+  email: string,
+  password: string,
+  role: 'ADMIN' | 'MENTOR' | 'MENTEE',
+  fullName: string
+) {
+  const hash = await bcrypt.hash(password, 10);
+  return prisma.user.create({
+    data: { email, password: hash, role, fullName, skills: [] },
+  });
+}
+
+export async function cleanupByEmail(email: string) {
+  // Remove dependent mentorship relations first, then the user + any tokens.
+  const user = await prisma.user.findUnique({ where: { email } });
+  if (user) {
+    await prisma.mentorshipRelation.deleteMany({
+      where: { OR: [{ mentorId: user.id }, { menteeId: user.id }] },
+    });
+    await prisma.user.delete({ where: { id: user.id } }).catch(() => {});
+  }
+  await prisma.invitationToken.deleteMany({ where: { email } });
+}

--- a/e2e/lifecycle.spec.ts
+++ b/e2e/lifecycle.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedInvite, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('mentee lifecycle: invite token -> register -> login -> portal', async ({ page }) => {
+  const email = uniqueEmail('mentee');
+  const password = 'MenteePass123!';
+  const token = await seedInvite(email, 'MENTEE');
+
+  try {
+    // Register using the invitation token
+    await page.goto(`/auth/register?token=${token}`);
+    await page.fill('input[name="token"]', token);
+    await page.fill('input[name="fullName"]', 'E2E Mentee');
+    await page.fill('input[name="email"]', email);
+    await page.fill('input[name="password"]', password);
+    await page.fill('input[name="confirmPassword"]', password);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.includes('/auth/signin'), { timeout: 20_000 });
+
+    // The account now exists in the DB
+    const created = await prisma.user.findUnique({ where: { email } });
+    expect(created?.role).toBe('MENTEE');
+
+    // Log in as the new mentee
+    await page.fill('input[type="email"], input[name="email"]', email);
+    await page.fill('input[type="password"]', password);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/portal'), { timeout: 20_000 });
+    await expect(page.getByText(/welcome/i)).toBeVisible();
+  } finally {
+    await cleanupByEmail(email);
+  }
+});
+
+test('mentor can sign in and reach the mentor dashboard', async ({ page }) => {
+  const email = uniqueEmail('mentor');
+  const password = 'MentorPass123!';
+  await seedUser(email, password, 'MENTOR', 'E2E Mentor');
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', email);
+    await page.fill('input[type="password"]', password);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/mentor'), { timeout: 20_000 });
+    await expect(page.getByText(/mentee|welcome/i).first()).toBeVisible();
+  } finally {
+    await cleanupByEmail(email);
+  }
+});
+
+test('mentee cannot access the admin area', async ({ page }) => {
+  const email = uniqueEmail('mentee-guard');
+  const password = 'MenteePass123!';
+  await seedUser(email, password, 'MENTEE', 'E2E Guard Mentee');
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', email);
+    await page.fill('input[type="password"]', password);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => !u.pathname.includes('/auth/signin'), { timeout: 20_000 });
+    // Attempt to open the admin area — layout guard should redirect away
+    await page.goto('/admin');
+    await page.waitForTimeout(1500);
+    expect(page.url()).not.toContain('/admin');
+  } finally {
+    await cleanupByEmail(email);
+  }
+});


### PR DESCRIPTION
## Özet
E2E kapsamını genişletir. Tüm testler token/kullanıcıyı **Prisma ile seed** eder; davet email yolunu kullanmaz → gerçek mail göndermez, CI'da ve her ortamda çalışır, veriyi temizler.

## Eklenenler
- **auth.spec.ts**: yetkisiz `/admin` → signin yönlenmesi · yanlış parola signin'de kalır · authenticated layout'ta Sign Out var.
- **lifecycle.spec.ts**: mentee davet-token → kayıt → login → `/portal` · mentor login → `/mentor` · mentee `/admin`'e giremiyor (layout guard).
- **helpers/db.ts**: seed/cleanup yardımcıları.

## Doğrulama
- [x] Lokal headed: **10/10** geçti (preview'a karşı).
- [ ] CI'da (taze MySQL) yeşil — bu PR'da koşacak.

Refs #41 #11