### PR TITLE
feat(account): universal settings + deletion + password policy (#138 #139 #144)

### DIFF
--- a/e2e/account-self-service.spec.ts
+++ b/e2e/account-self-service.spec.ts
@@ -23,7 +23,7 @@ test('a mentee can change password from /account; weak passwords are rejected', 
   try {
     await signIn(page, email, oldPw, '/portal');
     await page.goto('/account');
-    await expect(page.getByRole('heading', { name: 'Account' })).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByRole('heading', { name: 'Account', exact: true })).toBeVisible({ timeout: 10_000 });
 
     // Weak password (no uppercase) is rejected by the server policy.
     await page.getByLabel(/Current password/).fill(oldPw);

--- a/e2e/account-self-service.spec.ts
+++ b/e2e/account-self-service.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from '@playwright/test';
+import bcrypt from 'bcryptjs';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+async function signIn(page: import('@playwright/test').Page, email: string, pw: string, home: string) {
+  await page.goto('/auth/signin');
+  await page.fill('input[type="email"], input[name="email"]', email);
+  await page.fill('input[type="password"]', pw);
+  await page.click('button[type="submit"]');
+  await page.waitForURL((u) => u.pathname.startsWith(home), { timeout: 20_000 });
+}
+
+test('a mentee can change password from /account; weak passwords are rejected', async ({ page }) => {
+  const email = uniqueEmail('acctmentee');
+  const oldPw = 'OldPass123!';
+  const newPw = 'FreshPass456';
+  const user = await seedUser(email, oldPw, 'MENTEE', 'Acct Mentee');
+
+  try {
+    await signIn(page, email, oldPw, '/portal');
+    await page.goto('/account');
+    await expect(page.getByRole('heading', { name: 'Account' })).toBeVisible({ timeout: 10_000 });
+
+    // Weak password (no uppercase) is rejected by the server policy.
+    await page.getByLabel(/Current password/).fill(oldPw);
+    await page.getByLabel(/^New password/).fill('weakpass');
+    await page.getByLabel(/Confirm new password/).fill('weakpass');
+    await page.getByRole('button', { name: 'Update password' }).click();
+    await expect(page.getByText(/uppercase|at least 8/i)).toBeVisible({ timeout: 10_000 });
+
+    // Valid password succeeds.
+    await page.getByLabel(/Current password/).fill(oldPw);
+    await page.getByLabel(/^New password/).fill(newPw);
+    await page.getByLabel(/Confirm new password/).fill(newPw);
+    const done = page.waitForResponse((r) => r.url().includes('/api/account') && r.request().method() === 'PUT');
+    await page.getByRole('button', { name: 'Update password' }).click();
+    await done;
+    await page.waitForTimeout(400);
+
+    const fresh = await prisma.user.findUnique({ where: { id: user.id } });
+    expect(await bcrypt.compare(newPw, fresh!.password)).toBe(true);
+  } finally {
+    await cleanupByEmail(email);
+  }
+});
+
+test('a user can delete their own account', async ({ page }) => {
+  const email = uniqueEmail('delmentee');
+  const pw = 'DeletePass123';
+  const user = await seedUser(email, pw, 'MENTEE', 'Delete Me');
+
+  try {
+    await signIn(page, email, pw, '/portal');
+    await page.goto('/account');
+    await page.getByRole('button', { name: 'Delete my account' }).click();
+    const done = page.waitForResponse((r) => r.url().includes('/api/account') && r.request().method() === 'DELETE');
+    await page.getByRole('button', { name: 'Yes, delete' }).click();
+    await done;
+
+    await expect.poll(async () => prisma.user.findUnique({ where: { id: user.id } })).toBeNull();
+  } finally {
+    await cleanupByEmail(email);
+  }
+});

--- a/src/app/account/layout.tsx
+++ b/src/app/account/layout.tsx
@@ -1,0 +1,27 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { redirect } from 'next/navigation';
+import Link from 'next/link';
+import { ArrowLeft } from 'lucide-react';
+import { roleHome } from '@/lib/roleHome';
+
+// Standalone settings page available to every authenticated role.
+export default async function AccountLayout({ children }: { children: React.ReactNode }) {
+  const session = await getServerSession(authOptions);
+  if (!session) redirect('/auth/signin');
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-5xl mx-auto p-4 lg:p-8">
+        <Link
+          href={roleHome(session.user.role)}
+          className="inline-flex items-center gap-2 text-sm text-gray-500 hover:text-gray-700 mb-6"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          {session.user.name ?? 'Back'}
+        </Link>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -2,6 +2,6 @@
 
 import { AccountSettings } from '@/components/AccountSettings';
 
-export default function AdminAccountPage() {
+export default function AccountPage() {
   return <AccountSettings />;
 }

--- a/src/app/api/account/route.ts
+++ b/src/app/api/account/route.ts
@@ -4,11 +4,12 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import bcrypt from 'bcryptjs';
 import { z } from 'zod';
+import { passwordSchema } from '@/lib/password';
 
 const schema = z.object({
   email: z.string().email().optional(),
   currentPassword: z.string().optional(),
-  newPassword: z.string().min(8).optional(),
+  newPassword: passwordSchema.optional(),
 });
 
 export async function PUT(request: Request) {
@@ -54,6 +55,40 @@ export async function PUT(request: Request) {
     return NextResponse.json({ message: 'Account updated', emailChanged: !!data.email });
   } catch (error) {
     console.error('Account update error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+// DELETE — self-service account deletion.
+export async function DELETE() {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    // Don't allow deleting an account while impersonating it.
+    if (session.user.impersonatorId) {
+      return NextResponse.json({ error: 'Cannot delete an account while impersonating it' }, { status: 400 });
+    }
+
+    const id = session.user.id;
+
+    // The last remaining admin can't delete themselves.
+    if (session.user.role === 'ADMIN') {
+      const admins = await prisma.user.count({ where: { role: 'ADMIN' } });
+      if (admins <= 1) {
+        return NextResponse.json({ error: 'The last admin account cannot be deleted' }, { status: 400 });
+      }
+    }
+
+    // Remove rows that reference the user without a cascade, then the user
+    // (cvFile + tokens cascade via their onDelete: Cascade relations).
+    await prisma.mentorshipRelation.deleteMany({ where: { OR: [{ mentorId: id }, { menteeId: id }] } });
+    await prisma.statusChange.deleteMany({ where: { changedById: id } });
+    await prisma.user.delete({ where: { id } });
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error('Account delete error:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }

--- a/src/app/api/auth/reset/route.ts
+++ b/src/app/api/auth/reset/route.ts
@@ -2,10 +2,11 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import bcrypt from 'bcryptjs';
 import { prisma } from '@/lib/prisma';
+import { passwordSchema } from '@/lib/password';
 
 const schema = z.object({
   token: z.string().min(1),
-  password: z.string().min(8, 'Password must be at least 8 characters'),
+  password: passwordSchema,
 });
 
 // GET /api/auth/reset?token=... — lightweight validity check so the reset page

--- a/src/app/api/register/route.ts
+++ b/src/app/api/register/route.ts
@@ -4,11 +4,12 @@ import { prisma } from '@/lib/prisma';
 import { z } from 'zod';
 import { createEmailVerificationToken } from '@/lib/emailVerification';
 import { sendVerificationEmail } from '@/services/emailService';
+import { passwordSchema } from '@/lib/password';
 
 const registerSchema = z.object({
   token: z.string().optional(),
   email: z.string().email('Invalid email'),
-  password: z.string().min(8, 'Password must be at least 8 characters'),
+  password: passwordSchema,
   fullName: z.string().min(1, 'Full name is required'),
 });
 

--- a/src/app/company/layout.tsx
+++ b/src/app/company/layout.tsx
@@ -38,7 +38,7 @@ export default async function CompanyLayout({ children }: { children: React.Reac
           </nav>
 
           <div className="p-4 border-t border-gray-200">
-            <div className="flex items-center gap-3 mb-3 px-3">
+            <Link href="/account" title={t.account.nav} className="flex items-center gap-3 mb-3 px-3 py-1.5 rounded-lg hover:bg-gray-50 transition-colors">
               <div className="w-8 h-8 bg-indigo-100 rounded-full flex items-center justify-center">
                 <span className="text-indigo-700 font-semibold text-sm">{session.user.name?.[0] || 'C'}</span>
               </div>
@@ -46,7 +46,7 @@ export default async function CompanyLayout({ children }: { children: React.Reac
                 <p className="text-sm font-medium text-gray-900 truncate">{session.user.name}</p>
                 <p className="text-xs text-gray-500 truncate">{session.user.email}</p>
               </div>
-            </div>
+            </Link>
             <Link
               href="/api/auth/signout"
               className="flex items-center gap-2 w-full px-3 py-2 text-sm text-red-600 hover:bg-red-50 rounded-lg transition-colors"

--- a/src/app/mentor/layout.tsx
+++ b/src/app/mentor/layout.tsx
@@ -78,7 +78,7 @@ export default async function MentorLayout({ children }: { children: React.React
         </nav>
 
         <div className="p-4 border-t border-gray-200">
-          <div className="flex items-center gap-3 mb-3 px-3">
+          <Link href="/account" title={t.account.nav} className="flex items-center gap-3 mb-3 px-3 py-1.5 rounded-lg hover:bg-gray-50 transition-colors">
             <div className="w-8 h-8 bg-green-100 rounded-full flex items-center justify-center">
               <span className="text-green-700 font-semibold text-sm">
                 {session.user.name?.[0] || 'M'}
@@ -88,7 +88,7 @@ export default async function MentorLayout({ children }: { children: React.React
               <p className="text-sm font-medium text-gray-900 truncate">{session.user.name}</p>
               <p className="text-xs text-gray-500 truncate">{session.user.email}</p>
             </div>
-          </div>
+          </Link>
           <Link
             href="/api/auth/signout"
             className="flex items-center gap-2 w-full px-3 py-2 text-sm text-red-600 hover:bg-red-50 rounded-lg transition-colors"

--- a/src/app/portal/layout.tsx
+++ b/src/app/portal/layout.tsx
@@ -65,7 +65,7 @@ export default async function PortalLayout({ children }: { children: React.React
         </nav>
 
         <div className="p-4 border-t border-gray-200">
-          <div className="flex items-center gap-3 mb-3 px-3">
+          <Link href="/account" title={t.account.nav} className="flex items-center gap-3 mb-3 px-3 py-1.5 rounded-lg hover:bg-gray-50 transition-colors">
             <div className="w-8 h-8 bg-purple-100 rounded-full flex items-center justify-center">
               <span className="text-purple-700 font-semibold text-sm">
                 {session.user.name?.[0] || 'M'}
@@ -75,7 +75,7 @@ export default async function PortalLayout({ children }: { children: React.React
               <p className="text-sm font-medium text-gray-900 truncate">{session.user.name}</p>
               <p className="text-xs text-gray-500 truncate">{session.user.email}</p>
             </div>
-          </div>
+          </Link>
           <Link
             href="/api/auth/signout"
             className="flex items-center gap-2 w-full px-3 py-2 text-sm text-red-600 hover:bg-red-50 rounded-lg transition-colors"

--- a/src/components/AccountSettings.tsx
+++ b/src/components/AccountSettings.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useSession, signOut } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
+import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
+import { Input } from '@/components/ui/Input';
+import { Button } from '@/components/ui/Button';
+import { useT } from '@/i18n/client';
+
+// Universal account settings used by every role (admin/mentor/mentee/company):
+// change email, change password, and delete the account.
+export function AccountSettings() {
+  const t = useT();
+  const { update } = useSession();
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [msg, setMsg] = useState('');
+  const [err, setErr] = useState('');
+  const [savingEmail, setSavingEmail] = useState(false);
+  const [savingPw, setSavingPw] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  useEffect(() => {
+    fetch('/api/profile')
+      .then((r) => r.json())
+      .then(({ user }) => user && setEmail(user.email));
+  }, []);
+
+  const flash = (m: string, isErr = false) => {
+    setMsg(isErr ? '' : m);
+    setErr(isErr ? m : '');
+    setTimeout(() => { setMsg(''); setErr(''); }, 4000);
+  };
+
+  const call = async (body: object) => {
+    const res = await fetch('/api/account', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || (data.details && 'Validation failed') || 'Failed');
+    return data;
+  };
+
+  const submitEmail = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSavingEmail(true);
+    try {
+      await call({ email });
+      await update();
+      router.refresh();
+      flash(t.account.updated);
+    } catch (e2) {
+      flash(e2 instanceof Error ? e2.message : 'Failed', true);
+    } finally {
+      setSavingEmail(false);
+    }
+  };
+
+  const submitPassword = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (newPassword !== confirmPassword) return flash(t.account.passwordMismatch, true);
+    setSavingPw(true);
+    try {
+      await call({ currentPassword, newPassword });
+      setCurrentPassword(''); setNewPassword(''); setConfirmPassword('');
+      flash(t.account.updated);
+    } catch (e2) {
+      flash(e2 instanceof Error ? e2.message : 'Failed', true);
+    } finally {
+      setSavingPw(false);
+    }
+  };
+
+  const deleteAccount = async () => {
+    setDeleting(true);
+    try {
+      const res = await fetch('/api/account', { method: 'DELETE' });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Failed');
+      await signOut({ callbackUrl: '/' });
+    } catch (e2) {
+      flash(e2 instanceof Error ? e2.message : 'Failed', true);
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <div>
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold text-gray-900">{t.account.title}</h1>
+        <p className="text-gray-500 mt-1">{t.account.subtitle}</p>
+      </div>
+
+      {msg && <div className="mb-4 p-3 bg-green-50 border border-green-200 rounded-lg text-green-700 text-sm">✓ {msg}</div>}
+      {err && <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">{err}</div>}
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 max-w-4xl">
+        <Card>
+          <CardHeader><CardTitle>{t.account.emailSection}</CardTitle></CardHeader>
+          <form onSubmit={submitEmail} className="space-y-4">
+            <Input label={t.account.email} type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+            <Button type="submit" loading={savingEmail}>{t.account.updateEmail}</Button>
+          </form>
+        </Card>
+
+        <Card>
+          <CardHeader><CardTitle>{t.account.passwordSection}</CardTitle></CardHeader>
+          <form onSubmit={submitPassword} className="space-y-4">
+            <Input label={t.account.currentPassword} type="password" value={currentPassword} onChange={(e) => setCurrentPassword(e.target.value)} required />
+            <Input label={t.account.newPassword} type="password" hint={t.account.passwordHint} value={newPassword} onChange={(e) => setNewPassword(e.target.value)} required />
+            <Input label={t.account.confirmPassword} type="password" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} required />
+            <Button type="submit" loading={savingPw}>{t.account.updatePassword}</Button>
+          </form>
+        </Card>
+      </div>
+
+      <Card className="mt-6 max-w-4xl border-red-200">
+        <CardHeader><CardTitle>{t.account.deleteSection}</CardTitle></CardHeader>
+        <p className="text-sm text-gray-600 mb-4">{t.account.deleteWarning}</p>
+        {confirmDelete ? (
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-sm text-red-700">{t.account.deleteConfirm}</span>
+            <Button variant="danger" loading={deleting} onClick={deleteAccount}>{t.account.deleteYes}</Button>
+            <Button variant="outline" onClick={() => setConfirmDelete(false)}>{t.account.deleteCancel}</Button>
+          </div>
+        ) : (
+          <Button variant="danger" onClick={() => setConfirmDelete(true)}>{t.account.deleteButton}</Button>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -370,6 +370,13 @@ const en = {
     updated: 'Account updated',
     reloginNote: 'Sign out and back in for changes to take full effect.',
     passwordMismatch: 'New passwords do not match',
+    passwordHint: 'At least 8 characters, with an uppercase and a lowercase letter.',
+    deleteSection: 'Delete account',
+    deleteWarning: 'Permanently delete your account and associated data. This cannot be undone.',
+    deleteButton: 'Delete my account',
+    deleteConfirm: 'Are you sure?',
+    deleteYes: 'Yes, delete',
+    deleteCancel: 'Cancel',
   },
 };
 
@@ -743,6 +750,13 @@ const tr: Dict = {
     updated: 'Hesap güncellendi',
     reloginNote: 'Değişikliklerin tam etkili olması için çıkış yapıp tekrar giriş yap.',
     passwordMismatch: 'Yeni parolalar eşleşmiyor',
+    passwordHint: 'En az 8 karakter, bir büyük ve bir küçük harf.',
+    deleteSection: 'Hesabı sil',
+    deleteWarning: 'Hesabını ve ilişkili verilerini kalıcı olarak siler. Bu işlem geri alınamaz.',
+    deleteButton: 'Hesabımı sil',
+    deleteConfirm: 'Emin misin?',
+    deleteYes: 'Evet, sil',
+    deleteCancel: 'Vazgeç',
   },
 };
 

--- a/src/lib/password.ts
+++ b/src/lib/password.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+// Project password policy (deliberately moderate, per product decision):
+// at least 8 characters, with at least one uppercase and one lowercase letter.
+// No digit/symbol requirement.
+export const PASSWORD_MIN = 8;
+
+export const passwordSchema = z
+  .string()
+  .min(PASSWORD_MIN, `Password must be at least ${PASSWORD_MIN} characters`)
+  .regex(/[a-z]/, 'Password must include a lowercase letter')
+  .regex(/[A-Z]/, 'Password must include an uppercase letter');
+
+// Returns an error message, or null when the password satisfies the policy.
+export function validatePassword(pw: string): string | null {
+  const r = passwordSchema.safeParse(pw);
+  return r.success ? null : r.error.issues[0]?.message ?? 'Invalid password';
+}


### PR DESCRIPTION
## EPIC 13 — hesap self-service

- **#138**: `AccountSettings` ortak bileşen; /admin/account ve **her role açık yeni /account** sayfası kullanıyor. Sidebar kullanıcı blokları buraya linkli.
- **#139**: self-service **hesap silme** (DELETE /api/account) — tehlike bölgesi + onay; ilişkiler/status-change temizlenir, CV/token cascade; son admin veya impersonation sırasında engellenir; kullanıcı signOut edilir.
- **#144**: parola politikası (min 8, bir büyük + bir küçük) ortak zod şeması (`src/lib/password.ts`) — register, reset ve parola değiştirmede; UI'da ipucu.
- e2e: mentee /account'tan parola değiştirir (zayıf reddedilir); kullanıcı hesabını siler.

Closes #138
Closes #139
Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)