### PR TITLE
feat(company): proje seed (BCS-IT/OKAY/NFC/Abics) + import'ta bağlama (#28 #29)

### DIFF
--- a/prisma/seed.mjs
+++ b/prisma/seed.mjs
@@ -3,6 +3,9 @@ import bcrypt from 'bcryptjs';
 
 const prisma = new PrismaClient();
 
+// Partner companies / projects from the original spreadsheet.
+const SEED_COMPANIES = ['BCS-IT', 'OKAY', 'NFC', 'Abics'];
+
 async function main() {
   const email = process.env.SEED_ADMIN_EMAIL || 'admin@example.com';
   const password = process.env.SEED_ADMIN_PASSWORD || 'ChangeMe123!';
@@ -10,23 +13,23 @@ async function main() {
 
   const existing = await prisma.user.findUnique({ where: { email } });
   if (existing) {
-    console.log(`User already exists: ${email} — skipping seed.`);
-    return;
+    console.log(`User already exists: ${email} — skipping admin seed.`);
+  } else {
+    const hashedPassword = await bcrypt.hash(password, 12);
+    await prisma.user.create({
+      data: { email, password: hashedPassword, fullName, role: 'ADMIN', skills: [] },
+    });
+    console.log(`Created ADMIN user: ${email}`);
   }
 
-  const hashedPassword = await bcrypt.hash(password, 12);
-  await prisma.user.create({
-    data: {
-      email,
-      password: hashedPassword,
-      fullName,
-      role: 'ADMIN',
-      skills: [],
-    },
-  });
-
-  console.log(`Created ADMIN user: ${email}`);
-  console.log('Sign in at /auth/signin with this email and SEED_ADMIN_PASSWORD (or default ChangeMe123!).');
+  // Idempotent company seed (Company.name is not unique, so check first).
+  for (const name of SEED_COMPANIES) {
+    const found = await prisma.company.findFirst({ where: { name } });
+    if (!found) {
+      await prisma.company.create({ data: { name } });
+      console.log(`Created company: ${name}`);
+    }
+  }
 }
 
 main()

--- a/scripts/import-csv.mjs
+++ b/scripts/import-csv.mjs
@@ -145,10 +145,21 @@ async function apply(mapped) {
     if (!['ADMIN', 'MENTOR'].includes(owner.role))
       throw new Error(`Owner must be ADMIN or MENTOR (is ${owner.role})`);
 
+    // Find-or-create companies for the CSV "proje" column (cached).
+    const companyCache = new Map();
+    const companyId = async (name) => {
+      if (!name) return undefined;
+      if (companyCache.has(name)) return companyCache.get(name);
+      const found = (await prisma.company.findFirst({ where: { name } })) ?? (await prisma.company.create({ data: { name } }));
+      companyCache.set(name, found.id);
+      return found.id;
+    };
+
     let created = 0,
       updated = 0,
       relCreated = 0;
     for (const r of mapped) {
+      const relCompanyId = await companyId(r.project);
       const data = {
         fullName: r.fullName,
         role: 'MENTEE',
@@ -173,11 +184,16 @@ async function apply(mapped) {
       if (rel) {
         await prisma.mentorshipRelation.update({
           where: { id: rel.id },
-          data: { pipelineStatus: r.pipelineStatus },
+          data: { pipelineStatus: r.pipelineStatus, ...(relCompanyId ? { companyId: relCompanyId } : {}) },
         });
       } else {
         await prisma.mentorshipRelation.create({
-          data: { mentorId: owner.id, menteeId: user.id, pipelineStatus: r.pipelineStatus },
+          data: {
+            mentorId: owner.id,
+            menteeId: user.id,
+            pipelineStatus: r.pipelineStatus,
+            ...(relCompanyId ? { companyId: relCompanyId } : {}),
+          },
         });
         relCreated++;
       }


### PR DESCRIPTION
- seed.mjs: 4 partner şirketi/projeyi idempotent seed eder (admin varsa erken dönmüyor artık).\n- import-csv.mjs: CSV 'proje' kolonundan Company find-or-create edip her mentorship ilişkisine bağlar — import edilen mentee'ler projelerini taşır.\n\nCloses #28; #29'u ilerletir (mentee↔şirket bağı).\n\n> Companies CRUD + CompanyNeed (oluştur/göster) zaten mevcut (#30 büyük ölçüde hazır).