### PR TITLE
feat(admin): mentee profil/detay sayfası (#74)

### DIFF
--- a/e2e/admin-mentee.spec.ts
+++ b/e2e/admin-mentee.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+const ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@example.com';
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'ChangeMe123!';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('admin can open a mentee detail page with profile + mentorship', async ({ page }) => {
+  const mentorEmail = uniqueEmail('mentor');
+  const menteeEmail = uniqueEmail('mentee');
+  const mentor = await seedUser(mentorEmail, 'Pass1234!', 'MENTOR', 'Detail Mentor');
+  const mentee = await seedUser(menteeEmail, 'Pass1234!', 'MENTEE', 'Detail Mentee');
+  await prisma.user.update({ where: { id: mentee.id }, data: { city: 'Köln', university: 'TU' } });
+  await prisma.mentorshipRelation.create({
+    data: { mentorId: mentor.id, menteeId: mentee.id, pipelineStatus: 'INTERNSHIP_IN_PROGRESS_450' },
+  });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', ADMIN_EMAIL);
+    await page.fill('input[type="password"]', ADMIN_PASSWORD);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => !u.pathname.includes('/auth/signin'), { timeout: 20_000 });
+
+    await page.goto(`/admin/candidates/${mentee.id}`);
+    await expect(page.getByRole('heading', { name: 'Detail Mentee' })).toBeVisible();
+    await expect(page.getByText('Köln')).toBeVisible();
+    await expect(page.getByText('Detail Mentor')).toBeVisible();
+    await expect(page.getByText('450 · Staj devam ediyor').first()).toBeVisible();
+  } finally {
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(menteeEmail);
+  }
+});

