### PR TITLE
feat(import): Excel/CSV importer (dry-run + idempotent) (#22 #23 #24)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "autoprefixer": "^10.0.1",
+        "csv-parse": "^7.0.0",
         "eslint": "^8",
         "eslint-config-next": "^15.5.14",
         "postcss": "^8",
@@ -2401,6 +2402,13 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csv-parse": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-7.0.0.tgz",
+      "integrity": "sha512-CSssqPAK5us09FhMI9juM0jnqXUJP+rtWeIfivTYBLNH/8rnxkQlZvoRemF6MAyfNov9XU8mN2wwF/pP68sxTA==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "next lint",
     "test:e2e": "playwright test",
     "test:e2e:headed": "playwright test --headed",
+    "import:csv": "node scripts/import-csv.mjs",
     "postinstall": "prisma generate"
   },
   "dependencies": {
@@ -39,6 +40,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "autoprefixer": "^10.0.1",
+    "csv-parse": "^7.0.0",
     "eslint": "^8",
     "eslint-config-next": "^15.5.14",
     "postcss": "^8",

--- a/scripts/import-csv.mjs
+++ b/scripts/import-csv.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+/**
+ * Import the legacy mentoring spreadsheet (CSV) into the CRM.
+ *
+ * Usage:
+ *   node scripts/import-csv.mjs --file=data.csv                 # dry-run (no writes)
+ *   node scripts/import-csv.mjs --url="https://.../pub?output=csv"
+ *   node scripts/import-csv.mjs --file=data.csv --owner=admin@example.com --apply
+ *
+ * Dry-run is the default: it parses, maps and reports without touching the DB.
+ * --apply requires --owner (an existing MENTOR/ADMIN that owns the imported
+ * mentees). The import is idempotent: re-running upserts by (synthetic) email.
+ *
+ * Data hygiene: the "firma hesap bilgileri" column may contain credentials and
+ * is never imported. "46199" (empty-date artifact), "#REF!" and "-" become null.
+ */
+import { parse } from 'csv-parse/sync';
+import { readFileSync } from 'node:fs';
+
+const args = Object.fromEntries(
+  process.argv.slice(2).map((a) => {
+    const [k, ...v] = a.replace(/^--/, '').split('=');
+    return [k, v.length ? v.join('=') : true];
+  })
+);
+const APPLY = !!args.apply;
+
+const STATUS_MAP = {
+  100: 'APPLICATION_100',
+  220: 'APPROVAL_PENDING_220',
+  250: 'INTERVIEW_PENDING_250',
+  270: 'INTRODUCTION_PENDING_270',
+  300: 'INTERNSHIP_STARTING_300',
+  450: 'INTERNSHIP_IN_PROGRESS_450',
+  460: 'INTERNSHIP_DROPPED_460',
+  490: 'INTERNSHIP_COMPLETED_490',
+  500: 'JOB_SEEKING_500',
+  600: 'HIREABLE_600',
+  660: 'HIRED_660',
+  700: 'EMPLOYED_700',
+  800: 'INTERNSHIP_FOUND_ELSEWHERE_800',
+};
+
+const clean = (v) => {
+  const s = (v ?? '').trim();
+  if (!s || s === '-' || s === '#REF!' || s === '46199') return null;
+  return s;
+};
+const slug = (s) =>
+  s
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '.')
+    .replace(/^\.|\.$/g, '');
+
+const STATUS_KEYS = Object.keys(STATUS_MAP).map(Number);
+function mapStatus(raw) {
+  const s = clean(raw);
+  if (!s) return 'APPLICATION_100';
+  const m = s.match(/(\d{3})/);
+  if (!m) return 'APPLICATION_100';
+  const n = Number(m[1]);
+  if (STATUS_MAP[n]) return STATUS_MAP[n];
+  // In-between legacy codes (e.g. 230/260/440) -> nearest defined stage.
+  const nearest = STATUS_KEYS.reduce((a, b) => (Math.abs(b - n) < Math.abs(a - n) ? b : a));
+  return STATUS_MAP[nearest];
+}
+function waNumber(raw) {
+  const s = clean(raw);
+  if (!s) return null;
+  const m = s.match(/wa\.me\/(\+?\d+)/i);
+  return m ? m[1] : /^\+?\d{6,}$/.test(s) ? s : null;
+}
+function parseDate(raw) {
+  const s = clean(raw);
+  if (!s) return null;
+  const m = s.match(/^(\d{1,2})\.(\d{1,2})\.(\d{4})$/);
+  if (!m) return null;
+  const [, d, mo, y] = m;
+  const dt = new Date(Number(y), Number(mo) - 1, Number(d));
+  return isNaN(dt.getTime()) ? null : dt;
+}
+
+async function loadCsv() {
+  if (args.file) return readFileSync(args.file, 'utf8');
+  if (args.url) {
+    const res = await fetch(args.url, { redirect: 'follow' });
+    if (!res.ok) throw new Error(`Fetch failed: HTTP ${res.status}`);
+    return res.text();
+  }
+  throw new Error('Provide --file=<path> or --url=<published csv url>');
+}
+
+function mapRow(row) {
+  const fullName = clean(row['isim soyisim']);
+  if (!fullName) return null; // skip nameless rows
+  const realEmail = clean(row['Email']);
+  const email = realEmail || `imported.${slug(fullName)}@import.local`;
+  return {
+    fullName,
+    email,
+    syntheticEmail: !realEmail,
+    pipelineStatus: mapStatus(row['Status']),
+    whatsapp: waNumber(row['whatsapp']),
+    phone: clean(row['Telefon']) || waNumber(row['whatsapp']),
+    city: clean(row['Sehir']),
+    department: clean(row['Brans / IT alani egitiminiz']),
+    referralSource: clean(row['Referans']),
+    birthDate: parseDate(row['dtarihi']),
+    cvUrl: (() => {
+      const u = clean(row['cv']);
+      return u && /^https?:\/\//.test(u) ? u : null;
+    })(),
+    project: clean(row['proje']),
+  };
+}
+
+function report(rows, mapped) {
+  const byStatus = {};
+  let synthetic = 0;
+  for (const r of mapped) {
+    byStatus[r.pipelineStatus] = (byStatus[r.pipelineStatus] || 0) + 1;
+    if (r.syntheticEmail) synthetic++;
+  }
+  console.log(`\n=== Import ${APPLY ? '(APPLY)' : '(DRY-RUN — no writes)'} ===`);
+  console.log(`CSV rows: ${rows.length}`);
+  console.log(`Mapped (named) records: ${mapped.length}  | skipped nameless: ${rows.length - mapped.length}`);
+  console.log(`Real emails: ${mapped.length - synthetic}  | synthetic placeholder emails: ${synthetic}`);
+  console.log('Note: "firma hesap bilgileri" column is excluded (may contain credentials).');
+  console.log('\nPipeline status distribution:');
+  for (const k of Object.keys(byStatus).sort()) console.log(`  ${k}: ${byStatus[k]}`);
+  console.log('\nSample (first 5):');
+  for (const r of mapped.slice(0, 5))
+    console.log(`  - ${r.fullName} [${r.pipelineStatus}] city=${r.city ?? '-'} wa=${r.whatsapp ?? '-'} ref=${r.referralSource ?? '-'}`);
+}
+
+async function apply(mapped) {
+  if (!args.owner) throw new Error('--apply requires --owner=<mentor/admin email>');
+  const { PrismaClient } = await import('@prisma/client');
+  const prisma = new PrismaClient();
+  try {
+    const owner = await prisma.user.findUnique({ where: { email: String(args.owner) } });
+    if (!owner) throw new Error(`Owner not found: ${args.owner}`);
+    if (!['ADMIN', 'MENTOR'].includes(owner.role))
+      throw new Error(`Owner must be ADMIN or MENTOR (is ${owner.role})`);
+
+    let created = 0,
+      updated = 0,
+      relCreated = 0;
+    for (const r of mapped) {
+      const data = {
+        fullName: r.fullName,
+        role: 'MENTEE',
+        phone: r.phone,
+        whatsapp: r.whatsapp,
+        city: r.city,
+        department: r.department,
+        referralSource: r.referralSource,
+        birthDate: r.birthDate,
+        cvUrl: r.cvUrl,
+      };
+      const existing = await prisma.user.findUnique({ where: { email: r.email } });
+      const user = existing
+        ? ((updated++), await prisma.user.update({ where: { email: r.email }, data }))
+        : ((created++),
+          await prisma.user.create({
+            data: { ...data, email: r.email, password: '!imported-no-login' },
+          }));
+      const rel = await prisma.mentorshipRelation.findFirst({
+        where: { mentorId: owner.id, menteeId: user.id },
+      });
+      if (rel) {
+        await prisma.mentorshipRelation.update({
+          where: { id: rel.id },
+          data: { pipelineStatus: r.pipelineStatus },
+        });
+      } else {
+        await prisma.mentorshipRelation.create({
+          data: { mentorId: owner.id, menteeId: user.id, pipelineStatus: r.pipelineStatus },
+        });
+        relCreated++;
+      }
+    }
+    console.log(`\nApplied: users created=${created} updated=${updated}; relations created=${relCreated}`);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+const csv = await loadCsv();
+const rows = parse(csv, { columns: true, skip_empty_lines: true, relax_column_count: true });
+const mapped = rows.map(mapRow).filter(Boolean);
+report(rows, mapped);
+if (APPLY) await apply(mapped);
+else console.log('\n(Dry-run only. Re-run with --owner=<email> --apply to write.)');


### PR DESCRIPTION
## Özet
`scripts/import-csv.mjs` — eski mentorluk Excel'ini (CSV) CRM'e aktarır.

- **Status eşleme**: baştaki kod → PipelineStatus; ara kodlar (230/260/440) en yakın aşamaya.
- **Veri temizleme**: `firma hesap bilgileri` kolonu (kimlik bilgisi) **dışlanır**; `46199`/`#REF!`/`-` → null; isimsiz satırlar atlanır.
- **Sentetik email**: email'i olmayanlara deterministik placeholder (re-run'da upsert, duplicate yok).
- **Dry-run varsayılan** (DB'ye yazmaz) + özet rapor; `--apply --owner=<email>` ile gerçek import.

Gerçek veri commit edilmez — CSV runtime'da `--file/--url` ile verilir.

## Dry-run sonucu (87 kayıt)
19 gerçek email + 68 placeholder; status dağılımı: 450→23, 490→17, 700→12, 660→6, 460→7, 800→5 vb. Parola kolonu dışlandı.

Closes #22 #23 #24

## Doğrulama
- [x] Dry-run gerçek veriyle çalıştırıldı (yukarıdaki rapor).
- [ ] CI.