### PR TITLE
feat(auth): admin can reset a user's password (#109)

### DIFF
--- a/e2e/admin-reset-password.spec.ts
+++ b/e2e/admin-reset-password.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('admin can trigger a password reset for a user and gets a shareable link', async ({ page }) => {
+  const adminEmail = uniqueEmail('rstadmin');
+  const menteeEmail = uniqueEmail('rstmentee');
+  await seedUser(adminEmail, 'AdminPass123!', 'ADMIN', 'Reset Admin');
+  const mentee = await seedUser(menteeEmail, 'MenteePass123!', 'MENTEE', 'Reset Mentee');
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', 'AdminPass123!');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    await page.goto(`/admin/candidates/${mentee.id}`);
+    const done = page.waitForResponse(
+      (r) => r.url().includes(`/api/admin/users/${mentee.id}/reset-password`) && r.request().method() === 'POST'
+    );
+    await page.getByRole('button', { name: /Reset password/ }).click();
+    await done;
+
+    // The shareable reset link is shown and a token was persisted.
+    const link = await page.locator('input[readonly]').inputValue();
+    expect(link).toContain('/auth/reset?token=');
+    const token = await prisma.passwordResetToken.findFirst({
+      where: { userId: mentee.id, used: false },
+    });
+    expect(token).not.toBeNull();
+  } finally {
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/src/app/admin/candidates/[id]/page.tsx
+++ b/src/app/admin/candidates/[id]/page.tsx
@@ -6,7 +6,8 @@ import Link from 'next/link';
 import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Badge } from '@/components/ui/Badge';
 import { Select } from '@/components/ui/Select';
-import { ArrowLeft, ExternalLink } from 'lucide-react';
+import { Button } from '@/components/ui/Button';
+import { ArrowLeft, ExternalLink, KeyRound } from 'lucide-react';
 import { pipelineLabel, pipelineOptions } from '@/lib/pipeline';
 import { useT, useLocale } from '@/i18n/client';
 
@@ -56,6 +57,8 @@ export default function AdminMenteeDetailPage() {
   const [user, setUser] = useState<MenteeDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [resetting, setResetting] = useState(false);
+  const [resetUrl, setResetUrl] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     const res = await fetch(`/api/users/${id}`);
@@ -83,6 +86,17 @@ export default function AdminMenteeDetailPage() {
     [load]
   );
 
+  const resetPassword = useCallback(async () => {
+    setResetting(true);
+    try {
+      const res = await fetch(`/api/admin/users/${id}/reset-password`, { method: 'POST' });
+      const data = await res.json();
+      if (res.ok) setResetUrl(data.resetUrl);
+    } finally {
+      setResetting(false);
+    }
+  }, [id]);
+
   useEffect(() => {
     load();
   }, [load]);
@@ -104,9 +118,27 @@ export default function AdminMenteeDetailPage() {
             <h1 className="text-2xl font-bold text-gray-900">{user.fullName}</h1>
             <p className="text-gray-500">{user.email}</p>
           </div>
-          {rel && <Badge variant="info">{pipelineLabel(rel.pipelineStatus, locale)}</Badge>}
+          <div className="flex items-center gap-3">
+            {rel && <Badge variant="info">{pipelineLabel(rel.pipelineStatus, locale)}</Badge>}
+            <Button variant="outline" size="sm" loading={resetting} onClick={resetPassword}>
+              <KeyRound className="h-4 w-4 mr-1" />
+              {t.candidateDetail.resetPassword}
+            </Button>
+          </div>
         </div>
       </div>
+
+      {resetUrl && (
+        <div className="mb-6 rounded-lg border border-green-200 bg-green-50 p-4">
+          <p className="text-sm text-green-800 mb-2">{t.candidateDetail.resetPwHint}</p>
+          <input
+            readOnly
+            value={resetUrl}
+            onFocus={(e) => e.target.select()}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm bg-white text-gray-700"
+          />
+        </div>
+      )}
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <Card>

--- a/src/app/api/admin/users/[id]/reset-password/route.ts
+++ b/src/app/api/admin/users/[id]/reset-password/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { createPasswordResetToken } from '@/lib/passwordReset';
+import { sendPasswordResetEmail } from '@/services/emailService';
+
+// POST — admin triggers a password reset for any user: issues a single-use
+// reset token, emails the user a link, and returns the link so the admin can
+// share it manually if email delivery fails.
+export async function POST(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { id } = await params;
+  const user = await prisma.user.findUnique({ where: { id } });
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 });
+  }
+
+  const token = await createPasswordResetToken(user.id, 'RESET');
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+  const resetUrl = `${appUrl}/auth/reset?token=${token}`;
+  try {
+    await sendPasswordResetEmail({ to: user.email, token, fullName: user.fullName });
+  } catch (e) {
+    console.error('Admin reset email failed:', e);
+  }
+
+  return NextResponse.json({ ok: true, resetUrl });
+}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -78,6 +78,8 @@ const en = {
     noChanges: 'No changes yet',
     interactions: 'Interactions',
     noInteractions: 'No interactions logged',
+    resetPassword: 'Reset password',
+    resetPwHint: 'A reset link was emailed to this user. You can also share it directly:',
   },
   mentors: {
     title: 'Mentors',
@@ -333,6 +335,8 @@ const tr: Dict = {
     noChanges: 'Henüz değişiklik yok',
     interactions: 'Etkileşimler',
     noInteractions: 'Henüz etkileşim yok',
+    resetPassword: 'Parolayı sıfırla',
+    resetPwHint: 'Bu kullanıcıya bir sıfırlama bağlantısı e-postalandı. İstersen doğrudan da paylaşabilirsin:',
   },
   mentors: {
     title: 'Mentorlar',


### PR DESCRIPTION
## S8.4 · Admin: kullanıcı parolasını sıfırlama (EPIC 8 · #101)

EPIC 8'i tamamlar.

- **POST /api/admin/users/[id]/reset-password** (admin-only): RESET token üretir, kullanıcıya link e-postalar, linki yanıtta döner (email başarısızsa admin elle paylaşır).
- **Admin mentee detay**: "Parolayı sıfırla" butonu + paylaşılabilir link paneli.
- #106'daki `createPasswordResetToken` + `/auth/reset` akışını yeniden kullanır.
- i18n EN+TR.
- **e2e**: admin reset'e basar → link görünür + token kalıcı.

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)