### PR TITLE
feat(admin): tıklanabilir dashboard + status filtre + isim linkleri (#82 #83)

### DIFF
--- a/e2e/dashboard-links.spec.ts
+++ b/e2e/dashboard-links.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+const ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@example.com';
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'ChangeMe123!';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('candidates can be filtered by pipeline stage via ?status=', async ({ page }) => {
+  const mentorEmail = uniqueEmail('mentor');
+  const inEmail = uniqueEmail('in-stage');
+  const outEmail = uniqueEmail('out-stage');
+  const mentor = await seedUser(mentorEmail, 'Pass1234!', 'MENTOR', 'DL Mentor');
+  const inMentee = await seedUser(inEmail, 'Pass1234!', 'MENTEE', 'ZZ InStage Mentee');
+  const outMentee = await seedUser(outEmail, 'Pass1234!', 'MENTEE', 'ZZ OutStage Mentee');
+  await prisma.mentorshipRelation.create({
+    data: { mentorId: mentor.id, menteeId: inMentee.id, pipelineStatus: 'HIRED_660' },
+  });
+  await prisma.mentorshipRelation.create({
+    data: { mentorId: mentor.id, menteeId: outMentee.id, pipelineStatus: 'JOB_SEEKING_500' },
+  });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', ADMIN_EMAIL);
+    await page.fill('input[type="password"]', ADMIN_PASSWORD);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => !u.pathname.includes('/auth/signin'), { timeout: 20_000 });
+
+    // Dashboard stat card links to candidates
+    await page.goto('/admin');
+    await expect(page.locator('a[href="/admin/candidates"]').first()).toBeVisible();
+
+    // Filtered candidate list (as the dashboard pipeline bar links)
+    await page.goto('/admin/candidates?status=HIRED_660');
+    await page.waitForTimeout(1200);
+    await expect(page.getByText('660 · Hired')).toBeVisible(); // filter chip
+    await expect(page.getByText('ZZ InStage Mentee')).toBeVisible();
+    await expect(page.getByText('ZZ OutStage Mentee')).toHaveCount(0);
+
+    // Name links to the detail page
+    await page.getByRole('link', { name: 'ZZ InStage Mentee' }).click();
+    await page.waitForURL((u) => u.pathname.includes(`/admin/candidates/${inMentee.id}`), { timeout: 15_000 });
+  } finally {
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(inEmail);
+    await cleanupByEmail(outEmail);
+  }
+});

--- a/src/app/admin/candidates/page.tsx
+++ b/src/app/admin/candidates/page.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import Link from "next/link";
-import { useT } from "@/i18n/client";
+import { useT, useLocale } from "@/i18n/client";
+import { pipelineLabel } from '@/lib/pipeline';
 import { Card } from '@/components/ui/Card';
 import { Badge } from '@/components/ui/Badge';
 import { Button } from '@/components/ui/Button';
