### PR TITLE
fix(admin): sidebar'a Davet linki ekle (#53)

### DIFF
--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -27,3 +27,17 @@ test('authenticated admin sees a Sign Out control', async ({ page }) => {
   await page.goto('/admin');
   await expect(page.getByRole('link', { name: /sign out/i })).toBeVisible();
 });
+
+test('admin sidebar links to the invite page', async ({ page }) => {
+  await page.goto('/auth/signin');
+  await page.fill('input[type="email"], input[name="email"]', ADMIN_EMAIL);
+  await page.fill('input[type="password"]', ADMIN_PASSWORD);
+  await page.click('button[type="submit"]');
+  await page.waitForURL((u) => !u.pathname.includes('/auth/signin'), { timeout: 20_000 });
+  await page.goto('/admin');
+  const inviteLink = page.getByRole('link', { name: /davet/i });
+  await expect(inviteLink).toBeVisible();
+  await inviteLink.click();
+  await page.waitForURL((u) => u.pathname.includes('/admin/invite'), { timeout: 15_000 });
+  await expect(page.locator('input[type="email"]')).toBeVisible();
+});

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -2,7 +2,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
-import { GraduationCap, LayoutDashboard, Building2, Users, LogOut } from 'lucide-react';
+import { GraduationCap, LayoutDashboard, Building2, Users, Mail, LogOut } from 'lucide-react';
 
 export default async function AdminLayout({ children }: { children: React.ReactNode }) {
   const session = await getServerSession(authOptions);
@@ -55,6 +55,13 @@ export default async function AdminLayout({ children }: { children: React.ReactN
           >
             <Users className="h-5 w-5 text-gray-400 group-hover:text-blue-600" />
             Mentorships
+          </Link>
+          <Link
+            href="/admin/invite"
+            className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-gray-700 hover:bg-blue-50 hover:text-blue-700 transition-colors group"
+          >
+            <Mail className="h-5 w-5 text-gray-400 group-hover:text-blue-600" />
+            Davet Gönder
           </Link>
         </nav>
 


### PR DESCRIPTION
## Özet
`/admin/invite` sayfası vardı ama sadece dashboard kartından erişiliyordu; sol menüde link yoktu, admin bulamıyordu. Sidebar'a 'Davet Gönder' linki + E2E testi eklendi.

Closes #53

## Doğrulama
- [x] Lokal headed: auth testleri 4/4 (yeni nav testi dahil).
- [ ] CI.