### PR TITLE
feat(pipeline): aşama değişikliği audit log (#14)

### DIFF
--- a/e2e/history.spec.ts
+++ b/e2e/history.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('changing a stage records an entry in the status history', async ({ page }) => {
+  const mentorEmail = uniqueEmail('mentor');
+  const menteeEmail = uniqueEmail('mentee');
+  const password = 'HistPass123!';
+  const mentor = await seedUser(mentorEmail, password, 'MENTOR', 'History Mentor');
+  const mentee = await seedUser(menteeEmail, password, 'MENTEE', 'History Mentee');
+  const relation = await prisma.mentorshipRelation.create({
+    data: { mentorId: mentor.id, menteeId: mentee.id },
+  });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', mentorEmail);
+    await page.fill('input[type="password"]', password);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/mentor'), { timeout: 20_000 });
+
+    await page.goto(`/mentor/mentees/${relation.id}`);
+    await expect(page.getByText(/Aşama Geçmişi/)).toBeVisible();
+
+    // Change the stage
+    await page.getByLabel('Pipeline aşaması').selectOption('INTERNSHIP_IN_PROGRESS_450');
+    await page.waitForTimeout(1800);
+
+    // History records the transition
+    const entry = await prisma.statusChange.findFirst({ where: { relationId: relation.id } });
+    expect(entry?.toStatus).toBe('INTERNSHIP_IN_PROGRESS_450');
+    expect(entry?.fromStatus).toBe('APPLICATION_100');
+
+    // And it shows in the UI timeline
+    await page.reload();
+    const historyCard = page.locator('div', { hasText: /Aşama Geçmişi \(1\)/ }).last();
+    await expect(historyCard.getByText('450 · Staj devam ediyor')).toBeVisible();
+  } finally {
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(menteeEmail);
+  }
+});

--- a/e2e/history.spec.ts
+++ b/e2e/history.spec.ts
@@ -34,10 +34,12 @@ test('changing a stage records an entry in the status history', async ({ page })
     expect(entry?.toStatus).toBe('INTERNSHIP_IN_PROGRESS_450');
     expect(entry?.fromStatus).toBe('APPLICATION_100');
 
-    // And it shows in the UI timeline
+    // And it shows in the UI timeline (scope to the history list, not the select options)
     await page.reload();
-    const historyCard = page.locator('div', { hasText: /Aşama Geçmişi \(1\)/ }).last();
-    await expect(historyCard.getByText('450 · Staj devam ediyor')).toBeVisible();
+    await expect(page.getByText('Aşama Geçmişi (1)')).toBeVisible();
+    const entryItem = page.locator('ol li').first();
+    await expect(entryItem).toContainText('450 · Staj devam ediyor');
+    await expect(entryItem).toContainText('100 · İlk temas');
   } finally {
     await cleanupByEmail(mentorEmail);
     await cleanupByEmail(menteeEmail);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -59,6 +59,7 @@ model User {
 
   mentorRelations MentorshipRelation[] @relation("MentorRelations")
   menteeRelations MentorshipRelation[] @relation("MenteeRelations")
+  statusChanges   StatusChange[]       @relation("StatusChangedBy")
 }
 
 model Company {
@@ -93,10 +94,11 @@ model MentorshipRelation {
   status         MentorshipStatus @default(ACTIVE)
   pipelineStatus PipelineStatus   @default(APPLICATION_100)
 
-  mentor       User             @relation("MentorRelations", fields: [mentorId], references: [id])
-  mentee       User             @relation("MenteeRelations", fields: [menteeId], references: [id])
-  company      Company?         @relation(fields: [companyId], references: [id])
-  interactions InteractionLog[]
+  mentor        User             @relation("MentorRelations", fields: [mentorId], references: [id])
+  mentee        User             @relation("MenteeRelations", fields: [menteeId], references: [id])
+  company       Company?         @relation(fields: [companyId], references: [id])
+  interactions  InteractionLog[]
+  statusChanges StatusChange[]
 }
 
 model InteractionLog {
@@ -107,6 +109,19 @@ model InteractionLog {
   type       InteractionType
 
   relation MentorshipRelation @relation(fields: [relationId], references: [id], onDelete: Cascade)
+}
+
+// Audit trail of pipeline stage changes for a mentorship.
+model StatusChange {
+  id          String         @id @default(cuid())
+  relationId  String
+  fromStatus  PipelineStatus
+  toStatus    PipelineStatus
+  changedById String
+  createdAt   DateTime       @default(now())
+
+  relation  MentorshipRelation @relation(fields: [relationId], references: [id], onDelete: Cascade)
+  changedBy User               @relation("StatusChangedBy", fields: [changedById], references: [id])
 }
 
 model InvitationToken {

--- a/src/app/api/mentorship/[id]/route.ts
+++ b/src/app/api/mentorship/[id]/route.ts
@@ -39,6 +39,10 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
         },
         company: true,
         interactions: { orderBy: { date: 'desc' } },
+        statusChanges: {
+          orderBy: { createdAt: 'desc' },
+          include: { changedBy: { select: { fullName: true } } },
+        },
       },
     });
 
