### PR TITLE
feat(public): COMPANY role — read-only company portal (#116)

### DIFF
--- a/e2e/company-role.spec.ts
+++ b/e2e/company-role.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test';
+import bcrypt from 'bcryptjs';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('a COMPANY user sees their linked candidates read-only and cannot reach admin', async ({ page }) => {
+  const companyEmail = uniqueEmail('companyuser');
+  const mentorEmail = uniqueEmail('coMentor');
+  const menteeEmail = uniqueEmail('coMentee');
+  const pw = 'CompanyPass123!';
+
+  const company = await prisma.company.create({ data: { name: `Acme ${Date.now()}` } });
+  const companyUser = await prisma.user.create({
+    data: {
+      email: companyEmail,
+      password: await bcrypt.hash(pw, 10),
+      role: 'COMPANY',
+      fullName: 'Acme Observer',
+      companyId: company.id,
+      skills: [],
+    },
+  });
+  const mentor = await seedUser(mentorEmail, 'x', 'MENTOR', 'Co Mentor');
+  const mentee = await seedUser(menteeEmail, 'x', 'MENTEE', 'Linked Candidate');
+  const rel = await prisma.mentorshipRelation.create({
+    data: { mentorId: mentor.id, menteeId: mentee.id, companyId: company.id },
+  });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', companyEmail);
+    await page.fill('input[type="password"]', pw);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/company'), { timeout: 20_000 });
+
+    // Sees the candidate linked to its company.
+    await expect(page.getByText('Linked Candidate')).toBeVisible({ timeout: 10_000 });
+
+    // Cannot access the admin panel (redirected away).
+    await page.goto('/admin');
+    await page.waitForURL((u) => !u.pathname.startsWith('/admin'), { timeout: 20_000 });
+    expect(new URL(page.url()).pathname.startsWith('/admin')).toBe(false);
+  } finally {
+    await prisma.mentorshipRelation.deleteMany({ where: { id: rel.id } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+    await prisma.user.deleteMany({ where: { id: companyUser.id } });
+    await prisma.company.deleteMany({ where: { id: company.id } });
+  }
+});

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,6 +12,7 @@ enum Role {
   ADMIN
   MENTOR
   MENTEE
+  COMPANY
 }
 
 enum MentorshipStatus {
@@ -65,6 +66,8 @@ model User {
   isActive       Boolean   @default(true)
   // Opt-in: expose a limited, PII-free public profile at /p/[id].
   publicProfile  Boolean   @default(false)
+  // For COMPANY-role users: which company they observe (read-only).
+  companyId      String?
   createdAt      DateTime  @default(now())
   updatedAt      DateTime  @updatedAt
 
@@ -74,6 +77,7 @@ model User {
   passwordResetTokens     PasswordResetToken[]
   emailVerificationTokens EmailVerificationToken[]
   cvFile                  CvFile?
+  company                 Company?                 @relation("CompanyUsers", fields: [companyId], references: [id])
 }
 
 // A user's CV stored in the database (no external object storage needed, so it
@@ -101,6 +105,7 @@ model Company {
 
   needs       CompanyNeed[]
   mentorships MentorshipRelation[]
+  users       User[]               @relation("CompanyUsers")
 }
 
 model CompanyNeed {

--- a/src/app/admin/companies/page.tsx
+++ b/src/app/admin/companies/page.tsx
@@ -28,6 +28,31 @@ export default function CompaniesPage() {
   const [showForm, setShowForm] = useState(false);
   const [editingCompany, setEditingCompany] = useState<Company | null>(null);
   const [error, setError] = useState('');
+  const [clCompanyId, setClCompanyId] = useState('');
+  const [clEmail, setClEmail] = useState('');
+  const [clName, setClName] = useState('');
+  const [clMsg, setClMsg] = useState('');
+  const [clBusy, setClBusy] = useState(false);
+
+  const createCompanyLogin = async () => {
+    setClBusy(true);
+    setClMsg('');
+    try {
+      const res = await fetch('/api/admin/company-users', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ companyId: clCompanyId, email: clEmail, fullName: clName }),
+      });
+      const data = await res.json();
+      setClMsg(res.ok ? t.companiesPage.loginCreated : data.error || 'Failed');
+      if (res.ok) {
+        setClEmail('');
+        setClName('');
+      }
+    } finally {
+      setClBusy(false);
+    }
+  };
 
   const fetchCompanies = async () => {
     try {
@@ -116,6 +141,53 @@ export default function CompaniesPage() {
           {error}
         </div>
       )}
+
+      {/* Provision a read-only company login */}
+      <Card className="mb-6">
+        <CardHeader>
+          <CardTitle>{t.companiesPage.addLogin}</CardTitle>
+          <CardDescription>{t.companiesPage.addLoginHint}</CardDescription>
+        </CardHeader>
+        {clMsg && <p className="text-sm text-gray-700 mb-3">{clMsg}</p>}
+        <div className="flex flex-wrap items-end gap-2">
+          <select
+            value={clCompanyId}
+            onChange={(e) => setClCompanyId(e.target.value)}
+            className="px-3 py-2 border border-gray-300 rounded-lg text-sm"
+          >
+            <option value="">{t.companiesPage.selectCompany}</option>
+            {companies.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+          <input
+            type="text"
+            aria-label={t.companiesPage.loginName}
+            placeholder={t.companiesPage.loginName}
+            value={clName}
+            onChange={(e) => setClName(e.target.value)}
+            className="px-3 py-2 border border-gray-300 rounded-lg text-sm"
+          />
+          <input
+            type="email"
+            aria-label={t.companiesPage.loginEmail}
+            placeholder={t.companiesPage.loginEmail}
+            value={clEmail}
+            onChange={(e) => setClEmail(e.target.value)}
+            className="px-3 py-2 border border-gray-300 rounded-lg text-sm"
+          />
+          <Button
+            type="button"
+            loading={clBusy}
+            disabled={!clCompanyId || !clEmail || !clName}
+            onClick={createCompanyLogin}
+          >
+            {t.companiesPage.createLogin}
+          </Button>
+        </div>
+      </Card>
 
       {/* Create/Edit Modal */}
       {(showForm || editingCompany) && (

--- a/src/app/api/admin/company-users/route.ts
+++ b/src/app/api/admin/company-users/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { z } from 'zod';
+import { createPasswordResetToken } from '@/lib/passwordReset';
+import { sendPasswordResetEmail } from '@/services/emailService';
+
+const schema = z.object({
+  companyId: z.string().min(1),
+  email: z.string().email(),
+  fullName: z.string().min(1),
+});
+
+// POST — admin provisions a read-only COMPANY login for a company. The user is
+// created unverified with a placeholder password and emailed a set-password link.
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const parsed = schema.safeParse(await request.json());
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Validation failed' }, { status: 400 });
+  }
+  const { companyId, email, fullName } = parsed.data;
+
+  const company = await prisma.company.findUnique({ where: { id: companyId } });
+  if (!company) return NextResponse.json({ error: 'Company not found' }, { status: 404 });
+
+  const existing = await prisma.user.findUnique({ where: { email } });
+  if (existing) return NextResponse.json({ error: 'An account with this email already exists' }, { status: 409 });
+
+  const user = await prisma.user.create({
+    data: { email, fullName, role: 'COMPANY', companyId, password: '!company-no-login', emailVerified: false, skills: [] },
+  });
+
+  const token = await createPasswordResetToken(user.id, 'SET_INITIAL');
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+  try {
+    await sendPasswordResetEmail({ to: user.email, token, fullName: user.fullName, purpose: 'SET_INITIAL' });
+  } catch (e) {
+    console.error('Company-user set-password email failed:', e);
+  }
+
+  return NextResponse.json({ ok: true, setPasswordUrl: `${appUrl}/auth/reset?token=${token}` });
+}

--- a/src/app/api/mentorship/route.ts
+++ b/src/app/api/mentorship/route.ts
@@ -28,6 +28,9 @@ export async function GET(request: Request) {
       where.mentorId = session.user.id;
     } else if (session.user.role === 'MENTEE') {
       where.menteeId = session.user.id;
+    } else if (session.user.role === 'COMPANY') {
+      // Read-only: only relations linked to this company.
+      where.companyId = session.user.companyId ?? '__none__';
     }
 
     if (status) {

--- a/src/app/api/register/route.ts
+++ b/src/app/api/register/route.ts
@@ -28,7 +28,7 @@ export async function POST(request: Request) {
 
     // With a token: validate the invitation and use its role.
     // Without a token: open self-registration as a MENTOR.
-    let role: 'ADMIN' | 'MENTOR' | 'MENTEE' = 'MENTOR';
+    let role: 'ADMIN' | 'MENTOR' | 'MENTEE' | 'COMPANY' = 'MENTOR';
 
     if (token) {
       const invitation = await prisma.invitationToken.findUnique({ where: { token } });

--- a/src/app/company/layout.tsx
+++ b/src/app/company/layout.tsx
@@ -1,0 +1,67 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { redirect } from 'next/navigation';
+import Link from 'next/link';
+import { GraduationCap, LayoutDashboard, LogOut } from 'lucide-react';
+import { getServerDictionary } from '@/i18n/server';
+import { LanguageSwitcher } from '@/components/LanguageSwitcher';
+import { ResponsiveShell } from '@/components/ResponsiveShell';
+
+export default async function CompanyLayout({ children }: { children: React.ReactNode }) {
+  const session = await getServerSession(authOptions);
+
+  if (!session) redirect('/auth/signin');
+  if (session.user.role !== 'COMPANY' && session.user.role !== 'ADMIN') redirect('/');
+
+  const { locale, t } = await getServerDictionary();
+
+  return (
+    <ResponsiveShell
+      sidebar={
+        <aside className="w-64 h-full bg-white border-r border-gray-200 flex flex-col">
+          <div className="p-6 border-b border-gray-200">
+            <div className="flex items-center gap-2">
+              <GraduationCap className="h-7 w-7 text-blue-600" />
+              <span className="font-bold text-gray-900">InternshipCRM</span>
+            </div>
+            <p className="text-xs text-gray-500 mt-1">{t.panel.company}</p>
+          </div>
+
+          <nav className="flex-1 p-4 space-y-1 overflow-y-auto">
+            <Link
+              href="/company"
+              className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-gray-700 hover:bg-blue-50 hover:text-blue-700 transition-colors group"
+            >
+              <LayoutDashboard className="h-5 w-5 text-gray-400 group-hover:text-blue-600" />
+              {t.nav.dashboard}
+            </Link>
+          </nav>
+
+          <div className="p-4 border-t border-gray-200">
+            <div className="flex items-center gap-3 mb-3 px-3">
+              <div className="w-8 h-8 bg-indigo-100 rounded-full flex items-center justify-center">
+                <span className="text-indigo-700 font-semibold text-sm">{session.user.name?.[0] || 'C'}</span>
+              </div>
+              <div className="min-w-0">
+                <p className="text-sm font-medium text-gray-900 truncate">{session.user.name}</p>
+                <p className="text-xs text-gray-500 truncate">{session.user.email}</p>
+              </div>
+            </div>
+            <Link
+              href="/api/auth/signout"
+              className="flex items-center gap-2 w-full px-3 py-2 text-sm text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+            >
+              <LogOut className="h-4 w-4" />
+              {t.nav.signOut}
+            </Link>
+            <div className="mt-3 px-3">
+              <LanguageSwitcher current={locale} />
+            </div>
+          </div>
+        </aside>
+      }
+    >
+      {children}
+    </ResponsiveShell>
+  );
+}

--- a/src/app/company/page.tsx
+++ b/src/app/company/page.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
+import { Badge } from '@/components/ui/Badge';
+import { pipelineLabel } from '@/lib/pipeline';
+import { useT, useLocale } from '@/i18n/client';
+
+interface Relation {
+  id: string;
+  pipelineStatus: string;
+  mentee: { fullName: string; university?: string };
+  mentor: { fullName: string };
+}
+
+// Read-only company overview: the mentees linked to this company.
+export default function CompanyOverviewPage() {
+  const t = useT();
+  const locale = useLocale();
+  const [relations, setRelations] = useState<Relation[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch('/api/mentorship')
+      .then((r) => r.json())
+      .then((d) => setRelations(d.relations ?? []))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900">{t.company.title}</h1>
+        <p className="text-gray-500 mt-1">{t.company.subtitle}</p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>{t.company.candidates} ({relations.length})</CardTitle>
+        </CardHeader>
+        {loading ? (
+          <p className="text-center py-12 text-gray-400">{t.common.loading}</p>
+        ) : relations.length === 0 ? (
+          <p className="text-center py-12 text-gray-400">{t.company.none}</p>
+        ) : (
+          <div className="divide-y divide-gray-50">
+            {relations.map((r) => (
+              <div key={r.id} className="flex items-center justify-between gap-3 py-3">
+                <div className="min-w-0">
+                  <p className="text-sm font-medium text-gray-900 truncate">{r.mentee.fullName}</p>
+                  <p className="text-xs text-gray-500 truncate">
+                    {r.mentee.university ? `${r.mentee.university} · ` : ''}
+                    {t.company.mentor}: {r.mentor.fullName}
+                  </p>
+                </div>
+                <Badge variant="info" className="flex-shrink-0">
+                  {pipelineLabel(r.pipelineStatus, locale)}
+                </Badge>
+              </div>
+            ))}
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/src/app/portal/layout.tsx
+++ b/src/app/portal/layout.tsx
@@ -22,6 +22,10 @@ export default async function PortalLayout({ children }: { children: React.React
     redirect('/mentor');
   }
 
+  if (session.user.role === 'COMPANY') {
+    redirect('/company');
+  }
+
   const { locale, t } = await getServerDictionary();
 
   return (

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -23,8 +23,16 @@ const en = {
     admin: 'Admin Panel',
     mentor: 'Mentor Portal',
     mentee: 'Mentee Portal',
+    company: 'Company Portal',
   },
   lang: { en: 'English', tr: 'Türkçe', label: 'Language' },
+  company: {
+    title: 'Company overview',
+    subtitle: 'Candidates linked to your company (read-only)',
+    candidates: 'Candidates',
+    mentor: 'Mentor',
+    none: 'No candidates linked yet',
+  },
   common: {
     loading: 'Loading...',
     notFound: 'Not found',
@@ -102,6 +110,13 @@ const en = {
   companiesPage: {
     title: 'Companies',
     subtitle: 'Manage partner companies and their internship needs',
+    addLogin: 'Add a company login',
+    addLoginHint: 'Create a read-only login for a company to observe its linked candidates.',
+    selectCompany: 'Select a company…',
+    loginName: 'Contact name',
+    loginEmail: 'Login email',
+    createLogin: 'Create login',
+    loginCreated: 'Login created — we emailed a set-password link.',
   },
   invite: {
     title: 'Send Invitations',
@@ -381,8 +396,16 @@ const tr: Dict = {
     admin: 'Yönetim Paneli',
     mentor: 'Mentor Portalı',
     mentee: 'Mentee Portalı',
+    company: 'Şirket Portalı',
   },
   lang: { en: 'English', tr: 'Türkçe', label: 'Dil' },
+  company: {
+    title: 'Şirket genel görünümü',
+    subtitle: 'Şirketinize bağlı adaylar (salt-okunur)',
+    candidates: 'Adaylar',
+    mentor: 'Mentor',
+    none: 'Henüz bağlı aday yok',
+  },
   common: {
     loading: 'Yükleniyor...',
     notFound: 'Bulunamadı',
@@ -460,6 +483,13 @@ const tr: Dict = {
   companiesPage: {
     title: 'Şirketler',
     subtitle: 'Partner şirketleri ve staj ihtiyaçlarını yönet',
+    addLogin: 'Şirket girişi ekle',
+    addLoginHint: 'Bir şirketin kendi adaylarını izlemesi için salt-okunur giriş oluştur.',
+    selectCompany: 'Bir şirket seç…',
+    loginName: 'İletişim adı',
+    loginEmail: 'Giriş e-postası',
+    createLogin: 'Giriş oluştur',
+    loginCreated: 'Giriş oluşturuldu — parola belirleme bağlantısı e-postalandı.',
   },
   invite: {
     title: 'Davet Gönder',

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -46,6 +46,7 @@ export const authOptions: NextAuthOptions = {
           name: user.fullName,
           role: user.role,
           emailVerified: user.emailVerified,
+          companyId: user.companyId,
         };
       },
     }),
@@ -92,6 +93,7 @@ export const authOptions: NextAuthOptions = {
         token.id = user.id;
         token.role = (user as unknown as { role: string }).role;
         token.emailVerified = (user as unknown as { emailVerified: boolean }).emailVerified;
+        token.companyId = (user as unknown as { companyId?: string | null }).companyId ?? null;
         // Set when starting impersonation, absent on a normal/stop sign-in —
         // so this also clears it when returning to the original account.
         const u = user as unknown as { impersonatorId?: string; impersonatorName?: string };
@@ -108,6 +110,7 @@ export const authOptions: NextAuthOptions = {
           token.name = fresh.fullName;
           token.role = fresh.role;
           token.emailVerified = fresh.emailVerified;
+          token.companyId = fresh.companyId;
         }
       }
       return token;
@@ -119,6 +122,7 @@ export const authOptions: NextAuthOptions = {
         session.user.emailVerified = token.emailVerified as boolean;
         session.user.impersonatorId = (token.impersonatorId as string) ?? null;
         session.user.impersonatorName = (token.impersonatorName as string) ?? null;
+        session.user.companyId = (token.companyId as string) ?? null;
         if (token.email) session.user.email = token.email as string;
         if (token.name) session.user.name = token.name as string;
       }
@@ -138,6 +142,7 @@ declare module 'next-auth' {
       emailVerified?: boolean;
       impersonatorId?: string | null;
       impersonatorName?: string | null;
+      companyId?: string | null;
     };
   }
 }

--- a/src/lib/roleHome.ts
+++ b/src/lib/roleHome.ts
@@ -2,5 +2,6 @@
 export function roleHome(role?: string | null): string {
   if (role === 'ADMIN') return '/admin';
   if (role === 'MENTOR') return '/mentor';
+  if (role === 'COMPANY') return '/company';
   return '/portal';
 }


### PR DESCRIPTION
## S10.3 · COMPANY rolü — şirket girişi (read-only gözlem) (EPIC 10 · #103)

Backlog'u tamamlayan son story.

- **schema**: `Role`'e COMPANY; `User.companyId` (+ `Company.users`).
- **auth**: `companyId` JWT/session'da; `roleHome` → /company.
- **/company portalı** (layout + salt-okunur genel görünüm): COMPANY kullanıcısı yalnızca şirketine bağlı ilişkileri görür. `/api/mentorship` COMPANY için `companyId`'ye göre filtreler; portal layout COMPANY'yi /company'ye yönlendirir.
- **admin provisioning**: `POST /api/admin/company-users` COMPANY girişi oluşturur (doğrulanmamış, parola-belirleme e-postası); companies sayfasında form.
- i18n EN+TR.
- **e2e**: COMPANY kullanıcısı bağlı adayını görür, /admin'den geri yönlendirilir (yalnızca gözlem).

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)