### PR TITLE
feat(documents): CV upload / view / delete (#120)

### DIFF
--- a/e2e/cv-upload.spec.ts
+++ b/e2e/cv-upload.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+const PDF = Buffer.from('%PDF-1.4\n1 0 obj<</Type/Catalog>>endobj\ntrailer<</Root 1 0 R>>\n%%EOF');
+
+test('mentee can upload, view and delete their CV', async ({ page }) => {
+  const email = uniqueEmail('cvmentee');
+  const user = await seedUser(email, 'MenteePass123!', 'MENTEE', 'CV Mentee');
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', email);
+    await page.fill('input[type="password"]', 'MenteePass123!');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/portal'), { timeout: 20_000 });
+
+    await page.goto('/portal/profile');
+
+    // Upload a CV via the hidden file input.
+    const uploaded = page.waitForResponse(
+      (r) => r.url().endsWith('/api/cv') && r.request().method() === 'POST'
+    );
+    await page.locator('input[type="file"]').setInputFiles({
+      name: 'cv.pdf',
+      mimeType: 'application/pdf',
+      buffer: PDF,
+    });
+    await uploaded;
+
+    await expect(page.getByRole('link', { name: 'View CV' })).toBeVisible({ timeout: 10_000 });
+    const cv = await prisma.cvFile.findUnique({ where: { userId: user.id } });
+    expect(cv).not.toBeNull();
+    expect(cv!.contentType).toBe('application/pdf');
+
+    // Delete it.
+    const removed = page.waitForResponse(
+      (r) => r.url().includes(`/api/cv/${user.id}`) && r.request().method() === 'DELETE'
+    );
+    await page.getByRole('button', { name: 'Delete' }).click();
+    await removed;
+    await expect(page.getByText('No CV uploaded')).toBeVisible({ timeout: 10_000 });
+
+    const after = await prisma.cvFile.findUnique({ where: { userId: user.id } });
+    expect(after).toBeNull();
+  } finally {
+    await cleanupByEmail(email);
+  }
+});

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -71,6 +71,21 @@ model User {
   statusChanges           StatusChange[]           @relation("StatusChangedBy")
   passwordResetTokens     PasswordResetToken[]
   emailVerificationTokens EmailVerificationToken[]
+  cvFile                  CvFile?
+}
+
+// A user's CV stored in the database (no external object storage needed, so it
+// survives container redeploys). Served via /api/cv/[userId].
+model CvFile {
+  id          String   @id @default(cuid())
+  userId      String   @unique
+  filename    String
+  contentType String
+  size        Int
+  data        Bytes
+  uploadedAt  DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 
 model Company {

--- a/src/app/admin/candidates/[id]/page.tsx
+++ b/src/app/admin/candidates/[id]/page.tsx
@@ -7,8 +7,9 @@ import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Badge } from '@/components/ui/Badge';
 import { Select } from '@/components/ui/Select';
 import { Button } from '@/components/ui/Button';
-import { ArrowLeft, ExternalLink, KeyRound, Trash2, Plus } from 'lucide-react';
+import { ArrowLeft, KeyRound, Trash2, Plus } from 'lucide-react';
 import { pipelineLabel, pipelineOptions, PIPELINE_STATUSES } from '@/lib/pipeline';
+import { CvManager } from '@/components/CvManager';
 import { useT, useLocale } from '@/i18n/client';
 
 interface Interaction { id: string; date: string; notes: string; type: string }
@@ -201,11 +202,9 @@ export default function AdminMenteeDetailPage() {
                 </div>
               </div>
             )}
-            {user.cvUrl && (
-              <a href={user.cvUrl} target="_blank" rel="noopener noreferrer" className="flex items-center gap-1 text-sm text-blue-600 hover:underline">
-                <ExternalLink className="h-3 w-3" /> {t.candidateDetail.viewCv}
-              </a>
-            )}
+            <div className="pt-1">
+              <CvManager targetUserId={user.id} initialCvUrl={user.cvUrl} />
+            </div>
           </div>
         </Card>
 

