### PR TITLE
feat(i18n): pipeline aşama etiketleri EN/TR (#69)

### DIFF
--- a/e2e/admin-mentee.spec.ts
+++ b/e2e/admin-mentee.spec.ts
@@ -29,7 +29,7 @@ test('admin can open a mentee detail page with profile + mentorship', async ({ p
     await expect(page.getByRole('heading', { name: 'Detail Mentee' })).toBeVisible();
     await expect(page.getByText('Köln')).toBeVisible();
     await expect(page.getByText('Detail Mentor')).toBeVisible();
-    await expect(page.getByText('450 · Staj devam ediyor').first()).toBeVisible();
+    await expect(page.getByText('450 · Internship in progress').first()).toBeVisible();
   } finally {
     await cleanupByEmail(mentorEmail);
     await cleanupByEmail(menteeEmail);

--- a/e2e/board.spec.ts
+++ b/e2e/board.spec.ts
@@ -26,8 +26,8 @@ test('mentor board groups a mentee under its pipeline stage', async ({ page }) =
     await page.getByRole('link', { name: 'Board', exact: true }).click();
     await page.waitForURL((u) => u.pathname.includes('/mentor/board'), { timeout: 15_000 });
 
-    // The mentee card sits inside the "450 · Staj devam ediyor" column
-    const column = page.locator('div.w-64', { hasText: '450 · Staj devam ediyor' });
+    // The mentee card sits inside the "450 · Internship in progress" column
+    const column = page.locator('div.w-64', { hasText: '450 · Internship in progress' });
     await expect(column.getByText('Board Mentee')).toBeVisible();
   } finally {
     await cleanupByEmail(mentorEmail);

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -27,7 +27,7 @@ test('admin dashboard shows the pipeline distribution', async ({ page }) => {
 
     await page.goto('/admin');
     await expect(page.getByText('Mentees per stage')).toBeVisible();
-    await expect(page.getByText('450 · Staj devam ediyor')).toBeVisible();
+    await expect(page.getByText('450 · Internship in progress')).toBeVisible();
   } finally {
     await cleanupByEmail(mentorEmail);
     await cleanupByEmail(menteeEmail);

--- a/e2e/history.spec.ts
+++ b/e2e/history.spec.ts
@@ -38,8 +38,8 @@ test('changing a stage records an entry in the status history', async ({ page })
     await page.reload();
     await expect(page.getByText('Stage history (1)')).toBeVisible();
     const entryItem = page.locator('ol li').first();
-    await expect(entryItem).toContainText('450 · Staj devam ediyor');
-    await expect(entryItem).toContainText('100 · İlk temas');
+    await expect(entryItem).toContainText('450 · Internship in progress');
+    await expect(entryItem).toContainText('100 · First contact');
   } finally {
     await cleanupByEmail(mentorEmail);
     await cleanupByEmail(menteeEmail);

--- a/src/app/admin/candidates/[id]/page.tsx
+++ b/src/app/admin/candidates/[id]/page.tsx
@@ -7,7 +7,7 @@ import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Badge } from '@/components/ui/Badge';
 import { ArrowLeft, ExternalLink } from 'lucide-react';
 import { pipelineLabel } from '@/lib/pipeline';
-import { useT } from '@/i18n/client';
+import { useT, useLocale } from '@/i18n/client';
 
 interface Interaction { id: string; date: string; notes: string; type: string }
 interface StatusChange { id: string; fromStatus: string; toStatus: string; createdAt: string; changedBy: { fullName: string } }
@@ -51,6 +51,7 @@ function Field({ label, value }: { label: string; value?: string | number | null
 export default function AdminMenteeDetailPage() {
   const id = useParams().id as string;
   const t = useT();
+  const locale = useLocale();
   const [user, setUser] = useState<MenteeDetail | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -82,7 +83,7 @@ export default function AdminMenteeDetailPage() {
             <h1 className="text-2xl font-bold text-gray-900">{user.fullName}</h1>
             <p className="text-gray-500">{user.email}</p>
           </div>
-          {rel && <Badge variant="info">{pipelineLabel(rel.pipelineStatus)}</Badge>}
+          {rel && <Badge variant="info">{pipelineLabel(rel.pipelineStatus, locale)}</Badge>}
         </div>
       </div>
 
@@ -129,7 +130,7 @@ export default function AdminMenteeDetailPage() {
               <div className="flex flex-wrap gap-x-6 gap-y-2 text-sm">
                 <div><span className="text-gray-500">{t.candidateDetail.mentor}:</span> <span className="font-medium">{rel.mentor.fullName}</span></div>
                 {rel.company && <div><span className="text-gray-500">{t.candidateDetail.company}:</span> <span className="font-medium">{rel.company.name}</span></div>}
-                <div><span className="text-gray-500">{t.candidateDetail.stage}:</span> <span className="font-medium">{pipelineLabel(rel.pipelineStatus)}</span></div>
+                <div><span className="text-gray-500">{t.candidateDetail.stage}:</span> <span className="font-medium">{pipelineLabel(rel.pipelineStatus, locale)}</span></div>
               </div>
 
               <div>
@@ -140,9 +141,9 @@ export default function AdminMenteeDetailPage() {
                   <ol className="space-y-2">
                     {rel.statusChanges.map((sc) => (
                       <li key={sc.id} className="text-sm border-l-2 border-blue-100 pl-3">
-                        <span className="text-gray-400">{pipelineLabel(sc.fromStatus)}</span>
+                        <span className="text-gray-400">{pipelineLabel(sc.fromStatus, locale)}</span>
                         {' → '}
-                        <span className="font-medium">{pipelineLabel(sc.toStatus)}</span>
+                        <span className="font-medium">{pipelineLabel(sc.toStatus, locale)}</span>
                         <span className="text-xs text-gray-400"> · {sc.changedBy.fullName} · {new Date(sc.createdAt).toLocaleDateString()}</span>
                       </li>
                     ))}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -62,7 +62,7 @@ async function getStats() {
 export default async function AdminDashboard() {
   await getServerSession(authOptions);
   const stats = await getStats();
-  const { t } = await getServerDictionary();
+  const { locale, t } = await getServerDictionary();
 
   return (
     <div>
@@ -136,7 +136,7 @@ export default async function AdminDashboard() {
                 const count = stats.pipelineCounts[s] ?? 0;
                 return (
                   <div key={s} className="flex items-center gap-3">
-                    <span className="text-xs text-gray-600 w-56 flex-shrink-0 truncate">{pipelineLabel(s)}</span>
+                    <span className="text-xs text-gray-600 w-56 flex-shrink-0 truncate">{pipelineLabel(s, locale)}</span>
                     <div className="flex-1 bg-gray-100 rounded-full h-2.5 overflow-hidden">
                       <div
                         className="bg-blue-500 h-full rounded-full"

--- a/src/app/mentor/board/page.tsx
+++ b/src/app/mentor/board/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { GraduationCap } from 'lucide-react';
 import { PIPELINE_STATUSES, pipelineLabel } from '@/lib/pipeline';
-import { useT } from '@/i18n/client';
+import { useT, useLocale } from '@/i18n/client';
 
 interface Mentee {
   id: string;
@@ -21,6 +21,7 @@ interface Relation {
 
 export default function MentorBoardPage() {
   const t = useT();
+  const locale = useLocale();
   const router = useRouter();
   const [relations, setRelations] = useState<Relation[]>([]);
   const [loading, setLoading] = useState(true);
@@ -86,7 +87,7 @@ export default function MentorBoardPage() {
               }`}
             >
               <div className="flex items-center justify-between mb-3 px-1">
-                <span className="text-xs font-semibold text-gray-700">{pipelineLabel(status)}</span>
+                <span className="text-xs font-semibold text-gray-700">{pipelineLabel(status, locale)}</span>
                 <span className="text-xs text-gray-400 bg-white border border-gray-200 rounded-full px-2 py-0.5">
                   {items.length}
                 </span>

--- a/src/app/mentor/mentees/[id]/page.tsx
+++ b/src/app/mentor/mentees/[id]/page.tsx
@@ -10,7 +10,7 @@ import { Select } from '@/components/ui/Select';
 import { ArrowLeft, Plus, Trash2, ExternalLink } from 'lucide-react';
 import Link from 'next/link';
 import { pipelineOptions, pipelineLabel } from '@/lib/pipeline';
-import { useT } from '@/i18n/client';
+import { useT, useLocale } from '@/i18n/client';
 
 interface InteractionLog {
   id: string;
@@ -59,6 +59,7 @@ export default function MenteeDetailPage() {
   const params = useParams();
   const id = params.id as string;
   const t = useT();
+  const locale = useLocale();
 
   const [relation, setRelation] = useState<RelationDetail | null>(null);
   const [loading, setLoading] = useState(true);
@@ -153,7 +154,7 @@ export default function MenteeDetailPage() {
             <div className="w-full">
               <Select
                 label={t.mentor.pipelineStage}
-                options={pipelineOptions}
+                options={pipelineOptions(locale)}
                 value={relation.pipelineStatus}
                 disabled={savingStage}
                 onChange={(e) => handlePipelineChange(e.target.value)}
@@ -266,9 +267,9 @@ export default function MenteeDetailPage() {
               {relation.statusChanges.map((sc) => (
                 <li key={sc.id} className="text-sm border-l-2 border-blue-100 pl-3">
                   <p className="text-gray-700">
-                    <span className="text-gray-400">{pipelineLabel(sc.fromStatus)}</span>
+                    <span className="text-gray-400">{pipelineLabel(sc.fromStatus, locale)}</span>
                     {' → '}
-                    <span className="font-medium text-gray-900">{pipelineLabel(sc.toStatus)}</span>
+                    <span className="font-medium text-gray-900">{pipelineLabel(sc.toStatus, locale)}</span>
                   </p>
                   <p className="text-xs text-gray-400 mt-0.5">
                     {sc.changedBy.fullName} · {new Date(sc.createdAt).toLocaleString()}

--- a/src/lib/pipeline.ts
+++ b/src/lib/pipeline.ts
@@ -1,6 +1,7 @@
 // Single source of truth for the mentee pipeline stages (mirrors the Prisma
-// PipelineStatus enum). Used by the API for validation and the UI for labels.
-// Enum identifiers are English; display labels are Turkish (original spreadsheet).
+// PipelineStatus enum). Enum identifiers are English; display labels are
+// localized (EN/TR).
+import type { Locale } from '@/i18n/config';
 
 export const PIPELINE_STATUSES = [
   'APPLICATION_100',
@@ -20,28 +21,43 @@ export const PIPELINE_STATUSES = [
 
 export type PipelineStatus = (typeof PIPELINE_STATUSES)[number];
 
-// Turkish labels matching the original spreadsheet wording.
-export const PIPELINE_LABELS: Record<PipelineStatus, string> = {
-  APPLICATION_100: '100 · İlk temas',
-  APPROVAL_PENDING_220: '220 · Onay bekliyor',
-  INTERVIEW_PENDING_250: '250 · Görüşülecek',
-  INTRODUCTION_PENDING_270: '270 · Tanıştırılacak',
-  INTERNSHIP_STARTING_300: '300 · Staj başlayacak',
-  INTERNSHIP_IN_PROGRESS_450: '450 · Staj devam ediyor',
-  INTERNSHIP_DROPPED_460: '460 · Staj yarım bıraktı',
-  INTERNSHIP_COMPLETED_490: '490 · Staj bitti',
-  JOB_SEEKING_500: '500 · İş arıyor',
-  HIREABLE_600: '600 · İşe alınabilir',
-  HIRED_660: '660 · İşe alındı',
-  EMPLOYED_700: '700 · İş buldu',
-  INTERNSHIP_FOUND_ELSEWHERE_800: '800 · Başka yerde staj buldu',
+const LABELS: Record<Locale, Record<PipelineStatus, string>> = {
+  tr: {
+    APPLICATION_100: '100 · İlk temas',
+    APPROVAL_PENDING_220: '220 · Onay bekliyor',
+    INTERVIEW_PENDING_250: '250 · Görüşülecek',
+    INTRODUCTION_PENDING_270: '270 · Tanıştırılacak',
+    INTERNSHIP_STARTING_300: '300 · Staj başlayacak',
+    INTERNSHIP_IN_PROGRESS_450: '450 · Staj devam ediyor',
+    INTERNSHIP_DROPPED_460: '460 · Staj yarım bıraktı',
+    INTERNSHIP_COMPLETED_490: '490 · Staj bitti',
+    JOB_SEEKING_500: '500 · İş arıyor',
+    HIREABLE_600: '600 · İşe alınabilir',
+    HIRED_660: '660 · İşe alındı',
+    EMPLOYED_700: '700 · İş buldu',
+    INTERNSHIP_FOUND_ELSEWHERE_800: '800 · Başka yerde staj buldu',
+  },
+  en: {
+    APPLICATION_100: '100 · First contact',
+    APPROVAL_PENDING_220: '220 · Awaiting approval',
+    INTERVIEW_PENDING_250: '250 · To interview',
+    INTRODUCTION_PENDING_270: '270 · To introduce',
+    INTERNSHIP_STARTING_300: '300 · Internship starting',
+    INTERNSHIP_IN_PROGRESS_450: '450 · Internship in progress',
+    INTERNSHIP_DROPPED_460: '460 · Internship dropped',
+    INTERNSHIP_COMPLETED_490: '490 · Internship completed',
+    JOB_SEEKING_500: '500 · Job seeking',
+    HIREABLE_600: '600 · Hireable',
+    HIRED_660: '660 · Hired',
+    EMPLOYED_700: '700 · Employed',
+    INTERNSHIP_FOUND_ELSEWHERE_800: '800 · Internship elsewhere',
+  },
 };
 
-export const pipelineOptions = PIPELINE_STATUSES.map((value) => ({
-  value,
-  label: PIPELINE_LABELS[value],
-}));
+export function pipelineLabel(status: string, locale: Locale = 'en'): string {
+  return LABELS[locale]?.[status as PipelineStatus] ?? LABELS.en[status as PipelineStatus] ?? status;
+}
 
-export function pipelineLabel(status: string): string {
-  return PIPELINE_LABELS[status as PipelineStatus] ?? status;
+export function pipelineOptions(locale: Locale = 'en') {
+  return PIPELINE_STATUSES.map((value) => ({ value, label: pipelineLabel(value, locale) }));
 }


### PR DESCRIPTION
`pipelineLabel`/`pipelineOptions` artık locale alıyor; EN modunda İngilizce, TR modunda Türkçe aşama adları (önceden her yerde Türkçeydi). Call site'lar aktif locale'i geçiyor (client'ta useLocale, dashboard'da getLocale). e2e etiket assertion'ları EN varsayılana güncellendi.\n\nCloses #69 — **i18n epic'i (#64) tamamlanır.**\n\nNot: tarih biçimi tarayıcı locale'ini kullanıyor (sayısal, kabul edilebilir); istenirse ayrı bir polish olarak locale'e bağlanabilir.