### PR TITLE
feat(ui): mobil uyumlu layout — off-canvas sidebar (#51)

### DIFF
--- a/e2e/mentors.spec.ts
+++ b/e2e/mentors.spec.ts
@@ -10,7 +10,8 @@ test.afterAll(async () => {
 
 test('admin can open the Mentors list and see a mentor', async ({ page }) => {
   const mentorEmail = uniqueEmail('mentor');
-  await seedUser(mentorEmail, 'MentorPass123!', 'MENTOR', 'Listed Mentor');
+  const menteeName = 'Listed Mentor ' + Date.now();
+  await seedUser(mentorEmail, 'MentorPass123!', 'MENTOR', menteeName);
 
   try {
     await page.goto('/auth/signin');
@@ -23,7 +24,7 @@ test('admin can open the Mentors list and see a mentor', async ({ page }) => {
     await page.getByRole('link', { name: 'Mentors', exact: true }).click();
     await page.waitForURL((u) => u.pathname.includes('/admin/mentors'), { timeout: 15_000 });
 
-    await expect(page.getByText('Listed Mentor')).toBeVisible();
+    await expect(page.getByText(menteeName)).toBeVisible();
     await expect(page.getByText(mentorEmail)).toBeVisible();
   } finally {
     await cleanupByEmail(mentorEmail);

--- a/e2e/mobile.spec.ts
+++ b/e2e/mobile.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test';
+
+const ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@example.com';
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'ChangeMe123!';
+
+async function login(page: import('@playwright/test').Page) {
+  await page.goto('/auth/signin');
+  await page.fill('input[type="email"], input[name="email"]', ADMIN_EMAIL);
+  await page.fill('input[type="password"]', ADMIN_PASSWORD);
+  await page.click('button[type="submit"]');
+  await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+}
+
+test('mobile: sidebar is behind a hamburger; opens as a drawer', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 800 });
+  await login(page);
+
+  const hamburger = page.getByRole('button', { name: 'Open menu' });
+  await expect(hamburger).toBeVisible();
+  // Nav link is off-canvas (not in viewport) until the drawer opens
+  await expect(page.getByRole('link', { name: 'Send Invitation', exact: true })).not.toBeInViewport();
+
+  await hamburger.click();
+  await expect(page.getByRole('link', { name: 'Send Invitation', exact: true })).toBeInViewport();
+});
+
+test('desktop: sidebar is visible, no hamburger', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await login(page);
+  await expect(page.getByRole('button', { name: 'Open menu' })).toBeHidden();
+  await expect(page.getByRole('link', { name: 'Send Invitation', exact: true })).toBeInViewport();
+});

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { GraduationCap, LayoutDashboard, Building2, Users, UserCheck, Mail, LogOut } from 'lucide-react';
 import { getServerDictionary } from '@/i18n/server';
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
+import { ResponsiveShell } from '@/components/ResponsiveShell';
 
 export default async function AdminLayout({ children }: { children: React.ReactNode }) {
   const session = await getServerSession(authOptions);
@@ -20,9 +21,9 @@ export default async function AdminLayout({ children }: { children: React.ReactN
   const { locale, t } = await getServerDictionary();
 
   return (
-    <div className="min-h-screen bg-gray-50 flex">
-      {/* Sidebar */}
-      <aside className="w-64 bg-white border-r border-gray-200 flex flex-col sticky top-0 h-screen self-start">
+    <ResponsiveShell
+      sidebar={
+        <aside className="w-64 h-full bg-white border-r border-gray-200 flex flex-col">
         <div className="p-6 border-b border-gray-200">
           <div className="flex items-center gap-2">
             <GraduationCap className="h-7 w-7 text-blue-600" />
@@ -103,12 +104,10 @@ export default async function AdminLayout({ children }: { children: React.ReactN
             <LanguageSwitcher current={locale} />
           </div>
         </div>
-      </aside>
-
-      {/* Main content */}
-      <main className="flex-1 overflow-auto">
-        <div className="p-8">{children}</div>
-      </main>
-    </div>
+        </aside>
+      }
+    >
+      {children}
+    </ResponsiveShell>
   );
 }

--- a/src/app/mentor/layout.tsx
+++ b/src/app/mentor/layout.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { GraduationCap, LayoutDashboard, Columns3, Users, BookOpen, LogOut } from 'lucide-react';
 import { getServerDictionary } from '@/i18n/server';
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
+import { ResponsiveShell } from '@/components/ResponsiveShell';
 
 export default async function MentorLayout({ children }: { children: React.ReactNode }) {
   const session = await getServerSession(authOptions);
@@ -20,9 +21,9 @@ export default async function MentorLayout({ children }: { children: React.React
   const { locale, t } = await getServerDictionary();
 
   return (
-    <div className="min-h-screen bg-gray-50 flex">
-      {/* Sidebar */}
-      <aside className="w-64 bg-white border-r border-gray-200 flex flex-col sticky top-0 h-screen self-start">
+    <ResponsiveShell
+      sidebar={
+        <aside className="w-64 h-full bg-white border-r border-gray-200 flex flex-col">
         <div className="p-6 border-b border-gray-200">
           <div className="flex items-center gap-2">
             <GraduationCap className="h-7 w-7 text-blue-600" />
@@ -85,12 +86,10 @@ export default async function MentorLayout({ children }: { children: React.React
             <LanguageSwitcher current={locale} />
           </div>
         </div>
-      </aside>
-
-      {/* Main content */}
-      <main className="flex-1 overflow-auto">
-        <div className="p-8">{children}</div>
-      </main>
-    </div>
+        </aside>
+      }
+    >
+      {children}
+    </ResponsiveShell>
   );
 }

--- a/src/app/portal/layout.tsx
+++ b/src/app/portal/layout.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { GraduationCap, LayoutDashboard, User, BookOpen, LogOut } from 'lucide-react';
 import { getServerDictionary } from '@/i18n/server';
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
+import { ResponsiveShell } from '@/components/ResponsiveShell';
 
 export default async function PortalLayout({ children }: { children: React.ReactNode }) {
   const session = await getServerSession(authOptions);
@@ -24,9 +25,9 @@ export default async function PortalLayout({ children }: { children: React.React
   const { locale, t } = await getServerDictionary();
 
   return (
-    <div className="min-h-screen bg-gray-50 flex">
-      {/* Sidebar */}
-      <aside className="w-64 bg-white border-r border-gray-200 flex flex-col sticky top-0 h-screen self-start">
+    <ResponsiveShell
+      sidebar={
+        <aside className="w-64 h-full bg-white border-r border-gray-200 flex flex-col">
         <div className="p-6 border-b border-gray-200">
           <div className="flex items-center gap-2">
             <GraduationCap className="h-7 w-7 text-blue-600" />
@@ -82,12 +83,10 @@ export default async function PortalLayout({ children }: { children: React.React
             <LanguageSwitcher current={locale} />
           </div>
         </div>
-      </aside>
-
-      {/* Main content */}
-      <main className="flex-1 overflow-auto">
-        <div className="p-8">{children}</div>
-      </main>
-    </div>
+        </aside>
+      }
+    >
+      {children}
+    </ResponsiveShell>
   );
 }

--- a/src/components/ResponsiveShell.tsx
+++ b/src/components/ResponsiveShell.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useState } from 'react';
+import { Menu, X } from 'lucide-react';
+
+// App shell: sidebar is a static column on desktop and an off-canvas drawer
+// (with a hamburger top bar) on mobile.
+export function ResponsiveShell({
+  sidebar,
+  children,
+}: {
+  sidebar: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="min-h-screen bg-gray-50 lg:flex">
+      {/* Mobile top bar */}
+      <div className="lg:hidden sticky top-0 z-30 flex items-center justify-between bg-white border-b border-gray-200 h-14 px-4">
+        <span className="font-bold text-gray-900">InternshipCRM</span>
+        <button onClick={() => setOpen(true)} aria-label="Open menu" className="p-2 -mr-2 text-gray-600 hover:text-gray-900">
+          <Menu className="h-6 w-6" />
+        </button>
+      </div>
+
+      {/* Overlay (mobile only) */}
+      {open && (
+        <div className="fixed inset-0 bg-black/40 z-40 lg:hidden" onClick={() => setOpen(false)} aria-hidden />
+      )}
+
+      {/* Sidebar: drawer on mobile, sticky column on desktop */}
+      <div
+        className={`fixed inset-y-0 left-0 z-50 w-64 transition-transform duration-200 lg:sticky lg:top-0 lg:h-screen lg:z-auto lg:translate-x-0 ${
+          open ? 'translate-x-0' : '-translate-x-full'
+        }`}
+      >
+        <button
+          onClick={() => setOpen(false)}
+          aria-label="Close menu"
+          className="lg:hidden absolute top-3 right-3 z-10 p-1 text-gray-500 hover:text-gray-800"
+        >
+          <X className="h-5 w-5" />
+        </button>
+        {/* Close the drawer when a nav link is tapped */}
+        <div className="h-full" onClick={() => setOpen(false)}>
+          {sidebar}
+        </div>
+      </div>
+
+      <main className="flex-1 overflow-auto min-w-0">
+        <div className="p-4 lg:p-8">{children}</div>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
`ResponsiveShell`: sidebar desktop'ta sabit kolon, mobilde off-canvas drawer (hamburger üst bar + overlay, tıklayınca kapanır). Admin/mentor/mentee layout'larında. Küçük ekranda içerik padding'i daralır. Mobil/desktop e2e eklendi; mentors testi benzersiz isim kullanır.\n\nCloses #51