### PR TITLE
feat(admin): manual stage-history editing (#113)

### DIFF
--- a/e2e/admin-history-edit.spec.ts
+++ b/e2e/admin-history-edit.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('admin can add and delete stage-history entries', async ({ page }) => {
+  const adminEmail = uniqueEmail('histadmin');
+  const mentorEmail = uniqueEmail('histmentor');
+  const menteeEmail = uniqueEmail('histmentee');
+  const admin = await seedUser(adminEmail, 'AdminPass123!', 'ADMIN', 'History Admin');
+  const mentor = await seedUser(mentorEmail, 'MentorPass123!', 'MENTOR', 'History Mentor');
+  const mentee = await seedUser(menteeEmail, 'MenteePass123!', 'MENTEE', 'History Mentee');
+  const rel = await prisma.mentorshipRelation.create({
+    data: { mentorId: mentor.id, menteeId: mentee.id, pipelineStatus: 'APPLICATION_100' },
+  });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', 'AdminPass123!');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    await page.goto(`/admin/candidates/${mentee.id}`);
+
+    // Add a manual history entry.
+    await page.getByLabel('To', { exact: true }).selectOption('HIRED_660');
+    const added = page.waitForResponse(
+      (r) => r.url().includes('/api/status-changes') && r.request().method() === 'POST'
+    );
+    await page.getByRole('button', { name: 'Add entry' }).click();
+    await added;
+
+    const afterAdd = await prisma.statusChange.findMany({ where: { relationId: rel.id } });
+    expect(afterAdd).toHaveLength(1);
+    expect(afterAdd[0].changedById).toBe(admin.id);
+    expect(afterAdd[0].toStatus).toBe('HIRED_660');
+
+    // Delete it again.
+    const removed = page.waitForResponse(
+      (r) => r.url().includes('/api/status-changes/') && r.request().method() === 'DELETE'
+    );
+    await page.getByRole('button', { name: 'Delete entry' }).click();
+    await removed;
+
+    const afterDelete = await prisma.statusChange.findMany({ where: { relationId: rel.id } });
+    expect(afterDelete).toHaveLength(0);
+  } finally {
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/src/app/admin/candidates/[id]/page.tsx
+++ b/src/app/admin/candidates/[id]/page.tsx
@@ -7,8 +7,8 @@ import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Badge } from '@/components/ui/Badge';
 import { Select } from '@/components/ui/Select';
 import { Button } from '@/components/ui/Button';
-import { ArrowLeft, ExternalLink, KeyRound } from 'lucide-react';
-import { pipelineLabel, pipelineOptions } from '@/lib/pipeline';
+import { ArrowLeft, ExternalLink, KeyRound, Trash2, Plus } from 'lucide-react';
+import { pipelineLabel, pipelineOptions, PIPELINE_STATUSES } from '@/lib/pipeline';
 import { useT, useLocale } from '@/i18n/client';
 
 interface Interaction { id: string; date: string; notes: string; type: string }
@@ -96,6 +96,43 @@ export default function AdminMenteeDetailPage() {
       setResetting(false);
     }
   }, [id]);
