### PR TITLE
feat(pipeline): mentee aşamasını değiştirme — API + UI (#13)

### DIFF
--- a/e2e/pipeline.spec.ts
+++ b/e2e/pipeline.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('mentor can change a mentee pipeline stage and it persists', async ({ page }) => {
+  const mentorEmail = uniqueEmail('mentor');
+  const menteeEmail = uniqueEmail('mentee');
+  const password = 'StagePass123!';
+  const mentor = await seedUser(mentorEmail, password, 'MENTOR', 'Stage Mentor');
+  const mentee = await seedUser(menteeEmail, password, 'MENTEE', 'Stage Mentee');
+  const relation = await prisma.mentorshipRelation.create({
+    data: { mentorId: mentor.id, menteeId: mentee.id },
+  });
+
+  try {
+    // New mentorships start at the first stage
+    expect(relation.pipelineStatus).toBe('APPLICATION_100');
+
+    // Sign in as the mentor
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', mentorEmail);
+    await page.fill('input[type="password"]', password);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/mentor'), { timeout: 20_000 });
+
+    // Open the mentee detail page and move the stage forward
+    await page.goto(`/mentor/mentees/${relation.id}`);
+    await expect(page.getByLabel('Pipeline aşaması')).toBeVisible();
+    await page.getByLabel('Pipeline aşaması').selectOption('INTERNSHIP_IN_PROGRESS_450');
+    await page.waitForTimeout(1800);
+
+    // Persisted in the DB
+    const updated = await prisma.mentorshipRelation.findUnique({ where: { id: relation.id } });
+    expect(updated?.pipelineStatus).toBe('INTERNSHIP_IN_PROGRESS_450');
+
+    // And reflected after reload
+    await page.reload();
+    await expect(page.getByLabel('Pipeline aşaması')).toHaveValue('INTERNSHIP_IN_PROGRESS_450');
+  } finally {
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(menteeEmail);
+  }
+});

--- a/src/app/api/mentorship/[id]/route.ts
+++ b/src/app/api/mentorship/[id]/route.ts
@@ -2,10 +2,13 @@ import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { Prisma } from '@prisma/client';
 import { z } from 'zod';
+import { PIPELINE_STATUSES } from '@/lib/pipeline';
 
 const updateRelationSchema = z.object({
   status: z.enum(['ACTIVE', 'COMPLETED']).optional(),
+  pipelineStatus: z.enum(PIPELINE_STATUSES).optional(),
   companyId: z.string().nullable().optional(),
 });
 
@@ -95,7 +98,7 @@ export async function PUT(request: Request, { params }: { params: Promise<{ id: 
 
     const updated = await prisma.mentorshipRelation.update({
       where: { id },
-      data: parsed.data,
+      data: parsed.data as Prisma.MentorshipRelationUncheckedUpdateInput,
       include: {
         mentor: { select: { id: true, fullName: true, email: true } },
         mentee: { select: { id: true, fullName: true, email: true } },

--- a/src/app/mentor/mentees/[id]/page.tsx
+++ b/src/app/mentor/mentees/[id]/page.tsx
@@ -9,6 +9,7 @@ import { Input } from '@/components/ui/Input';
 import { Select } from '@/components/ui/Select';
 import { ArrowLeft, Plus, Trash2, ExternalLink } from 'lucide-react';
 import Link from 'next/link';
+import { pipelineOptions } from '@/lib/pipeline';
 
 interface InteractionLog {
   id: string;
@@ -20,6 +21,7 @@ interface InteractionLog {
 interface RelationDetail {
   id: string;
   status: string;
+  pipelineStatus: string;
   startDate: string;
   mentee: {
     fullName: string;
@@ -51,6 +53,8 @@ export default function MenteeDetailPage() {
   const [formData, setFormData] = useState({ date: '', notes: '', type: 'Meeting' });
   const [submitting, setSubmitting] = useState(false);
   const [formError, setFormError] = useState('');
+  const [savingStage, setSavingStage] = useState(false);
+  const [stageError, setStageError] = useState('');
 
   const fetchRelation = useCallback(async () => {
     const res = await fetch(`/api/mentorship/${id}`);
@@ -95,6 +99,27 @@ export default function MenteeDetailPage() {
     await fetchRelation();
   };
 
+  const handlePipelineChange = async (pipelineStatus: string) => {
+    setSavingStage(true);
+    setStageError('');
+    try {
+      const res = await fetch(`/api/mentorship/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ pipelineStatus }),
+      });
+      if (!res.ok) {
+        const body = await res.json();
+        throw new Error(body.error || 'Failed to update stage');
+      }
+      await fetchRelation();
+    } catch (err) {
+      setStageError(err instanceof Error ? err.message : 'Failed to update stage');
+    } finally {
+      setSavingStage(false);
+    }
+  };
+
   if (loading) return <div className="text-center py-12 text-gray-400">Loading...</div>;
   if (!relation) return <div className="text-center py-12 text-gray-400">Relation not found</div>;
 
@@ -110,7 +135,19 @@ export default function MenteeDetailPage() {
             <h1 className="text-2xl font-bold text-gray-900">{relation.mentee.fullName}</h1>
             <p className="text-gray-500">{relation.mentee.email}</p>
           </div>
-          <StatusBadge status={relation.status} />
+          <div className="flex flex-col items-end gap-2 min-w-[240px]">
+            <StatusBadge status={relation.status} />
+            <div className="w-full">
+              <Select
+                label="Pipeline aşaması"
+                options={pipelineOptions}
+                value={relation.pipelineStatus}
+                disabled={savingStage}
+                onChange={(e) => handlePipelineChange(e.target.value)}
+              />
+              {stageError && <p className="text-xs text-red-600 mt-1">{stageError}</p>}
+            </div>
+          </div>
         </div>
       </div>
 

--- a/src/lib/pipeline.ts
+++ b/src/lib/pipeline.ts
@@ -1,0 +1,47 @@
+// Single source of truth for the mentee pipeline stages (mirrors the Prisma
+// PipelineStatus enum). Used by the API for validation and the UI for labels.
+// Enum identifiers are English; display labels are Turkish (original spreadsheet).
+
+export const PIPELINE_STATUSES = [
+  'APPLICATION_100',
+  'APPROVAL_PENDING_220',
+  'INTERVIEW_PENDING_250',
+  'INTRODUCTION_PENDING_270',
+  'INTERNSHIP_STARTING_300',
+  'INTERNSHIP_IN_PROGRESS_450',
+  'INTERNSHIP_DROPPED_460',
+  'INTERNSHIP_COMPLETED_490',
+  'JOB_SEEKING_500',
+  'HIREABLE_600',
+  'HIRED_660',
+  'EMPLOYED_700',
+  'INTERNSHIP_FOUND_ELSEWHERE_800',
+] as const;
+
+export type PipelineStatus = (typeof PIPELINE_STATUSES)[number];
+
+// Turkish labels matching the original spreadsheet wording.
+export const PIPELINE_LABELS: Record<PipelineStatus, string> = {
+  APPLICATION_100: '100 · İlk temas',
+  APPROVAL_PENDING_220: '220 · Onay bekliyor',
+  INTERVIEW_PENDING_250: '250 · Görüşülecek',
+  INTRODUCTION_PENDING_270: '270 · Tanıştırılacak',
+  INTERNSHIP_STARTING_300: '300 · Staj başlayacak',
+  INTERNSHIP_IN_PROGRESS_450: '450 · Staj devam ediyor',
+  INTERNSHIP_DROPPED_460: '460 · Staj yarım bıraktı',
+  INTERNSHIP_COMPLETED_490: '490 · Staj bitti',
+  JOB_SEEKING_500: '500 · İş arıyor',
+  HIREABLE_600: '600 · İşe alınabilir',
+  HIRED_660: '660 · İşe alındı',
+  EMPLOYED_700: '700 · İş buldu',
+  INTERNSHIP_FOUND_ELSEWHERE_800: '800 · Başka yerde staj buldu',
+};
+
+export const pipelineOptions = PIPELINE_STATUSES.map((value) => ({
+  value,
+  label: PIPELINE_LABELS[value],
+}));
+
+export function pipelineLabel(status: string): string {
+  return PIPELINE_LABELS[status as PipelineStatus] ?? status;
+}


### PR DESCRIPTION
## Özet
Mentor, bir mentee'nin pipeline aşamasını mentee detay sayfasından değiştirebilir. #12'de eklenen `pipelineStatus` alanını kullanılabilir yapar.

## İçerik
- **`src/lib/pipeline.ts`**: tek kaynak — PipelineStatus değerleri (şemadaki İngilizce id'ler) + Türkçe görünen etiketler.
- **`PUT /api/mentorship/[id]`**: `pipelineStatus` kabul eder (enum'a karşı doğrulanır).
- **Mentee detay sayfası**: aşama seçici (değiştir → PUT → reload'da yansır).
- **`e2e/pipeline.spec.ts`**: mentor aşamayı değiştirir → DB'de kalıcı + UI'da yansıyor.

## Not — enum hizalaması
`main`'deki şemada enum identifier'ları İngilizce (`APPLICATION_100`…), etiketler Türkçe. #13 kodunu buna hizaladım (önceki taslakta `BASVURU_*` vardı).

## Doğrulama
- [x] Lokal headed: **11/11** test geçti (yeni pipeline testi dahil).
- [x] typecheck + lint temiz.
- [ ] CI (taze MySQL) — bu PR'da koşacak.

Closes #13