### PR TITLE
feat(auth): girişli kullanıcıyı / ve /auth/signin'den panele yönlendir (#89)

### DIFF
--- a/e2e/redirect.spec.ts
+++ b/e2e/redirect.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+
+const ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@example.com';
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'ChangeMe123!';
+
+test('signed-in user is redirected away from / and /auth/signin', async ({ page }) => {
+  await page.goto('/auth/signin');
+  await page.fill('input[type="email"], input[name="email"]', ADMIN_EMAIL);
+  await page.fill('input[type="password"]', ADMIN_PASSWORD);
+  await page.click('button[type="submit"]');
+  await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+  // Home page redirects to the role dashboard
+  await page.goto('/');
+  await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 15_000 });
+
+  // Sign-in page too
+  await page.goto('/auth/signin');
+  await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 15_000 });
+  expect(page.url()).not.toContain('/auth/signin');
+});

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 import { useT } from "@/i18n/client";
 
-import { useState } from 'react';
-import { signIn } from 'next-auth/react';
+import { useState, useEffect } from 'react';
+import { signIn, useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -11,6 +11,7 @@ import Link from 'next/link';
 import { GraduationCap } from 'lucide-react';
 import { Input } from '@/components/ui/Input';
 import { Button } from '@/components/ui/Button';
+import { roleHome } from '@/lib/roleHome';
 
 const signinSchema = z.object({
   email: z.string().email('Invalid email address'),
@@ -22,8 +23,16 @@ type SignInData = z.infer<typeof signinSchema>;
 export default function SignInPage() {
   const t = useT();
   const router = useRouter();
+  const { data: session, status } = useSession();
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+
+  // Already signed in → go straight to the role dashboard.
+  useEffect(() => {
+    if (status === 'authenticated') {
+      router.replace(roleHome(session?.user?.role));
+    }
+  }, [status, session, router]);
 
   const {
     register,
@@ -50,15 +59,8 @@ export default function SignInPage() {
     }
 
     const res = await fetch('/api/auth/session');
-    const session = await res.json();
-
-    if (session?.user?.role === 'ADMIN') {
-      router.push('/admin');
-    } else if (session?.user?.role === 'MENTOR') {
-      router.push('/mentor');
-    } else {
-      router.push('/portal');
-    }
+    const fresh = await res.json();
+    router.push(roleHome(fresh?.user?.role));
   });
 
   return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,14 @@
 import Link from 'next/link';
 import { GraduationCap, Users, Building2, ArrowRight, CheckCircle } from 'lucide-react';
+import { getServerSession } from 'next-auth';
+import { redirect } from 'next/navigation';
+import { authOptions } from '@/lib/auth';
+import { roleHome } from '@/lib/roleHome';
 
-export default function HomePage() {
+export default async function HomePage() {
+  const session = await getServerSession(authOptions);
+  if (session) redirect(roleHome(session.user.role));
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-indigo-50">
       {/* Header */}

--- a/src/lib/roleHome.ts
+++ b/src/lib/roleHome.ts
@@ -1,0 +1,6 @@
+// The landing route for a given role after sign-in.
+export function roleHome(role?: string | null): string {
+  if (role === 'ADMIN') return '/admin';
+  if (role === 'MENTOR') return '/mentor';
+  return '/portal';
+}


### PR DESCRIPTION
Girişli kullanıcı landing veya signin'e gelince doğrudan rol paneline (admin/mentor/portal) gider. Paylaşılan `roleHome()` helper'ı; ana sayfa server-side, signin client-side (useSession) yönlendirir.\n\nCloses #89\n\n> Lokal e2e preview DB yavaşlığından bazı seed-ağır testlerde timeout aldı (DB sorunu, kod değil); CI yerel MySQL ile doğruluyor. redirect testi headed geçti.