+
+  // Manual stage-history corrections (S9.4): add or remove audit entries.
+  const [histFrom, setHistFrom] = useState(PIPELINE_STATUSES[0] as string);
+  const [histTo, setHistTo] = useState(PIPELINE_STATUSES[0] as string);
+  const [histDate, setHistDate] = useState('');
+  const [histBusy, setHistBusy] = useState(false);
+
+  const addHistory = useCallback(
+    async (relationId: string) => {
+      setHistBusy(true);
+      try {
+        await fetch('/api/status-changes', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            relationId,
+            fromStatus: histFrom,
+            toStatus: histTo,
+            ...(histDate ? { createdAt: new Date(histDate).toISOString() } : {}),
+          }),
+        });
+        setHistDate('');
+        await load();
+      } finally {
+        setHistBusy(false);
+      }
+    },
+    [histFrom, histTo, histDate, load]
+  );
+
+  const deleteHistory = useCallback(
+    async (changeId: string) => {
+      await fetch(`/api/status-changes/${changeId}`, { method: 'DELETE' });
+      await load();
+    },
+    [load]
+  );
 
   useEffect(() => {
     load();
@@ -202,15 +239,47 @@ export default function AdminMenteeDetailPage() {
                 ) : (
                   <ol className="space-y-2">
                     {rel.statusChanges.map((sc) => (
-                      <li key={sc.id} className="text-sm border-l-2 border-blue-100 pl-3">
-                        <span className="text-gray-400">{pipelineLabel(sc.fromStatus, locale)}</span>
-                        {' → '}
-                        <span className="font-medium">{pipelineLabel(sc.toStatus, locale)}</span>
-                        <span className="text-xs text-gray-400"> · {sc.changedBy.fullName} · {new Date(sc.createdAt).toLocaleDateString()}</span>
+                      <li key={sc.id} className="group flex items-center gap-2 text-sm border-l-2 border-blue-100 pl-3">
+                        <span className="flex-1 min-w-0">
+                          <span className="text-gray-400">{pipelineLabel(sc.fromStatus, locale)}</span>
+                          {' → '}
+                          <span className="font-medium">{pipelineLabel(sc.toStatus, locale)}</span>
+                          <span className="text-xs text-gray-400"> · {sc.changedBy.fullName} · {new Date(sc.createdAt).toLocaleDateString()}</span>
+                        </span>
+                        <button
+                          onClick={() => deleteHistory(sc.id)}
+                          title={t.candidateDetail.deleteEntry}
+                          className="text-gray-300 hover:text-red-500 opacity-0 group-hover:opacity-100 transition"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </button>
                       </li>
                     ))}
                   </ol>
                 )}
+
+                {/* Manually add a correcting history entry */}
+                <div className="mt-3 flex flex-wrap items-end gap-2 rounded-lg border border-gray-100 bg-gray-50 p-3">
+                  <div className="w-40">
+                    <Select label={t.candidateDetail.from} options={pipelineOptions(locale)} value={histFrom} onChange={(e) => setHistFrom(e.target.value)} />
+                  </div>
+                  <div className="w-40">
+                    <Select label={t.candidateDetail.to} options={pipelineOptions(locale)} value={histTo} onChange={(e) => setHistTo(e.target.value)} />
+                  </div>
+                  <div>
+                    <label className="block text-xs text-gray-500 mb-1">{t.candidateDetail.date}</label>
+                    <input
+                      type="date"
+                      value={histDate}
+                      onChange={(e) => setHistDate(e.target.value)}
+                      className="px-3 py-2 border border-gray-300 rounded-lg text-sm"
+                    />
+                  </div>
+                  <Button size="sm" loading={histBusy} onClick={() => addHistory(rel.id)}>
+                    <Plus className="h-4 w-4 mr-1" />
+                    {t.candidateDetail.addEntry}
+                  </Button>
+                </div>
               </div>
 
               <div>

--- a/src/app/api/status-changes/[id]/route.ts
+++ b/src/app/api/status-changes/[id]/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+// DELETE — admin removes an incorrect stage-history entry.
+export async function DELETE(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { id } = await params;
+  try {
+    await prisma.statusChange.delete({ where: { id } });
+  } catch {
+    return NextResponse.json({ error: 'Entry not found' }, { status: 404 });
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/status-changes/route.ts
+++ b/src/app/api/status-changes/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { z } from 'zod';
+import type { PipelineStatus } from '@prisma/client';
+import { PIPELINE_STATUSES } from '@/lib/pipeline';
+
+const stage = z.enum(PIPELINE_STATUSES as unknown as [string, ...string[]]);
+const schema = z.object({
+  relationId: z.string().min(1),
+  fromStatus: stage,
+  toStatus: stage,
+  createdAt: z.string().datetime().optional(),
+});
+
+// POST — admin manually adds a stage-history entry to correct the audit trail.
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const parsed = schema.safeParse(await request.json());
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const { relationId, fromStatus, toStatus, createdAt } = parsed.data;
+  const relation = await prisma.mentorshipRelation.findUnique({ where: { id: relationId } });
+  if (!relation) {
+    return NextResponse.json({ error: 'Relation not found' }, { status: 404 });
+  }
+
+  const change = await prisma.statusChange.create({
+    data: {
+      relationId,
+      fromStatus: fromStatus as PipelineStatus,
+      toStatus: toStatus as PipelineStatus,
+      changedById: session.user.id,
+      ...(createdAt ? { createdAt: new Date(createdAt) } : {}),
+    },
+  });
+
+  return NextResponse.json({ change }, { status: 201 });
+}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -81,6 +81,11 @@ const en = {
     noInteractions: 'No interactions logged',
     resetPassword: 'Reset password',
     resetPwHint: 'A reset link was emailed to this user. You can also share it directly:',
+    from: 'From',
+    to: 'To',
+    date: 'Date',
+    addEntry: 'Add entry',
+    deleteEntry: 'Delete entry',
   },
   mentors: {
     title: 'Mentors',
@@ -360,6 +365,11 @@ const tr: Dict = {
     noInteractions: 'Henüz etkileşim yok',
     resetPassword: 'Parolayı sıfırla',
     resetPwHint: 'Bu kullanıcıya bir sıfırlama bağlantısı e-postalandı. İstersen doğrudan da paylaşabilirsin:',
+    from: 'Önceki',
+    to: 'Sonraki',
+    date: 'Tarih',
+    addEntry: 'Kayıt ekle',
+    deleteEntry: 'Kaydı sil',
   },
   mentors: {
     title: 'Mentorlar',


### PR DESCRIPTION
## S9.4 · Aşama geçmişini manuel düzenleme (EPIC 9 · #102) — epic'i tamamlar

- **POST /api/status-changes** (admin): manuel StatusChange ekler (from/to + opsiyonel tarih), admin'e atfedilir.
- **DELETE /api/status-changes/[id]** (admin): hatalı kaydı siler.
- **Admin mentee detay**: her satırda çöp kutusu + timeline altında ekleme formu (from/to select + tarih).
- i18n EN+TR.
- **e2e**: admin kayıt ekler (kalıcı + atıflı) sonra siler.

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)