@@ -105,6 +109,18 @@ export async function PUT(request: Request, { params }: { params: Promise<{ id: 
         company: { select: { id: true, name: true } },
       },
     });
+
+    // Record an audit entry when the pipeline stage actually changes.
+    if (parsed.data.pipelineStatus && parsed.data.pipelineStatus !== relation.pipelineStatus) {
+      await prisma.statusChange.create({
+        data: {
+          relationId: id,
+          fromStatus: relation.pipelineStatus,
+          toStatus: parsed.data.pipelineStatus,
+          changedById: session.user.id,
+        },
+      });
+    }
 
     return NextResponse.json({ relation: updated });
   } catch (error) {

--- a/src/app/mentor/mentees/[id]/page.tsx
+++ b/src/app/mentor/mentees/[id]/page.tsx
@@ -9,7 +9,7 @@ import { Input } from '@/components/ui/Input';
 import { Select } from '@/components/ui/Select';
 import { ArrowLeft, Plus, Trash2, ExternalLink } from 'lucide-react';
 import Link from 'next/link';
-import { pipelineOptions } from '@/lib/pipeline';
+import { pipelineOptions, pipelineLabel } from '@/lib/pipeline';
 
 interface InteractionLog {
   id: string;
@@ -35,6 +35,13 @@ interface RelationDetail {
   };
   company: { name: string; industry?: string } | null;
   interactions: InteractionLog[];
+  statusChanges: {
+    id: string;
+    fromStatus: string;
+    toStatus: string;
+    createdAt: string;
+    changedBy: { fullName: string };
+  }[];
 }
 
 const typeOptions = [
@@ -213,6 +220,31 @@ export default function MenteeDetailPage() {
               </div>
             )}
           </div>
+        </Card>
+
+        {/* Pipeline stage history */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Aşama Geçmişi ({relation.statusChanges.length})</CardTitle>
+          </CardHeader>
+          {relation.statusChanges.length === 0 ? (
+            <p className="text-sm text-gray-400 text-center py-6">Henüz aşama değişikliği yok</p>
+          ) : (
+            <ol className="space-y-3">
+              {relation.statusChanges.map((sc) => (
+                <li key={sc.id} className="text-sm border-l-2 border-blue-100 pl-3">
+                  <p className="text-gray-700">
+                    <span className="text-gray-400">{pipelineLabel(sc.fromStatus)}</span>
+                    {' → '}
+                    <span className="font-medium text-gray-900">{pipelineLabel(sc.toStatus)}</span>
+                  </p>
+                  <p className="text-xs text-gray-400 mt-0.5">
+                    {sc.changedBy.fullName} · {new Date(sc.createdAt).toLocaleString()}
+                  </p>
+                </li>
+              ))}
+            </ol>
+          )}
         </Card>
 
         {/* Interactions */}


### PR DESCRIPTION
## Özet
Pipeline aşaması her değiştiğinde kim/ne zaman/neyden-neye kaydı tutulur; mentee detayında zaman çizelgesi gösterilir. Pipeline epic'ini (#11) tamamlar.

- **Prisma**: `StatusChange` modeli (relation, from/to, changedBy, createdAt).
- **PUT /api/mentorship/[id]**: aşama gerçekten değişince StatusChange yazar; GET geçmişi actor adıyla döndürür.
- **Mentee detay**: 'Aşama Geçmişi' timeline (from → to, kim, ne zaman).
- **e2e/history.spec.ts**: aşama değiştir → kayıt + UI'da görünüm.

Closes #14

## Not
Additive şema (yeni `StatusChange` tablosu) — preview/prod'a `db push` ile eklenir; mevcut veriyi etkilemez.

## Doğrulama
- [x] typecheck + lint temiz.
- [ ] CI (taze MySQL) + preview deploy sonrası headed.