### PR TITLE
feat(pipeline): mentor kanban panosu — aşamalara göre (#15)

### DIFF
--- a/e2e/board.spec.ts
+++ b/e2e/board.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('mentor board groups a mentee under its pipeline stage', async ({ page }) => {
+  const mentorEmail = uniqueEmail('mentor');
+  const menteeEmail = uniqueEmail('mentee');
+  const password = 'BoardPass123!';
+  const mentor = await seedUser(mentorEmail, password, 'MENTOR', 'Board Mentor');
+  const mentee = await seedUser(menteeEmail, password, 'MENTEE', 'Board Mentee');
+  await prisma.mentorshipRelation.create({
+    data: { mentorId: mentor.id, menteeId: mentee.id, pipelineStatus: 'INTERNSHIP_IN_PROGRESS_450' },
+  });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', mentorEmail);
+    await page.fill('input[type="password"]', password);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/mentor'), { timeout: 20_000 });
+
+    // Navigate via the sidebar "Pano" link
+    await page.getByRole('link', { name: /pano/i }).click();
+    await page.waitForURL((u) => u.pathname.includes('/mentor/board'), { timeout: 15_000 });
+
+    // The mentee card sits inside the "450 · Staj devam ediyor" column
+    const column = page.locator('div.w-64', { hasText: '450 · Staj devam ediyor' });
+    await expect(column.getByText('Board Mentee')).toBeVisible();
+  } finally {
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(menteeEmail);
+  }
+});

--- a/src/app/mentor/board/page.tsx
+++ b/src/app/mentor/board/page.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import { GraduationCap } from 'lucide-react';
+import { PIPELINE_STATUSES, pipelineLabel } from '@/lib/pipeline';
+
+interface Mentee {
+  id: string;
+  fullName: string;
+  university?: string;
+}
+
+interface Relation {
+  id: string;
+  pipelineStatus: string;
+  mentee: Mentee;
+  _count: { interactions: number };
+}
+
+export default function MentorBoardPage() {
+  const router = useRouter();
+  const [relations, setRelations] = useState<Relation[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [dragOver, setDragOver] = useState<string | null>(null);
+
+  const fetchRelations = useCallback(async () => {
+    const res = await fetch('/api/mentorship');
+    const data = await res.json();
+    setRelations(data.relations ?? []);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    fetchRelations();
+  }, [fetchRelations]);
+
+  const moveTo = async (relationId: string, pipelineStatus: string) => {
+    const prev = relations;
+    // optimistic update
+    setRelations((rs) => rs.map((r) => (r.id === relationId ? { ...r, pipelineStatus } : r)));
+    try {
+      const res = await fetch(`/api/mentorship/${relationId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ pipelineStatus }),
+      });
+      if (!res.ok) throw new Error('Failed');
+    } catch {
+      setRelations(prev); // revert on failure
+    }
+  };
+
+  if (loading) return <div className="text-center py-12 text-gray-400">Loading...</div>;
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900">Pano</h1>
+        <p className="text-gray-500 mt-1">
+          Mentee&apos;lerini aşamalara göre takip et — kartı sürükleyip bırakarak aşama değiştir
+        </p>
+      </div>
+
+      <div className="flex gap-4 overflow-x-auto pb-4">
+        {PIPELINE_STATUSES.map((status) => {
+          const items = relations.filter((r) => r.pipelineStatus === status);
+          return (
+            <div
+              key={status}
+              onDragOver={(e) => {
+                e.preventDefault();
+                setDragOver(status);
+              }}
+              onDragLeave={() => setDragOver((s) => (s === status ? null : s))}
+              onDrop={(e) => {
+                e.preventDefault();
+                setDragOver(null);
+                const id = e.dataTransfer.getData('relationId');
+                if (id) moveTo(id, status);
+              }}
+              className={`flex-shrink-0 w-64 rounded-xl border p-3 transition-colors ${
+                dragOver === status ? 'border-blue-400 bg-blue-50' : 'border-gray-200 bg-gray-50'
+              }`}
+            >
+              <div className="flex items-center justify-between mb-3 px-1">
+                <span className="text-xs font-semibold text-gray-700">{pipelineLabel(status)}</span>
+                <span className="text-xs text-gray-400 bg-white border border-gray-200 rounded-full px-2 py-0.5">
+                  {items.length}
+                </span>
+              </div>
+
+              <div className="space-y-2 min-h-[40px]">
+                {items.map((r) => (
+                  <div
+                    key={r.id}
+                    draggable
+                    onDragStart={(e) => e.dataTransfer.setData('relationId', r.id)}
+                    onClick={() => router.push(`/mentor/mentees/${r.id}`)}
+                    className="bg-white border border-gray-200 rounded-lg p-3 cursor-grab active:cursor-grabbing hover:border-blue-300 hover:shadow-sm transition"
+                  >
+                    <p className="text-sm font-medium text-gray-900 truncate">{r.mentee.fullName}</p>
+                    {r.mentee.university && (
+                      <p className="text-xs text-gray-500 truncate mt-0.5">{r.mentee.university}</p>
+                    )}
+                    <div className="flex items-center gap-1 text-xs text-gray-400 mt-2">
+                      <GraduationCap className="h-3 w-3" />
+                      {r._count.interactions} etkileşim
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/app/mentor/layout.tsx
+++ b/src/app/mentor/layout.tsx
@@ -2,7 +2,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
-import { GraduationCap, LayoutDashboard, Users, BookOpen, LogOut } from 'lucide-react';
+import { GraduationCap, LayoutDashboard, Columns3, Users, BookOpen, LogOut } from 'lucide-react';
 
 export default async function MentorLayout({ children }: { children: React.ReactNode }) {
   const session = await getServerSession(authOptions);
@@ -34,6 +34,13 @@ export default async function MentorLayout({ children }: { children: React.React
           >
             <LayoutDashboard className="h-5 w-5 text-gray-400 group-hover:text-blue-600" />
             Dashboard
+          </Link>
+          <Link
+            href="/mentor/board"
+            className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-gray-700 hover:bg-blue-50 hover:text-blue-700 transition-colors group"
+          >
+            <Columns3 className="h-5 w-5 text-gray-400 group-hover:text-blue-600" />
+            Pano
           </Link>
           <Link
             href="/mentor/mentees"


### PR DESCRIPTION
## Özet
`/mentor/board`: mentee'leri pipeline aşamalarına göre kolonlayan kanban. Excel'deki status kolonunun görsel karşılığı.

- Her aşama bir kolon; mentee kartları doğru kolonda, etkileşim sayısı + kolon toplamı.
- **Sürükle-bırak** (native HTML5) ile aşama değiştir → `PUT /api/mentorship/[id]` (optimistic, hata olursa geri alır).
- Kart → mentee detayına link. Sidebar'a 'Pano' linki.
- `e2e/board.spec.ts`: mentee doğru aşama kolonunda görünüyor.

Closes #15

## Doğrulama
- [x] Lokal headed: **14/14** test geçti.
- [x] typecheck + lint temiz.
- [ ] CI.