### PR TITLE
feat(auth): mentee set-password link on creation (#107)

### DIFF
--- a/e2e/mentee-setpw.spec.ts
+++ b/e2e/mentee-setpw.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('adding a mentee with an email yields a set-password link the mentee can use to sign in', async ({
+  page,
+}) => {
+  const mentorEmail = uniqueEmail('setpw-mentor');
+  const menteeEmail = uniqueEmail('setpw-mentee');
+  const mentorPw = 'MentorPass123!';
+  const menteePw = 'MenteeChosen456!';
+  await seedUser(mentorEmail, mentorPw, 'MENTOR', 'SetPw Mentor');
+
+  try {
+    // Sign in as the mentor.
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', mentorEmail);
+    await page.fill('input[type="password"]', mentorPw);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/mentor'), { timeout: 20_000 });
+
+    // Create a mentee WITH an email.
+    await page.goto('/mentor/mentees/new');
+    await page.getByLabel(/Full Name/).fill('New Mentee Person');
+    await page.getByLabel(/Email/).fill(menteeEmail);
+    const created = page.waitForResponse(
+      (r) => r.url().includes('/api/mentor/mentees') && r.request().method() === 'POST'
+    );
+    await page.getByRole('button', { name: 'Create' }).click();
+    await created;
+
+    // The set-password link is shown; grab it.
+    await expect(page.getByText('Mentee created')).toBeVisible({ timeout: 10_000 });
+    const link = await page.locator('input[readonly]').inputValue();
+    expect(link).toContain('/auth/reset?token=');
+    const token = new URL(link).searchParams.get('token')!;
+    expect(token).toBeTruthy();
+
+    // Mentee follows the link and chooses a password.
+    await page.goto(`/auth/reset?token=${token}`);
+    await page.getByLabel(/New password/).fill(menteePw);
+    await page.getByLabel(/Confirm Password/i).fill(menteePw);
+    const done = page.waitForResponse(
+      (r) => r.url().includes('/api/auth/reset') && r.request().method() === 'POST'
+    );
+    await page.getByRole('button', { name: /Update password/ }).click();
+    await done;
+    await page.waitForURL((u) => u.pathname.startsWith('/auth/signin'), { timeout: 20_000 });
+
+    // Mentee can now sign in with their chosen password → lands on the portal.
+    await page.fill('input[type="email"], input[name="email"]', menteeEmail);
+    await page.fill('input[type="password"]', menteePw);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/portal'), { timeout: 20_000 });
+  } finally {
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+  }
+});

--- a/e2e/mentee-setpw.spec.ts
+++ b/e2e/mentee-setpw.spec.ts
@@ -50,7 +50,12 @@ test('adding a mentee with an email yields a set-password link the mentee can us
     await done;
     await page.waitForURL((u) => u.pathname.startsWith('/auth/signin'), { timeout: 20_000 });
 
+    // Drop the mentor's still-active session before signing in as the mentee,
+    // otherwise /auth/signin redirects the authenticated mentor away.
+    await page.context().clearCookies();
+
     // Mentee can now sign in with their chosen password → lands on the portal.
+    await page.goto('/auth/signin');
     await page.fill('input[type="email"], input[name="email"]', menteeEmail);
     await page.fill('input[type="password"]', menteePw);
     await page.click('button[type="submit"]');

--- a/src/app/api/mentor/mentees/route.ts
+++ b/src/app/api/mentor/mentees/route.ts
@@ -4,6 +4,8 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import crypto from 'crypto';
 import { z } from 'zod';
+import { createPasswordResetToken } from '@/lib/passwordReset';
+import { sendPasswordResetEmail } from '@/services/emailService';
 
 const schema = z.object({
   fullName: z.string().min(1),
@@ -32,11 +34,12 @@ export async function POST(request: Request) {
     }
     const { fullName, email, ...rest } = parsed.data;
 
-    // Use the given email, or a deterministic placeholder for non-login tracked mentees.
-    const finalEmail =
-      email && email.length > 0
-        ? email
-        : `mentee.${slug(fullName)}.${crypto.randomBytes(2).toString('hex')}@import.local`;
+    // A real email means the mentee can be invited to set a password and log in.
+    // No email → a deterministic placeholder for a tracking-only mentee (no login).
+    const hasRealEmail = !!(email && email.length > 0);
+    const finalEmail = hasRealEmail
+      ? email!
+      : `mentee.${slug(fullName)}.${crypto.randomBytes(2).toString('hex')}@import.local`;
 
     const existing = await prisma.user.findUnique({ where: { email: finalEmail } });
     if (existing) {
@@ -63,7 +66,27 @@ export async function POST(request: Request) {
       data: { mentorId: session.user.id, menteeId: mentee.id },
     });
 
-    return NextResponse.json({ menteeId: mentee.id }, { status: 201 });
+    // If the mentee has a real email, send a "set your password" link so they
+    // can activate their account. The link is also returned so the UI can show
+    // it (and the mentor can share it manually) even if the email fails.
+    let setPasswordUrl: string | null = null;
+    if (hasRealEmail) {
+      const token = await createPasswordResetToken(mentee.id, 'SET_INITIAL');
+      const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+      setPasswordUrl = `${appUrl}/auth/reset?token=${token}`;
+      try {
+        await sendPasswordResetEmail({
+          to: mentee.email,
+          token,
+          fullName: mentee.fullName,
+          purpose: 'SET_INITIAL',
+        });
+      } catch (e) {
+        console.error('Mentee set-password email failed:', e);
+      }
+    }
+
+    return NextResponse.json({ menteeId: mentee.id, setPasswordUrl }, { status: 201 });
   } catch (error) {
     console.error('Create mentee error:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });

--- a/src/app/mentor/mentees/new/page.tsx
+++ b/src/app/mentor/mentees/new/page.tsx
@@ -17,6 +17,8 @@ export default function NewMenteePage() {
   });
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
+  const [setPasswordUrl, setSetPasswordUrl] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
 
   const set = (k: string, v: string) => setForm((p) => ({ ...p, [k]: v }));
 
@@ -32,12 +34,58 @@ export default function NewMenteePage() {
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || 'Failed');
-      router.push('/mentor/mentees');
+      // With a real email, show the set-password link so the mentor can share
+      // it if the email doesn't arrive; otherwise go straight to the list.
+      if (data.setPasswordUrl) {
+        setSetPasswordUrl(data.setPasswordUrl);
+        setSaving(false);
+      } else {
+        router.push('/mentor/mentees');
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed');
       setSaving(false);
     }
   };
+
+  if (setPasswordUrl) {
+    return (
+      <div>
+        <Link href="/mentor/mentees" className="flex items-center gap-2 text-sm text-gray-500 hover:text-gray-700 mb-4">
+          <ArrowLeft className="h-4 w-4" />
+          {t.mentor.backToMentees}
+        </Link>
+        <Card className="max-w-2xl">
+          <CardHeader><CardTitle>{t.mentor.menteeCreated}</CardTitle></CardHeader>
+          <div className="space-y-4">
+            <p className="text-sm text-gray-600">{t.mentor.setPwLinkHint}</p>
+            <div className="flex items-center gap-2">
+              <input
+                readOnly
+                value={setPasswordUrl}
+                className="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm bg-gray-50 text-gray-700"
+                onFocus={(e) => e.target.select()}
+              />
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={() => {
+                  navigator.clipboard?.writeText(setPasswordUrl);
+                  setCopied(true);
+                  setTimeout(() => setCopied(false), 2000);
+                }}
+              >
+                {copied ? t.mentor.copied : t.mentor.copyLink}
+              </Button>
+            </div>
+            <Button type="button" onClick={() => router.push('/mentor/mentees')}>
+              {t.mentor.backToMentees}
+            </Button>
+          </div>
+        </Card>
+      </div>
+    );
+  }
 
   return (
     <div>

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -153,6 +153,11 @@ const en = {
     department: 'Department',
     referral: 'Referral',
     create: 'Create',
+    menteeCreated: 'Mentee created',
+    setPwLinkHint:
+      'We emailed the mentee a link to set their password and activate their account. If it doesn’t arrive, share this link with them directly:',
+    copyLink: 'Copy link',
+    copied: 'Copied!',
   },
   auth: {
     welcomeBack: 'Welcome back',
@@ -395,6 +400,11 @@ const tr: Dict = {
     department: 'Bölüm',
     referral: 'Referans',
     create: 'Oluştur',
+    menteeCreated: 'Mentee oluşturuldu',
+    setPwLinkHint:
+      'Mentee’ye parolasını belirleyip hesabını aktifleştirmesi için bir bağlantı e-postaladık. Ulaşmazsa bu bağlantıyı doğrudan onunla paylaşabilirsin:',
+    copyLink: 'Bağlantıyı kopyala',
+    copied: 'Kopyalandı!',
   },
   auth: {
     welcomeBack: 'Tekrar hoş geldin',


### PR DESCRIPTION
## S8.2 · Mentee davetinde parola-oluşturma linki (EPIC 8 · #101)

Mentor/admin **gerçek email ile** bir mentee eklediğinde, mentee artık "parolanı oluştur" linkli bir email alıyor (SET_INITIAL token, 7 gün) — böylece hesabını aktifleştirip giriş yapabiliyor. Önceden mentee giriş-yapılamaz placeholder parola ile oluşturuluyordu.

### Değişiklikler
- `/api/mentor/mentees`: gerçek emaili olan mentee için SET_INITIAL token + email; yanıtta `setPasswordUrl` döner (email hatası süreci bloklamaz). Email'siz (takip-amaçlı) mentee davranışı aynı.
- **Yeni mentee sayfası**: başarıda parola linkini kopyala butonuyla gösterir (email gelmezse mentor elle paylaşır).
- #106'daki `/auth/reset` akışı + `PasswordResetToken` yeniden kullanılır.
- i18n EN+TR.
- **e2e**: emailli mentee ekle → linkle parola belirle → mentee giriş yapıp portala düşer.

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)