### PR TITLE
feat(admin): hesap sayfası — e-posta + parola değiştirme (#84)

### DIFF
--- a/e2e/account.spec.ts
+++ b/e2e/account.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+import bcrypt from 'bcryptjs';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('admin can change their password from the account page', async ({ page }) => {
+  const email = uniqueEmail('acct-admin');
+  const oldPw = 'OldPass123!';
+  const newPw = 'NewPass456!';
+  await seedUser(email, oldPw, 'ADMIN', 'Account Admin');
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', email);
+    await page.fill('input[type="password"]', oldPw);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    await page.goto('/admin/account');
+    await page.getByLabel(/Current password/).fill(oldPw);
+    await page.getByLabel(/^New password/).fill(newPw);
+    await page.getByLabel(/Confirm new password/).fill(newPw);
+    const done = page.waitForResponse(
+      (r) => r.url().includes('/api/account') && r.request().method() === 'PUT'
+    );
+    await page.getByRole('button', { name: 'Update password' }).click();
+    await done;
+    await page.waitForTimeout(500);
+
+    const user = await prisma.user.findUnique({ where: { email } });
+    expect(await bcrypt.compare(newPw, user!.password)).toBe(true);
+  } finally {
+    await cleanupByEmail(email);
+  }
+});

--- a/src/app/admin/account/page.tsx
+++ b/src/app/admin/account/page.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
+import { Input } from '@/components/ui/Input';
+import { Button } from '@/components/ui/Button';
+import { useT } from '@/i18n/client';
+
+export default function AccountPage() {
+  const t = useT();
+  const [email, setEmail] = useState('');
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [msg, setMsg] = useState('');
+  const [err, setErr] = useState('');
+  const [savingEmail, setSavingEmail] = useState(false);
+  const [savingPw, setSavingPw] = useState(false);
+
+  useEffect(() => {
+    fetch('/api/profile')
+      .then((r) => r.json())
+      .then(({ user }) => user && setEmail(user.email));
+  }, []);
+
+  const flash = (m: string, isErr = false) => {
+    setMsg(isErr ? '' : m);
+    setErr(isErr ? m : '');
+    setTimeout(() => { setMsg(''); setErr(''); }, 4000);
+  };
+
+  const call = async (body: object) => {
+    const res = await fetch('/api/account', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || 'Failed');
+    return data;
+  };
+
+  const submitEmail = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSavingEmail(true);
+    try {
+      await call({ email });
+      flash(`${t.account.updated}. ${t.account.reloginNote}`);
+    } catch (e2) {
+      flash(e2 instanceof Error ? e2.message : 'Failed', true);
+    } finally {
+      setSavingEmail(false);
+    }
+  };
+
+  const submitPassword = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (newPassword !== confirmPassword) return flash(t.account.passwordMismatch, true);
+    setSavingPw(true);
+    try {
+      await call({ currentPassword, newPassword });
+      setCurrentPassword(''); setNewPassword(''); setConfirmPassword('');
+      flash(t.account.updated);
+    } catch (e2) {
+      flash(e2 instanceof Error ? e2.message : 'Failed', true);
+    } finally {
+      setSavingPw(false);
+    }
+  };
+
+  return (
+    <div>
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold text-gray-900">{t.account.title}</h1>
+        <p className="text-gray-500 mt-1">{t.account.subtitle}</p>
+      </div>
+
+      {msg && <div className="mb-4 p-3 bg-green-50 border border-green-200 rounded-lg text-green-700 text-sm">✓ {msg}</div>}
+      {err && <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">{err}</div>}
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 max-w-4xl">
+        <Card>
+          <CardHeader><CardTitle>{t.account.emailSection}</CardTitle></CardHeader>
+          <form onSubmit={submitEmail} className="space-y-4">
+            <Input label={t.account.email} type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+            <Button type="submit" loading={savingEmail}>{t.account.updateEmail}</Button>
+          </form>
+        </Card>
+
+        <Card>
+          <CardHeader><CardTitle>{t.account.passwordSection}</CardTitle></CardHeader>
+          <form onSubmit={submitPassword} className="space-y-4">
+            <Input label={t.account.currentPassword} type="password" value={currentPassword} onChange={(e) => setCurrentPassword(e.target.value)} required />
+            <Input label={t.account.newPassword} type="password" value={newPassword} onChange={(e) => setNewPassword(e.target.value)} required />
+            <Input label={t.account.confirmPassword} type="password" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} required />
+            <Button type="submit" loading={savingPw}>{t.account.updatePassword}</Button>
+          </form>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -77,7 +77,11 @@ export default async function AdminLayout({ children }: { children: React.ReactN
         </nav>
 
         <div className="p-4 border-t border-gray-200">
-          <div className="flex items-center gap-3 mb-3 px-3">
+          <Link
+            href="/admin/account"
+            title={t.account.title}
+            className="flex items-center gap-3 mb-3 px-3 py-1.5 rounded-lg hover:bg-gray-50 transition-colors"
+          >
             <div className="w-8 h-8 bg-blue-100 rounded-full flex items-center justify-center">
               <span className="text-blue-700 font-semibold text-sm">
                 {session.user.name?.[0] || 'A'}
@@ -87,7 +91,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
               <p className="text-sm font-medium text-gray-900 truncate">{session.user.name}</p>
               <p className="text-xs text-gray-500 truncate">{session.user.email}</p>
             </div>
-          </div>
+          </Link>
           <Link
             href="/api/auth/signout"
             className="flex items-center gap-2 w-full px-3 py-2 text-sm text-red-600 hover:bg-red-50 rounded-lg transition-colors"

--- a/src/app/api/account/route.ts
+++ b/src/app/api/account/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import bcrypt from 'bcryptjs';
+import { z } from 'zod';
+
+const schema = z.object({
+  email: z.string().email().optional(),
+  currentPassword: z.string().optional(),
+  newPassword: z.string().min(8).optional(),
+});
+
+export async function PUT(request: Request) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    const parsed = schema.safeParse(await request.json());
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 });
+    }
+    const { email, currentPassword, newPassword } = parsed.data;
+
+    const user = await prisma.user.findUnique({ where: { id: session.user.id } });
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    const data: { email?: string; password?: string } = {};
+
+    if (email && email !== user.email) {
+      const taken = await prisma.user.findUnique({ where: { email } });
+      if (taken) {
+        return NextResponse.json({ error: 'Email already in use' }, { status: 409 });
+      }
+      data.email = email;
+    }
+
+    if (newPassword) {
+      if (!currentPassword || !(await bcrypt.compare(currentPassword, user.password))) {
+        return NextResponse.json({ error: 'Current password is incorrect' }, { status: 400 });
+      }
+      data.password = await bcrypt.hash(newPassword, 12);
+    }
+
+    if (Object.keys(data).length === 0) {
+      return NextResponse.json({ message: 'Nothing to update' });
+    }
+
+    await prisma.user.update({ where: { id: user.id }, data });
+    // Note: email/password changes apply on next sign-in (the JWT keeps the old email until then).
+    return NextResponse.json({ message: 'Account updated', emailChanged: !!data.email });
+  } catch (error) {
+    console.error('Account update error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -198,6 +198,22 @@ const en = {
     back: 'Back',
     complete: 'Complete Profile',
   },
+  account: {
+    title: 'Account',
+    subtitle: 'Manage your email and password',
+    nav: 'Account',
+    emailSection: 'Email',
+    email: 'Email address',
+    updateEmail: 'Update email',
+    passwordSection: 'Password',
+    currentPassword: 'Current password',
+    newPassword: 'New password',
+    confirmPassword: 'Confirm new password',
+    updatePassword: 'Update password',
+    updated: 'Account updated',
+    reloginNote: 'Sign out and back in for changes to take full effect.',
+    passwordMismatch: 'New passwords do not match',
+  },
 };
 
 type Dict = typeof en;
