### PR TITLE
fix(ui): sidebar'ı viewport'a sabitle (uzun sayfalar) (#72)

### DIFF
--- a/e2e/layout.spec.ts
+++ b/e2e/layout.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+
+const ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@example.com';
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'ChangeMe123!';
+
+test('sidebar footer (Sign Out) stays in the viewport on long pages', async ({ page }) => {
+  await page.goto('/auth/signin');
+  await page.fill('input[type="email"], input[name="email"]', ADMIN_EMAIL);
+  await page.fill('input[type="password"]', ADMIN_PASSWORD);
+  await page.click('button[type="submit"]');
+  await page.waitForURL((u) => !u.pathname.includes('/auth/signin'), { timeout: 20_000 });
+
+  // Mentorships is a long list; the sticky sidebar should keep Sign Out on screen.
+  await page.goto('/admin/mentorship');
+  await page.waitForTimeout(1000);
+  await expect(page.getByRole('link', { name: 'Sign Out', exact: true })).toBeInViewport();
+});

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -22,7 +22,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
   return (
     <div className="min-h-screen bg-gray-50 flex">
       {/* Sidebar */}
-      <aside className="w-64 bg-white border-r border-gray-200 flex flex-col">
+      <aside className="w-64 bg-white border-r border-gray-200 flex flex-col sticky top-0 h-screen self-start">
         <div className="p-6 border-b border-gray-200">
           <div className="flex items-center gap-2">
             <GraduationCap className="h-7 w-7 text-blue-600" />
@@ -31,7 +31,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
           <p className="text-xs text-gray-500 mt-1">{t.panel.admin}</p>
         </div>
 
-        <nav className="flex-1 p-4 space-y-1">
+        <nav className="flex-1 p-4 space-y-1 overflow-y-auto">
           <Link
             href="/admin"
             className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-gray-700 hover:bg-blue-50 hover:text-blue-700 transition-colors group"

--- a/src/app/mentor/layout.tsx
+++ b/src/app/mentor/layout.tsx
@@ -22,7 +22,7 @@ export default async function MentorLayout({ children }: { children: React.React
   return (
     <div className="min-h-screen bg-gray-50 flex">
       {/* Sidebar */}
-      <aside className="w-64 bg-white border-r border-gray-200 flex flex-col">
+      <aside className="w-64 bg-white border-r border-gray-200 flex flex-col sticky top-0 h-screen self-start">
         <div className="p-6 border-b border-gray-200">
           <div className="flex items-center gap-2">
             <GraduationCap className="h-7 w-7 text-blue-600" />
@@ -31,7 +31,7 @@ export default async function MentorLayout({ children }: { children: React.React
           <p className="text-xs text-gray-500 mt-1">{t.panel.mentor}</p>
         </div>
 
-        <nav className="flex-1 p-4 space-y-1">
+        <nav className="flex-1 p-4 space-y-1 overflow-y-auto">
           <Link
             href="/mentor"
             className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-gray-700 hover:bg-blue-50 hover:text-blue-700 transition-colors group"

--- a/src/app/portal/layout.tsx
+++ b/src/app/portal/layout.tsx
@@ -26,7 +26,7 @@ export default async function PortalLayout({ children }: { children: React.React
   return (
     <div className="min-h-screen bg-gray-50 flex">
       {/* Sidebar */}
-      <aside className="w-64 bg-white border-r border-gray-200 flex flex-col">
+      <aside className="w-64 bg-white border-r border-gray-200 flex flex-col sticky top-0 h-screen self-start">
         <div className="p-6 border-b border-gray-200">
           <div className="flex items-center gap-2">
             <GraduationCap className="h-7 w-7 text-blue-600" />
@@ -35,7 +35,7 @@ export default async function PortalLayout({ children }: { children: React.React
           <p className="text-xs text-gray-500 mt-1">{t.panel.mentee}</p>
         </div>
 
-        <nav className="flex-1 p-4 space-y-1">
+        <nav className="flex-1 p-4 space-y-1 overflow-y-auto">
           <Link
             href="/portal"
             className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-gray-700 hover:bg-blue-50 hover:text-blue-700 transition-colors group"


### PR DESCRIPTION
Liste uzun olunca sidebar tüm sayfa boyunca uzuyor, Çıkış/dil alta düşüyordu. Sidebar artık `sticky top-0 h-screen` — footer hep görünür; nav taşarsa kendi içinde kayar. 3 role layout'a da uygulandı. e2e/layout.spec.ts: uzun sayfada Çıkış viewport'ta.\n\nCloses #72