--- a/src/app/admin/candidates/[id]/page.tsx
+++ b/src/app/admin/candidates/[id]/page.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
+import { Badge } from '@/components/ui/Badge';
+import { ArrowLeft, ExternalLink } from 'lucide-react';
+import { pipelineLabel } from '@/lib/pipeline';
+
+interface Interaction { id: string; date: string; notes: string; type: string }
+interface StatusChange { id: string; fromStatus: string; toStatus: string; createdAt: string; changedBy: { fullName: string } }
+interface Relation {
+  id: string;
+  status: string;
+  pipelineStatus: string;
+  startDate: string;
+  mentor: { fullName: string; email: string };
+  company: { name: string; industry?: string } | null;
+  interactions: Interaction[];
+  statusChanges: StatusChange[];
+}
+interface MenteeDetail {
+  id: string;
+  fullName: string;
+  email: string;
+  phone?: string;
+  whatsapp?: string;
+  city?: string;
+  birthDate?: string;
+  referralSource?: string;
+  university?: string;
+  department?: string;
+  graduationYear?: number;
+  skills: string[];
+  cvUrl?: string;
+  menteeRelations: Relation[];
+}
+
+function Field({ label, value }: { label: string; value?: string | number | null }) {
+  if (value === undefined || value === null || value === '') return null;
+  return (
+    <div>
+      <p className="text-xs text-gray-500">{label}</p>
+      <p className="text-sm text-gray-900">{value}</p>
+    </div>
+  );
+}
+
+export default function AdminMenteeDetailPage() {
+  const id = useParams().id as string;
+  const [user, setUser] = useState<MenteeDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    const res = await fetch(`/api/users/${id}`);
+    const data = await res.json();
+    setUser(data.user ?? null);
+    setLoading(false);
+  }, [id]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  if (loading) return <div className="text-center py-12 text-gray-400">Loading...</div>;
+  if (!user) return <div className="text-center py-12 text-gray-400">Not found</div>;
+
+  const rel = user.menteeRelations[0];
+
+  return (
+    <div>
+      <div className="mb-6">
+        <Link href="/admin/candidates" className="flex items-center gap-2 text-sm text-gray-500 hover:text-gray-700 mb-4">
+          <ArrowLeft className="h-4 w-4" />
+          Back to candidates
+        </Link>
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">{user.fullName}</h1>
+            <p className="text-gray-500">{user.email}</p>
+          </div>
+          {rel && <Badge variant="info">{pipelineLabel(rel.pipelineStatus)}</Badge>}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Profile</CardTitle>
+          </CardHeader>
+          <div className="space-y-3">
+            <Field label="University" value={user.university} />
+            <Field label="Department" value={user.department} />
+            <Field label="Graduation Year" value={user.graduationYear} />
+            <Field label="Phone" value={user.phone} />
+            <Field label="WhatsApp" value={user.whatsapp} />
+            <Field label="City" value={user.city} />
+            <Field label="Birth Date" value={user.birthDate ? new Date(user.birthDate).toLocaleDateString() : null} />
+            <Field label="Referral" value={user.referralSource} />
+            {user.skills.length > 0 && (
+              <div>
+                <p className="text-xs text-gray-500 mb-1">Skills</p>
+                <div className="flex flex-wrap gap-1">
+                  {user.skills.map((s) => (
+                    <Badge key={s} variant="info" className="text-xs">{s}</Badge>
+                  ))}
+                </div>
+              </div>
+            )}
+            {user.cvUrl && (
+              <a href={user.cvUrl} target="_blank" rel="noopener noreferrer" className="flex items-center gap-1 text-sm text-blue-600 hover:underline">
+                <ExternalLink className="h-3 w-3" /> View CV
+              </a>
+            )}
+          </div>
+        </Card>
+
+        <Card className="lg:col-span-2">
+          <CardHeader>
+            <CardTitle>Mentorship</CardTitle>
+          </CardHeader>
+          {!rel ? (
+            <p className="text-sm text-gray-400 py-6 text-center">Not assigned to a mentor yet</p>
+          ) : (
+            <div className="space-y-4">
+              <div className="flex flex-wrap gap-x-6 gap-y-2 text-sm">
+                <div><span className="text-gray-500">Mentor:</span> <span className="font-medium">{rel.mentor.fullName}</span></div>
+                {rel.company && <div><span className="text-gray-500">Company:</span> <span className="font-medium">{rel.company.name}</span></div>}
+                <div><span className="text-gray-500">Stage:</span> <span className="font-medium">{pipelineLabel(rel.pipelineStatus)}</span></div>
+              </div>
+
+              <div>
+                <p className="text-sm font-semibold text-gray-700 mb-2">Stage history ({rel.statusChanges.length})</p>
+                {rel.statusChanges.length === 0 ? (
+                  <p className="text-xs text-gray-400">No changes yet</p>
+                ) : (
+                  <ol className="space-y-2">
+                    {rel.statusChanges.map((sc) => (
+                      <li key={sc.id} className="text-sm border-l-2 border-blue-100 pl-3">
+                        <span className="text-gray-400">{pipelineLabel(sc.fromStatus)}</span>
+                        {' → '}
+                        <span className="font-medium">{pipelineLabel(sc.toStatus)}</span>
+                        <span className="text-xs text-gray-400"> · {sc.changedBy.fullName} · {new Date(sc.createdAt).toLocaleDateString()}</span>
+                      </li>
+                    ))}
+                  </ol>
+                )}
+              </div>
+
+              <div>
+                <p className="text-sm font-semibold text-gray-700 mb-2">Interactions ({rel.interactions.length})</p>
+                {rel.interactions.length === 0 ? (
+                  <p className="text-xs text-gray-400">No interactions logged</p>
+                ) : (
+                  <div className="space-y-2">
+                    {rel.interactions.map((i) => (
+                      <div key={i.id} className="flex items-start gap-2 text-sm">
+                        <Badge variant={i.type === 'Meeting' ? 'info' : i.type === 'Feedback' ? 'success' : 'warning'} className="text-xs flex-shrink-0">{i.type}</Badge>
+                        <div>
+                          <p className="text-gray-700">{i.notes}</p>
+                          <p className="text-xs text-gray-400">{new Date(i.date).toLocaleDateString()}</p>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/candidates/page.tsx
+++ b/src/app/admin/candidates/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
+import Link from 'next/link';
 import { Card } from '@/components/ui/Card';
 import { Badge } from '@/components/ui/Badge';
 import { Button } from '@/components/ui/Button';
@@ -144,7 +145,12 @@ export default function CandidatesPage() {
               <Card key={candidate.id}>
                 <div className="flex items-start justify-between mb-3">
                   <div>
-                    <h3 className="font-semibold text-gray-900">{candidate.fullName}</h3>
+                    <Link
+                      href={`/admin/candidates/${candidate.id}`}
+                      className="font-semibold text-gray-900 hover:text-blue-700 hover:underline"
+                    >
+                      {candidate.fullName}
+                    </Link>
                     <p className="text-sm text-gray-500">{candidate.email}</p>
                   </div>
                   {activeRelation ? (

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+export async function GET(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params;
+    const session = await getServerSession(authOptions);
+    if (!session || session.user.role !== 'ADMIN') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { id },
+      select: {
+        id: true,
+        email: true,
+        fullName: true,
+        role: true,
+        phone: true,
+        whatsapp: true,
+        city: true,
+        birthDate: true,
+        referralSource: true,
+        university: true,
+        department: true,
+        graduationYear: true,
+        skills: true,
+        cvUrl: true,
+        createdAt: true,
+        menteeRelations: {
+          orderBy: { startDate: 'desc' },
+          include: {
+            mentor: { select: { fullName: true, email: true } },
+            company: { select: { name: true, industry: true } },
+            interactions: { orderBy: { date: 'desc' } },
+            statusChanges: {
+              orderBy: { createdAt: 'desc' },
+              include: { changedBy: { select: { fullName: true } } },
+            },
+          },
+        },
+      },
+    });
+
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    return NextResponse.json({ user });
+  } catch (error) {
+    console.error('Get user error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
Admin Candidates'tan bir mentee'ye tıklayınca detay açılıyor: tüm profil (şehir/whatsapp/doğum tarihi/referans dahil), mentorluk (mentor/şirket/aşama), aşama geçmişi, etkileşimler. Liste'deki isimler artık linkli. Yeni `GET /api/users/[id]`. e2e/admin-mentee.spec.ts eklendi.\n\nCloses #74