### PR TITLE
feat(admin): Mentor listesi ekranı (#63)

### DIFF
--- a/e2e/mentors.spec.ts
+++ b/e2e/mentors.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+const ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@example.com';
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'ChangeMe123!';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('admin can open the Mentors list and see a mentor', async ({ page }) => {
+  const mentorEmail = uniqueEmail('mentor');
+  await seedUser(mentorEmail, 'MentorPass123!', 'MENTOR', 'Listed Mentor');
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', ADMIN_EMAIL);
+    await page.fill('input[type="password"]', ADMIN_PASSWORD);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => !u.pathname.includes('/auth/signin'), { timeout: 20_000 });
+
+    await page.goto('/admin');
+    await page.getByRole('link', { name: 'Mentors', exact: true }).click();
+    await page.waitForURL((u) => u.pathname.includes('/admin/mentors'), { timeout: 15_000 });
+
+    await expect(page.getByText('Listed Mentor')).toBeVisible();
+    await expect(page.getByText(mentorEmail)).toBeVisible();
+  } finally {
+    await cleanupByEmail(mentorEmail);
+  }
+});

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -2,7 +2,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
-import { GraduationCap, LayoutDashboard, Building2, Users, Mail, LogOut } from 'lucide-react';
+import { GraduationCap, LayoutDashboard, Building2, Users, UserCheck, Mail, LogOut } from 'lucide-react';
 
 export default async function AdminLayout({ children }: { children: React.ReactNode }) {
   const session = await getServerSession(authOptions);
@@ -48,6 +48,13 @@ export default async function AdminLayout({ children }: { children: React.ReactN
           >
             <Users className="h-5 w-5 text-gray-400 group-hover:text-blue-600" />
             Candidates
+          </Link>
+          <Link
+            href="/admin/mentors"
+            className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-gray-700 hover:bg-blue-50 hover:text-blue-700 transition-colors group"
+          >
+            <UserCheck className="h-5 w-5 text-gray-400 group-hover:text-blue-600" />
+            Mentors
           </Link>
           <Link
             href="/admin/mentorship"

--- a/src/app/admin/mentors/page.tsx
+++ b/src/app/admin/mentors/page.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
+import { Badge } from '@/components/ui/Badge';
+import { Users } from 'lucide-react';
+
+interface MentorUser {
+  id: string;
+  fullName: string;
+  email: string;
+  department?: string;
+  phone?: string;
+  _count: { mentorRelations: number };
+}
+
+export default function MentorsPage() {
+  const [mentors, setMentors] = useState<MentorUser[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch('/api/users')
+      .then((res) => res.json())
+      .then(({ users }) => {
+        setMentors((users ?? []).filter((u: { role: string }) => u.role === 'MENTOR'));
+        setLoading(false);
+      });
+  }, []);
+
+  return (
+    <div>
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold text-gray-900">Mentors</h1>
+        <p className="text-gray-500 mt-1">All mentors on the platform</p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Mentors ({mentors.length})</CardTitle>
+        </CardHeader>
+
+        {loading ? (
+          <p className="text-center py-12 text-gray-400">Loading...</p>
+        ) : mentors.length === 0 ? (
+          <p className="text-center py-12 text-gray-400">No mentors yet</p>
+        ) : (
+          <div className="divide-y divide-gray-50">
+            {mentors.map((m) => (
+              <div key={m.id} className="flex items-center justify-between py-3">
+                <div className="flex items-center gap-3 min-w-0">
+                  <div className="w-9 h-9 bg-green-100 rounded-full flex items-center justify-center flex-shrink-0">
+                    <span className="text-green-700 font-semibold text-sm">{m.fullName?.[0] || 'M'}</span>
+                  </div>
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-gray-900 truncate">{m.fullName}</p>
+                    <p className="text-xs text-gray-500 truncate">
+                      {m.email}
+                      {m.department ? ` · ${m.department}` : ''}
+                    </p>
+                  </div>
+                </div>
+                <Badge variant="info" className="flex items-center gap-1 flex-shrink-0">
+                  <Users className="h-3 w-3" />
+                  {m._count.mentorRelations} mentee
+                </Badge>
+              </div>
+            ))}
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -21,7 +21,9 @@ export async function GET() {
         department: true,
         graduationYear: true,
         skills: true,
+        phone: true,
         createdAt: true,
+        _count: { select: { mentorRelations: true } },
       },
       orderBy: { createdAt: 'desc' },
     });


### PR DESCRIPTION
Dashboard mentor sayısını gösteriyordu ama mentorları görecek ekran yoktu. `/admin/mentors` listesi (isim, e-posta, bölüm, mentee sayısı) + sidebar'da 'Mentors' linki. `/api/users` artık mentorRelations sayısını döndürüyor. e2e/mentors.spec.ts eklendi.\n\nCloses #63