### PR TITLE
fix(auth): sidebar email updates without re-login (#98)

### DIFF
--- a/e2e/account.spec.ts
+++ b/e2e/account.spec.ts
@@ -36,3 +36,35 @@ test('admin can change their password from the account page', async ({ page }) =
     await cleanupByEmail(email);
   }
 });
+
+test('changing email updates the sidebar without a re-login', async ({ page }) => {
+  const email = uniqueEmail('acct-mail');
+  const newEmail = uniqueEmail('acct-mail-new');
+  const pw = 'MailPass123!';
+  await seedUser(email, pw, 'ADMIN', 'Mail Admin');
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', email);
+    await page.fill('input[type="password"]', pw);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    await page.goto('/admin/account');
+    // sidebar shows the original email
+    await expect(page.getByText(email, { exact: true })).toBeVisible();
+
+    await page.getByLabel(/Email address/).fill(newEmail);
+    const done = page.waitForResponse(
+      (r) => r.url().includes('/api/account') && r.request().method() === 'PUT'
+    );
+    await page.getByRole('button', { name: 'Update email' }).click();
+    await done;
+
+    // sidebar reflects the new email immediately (session refreshed, no re-login)
+    await expect(page.getByText(newEmail, { exact: true })).toBeVisible({ timeout: 10_000 });
+  } finally {
+    await cleanupByEmail(email);
+    await cleanupByEmail(newEmail);
+  }
+});

--- a/src/app/admin/account/page.tsx
+++ b/src/app/admin/account/page.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { useSession } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
 import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Input } from '@/components/ui/Input';
 import { Button } from '@/components/ui/Button';
@@ -8,6 +10,8 @@ import { useT } from '@/i18n/client';
 
 export default function AccountPage() {
   const t = useT();
+  const { update } = useSession();
+  const router = useRouter();
   const [email, setEmail] = useState('');
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
@@ -45,7 +49,11 @@ export default function AccountPage() {
     setSavingEmail(true);
     try {
       await call({ email });
-      flash(`${t.account.updated}. ${t.account.reloginNote}`);
+      // Refresh the JWT (jwt callback re-reads the user) then re-render the
+      // server layout so the sidebar shows the new email immediately.
+      await update();
+      router.refresh();
+      flash(t.account.updated);
     } catch (e2) {
       flash(e2 instanceof Error ? e2.message : 'Failed', true);
     } finally {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -46,10 +46,21 @@ export const authOptions: NextAuthOptions = {
     }),
   ],
   callbacks: {
-    async jwt({ token, user }) {
+    async jwt({ token, user, trigger }) {
       if (user) {
         token.id = user.id;
         token.role = (user as unknown as { role: string }).role;
+      }
+      // On a client-side session update() (e.g. after changing email/profile),
+      // re-read the user so the token — and thus the UI that reads the session,
+      // like the sidebar — reflects the latest values without a re-login.
+      if (trigger === 'update' && token.id) {
+        const fresh = await prisma.user.findUnique({ where: { id: token.id as string } });
+        if (fresh) {
+          token.email = fresh.email;
+          token.name = fresh.fullName;
+          token.role = fresh.role;
+        }
       }
       return token;
     },
@@ -57,6 +68,8 @@ export const authOptions: NextAuthOptions = {
       if (token) {
         session.user.id = token.id as string;
         session.user.role = token.role as string;
+        if (token.email) session.user.email = token.email as string;
+        if (token.name) session.user.name = token.name as string;
       }
       return session;
     },


### PR DESCRIPTION
## Problem
Changing the account email updated the DB, but the NextAuth JWT kept the old email, so the sidebar's user block kept showing the stale address until the next sign-in.

## Fix
- `jwt` callback: on a client-side `update()` trigger, re-read the user from the DB and refresh token `email`/`name`/`role`.
- `session` callback: map token `email`/`name` onto `session.user`.
- Account page: after a successful email change, call `update()` then `router.refresh()` so the server-rendered sidebar reflects the new email immediately.
- e2e: new test asserting the sidebar updates without a re-login.

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)