@@ -397,6 +413,22 @@ const tr: Dict = {
     continue: 'Devam',
     back: 'Geri',
     complete: 'Profili Tamamla',
+  },
+  account: {
+    title: 'Hesap',
+    subtitle: 'E-posta ve parolanı yönet',
+    nav: 'Hesap',
+    emailSection: 'E-posta',
+    email: 'E-posta adresi',
+    updateEmail: 'E-postayı güncelle',
+    passwordSection: 'Parola',
+    currentPassword: 'Mevcut parola',
+    newPassword: 'Yeni parola',
+    confirmPassword: 'Yeni parolayı onayla',
+    updatePassword: 'Parolayı güncelle',
+    updated: 'Hesap güncellendi',
+    reloginNote: 'Değişikliklerin tam etkili olması için çıkış yapıp tekrar giriş yap.',
+    passwordMismatch: 'Yeni parolalar eşleşmiyor',
   },
 };
 


### PR DESCRIPTION
- `PUT /api/account`: e-posta (benzersizlik kontrollü) ve/veya parola (yeni hash atamadan önce mevcut parolayı bcrypt ile doğrular) değiştirme.\n- `/admin/account` sayfası: ayrı e-posta ve parola formları (EN/TR).\n- Admin sidebar'daki kullanıcı bloğu hesap sayfasına linkli.\n\ne2e/account.spec.ts: parola değişimi (bcrypt doğrulamasıyla).\n\nCloses #84