### PR TITLE
feat(admin): mentee detayından aşama değiştirme + geri alma (#81 #85)

### DIFF
--- a/e2e/admin-status.spec.ts
+++ b/e2e/admin-status.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+const ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@example.com';
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'ChangeMe123!';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('admin can move a completed mentee back to an earlier stage; history is appended', async ({ page }) => {
+  const mentorEmail = uniqueEmail('mentor');
+  const menteeEmail = uniqueEmail('mentee');
+  const mentor = await seedUser(mentorEmail, 'Pass1234!', 'MENTOR', 'Status Mentor');
+  const mentee = await seedUser(menteeEmail, 'Pass1234!', 'MENTEE', 'Status Mentee');
+  const relation = await prisma.mentorshipRelation.create({
+    data: { mentorId: mentor.id, menteeId: mentee.id, pipelineStatus: 'EMPLOYED_700' },
+  });
+  // Pre-existing history that must be preserved
+  await prisma.statusChange.create({
+    data: { relationId: relation.id, fromStatus: 'APPLICATION_100', toStatus: 'EMPLOYED_700', changedById: mentor.id },
+  });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', ADMIN_EMAIL);
+    await page.fill('input[type="password"]', ADMIN_PASSWORD);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => !u.pathname.includes('/auth/signin'), { timeout: 20_000 });
+
+    await page.goto(`/admin/candidates/${mentee.id}`);
+    await expect(page.getByLabel('Stage')).toBeVisible();
+    // Move backward 700 -> 220, waiting for the PUT to complete
+    const putDone = page.waitForResponse(
+      (r) => r.url().includes(`/api/mentorship/${relation.id}`) && r.request().method() === 'PUT'
+    );
+    await page.getByLabel('Stage').selectOption('APPROVAL_PENDING_220');
+    await putDone;
+    await page.waitForTimeout(600);
+
+    const updated = await prisma.mentorshipRelation.findUnique({ where: { id: relation.id } });
+    expect(updated?.pipelineStatus).toBe('APPROVAL_PENDING_220');
+
+    // Old history preserved + new entry appended (2 total)
+    const changes = await prisma.statusChange.findMany({ where: { relationId: relation.id } });
+    expect(changes.length).toBe(2);
+    expect(changes.some((c) => c.fromStatus === 'EMPLOYED_700' && c.toStatus === 'APPROVAL_PENDING_220')).toBe(true);
+    expect(changes.some((c) => c.fromStatus === 'APPLICATION_100' && c.toStatus === 'EMPLOYED_700')).toBe(true);
+  } finally {
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(menteeEmail);
+  }
+});

--- a/src/app/admin/candidates/[id]/page.tsx
+++ b/src/app/admin/candidates/[id]/page.tsx
@@ -5,8 +5,9 @@ import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Badge } from '@/components/ui/Badge';
+import { Select } from '@/components/ui/Select';
 import { ArrowLeft, ExternalLink } from 'lucide-react';
-import { pipelineLabel } from '@/lib/pipeline';
+import { pipelineLabel, pipelineOptions } from '@/lib/pipeline';
 import { useT, useLocale } from '@/i18n/client';
 
 interface Interaction { id: string; date: string; notes: string; type: string }
@@ -54,6 +55,7 @@ export default function AdminMenteeDetailPage() {
   const locale = useLocale();
   const [user, setUser] = useState<MenteeDetail | null>(null);
   const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
 
   const load = useCallback(async () => {
     const res = await fetch(`/api/users/${id}`);
@@ -61,6 +63,25 @@ export default function AdminMenteeDetailPage() {
     setUser(data.user ?? null);
     setLoading(false);
   }, [id]);
+
+  // Change the pipeline stage. Any transition is allowed (incl. moving back,
+  // e.g. 700 -> 220); the audit log only ever appends, so history is preserved.
+  const changeStage = useCallback(
+    async (relationId: string, pipelineStatus: string) => {
+      setSaving(true);
+      try {
+        await fetch(`/api/mentorship/${relationId}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ pipelineStatus }),
+        });
+        await load();
+      } finally {
+        setSaving(false);
+      }
+    },
+    [load]
+  );
 
   useEffect(() => {
     load();
@@ -130,7 +151,16 @@ export default function AdminMenteeDetailPage() {
               <div className="flex flex-wrap gap-x-6 gap-y-2 text-sm">
                 <div><span className="text-gray-500">{t.candidateDetail.mentor}:</span> <span className="font-medium">{rel.mentor.fullName}</span></div>
                 {rel.company && <div><span className="text-gray-500">{t.candidateDetail.company}:</span> <span className="font-medium">{rel.company.name}</span></div>}
-                <div><span className="text-gray-500">{t.candidateDetail.stage}:</span> <span className="font-medium">{pipelineLabel(rel.pipelineStatus, locale)}</span></div>
+              </div>
+
+              <div className="max-w-xs">
+                <Select
+                  label={t.candidateDetail.stage}
+                  options={pipelineOptions(locale)}
+                  value={rel.pipelineStatus}
+                  disabled={saving}
+                  onChange={(e) => changeStage(rel.id, e.target.value)}
+                />
               </div>
 
               <div>


### PR DESCRIPTION
Admin mentee detayı salt-okunurdu. Aşama seçici eklendi (import edilen mentee'lerin owner'ı admin olduğu için yönetimi buradan). Her geçişe izin var — **geri alma dahil (700→220)**; audit log append-only olduğundan **geçmiş aşama geçmişi korunur**. Mevcut PUT (ADMIN yetkili) kullanılır.\n\ne2e/admin-status.spec.ts: 700→220 geri geçiş + history korunuyor (eski+yeni=2).\n\nCloses #81 #85\n\n> Not: Lokal e2e şu an preview DB erişimi geçici kapalı olduğu için koşulamadı; CI kendi MySQL'iyle doğrular.