### PR TITLE
feat(invite): email başarısız olsa da davet + paylaşılabilir link (#56)

### DIFF
--- a/e2e/invite.spec.ts
+++ b/e2e/invite.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+import { prisma, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+const ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@example.com';
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'ChangeMe123!';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('admin invite surfaces a shareable registration link', async ({ page }) => {
+  const email = uniqueEmail('invitee');
+  try {
+    // Sign in as admin and open the invite page
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', ADMIN_EMAIL);
+    await page.fill('input[type="password"]', ADMIN_PASSWORD);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => !u.pathname.includes('/auth/signin'), { timeout: 20_000 });
+    await page.goto('/admin/invite');
+
+    // Send an invitation
+    await page.fill('input[type="email"]', email);
+    await page.click('button[type="submit"]');
+
+    // A shareable register link is shown (regardless of email delivery)
+    const linkInput = page.locator(`input[value*="/auth/register?token="]`);
+    await expect(linkInput).toBeVisible({ timeout: 10_000 });
+    const value = await linkInput.inputValue();
+    expect(value).toContain('/auth/register?token=');
+
+    // It was persisted as an invitation token
+    const token = await prisma.invitationToken.findFirst({ where: { email } });
+    expect(token).not.toBeNull();
+  } finally {
+    await cleanupByEmail(email);
+  }
+});

--- a/src/app/admin/invite/page.tsx
+++ b/src/app/admin/invite/page.tsx
@@ -9,7 +9,7 @@ import { Input } from '@/components/ui/Input';
 import { Button } from '@/components/ui/Button';
 import { Select } from '@/components/ui/Select';
 import { Badge } from '@/components/ui/Badge';
-import { Send, Mail } from 'lucide-react';
+import { Send, Mail, Copy, Check } from 'lucide-react';
 
 const inviteSchema = z.object({
   email: z.string().email('Invalid email'),
@@ -28,7 +28,20 @@ export default function InvitePage() {
   const [success, setSuccess] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
-  const [sentInvites, setSentInvites] = useState<{ email: string; role: string; time: string }[]>([]);
+  const [sentInvites, setSentInvites] = useState<
+    { email: string; role: string; time: string; registerUrl: string; emailSent: boolean }[]
+  >([]);
+  const [copied, setCopied] = useState<string | null>(null);
+
+  const copyLink = async (url: string) => {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(url);
+      setTimeout(() => setCopied(null), 1500);
+    } catch {
+      /* clipboard unavailable */
+    }
+  };
 
   const {
     register,
@@ -58,9 +71,19 @@ export default function InvitePage() {
         throw new Error(body.error || 'Failed to send invitation');
       }
 
-      setSuccess(`Invitation sent to ${data.email}`);
+      setSuccess(
+        body.emailSent
+          ? `Invitation emailed to ${data.email}`
+          : `Invitation created for ${data.email} — email not delivered, share the link below manually`
+      );
       setSentInvites((prev) => [
-        { email: data.email, role: data.role, time: new Date().toLocaleString() },
+        {
+          email: data.email,
+          role: data.role,
+          time: new Date().toLocaleString(),
+          registerUrl: body.registerUrl ?? '',
+          emailSent: !!body.emailSent,
+        },
         ...prev,
       ]);
       reset({ role: 'MENTEE' });
@@ -125,8 +148,8 @@ export default function InvitePage() {
             <ol className="text-sm text-blue-700 space-y-1 list-decimal list-inside">
               <li>Enter the recipient&apos;s email and select their role</li>
               <li>They receive an email with a registration link</li>
+              <li>If email isn&apos;t delivered, copy the link and share it manually</li>
               <li>The link expires in 7 days</li>
-              <li>They register using their email + the token</li>
             </ol>
           </div>
         </Card>
@@ -142,25 +165,50 @@ export default function InvitePage() {
           ) : (
             <div className="space-y-3">
               {sentInvites.map((invite, idx) => (
-                <div
-                  key={idx}
-                  className="flex items-center justify-between py-3 border-b border-gray-50 last:border-0"
-                >
-                  <div>
-                    <p className="text-sm font-medium text-gray-900">{invite.email}</p>
-                    <p className="text-xs text-gray-400">{invite.time}</p>
+                <div key={idx} className="py-3 border-b border-gray-50 last:border-0">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="text-sm font-medium text-gray-900">{invite.email}</p>
+                      <p className="text-xs text-gray-400">
+                        {invite.time} · {invite.emailSent ? 'emailed' : 'not emailed'}
+                      </p>
+                    </div>
+                    <Badge
+                      variant={
+                        invite.role === 'ADMIN'
+                          ? 'danger'
+                          : invite.role === 'MENTOR'
+                          ? 'info'
+                          : 'success'
+                      }
+                    >
+                      {invite.role}
+                    </Badge>
                   </div>
-                  <Badge
-                    variant={
-                      invite.role === 'ADMIN'
-                        ? 'danger'
-                        : invite.role === 'MENTOR'
-                        ? 'info'
-                        : 'success'
-                    }
-                  >
-                    {invite.role}
-                  </Badge>
+                  {invite.registerUrl && (
+                    <div className="mt-2 flex items-center gap-2">
+                      <input
+                        readOnly
+                        value={invite.registerUrl}
+                        className="flex-1 min-w-0 text-xs bg-gray-50 border border-gray-200 rounded px-2 py-1.5 text-gray-600"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => copyLink(invite.registerUrl)}
+                        className="flex items-center gap-1 text-xs text-blue-600 hover:text-blue-800 flex-shrink-0"
+                      >
+                        {copied === invite.registerUrl ? (
+                          <>
+                            <Check className="h-3.5 w-3.5" /> Kopyalandı
+                          </>
+                        ) : (
+                          <>
+                            <Copy className="h-3.5 w-3.5" /> Kopyala
+                          </>
+                        )}
+                      </button>
+                    </div>
+                  )}
                 </div>
               ))}
             </div>

--- a/src/app/api/invite/route.ts
+++ b/src/app/api/invite/route.ts
@@ -62,10 +62,27 @@ export async function POST(request: Request) {
       },
     });
 
-    await sendInvitationEmail({ to: email, token, role });
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+    const registerUrl = `${appUrl}/auth/register?token=${token}`;
+
+    // The token is already persisted, so a failed/blocked email must not lose the
+    // invitation — the admin can still share registerUrl manually. Report delivery
+    // status instead of 500-ing.
+    let emailSent = false;
+    try {
+      await sendInvitationEmail({ to: email, token, role });
+      emailSent = !!process.env.SMTP_USER;
+    } catch (mailErr) {
+      console.error('Invitation email failed (token still valid):', mailErr);
+    }
 
     return NextResponse.json(
-      { message: 'Invitation sent successfully', invitationId: invitation.id },
+      {
+        message: emailSent ? 'Invitation sent' : 'Invitation created (share the link manually)',
+        invitationId: invitation.id,
+        registerUrl,
+        emailSent,
+      },
       { status: 201 }
     );
   } catch (error) {


### PR DESCRIPTION
## Özet
Email teslimi DNS'e bağlı (#55) olduğundan, davet akışını email'den bağımsız olarak dayanıklı ve kullanışlı yapar.

- **API**: email gönderimi try/catch'te → başarısızlıkta 500 yok, token korunur; yanıtta `registerUrl` + `emailSent`.
- **UI**: her davet için **kopyalanabilir kayıt linki**; mesaj email durumunu yansıtır ('emailed' / 'share manually').
- **e2e/invite.spec.ts**: davet paylaşılabilir link gösteriyor.

Closes #56 · İlgili #55

## Doğrulama
- [x] Lokal headed: invite testi geçti (email başarısız olsa bile link gösterildi).
- [x] typecheck + lint temiz.
- [ ] CI.