--- a/src/app/api/cv/[userId]/route.ts
+++ b/src/app/api/cv/[userId]/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { canAccessCv } from '@/lib/cvAccess';
+
+// GET — download a user's CV (access-controlled).
+export async function GET(_request: Request, { params }: { params: Promise<{ userId: string }> }) {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { userId } = await params;
+  if (!(await canAccessCv(session.user, userId))) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const cv = await prisma.cvFile.findUnique({ where: { userId } });
+  if (!cv) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+  return new NextResponse(Buffer.from(cv.data), {
+    headers: {
+      'Content-Type': cv.contentType,
+      'Content-Disposition': `inline; filename="${cv.filename.replace(/"/g, '')}"`,
+      'Content-Length': String(cv.size),
+    },
+  });
+}
+
+// DELETE — remove a user's CV.
+export async function DELETE(_request: Request, { params }: { params: Promise<{ userId: string }> }) {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { userId } = await params;
+  if (!(await canAccessCv(session.user, userId))) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  await prisma.cvFile.deleteMany({ where: { userId } });
+  await prisma.user.update({ where: { id: userId }, data: { cvUrl: null } });
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/cv/route.ts
+++ b/src/app/api/cv/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { canAccessCv } from '@/lib/cvAccess';
+
+const MAX_BYTES = 5 * 1024 * 1024; // 5 MB
+const ALLOWED = new Set([
+  'application/pdf',
+  'application/msword',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+]);
+
+// POST (multipart) — upload/replace a CV. field "file", optional "targetUserId".
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const form = await request.formData();
+  const file = form.get('file');
+  const targetUserId = (form.get('targetUserId') as string) || session.user.id;
+
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: 'No file provided' }, { status: 400 });
+  }
+  if (!(await canAccessCv(session.user, targetUserId))) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+  if (!ALLOWED.has(file.type)) {
+    return NextResponse.json({ error: 'Only PDF or Word documents are allowed' }, { status: 400 });
+  }
+  if (file.size > MAX_BYTES) {
+    return NextResponse.json({ error: 'File too large (max 5 MB)' }, { status: 400 });
+  }
+
+  const data = Buffer.from(await file.arrayBuffer());
+  await prisma.cvFile.upsert({
+    where: { userId: targetUserId },
+    create: { userId: targetUserId, filename: file.name, contentType: file.type, size: file.size, data },
+    update: { filename: file.name, contentType: file.type, size: file.size, data },
+  });
+  await prisma.user.update({ where: { id: targetUserId }, data: { cvUrl: `/api/cv/${targetUserId}` } });
+
+  return NextResponse.json({ ok: true, filename: file.name });
+}

--- a/src/app/portal/profile/page.tsx
+++ b/src/app/portal/profile/page.tsx
@@ -9,6 +9,7 @@ import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Input } from '@/components/ui/Input';
 import { Button } from '@/components/ui/Button';
 import { Select } from '@/components/ui/Select';
