### PR TITLE
feat(admin): kanban board across all mentorships (#112)

### DIFF
--- a/e2e/admin-board.spec.ts
+++ b/e2e/admin-board.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('admin board shows every mentor\'s mentees grouped by stage', async ({ page }) => {
+  const adminEmail = uniqueEmail('bdadmin');
+  const mentorEmail = uniqueEmail('bdmentor');
+  const menteeEmail = uniqueEmail('bdmentee');
+  await seedUser(adminEmail, 'AdminPass123!', 'ADMIN', 'Board Admin');
+  const mentor = await seedUser(mentorEmail, 'MentorPass123!', 'MENTOR', 'Listed Board Mentor');
+  const mentee = await seedUser(menteeEmail, 'MenteePass123!', 'MENTEE', 'Board Admin Mentee');
+  await prisma.mentorshipRelation.create({
+    data: { mentorId: mentor.id, menteeId: mentee.id, pipelineStatus: 'INTERNSHIP_IN_PROGRESS_450' },
+  });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', 'AdminPass123!');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    await page.getByRole('link', { name: 'Board', exact: true }).click();
+    await page.waitForURL((u) => u.pathname.includes('/admin/board'), { timeout: 15_000 });
+
+    // The mentee card sits in the "450 · Internship in progress" column and
+    // shows the owning mentor's name (admin sees all mentors).
+    const column = page.locator('div.w-64', { hasText: '450 · Internship in progress' });
+    await expect(column.getByText('Board Admin Mentee')).toBeVisible();
+    await expect(column.getByText('Listed Board Mentor')).toBeVisible();
+  } finally {
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/src/app/admin/board/page.tsx
+++ b/src/app/admin/board/page.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import { GraduationCap, User } from 'lucide-react';
+import { PIPELINE_STATUSES, pipelineLabel } from '@/lib/pipeline';
+import { useT, useLocale } from '@/i18n/client';
+
+interface Relation {
+  id: string;
+  pipelineStatus: string;
+  mentee: { id: string; fullName: string; university?: string };
+  mentor: { fullName: string };
+  _count: { interactions: number };
+}
+
+// Admin kanban across ALL mentorship relations (every mentor's mentees).
+// Reuses the mentor-board mechanics: drag a card to change its pipeline stage.
+export default function AdminBoardPage() {
+  const t = useT();
+  const locale = useLocale();
+  const router = useRouter();
+  const [relations, setRelations] = useState<Relation[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [dragOver, setDragOver] = useState<string | null>(null);
+
+  const fetchRelations = useCallback(async () => {
+    const res = await fetch('/api/mentorship');
+    const data = await res.json();
+    setRelations(data.relations ?? []);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    fetchRelations();
+  }, [fetchRelations]);
+
+  const moveTo = async (relationId: string, pipelineStatus: string) => {
+    const prev = relations;
+    setRelations((rs) => rs.map((r) => (r.id === relationId ? { ...r, pipelineStatus } : r)));
+    try {
+      const res = await fetch(`/api/mentorship/${relationId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ pipelineStatus }),
+      });
+      if (!res.ok) throw new Error('Failed');
+    } catch {
+      setRelations(prev);
+    }
+  };
+
+  if (loading) return <div className="text-center py-12 text-gray-400">{t.common.loading}</div>;
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900">{t.nav.board}</h1>
+        <p className="text-gray-500 mt-1">{t.adminBoard.subtitle}</p>
+      </div>
+
+      <div className="flex gap-4 overflow-x-auto pb-4">
+        {PIPELINE_STATUSES.map((status) => {
+          const items = relations.filter((r) => r.pipelineStatus === status);
+          return (
+            <div
+              key={status}
+              onDragOver={(e) => {
+                e.preventDefault();
+                setDragOver(status);
+              }}
+              onDragLeave={() => setDragOver((s) => (s === status ? null : s))}
+              onDrop={(e) => {
+                e.preventDefault();
+                setDragOver(null);
+                const id = e.dataTransfer.getData('relationId');
+                if (id) moveTo(id, status);
+              }}
+              className={`flex-shrink-0 w-64 rounded-xl border p-3 transition-colors ${
+                dragOver === status ? 'border-blue-400 bg-blue-50' : 'border-gray-200 bg-gray-50'
+              }`}
+            >
+              <div className="flex items-center justify-between mb-3 px-1">
+                <span className="text-xs font-semibold text-gray-700">{pipelineLabel(status, locale)}</span>
+                <span className="text-xs text-gray-400 bg-white border border-gray-200 rounded-full px-2 py-0.5">
+                  {items.length}
+                </span>
+              </div>
+
+              <div className="space-y-2 min-h-[40px]">
+                {items.map((r) => (
+                  <div
+                    key={r.id}
+                    draggable
+                    onDragStart={(e) => e.dataTransfer.setData('relationId', r.id)}
+                    onClick={() => router.push(`/admin/candidates/${r.mentee.id}`)}
+                    className="bg-white border border-gray-200 rounded-lg p-3 cursor-grab active:cursor-grabbing hover:border-blue-300 hover:shadow-sm transition"
+                  >
+                    <p className="text-sm font-medium text-gray-900 truncate">{r.mentee.fullName}</p>
+                    {r.mentee.university && (
+                      <p className="text-xs text-gray-500 truncate mt-0.5">{r.mentee.university}</p>
+                    )}
+                    <div className="flex items-center gap-3 text-xs text-gray-400 mt-2">
+                      <span className="flex items-center gap-1 truncate">
+                        <User className="h-3 w-3 flex-shrink-0" />
+                        {r.mentor.fullName}
+                      </span>
+                      <span className="flex items-center gap-1 flex-shrink-0">
+                        <GraduationCap className="h-3 w-3" />
+                        {r._count.interactions}
+                      </span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -2,7 +2,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
-import { GraduationCap, LayoutDashboard, Building2, Users, UserCheck, UserCog, Mail, LogOut } from 'lucide-react';
+import { GraduationCap, LayoutDashboard, Columns3, Building2, Users, UserCheck, UserCog, Mail, LogOut } from 'lucide-react';
 import { getServerDictionary } from '@/i18n/server';
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
 import { ResponsiveShell } from '@/components/ResponsiveShell';
@@ -39,6 +39,13 @@ export default async function AdminLayout({ children }: { children: React.ReactN
           >
             <LayoutDashboard className="h-5 w-5 text-gray-400 group-hover:text-blue-600" />
             {t.nav.dashboard}
+          </Link>
+          <Link
+            href="/admin/board"
+            className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-gray-700 hover:bg-blue-50 hover:text-blue-700 transition-colors group"
+          >
+            <Columns3 className="h-5 w-5 text-gray-400 group-hover:text-blue-600" />
+            {t.nav.board}
           </Link>
           <Link
             href="/admin/companies"

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -213,6 +213,9 @@ const en = {
     viewingAs: 'You are viewing the app as {name}.',
     return: 'Return to your account',
   },
+  adminBoard: {
+    subtitle: 'All mentees across every mentor — drag a card to change its stage',
+  },
   portal: {
     welcome: 'Welcome',
     dashSubtitle: 'Your internship dashboard',
@@ -488,6 +491,9 @@ const tr: Dict = {
   impersonation: {
     viewingAs: 'Uygulamayı {name} olarak görüntülüyorsun.',
     return: 'Kendi hesabına dön',
+  },
+  adminBoard: {
+    subtitle: 'Tüm mentorların tüm mentee’leri — aşamayı değiştirmek için kartı sürükle',
   },
   portal: {
     welcome: 'Hoş geldin',


### PR DESCRIPTION
## S9.3 · Admin'e tam mentor yetenekleri (kanban/board) (EPIC 9 · #102)

- **/admin/board**: tüm mentorluk ilişkileri üzerinde kanban (her mentorun mentee'leri); aşamayı değiştirmek için kartı sürükle. Kartlar mentoru gösterir; tıklayınca admin mentee detayına gider. `GET /api/mentorship` admin'e zaten tümünü döner, PUT admin'e zaten izinli — bu mevcut uçlar üzerine bir görünüm.
- Admin sidebar'a **Board** eklendi.
- i18n EN+TR.
- **e2e**: admin board mentee'yi aşamasına gruplar + mentorunu gösterir.

Not: admin zaten aşama değiştirebiliyor (mentee detay) ve #111 impersonation ile mentorun yaptığı her şeyi yapabiliyor — bu eksik olan kanban'ı ekliyor.

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)