### PR TITLE
feat(i18n): temel + EN/TR dil değiştirici (tüm layout'lar) (#65)

### DIFF
--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -35,7 +35,7 @@ test('admin sidebar links to the invite page', async ({ page }) => {
   await page.click('button[type="submit"]');
   await page.waitForURL((u) => !u.pathname.includes('/auth/signin'), { timeout: 20_000 });
   await page.goto('/admin');
-  const inviteLink = page.getByRole('link', { name: /davet/i });
+  const inviteLink = page.getByRole('link', { name: 'Send Invitation', exact: true });
   await expect(inviteLink).toBeVisible();
   await inviteLink.click();
   await page.waitForURL((u) => u.pathname.includes('/admin/invite'), { timeout: 15_000 });

--- a/e2e/board.spec.ts
+++ b/e2e/board.spec.ts
@@ -22,8 +22,8 @@ test('mentor board groups a mentee under its pipeline stage', async ({ page }) =
     await page.click('button[type="submit"]');
     await page.waitForURL((u) => u.pathname.startsWith('/mentor'), { timeout: 20_000 });
 
-    // Navigate via the sidebar "Pano" link
-    await page.getByRole('link', { name: /pano/i }).click();
+    // Navigate via the sidebar "Board" link (default locale is English)
+    await page.getByRole('link', { name: 'Board', exact: true }).click();
     await page.waitForURL((u) => u.pathname.includes('/mentor/board'), { timeout: 15_000 });
 
     // The mentee card sits inside the "450 · Staj devam ediyor" column

--- a/e2e/i18n.spec.ts
+++ b/e2e/i18n.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test';
+
+const ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@example.com';
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'ChangeMe123!';
+
+test('language switcher toggles the admin nav between EN and TR', async ({ page }) => {
+  await page.goto('/auth/signin');
+  await page.fill('input[type="email"], input[name="email"]', ADMIN_EMAIL);
+  await page.fill('input[type="password"]', ADMIN_PASSWORD);
+  await page.click('button[type="submit"]');
+  await page.waitForURL((u) => !u.pathname.includes('/auth/signin'), { timeout: 20_000 });
+  await page.goto('/admin');
+
+  // Default locale is English (exact avoids matching the "Send Invitations" card)
+  await expect(page.getByRole('link', { name: 'Send Invitation', exact: true })).toBeVisible();
+
+  // Switch to Turkish — the switcher sets a cookie and reloads
+  await page.getByRole('button', { name: 'tr' }).click();
+  await page.waitForLoadState('load');
+  await expect(page.getByRole('link', { name: 'Davet Gönder', exact: true })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Adaylar', exact: true })).toBeVisible();
+
+  // Preference persists across navigations (cookie-based)
+  await page.goto('/admin/mentorship');
+  await expect(page.getByRole('link', { name: 'Davet Gönder', exact: true })).toBeVisible();
+});

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -3,6 +3,8 @@ import { authOptions } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import { GraduationCap, LayoutDashboard, Building2, Users, UserCheck, Mail, LogOut } from 'lucide-react';
+import { getServerDictionary } from '@/i18n/server';
+import { LanguageSwitcher } from '@/components/LanguageSwitcher';
 
 export default async function AdminLayout({ children }: { children: React.ReactNode }) {
   const session = await getServerSession(authOptions);
@@ -15,6 +17,8 @@ export default async function AdminLayout({ children }: { children: React.ReactN
     redirect('/');
   }
 
+  const { locale, t } = await getServerDictionary();
+
   return (
     <div className="min-h-screen bg-gray-50 flex">
       {/* Sidebar */}
@@ -24,7 +28,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
             <GraduationCap className="h-7 w-7 text-blue-600" />
             <span className="font-bold text-gray-900">InternshipCRM</span>
           </div>
-          <p className="text-xs text-gray-500 mt-1">Admin Panel</p>
+          <p className="text-xs text-gray-500 mt-1">{t.panel.admin}</p>
         </div>
 
         <nav className="flex-1 p-4 space-y-1">
@@ -33,42 +37,42 @@ export default async function AdminLayout({ children }: { children: React.ReactN
             className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-gray-700 hover:bg-blue-50 hover:text-blue-700 transition-colors group"
           >
             <LayoutDashboard className="h-5 w-5 text-gray-400 group-hover:text-blue-600" />
-            Dashboard
+            {t.nav.dashboard}
           </Link>
           <Link
             href="/admin/companies"
             className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-gray-700 hover:bg-blue-50 hover:text-blue-700 transition-colors group"
           >
             <Building2 className="h-5 w-5 text-gray-400 group-hover:text-blue-600" />
-            Companies
+            {t.nav.companies}
           </Link>
           <Link
             href="/admin/candidates"
             className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-gray-700 hover:bg-blue-50 hover:text-blue-700 transition-colors group"
           >
             <Users className="h-5 w-5 text-gray-400 group-hover:text-blue-600" />
-            Candidates
+            {t.nav.candidates}
           </Link>
           <Link
             href="/admin/mentors"
             className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-gray-700 hover:bg-blue-50 hover:text-blue-700 transition-colors group"
           >
             <UserCheck className="h-5 w-5 text-gray-400 group-hover:text-blue-600" />
-            Mentors
+            {t.nav.mentors}
           </Link>
           <Link
             href="/admin/mentorship"
             className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-gray-700 hover:bg-blue-50 hover:text-blue-700 transition-colors group"
           >
             <Users className="h-5 w-5 text-gray-400 group-hover:text-blue-600" />
-            Mentorships
+            {t.nav.mentorships}
           </Link>
           <Link
             href="/admin/invite"
             className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-gray-700 hover:bg-blue-50 hover:text-blue-700 transition-colors group"
           >
             <Mail className="h-5 w-5 text-gray-400 group-hover:text-blue-600" />
-            Davet Gönder
+            {t.nav.invite}
           </Link>
         </nav>
 
@@ -89,8 +93,11 @@ export default async function AdminLayout({ children }: { children: React.ReactN
             className="flex items-center gap-2 w-full px-3 py-2 text-sm text-red-600 hover:bg-red-50 rounded-lg transition-colors"
           >
             <LogOut className="h-4 w-4" />
-            Sign Out
+            {t.nav.signOut}
           </Link>
+          <div className="mt-3 px-3">
+            <LanguageSwitcher current={locale} />
+          </div>
         </div>
       </aside>
 

--- a/src/app/mentor/layout.tsx
+++ b/src/app/mentor/layout.tsx
@@ -3,6 +3,8 @@ import { authOptions } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import { GraduationCap, LayoutDashboard, Columns3, Users, BookOpen, LogOut } from 'lucide-react';
+import { getServerDictionary } from '@/i18n/server';
+import { LanguageSwitcher } from '@/components/LanguageSwitcher';
 
 export default async function MentorLayout({ children }: { children: React.ReactNode }) {
   const session = await getServerSession(authOptions);
@@ -15,6 +17,8 @@ export default async function MentorLayout({ children }: { children: React.React
     redirect('/');
   }
 
+  const { locale, t } = await getServerDictionary();
+
   return (
     <div className="min-h-screen bg-gray-50 flex">
       {/* Sidebar */}
@@ -24,7 +28,7 @@ export default async function MentorLayout({ children }: { children: React.React
             <GraduationCap className="h-7 w-7 text-blue-600" />
             <span className="font-bold text-gray-900">InternshipCRM</span>
           </div>
-          <p className="text-xs text-gray-500 mt-1">Mentor Portal</p>
+          <p className="text-xs text-gray-500 mt-1">{t.panel.mentor}</p>
         </div>
 
         <nav className="flex-1 p-4 space-y-1">
@@ -33,28 +37,28 @@ export default async function MentorLayout({ children }: { children: React.React
             className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-gray-700 hover:bg-blue-50 hover:text-blue-700 transition-colors group"
           >
             <LayoutDashboard className="h-5 w-5 text-gray-400 group-hover:text-blue-600" />
-            Dashboard
+            {t.nav.dashboard}
           </Link>
           <Link
             href="/mentor/board"
             className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-gray-700 hover:bg-blue-50 hover:text-blue-700 transition-colors group"
           >
             <Columns3 className="h-5 w-5 text-gray-400 group-hover:text-blue-600" />
-            Pano
+            {t.nav.board}
           </Link>
           <Link
             href="/mentor/mentees"
             className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-gray-700 hover:bg-blue-50 hover:text-blue-700 transition-colors group"
           >
             <Users className="h-5 w-5 text-gray-400 group-hover:text-blue-600" />
-            My Mentees
+            {t.nav.myMentees}
           </Link>
           <Link
             href="/mentor/interactions"
             className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-gray-700 hover:bg-blue-50 hover:text-blue-700 transition-colors group"
           >
             <BookOpen className="h-5 w-5 text-gray-400 group-hover:text-blue-600" />
-            Interaction Logs
+            {t.nav.interactionLogs}
           </Link>
         </nav>
 
@@ -75,8 +79,11 @@ export default async function MentorLayout({ children }: { children: React.React
             className="flex items-center gap-2 w-full px-3 py-2 text-sm text-red-600 hover:bg-red-50 rounded-lg transition-colors"
           >
             <LogOut className="h-4 w-4" />
-            Sign Out
+            {t.nav.signOut}
           </Link>
+          <div className="mt-3 px-3">
+            <LanguageSwitcher current={locale} />
+          </div>
         </div>
       </aside>
 

--- a/src/app/portal/layout.tsx
+++ b/src/app/portal/layout.tsx
@@ -3,6 +3,8 @@ import { authOptions } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import { GraduationCap, LayoutDashboard, User, BookOpen, LogOut } from 'lucide-react';
+import { getServerDictionary } from '@/i18n/server';
+import { LanguageSwitcher } from '@/components/LanguageSwitcher';
 
 export default async function PortalLayout({ children }: { children: React.ReactNode }) {
   const session = await getServerSession(authOptions);
@@ -19,6 +21,8 @@ export default async function PortalLayout({ children }: { children: React.React
     redirect('/mentor');
   }
 
+  const { locale, t } = await getServerDictionary();
+
   return (
     <div className="min-h-screen bg-gray-50 flex">
       {/* Sidebar */}
@@ -28,7 +32,7 @@ export default async function PortalLayout({ children }: { children: React.React
             <GraduationCap className="h-7 w-7 text-blue-600" />
             <span className="font-bold text-gray-900">InternshipCRM</span>
           </div>
-          <p className="text-xs text-gray-500 mt-1">Mentee Portal</p>
+          <p className="text-xs text-gray-500 mt-1">{t.panel.mentee}</p>
         </div>
 
         <nav className="flex-1 p-4 space-y-1">
@@ -37,21 +41,21 @@ export default async function PortalLayout({ children }: { children: React.React
             className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-gray-700 hover:bg-blue-50 hover:text-blue-700 transition-colors group"
           >
             <LayoutDashboard className="h-5 w-5 text-gray-400 group-hover:text-blue-600" />
-            Dashboard
+            {t.nav.dashboard}
           </Link>
           <Link
             href="/portal/profile"
             className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-gray-700 hover:bg-blue-50 hover:text-blue-700 transition-colors group"
           >
             <User className="h-5 w-5 text-gray-400 group-hover:text-blue-600" />
-            My Profile
+            {t.nav.myProfile}
           </Link>
           <Link
             href="/portal/interactions"
             className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-gray-700 hover:bg-blue-50 hover:text-blue-700 transition-colors group"
           >
             <BookOpen className="h-5 w-5 text-gray-400 group-hover:text-blue-600" />
-            Interaction Logs
+            {t.nav.interactionLogs}
           </Link>
         </nav>
 
@@ -72,8 +76,11 @@ export default async function PortalLayout({ children }: { children: React.React
             className="flex items-center gap-2 w-full px-3 py-2 text-sm text-red-600 hover:bg-red-50 rounded-lg transition-colors"
           >
             <LogOut className="h-4 w-4" />
-            Sign Out
+            {t.nav.signOut}
           </Link>
+          <div className="mt-3 px-3">
+            <LanguageSwitcher current={locale} />
+          </div>
         </div>
       </aside>
 

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { Languages } from 'lucide-react';
+import { locales, type Locale, LOCALE_COOKIE } from '@/i18n/config';
+
+export function LanguageSwitcher({ current }: { current: Locale }) {
+  const set = (locale: Locale) => {
+    if (locale === current) return;
+    // 1 year cookie; a full reload re-renders the server layout with the new locale.
+    document.cookie = `${LOCALE_COOKIE}=${locale}; path=/; max-age=${60 * 60 * 24 * 365}`;
+    window.location.reload();
+  };
+
+  return (
+    <div className="flex items-center gap-1 text-xs" aria-label="Language">
+      <Languages className="h-3.5 w-3.5 text-gray-400" />
+      {locales.map((l) => (
+        <button
+          key={l}
+          type="button"
+          onClick={() => set(l)}
+          className={`px-1.5 py-0.5 rounded uppercase transition-colors ${
+            l === current ? 'bg-blue-100 text-blue-700 font-semibold' : 'text-gray-500 hover:text-gray-800'
+          }`}
+        >
+          {l}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -1,0 +1,8 @@
+export const locales = ['en', 'tr'] as const;
+export type Locale = (typeof locales)[number];
+export const defaultLocale: Locale = 'en';
+export const LOCALE_COOKIE = 'locale';
+
+export function isLocale(v: string | undefined): v is Locale {
+  return !!v && (locales as readonly string[]).includes(v);
+}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -1,0 +1,56 @@
+import type { Locale } from './config';
+
+// UI string dictionary. Add keys here and reference them via getDictionary()
+// (server components) or the useT() hook (client components).
+const en = {
+  nav: {
+    dashboard: 'Dashboard',
+    companies: 'Companies',
+    candidates: 'Candidates',
+    mentors: 'Mentors',
+    mentorships: 'Mentorships',
+    invite: 'Send Invitation',
+    myMentees: 'My Mentees',
+    board: 'Board',
+    interactionLogs: 'Interaction Logs',
+    myProfile: 'My Profile',
+    signOut: 'Sign Out',
+  },
+  panel: {
+    admin: 'Admin Panel',
+    mentor: 'Mentor Portal',
+    mentee: 'Mentee Portal',
+  },
+  lang: { en: 'English', tr: 'Türkçe', label: 'Language' },
+};
+
+type Dict = typeof en;
+
+const tr: Dict = {
+  nav: {
+    dashboard: 'Panel',
+    companies: 'Şirketler',
+    candidates: 'Adaylar',
+    mentors: 'Mentorlar',
+    mentorships: 'Mentorluklar',
+    invite: 'Davet Gönder',
+    myMentees: 'Mentee’lerim',
+    board: 'Pano',
+    interactionLogs: 'Etkileşim Kayıtları',
+    myProfile: 'Profilim',
+    signOut: 'Çıkış Yap',
+  },
+  panel: {
+    admin: 'Yönetim Paneli',
+    mentor: 'Mentor Portalı',
+    mentee: 'Mentee Portalı',
+  },
+  lang: { en: 'English', tr: 'Türkçe', label: 'Dil' },
+};
+
+export const dictionaries: Record<Locale, Dict> = { en, tr };
+export type Dictionary = Dict;
+
+export function getDictionary(locale: Locale): Dict {
+  return dictionaries[locale] ?? en;
+}

--- a/src/i18n/server.ts
+++ b/src/i18n/server.ts
@@ -1,0 +1,15 @@
+import { cookies } from 'next/headers';
+import { defaultLocale, isLocale, LOCALE_COOKIE, type Locale } from './config';
+import { getDictionary } from './dictionaries';
+
+// Read the active locale from the cookie (server components).
+export async function getLocale(): Promise<Locale> {
+  const store = await cookies();
+  const v = store.get(LOCALE_COOKIE)?.value;
+  return isLocale(v) ? v : defaultLocale;
+}
+
+export async function getServerDictionary() {
+  const locale = await getLocale();
+  return { locale, t: getDictionary(locale) };
+}


### PR DESCRIPTION
## Özet
i18n altyapısı + en görünür yer olan layout nav'ları EN/TR. Varsayılan **EN**, sidebar'da dil değiştirici (cookie tabanlı).

- `src/i18n`: locale config (default EN), en/tr sözlük, cookie okuyan sunucu yardımcısı.
- `LanguageSwitcher`: cookie set + reload.
- Admin/Mentor/Mentee layout: nav etiketleri, panel başlıkları, Sign Out sözlükten; her sidebar'a dil değiştirici.
- `e2e/i18n.spec.ts`: EN varsayılan + TR geçiş + kalıcılık.

i18n epic'inin (#64) ilk dilimi; sayfa içerikleri #66–#69'da gelecek. Bu, senin gösterdiğin karışık menüyü tutarlı hale getirir.

Closes #65

## Doğrulama
- [x] Lokal headed: 18/18 test geçti.
- [ ] CI.