+import { CvManager } from '@/components/CvManager';
 
 const profileSchema = z.object({
   fullName: z.string().min(1, 'Full name is required'),
@@ -39,6 +40,8 @@ export default function ProfilePage() {
   const [saving, setSaving] = useState(false);
   const [success, setSuccess] = useState(false);
   const [error, setError] = useState('');
+  const [userId, setUserId] = useState('');
+  const [initialCv, setInitialCv] = useState<string | null>(null);
 
   const {
     register,
@@ -54,6 +57,8 @@ export default function ProfilePage() {
       .then((res) => res.json())
       .then(({ user }) => {
         if (user) {
+          setUserId(user.id);
+          setInitialCv(user.cvUrl || null);
           reset({
             fullName: user.fullName,
             phone: user.phone || '',
@@ -198,6 +203,11 @@ export default function ProfilePage() {
                 {...register('cvUrl')}
                 error={errors.cvUrl?.message}
               />
+              {userId && (
+                <div className="border-t border-gray-100 pt-4">
+                  <CvManager targetUserId={userId} initialCvUrl={initialCv} />
+                </div>
+              )}
             </div>
           </div>
 

--- a/src/components/CvManager.tsx
+++ b/src/components/CvManager.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { FileText, Trash2, Upload } from 'lucide-react';
+import { Button } from '@/components/ui/Button';
+import { useT } from '@/i18n/client';
+
+// Upload / view / replace / delete a CV. Used by the mentee (self) on the
+// portal profile and by mentor/admin on a mentee's detail page.
+export function CvManager({ targetUserId, initialCvUrl }: { targetUserId?: string; initialCvUrl?: string | null }) {
+  const t = useT();
+  const [cvUrl, setCvUrl] = useState<string | null>(initialCvUrl ?? null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const upload = async (file: File) => {
+    setBusy(true);
+    setError('');
+    try {
+      const fd = new FormData();
+      fd.append('file', file);
+      if (targetUserId) fd.append('targetUserId', targetUserId);
+      const res = await fetch('/api/cv', { method: 'POST', body: fd });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Upload failed');
+      setCvUrl(targetUserId ? `/api/cv/${targetUserId}` : data.url ?? '/api/cv/me');
+      // cache-bust the view link
+      setCvUrl((u) => (u ? `${u.split('?')[0]}?t=${Date.now()}` : u));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Upload failed');
+    } finally {
+      setBusy(false);
+      if (fileRef.current) fileRef.current.value = '';
+    }
+  };
+
+  const remove = async () => {
+    if (!cvUrl) return;
+    setBusy(true);
+    try {
+      const base = cvUrl.split('?')[0];
+      await fetch(base, { method: 'DELETE' });
+      setCvUrl(null);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div>
+      <p className="text-xs text-gray-500 mb-1">{t.cv.title}</p>
+      {error && <p className="text-xs text-red-600 mb-1">{error}</p>}
+      <div className="flex flex-wrap items-center gap-2">
+        {cvUrl ? (
+          <a
+            href={cvUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 text-sm text-blue-600 hover:underline"
+          >
+            <FileText className="h-4 w-4" /> {t.cv.view}
+          </a>
+        ) : (
+          <span className="text-sm text-gray-400">{t.cv.none}</span>
+        )}
+
+        <input
+          ref={fileRef}
+          type="file"
+          accept=".pdf,.doc,.docx,application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+          className="hidden"
+          onChange={(e) => {
+            const f = e.target.files?.[0];
+            if (f) upload(f);
+          }}
+        />
+        <Button type="button" variant="outline" size="sm" loading={busy} onClick={() => fileRef.current?.click()}>
+          <Upload className="h-4 w-4 mr-1" />
+          {cvUrl ? t.cv.replace : t.cv.upload}
+        </Button>
+        {cvUrl && (
+          <Button type="button" variant="ghost" size="sm" disabled={busy} onClick={remove}>
+            <Trash2 className="h-4 w-4 mr-1" />
+            {t.cv.delete}
+          </Button>
+        )}
+      </div>
+      <p className="text-xs text-gray-400 mt-1">{t.cv.hint}</p>
+    </div>
+  );
+}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -256,6 +256,15 @@ const en = {
     yes: "Yes, I'll attend",
     no: "Can't attend",
   },
+  cv: {
+    title: 'CV / Resume',
+    upload: 'Upload CV',
+    replace: 'Replace CV',
+    view: 'View CV',
+    delete: 'Delete',
+    none: 'No CV uploaded',
+    hint: 'PDF or Word, up to 5 MB.',
+  },
   portal: {
     welcome: 'Welcome',
     dashSubtitle: 'Your internship dashboard',
@@ -574,6 +583,15 @@ const tr: Dict = {
     declined: 'Katılamayacağını bildirdiğin için teşekkürler.',
     yes: 'Evet, katılacağım',
     no: 'Katılamam',
+  },
+  cv: {
+    title: 'CV / Özgeçmiş',
+    upload: 'CV yükle',
+    replace: 'CV’yi değiştir',
+    view: 'CV’yi gör',
+    delete: 'Sil',
+    none: 'CV yüklenmemiş',
+    hint: 'PDF veya Word, en fazla 5 MB.',
   },
   portal: {
     welcome: 'Hoş geldin',

--- a/src/lib/cvAccess.ts
+++ b/src/lib/cvAccess.ts
@@ -1,0 +1,20 @@
+import { prisma } from '@/lib/prisma';
+
+interface SessionUser {
+  id: string;
+  role: string;
+}
+
+// A CV is accessible to the owner, any admin, or a mentor who mentors that user.
+export async function canAccessCv(user: SessionUser, targetUserId: string) {
+  if (user.id === targetUserId) return true;
+  if (user.role === 'ADMIN') return true;
+  if (user.role === 'MENTOR') {
+    const rel = await prisma.mentorshipRelation.findFirst({
+      where: { mentorId: user.id, menteeId: targetUserId },
+      select: { id: true },
+    });
+    return !!rel;
+  }
+  return false;
+}


### PR DESCRIPTION
## S12.1 · CV upload / sil / yönet (EPIC 12 · #105)

- **schema**: `CvFile` (kullanıcı başına bir tane, byte'lar DB'de → harici depolama olmadan redeploy'a dayanıklı).
- **POST /api/cv** (multipart): yükle/değiştir, tip (PDF/Word) + boyut (≤5MB) doğrular; `User.cvUrl`'i `/api/cv/[id]` yapar. **GET /api/cv/[userId]** dosyayı sunar; **DELETE** siler. Erişim kontrolü (`lib/cvAccess`): sahip, admin veya mentee'nin mentoru.
- **CvManager** bileşeni (yükle/değiştir/gör/sil) portal profilde (mentee, kendi) ve admin mentee detayda (admin/mentor).
- i18n EN+TR.
- **e2e**: mentee PDF yükler, view linkini görür, siler.

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)