@@ -37,12 +38,19 @@ const graduationYearOptions = [
 
 export default function CandidatesPage() {
   const t = useT();
+  const locale = useLocale();
   const [candidates, setCandidates] = useState<Candidate[]>([]);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
   const [skillFilter, setSkillFilter] = useState('');
   const [yearFilter, setYearFilter] = useState('');
+  const [statusFilter, setStatusFilter] = useState('');
   const [error, setError] = useState('');
+
+  // Read an optional ?status= filter from the URL (e.g. from dashboard pipeline bars)
+  useEffect(() => {
+    setStatusFilter(new URLSearchParams(window.location.search).get('status') || '');
+  }, []);
 
   const fetchCandidates = useCallback(async () => {
     setLoading(true);
@@ -51,6 +59,7 @@ export default function CandidatesPage() {
       if (skillFilter) params.set('skills', skillFilter);
       if (yearFilter) params.set('graduationYear', yearFilter);
       if (search) params.set('search', search);
+      if (statusFilter) params.set('status', statusFilter);
 
       const res = await fetch(`/api/candidates?${params}`);
       const data = await res.json();
@@ -60,7 +69,7 @@ export default function CandidatesPage() {
     } finally {
       setLoading(false);
     }
-  }, [skillFilter, yearFilter, search]);
+  }, [skillFilter, yearFilter, search, statusFilter]);
 
   useEffect(() => {
     const timeout = setTimeout(fetchCandidates, 300);
@@ -72,6 +81,22 @@ export default function CandidatesPage() {
       <div className="mb-8">
         <h1 className="text-2xl font-bold text-gray-900">{t.candidates.title}</h1>
         <p className="text-gray-500 mt-1">{t.candidates.subtitle}</p>
+        {statusFilter && (
+          <div className="mt-3 inline-flex items-center gap-2 bg-blue-50 border border-blue-200 rounded-full px-3 py-1 text-sm text-blue-700">
+            {pipelineLabel(statusFilter, locale)}
+            <button
+              type="button"
+              onClick={() => {
+                setStatusFilter('');
+                window.history.replaceState(null, '', '/admin/candidates');
+              }}
+              className="text-blue-500 hover:text-blue-800"
+              aria-label="clear filter"
+            >
+              ✕
+            </button>
+          </div>
+        )}
       </div>
 
       {error && (

--- a/src/app/admin/mentorship/page.tsx
+++ b/src/app/admin/mentorship/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useT } from "@/i18n/client";
+import Link from "next/link";
 
 import { useState, useEffect } from 'react';
 import { Card } from '@/components/ui/Card';
@@ -189,7 +190,7 @@ export default function MentorshipPage() {
               <div className="flex items-center justify-between">
                 <div className="flex-1">
                   <div className="flex items-center gap-3 mb-2">
-                    <span className="font-semibold text-gray-900">{rel.mentee.fullName}</span>
+                    <Link href={`/admin/candidates/${rel.mentee.id}`} className="font-semibold text-gray-900 hover:text-blue-700 hover:underline">{rel.mentee.fullName}</Link>
                     <span className="text-gray-400">→</span>
                     <span className="font-semibold text-gray-900">{rel.mentor.fullName}</span>
                     <StatusBadge status={rel.status} />

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -20,7 +20,7 @@ async function getStats() {
         orderBy: { startDate: 'desc' },
         include: {
           mentor: { select: { fullName: true } },
-          mentee: { select: { fullName: true } },
+          mentee: { select: { id: true, fullName: true } },
           company: { select: { name: true } },
         },
       }),
@@ -73,53 +73,61 @@ export default async function AdminDashboard() {
 
       {/* Stats Grid */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
-        <Card>
-          <div className="flex items-center gap-4">
-            <div className="w-12 h-12 bg-blue-100 rounded-xl flex items-center justify-center">
-              <Users className="h-6 w-6 text-blue-600" />
+        <Link href="/admin/candidates" className="block">
+          <Card className="hover:border-blue-200 hover:shadow-md transition-all cursor-pointer">
+            <div className="flex items-center gap-4">
+              <div className="w-12 h-12 bg-blue-100 rounded-xl flex items-center justify-center">
+                <Users className="h-6 w-6 text-blue-600" />
+              </div>
+              <div>
+                <p className="text-2xl font-bold text-gray-900">{stats.menteeCount}</p>
+                <p className="text-sm text-gray-500">{t.dashboard.mentees}</p>
+              </div>
             </div>
-            <div>
-              <p className="text-2xl font-bold text-gray-900">{stats.menteeCount}</p>
-              <p className="text-sm text-gray-500">{t.dashboard.mentees}</p>
-            </div>
-          </div>
-        </Card>
+          </Card>
+        </Link>
 
-        <Card>
-          <div className="flex items-center gap-4">
-            <div className="w-12 h-12 bg-green-100 rounded-xl flex items-center justify-center">
-              <Users className="h-6 w-6 text-green-600" />
+        <Link href="/admin/mentors" className="block">
+          <Card className="hover:border-blue-200 hover:shadow-md transition-all cursor-pointer">
+            <div className="flex items-center gap-4">
+              <div className="w-12 h-12 bg-green-100 rounded-xl flex items-center justify-center">
+                <Users className="h-6 w-6 text-green-600" />
+              </div>
+              <div>
+                <p className="text-2xl font-bold text-gray-900">{stats.mentorCount}</p>
+                <p className="text-sm text-gray-500">{t.dashboard.mentors}</p>
+              </div>
             </div>
-            <div>
-              <p className="text-2xl font-bold text-gray-900">{stats.mentorCount}</p>
-              <p className="text-sm text-gray-500">{t.dashboard.mentors}</p>
-            </div>
-          </div>
-        </Card>
+          </Card>
+        </Link>
 
-        <Card>
-          <div className="flex items-center gap-4">
-            <div className="w-12 h-12 bg-purple-100 rounded-xl flex items-center justify-center">
-              <Building2 className="h-6 w-6 text-purple-600" />
+        <Link href="/admin/companies" className="block">
+          <Card className="hover:border-blue-200 hover:shadow-md transition-all cursor-pointer">
+            <div className="flex items-center gap-4">
+              <div className="w-12 h-12 bg-purple-100 rounded-xl flex items-center justify-center">
+                <Building2 className="h-6 w-6 text-purple-600" />
+              </div>
+              <div>
+                <p className="text-2xl font-bold text-gray-900">{stats.companyCount}</p>
+                <p className="text-sm text-gray-500">{t.dashboard.companies}</p>
+              </div>
             </div>
-            <div>
-              <p className="text-2xl font-bold text-gray-900">{stats.companyCount}</p>
-              <p className="text-sm text-gray-500">{t.dashboard.companies}</p>
-            </div>
-          </div>
-        </Card>
+          </Card>
+        </Link>
 
-        <Card>
-          <div className="flex items-center gap-4">
-            <div className="w-12 h-12 bg-orange-100 rounded-xl flex items-center justify-center">
-              <BookOpen className="h-6 w-6 text-orange-600" />
+        <Link href="/admin/mentorship" className="block">
+          <Card className="hover:border-blue-200 hover:shadow-md transition-all cursor-pointer">
+            <div className="flex items-center gap-4">
+              <div className="w-12 h-12 bg-orange-100 rounded-xl flex items-center justify-center">
+                <BookOpen className="h-6 w-6 text-orange-600" />
+              </div>
+              <div>
+                <p className="text-2xl font-bold text-gray-900">{stats.activeRelations}</p>
+                <p className="text-sm text-gray-500">{t.dashboard.activeMentorships}</p>
+              </div>
             </div>
-            <div>
-              <p className="text-2xl font-bold text-gray-900">{stats.activeRelations}</p>
-              <p className="text-sm text-gray-500">{t.dashboard.activeMentorships}</p>
-            </div>
-          </div>
-        </Card>
+          </Card>
+        </Link>
       </div>
 
       {/* Pipeline distribution */}
@@ -135,7 +143,11 @@ export default async function AdminDashboard() {
               {PIPELINE_STATUSES.map((s) => {
                 const count = stats.pipelineCounts[s] ?? 0;
                 return (
-                  <div key={s} className="flex items-center gap-3">
+                  <Link
+                    key={s}
+                    href={`/admin/candidates?status=${s}`}
+                    className="flex items-center gap-3 rounded-lg px-1 py-0.5 hover:bg-blue-50 transition-colors"
+                  >
                     <span className="text-xs text-gray-600 w-56 flex-shrink-0 truncate">{pipelineLabel(s, locale)}</span>
                     <div className="flex-1 bg-gray-100 rounded-full h-2.5 overflow-hidden">
                       <div
@@ -144,7 +156,7 @@ export default async function AdminDashboard() {
                       />
                     </div>
                     <span className="text-xs font-medium text-gray-700 w-8 text-right flex-shrink-0">{count}</span>
-                  </div>
+                  </Link>
                 );
               })}
             </div>
@@ -174,7 +186,11 @@ export default async function AdminDashboard() {
               <div key={rel.id} className="flex items-center justify-between py-2">
                 <div>
                   <p className="text-sm font-medium text-gray-900">
-                    {rel.mentee.fullName} → {rel.mentor.fullName}
+                    <Link href={`/admin/candidates/${rel.mentee.id}`} className="hover:text-blue-700 hover:underline">
+                      {rel.mentee.fullName}
+                    </Link>
+                    {' → '}
+                    {rel.mentor.fullName}
                   </p>
                   {rel.company && (
                     <p className="text-xs text-gray-500">{rel.company.name}</p>
@@ -206,7 +222,9 @@ export default async function AdminDashboard() {
             {stats.recentCandidates.map((candidate) => (
               <div key={candidate.id} className="flex items-start justify-between py-2">
                 <div>
-                  <p className="text-sm font-medium text-gray-900">{candidate.fullName}</p>
+                  <Link href={`/admin/candidates/${candidate.id}`} className="text-sm font-medium text-gray-900 hover:text-blue-700 hover:underline">
+                    {candidate.fullName}
+                  </Link>
                   <p className="text-xs text-gray-500">{candidate.university || candidate.email}</p>
                 </div>
                 <div className="flex flex-wrap gap-1 max-w-[120px] justify-end">

--- a/src/app/api/candidates/route.ts
+++ b/src/app/api/candidates/route.ts
@@ -15,10 +15,15 @@ export async function GET(request: Request) {
     const skills = searchParams.get('skills');
     const graduationYear = searchParams.get('graduationYear');
     const search = searchParams.get('search');
+    const pipelineStatus = searchParams.get('status');
 
     const where: Record<string, unknown> = {
       role: 'MENTEE',
     };
+
+    if (pipelineStatus) {
+      where.menteeRelations = { some: { pipelineStatus } };
+    }
 
     // skills filtering is applied in-memory after fetching (MySQL JSON arrays don't support hasSome)
     const skillList = skills


### PR DESCRIPTION
- Dashboard stat kartları ilgili sayfalara linkli; pipeline barları /admin/candidates?status=<aşama> (filtreli) gider.
- Candidates listesi ?status= okur + temizlenebilir filtre chip'i; /api/candidates status (pipelineStatus) filtresi destekler.
- Mentee isimleri dashboard (son mentorluklar, yeni adaylar) ve mentorluk listesinden detay sayfasına linkli.

Closes #82 #83

> EN'de Türkçe status sorunu #69 ile çözüldü. Lokal e2e preview DB geçici kapalı; CI doğruluyor.