### PR TITLE
feat(account): profile picture / avatar (#140)

### DIFF
--- a/e2e/avatar.spec.ts
+++ b/e2e/avatar.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+const PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC',
+  'base64'
+);
+
+test('a user can upload and remove a profile picture', async ({ page }) => {
+  const email = uniqueEmail('avamentee');
+  const user = await seedUser(email, 'AvatarPass123', 'MENTEE', 'Ava Tar');
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', email);
+    await page.fill('input[type="password"]', 'AvatarPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/portal'), { timeout: 20_000 });
+
+    await page.goto('/account');
+    const uploaded = page.waitForResponse((r) => r.url().endsWith('/api/avatar') && r.request().method() === 'POST');
+    await page.locator('input[type="file"]').setInputFiles({ name: 'me.png', mimeType: 'image/png', buffer: PNG });
+    await uploaded;
+
+    await expect.poll(async () => prisma.avatarFile.findUnique({ where: { userId: user.id } })).not.toBeNull();
+    const u1 = await prisma.user.findUnique({ where: { id: user.id } });
+    expect(u1!.avatarUrl).toContain(`/api/avatar/${user.id}`);
+
+    // Remove it.
+    const removed = page.waitForResponse((r) => r.url().includes(`/api/avatar/${user.id}`) && r.request().method() === 'DELETE');
+    await page.getByRole('button', { name: 'Remove' }).click();
+    await removed;
+    await expect.poll(async () => prisma.avatarFile.findUnique({ where: { userId: user.id } })).toBeNull();
+  } finally {
+    await cleanupByEmail(email);
+  }
+});

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,6 +55,7 @@ model User {
   graduationYear Int?
   skills         Json      @default("[]")
   cvUrl          String?
+  avatarUrl      String?
   whatsapp       String?
   city           String?
   birthDate      DateTime?
@@ -77,7 +78,20 @@ model User {
   passwordResetTokens     PasswordResetToken[]
   emailVerificationTokens EmailVerificationToken[]
   cvFile                  CvFile?
+  avatarFile              AvatarFile?
   company                 Company?                 @relation("CompanyUsers", fields: [companyId], references: [id])
+}
+
+// A user's profile picture, stored in the database (same approach as CvFile).
+model AvatarFile {
+  id          String   @id @default(cuid())
+  userId      String   @unique
+  contentType String
+  size        Int
+  data        Bytes
+  uploadedAt  DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 
 // A user's CV stored in the database (no external object storage needed, so it

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -6,6 +6,8 @@ import { GraduationCap, LayoutDashboard, Columns3, Building2, Users, UserCheck, 
 import { getServerDictionary } from '@/i18n/server';
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
 import { ResponsiveShell } from '@/components/ResponsiveShell';
+import { SidebarAvatar } from '@/components/SidebarAvatar';
+import { prisma } from '@/lib/prisma';
 
 export default async function AdminLayout({ children }: { children: React.ReactNode }) {
   const session = await getServerSession(authOptions);
@@ -19,6 +21,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
   }
 
   const { locale, t } = await getServerDictionary();
+  const me = await prisma.user.findUnique({ where: { id: session.user.id }, select: { avatarUrl: true } });
 
   return (
     <ResponsiveShell
@@ -97,11 +100,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
             title={t.account.title}
             className="flex items-center gap-3 mb-3 px-3 py-1.5 rounded-lg hover:bg-gray-50 transition-colors"
           >
-            <div className="w-8 h-8 bg-blue-100 rounded-full flex items-center justify-center">
-              <span className="text-blue-700 font-semibold text-sm">
-                {session.user.name?.[0] || 'A'}
-              </span>
-            </div>
+            <SidebarAvatar avatarUrl={me?.avatarUrl} name={session.user.name} fallback="A" className="bg-blue-100 text-blue-700" />
             <div className="min-w-0">
               <p className="text-sm font-medium text-gray-900 truncate">{session.user.name}</p>
               <p className="text-xs text-gray-500 truncate">{session.user.email}</p>

--- a/src/app/api/avatar/[userId]/route.ts
+++ b/src/app/api/avatar/[userId]/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+// GET — fetch a user's avatar. Any authenticated user may view avatars
+// (they're shown across lists, sidebars and profiles).
+export async function GET(_request: Request, { params }: { params: Promise<{ userId: string }> }) {
+  const { userId } = await params;
+  const session = await getServerSession(authOptions);
+  // Anonymous viewers may only see the avatar of a user with a public profile.
+  if (!session) {
+    const u = await prisma.user.findUnique({ where: { id: userId }, select: { publicProfile: true } });
+    if (!u?.publicProfile) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const avatar = await prisma.avatarFile.findUnique({ where: { userId } });
+  if (!avatar) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+  return new NextResponse(Buffer.from(avatar.data), {
+    headers: {
+      'Content-Type': avatar.contentType,
+      'Content-Length': String(avatar.size),
+      'Cache-Control': 'private, max-age=300',
+    },
+  });
+}
+
+// DELETE — remove own avatar (or admin removes anyone's).
+export async function DELETE(_request: Request, { params }: { params: Promise<{ userId: string }> }) {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { userId } = await params;
+  if (userId !== session.user.id && session.user.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  await prisma.avatarFile.deleteMany({ where: { userId } });
+  await prisma.user.update({ where: { id: userId }, data: { avatarUrl: null } });
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/avatar/route.ts
+++ b/src/app/api/avatar/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+const MAX_BYTES = 2 * 1024 * 1024; // 2 MB
+const ALLOWED = new Set(['image/png', 'image/jpeg', 'image/webp', 'image/gif']);
+
+// POST (multipart) — upload/replace own avatar (admin may set anyone's via targetUserId).
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const form = await request.formData();
+  const file = form.get('file');
+  const targetUserId = (form.get('targetUserId') as string) || session.user.id;
+
+  if (targetUserId !== session.user.id && session.user.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: 'No file provided' }, { status: 400 });
+  }
+  if (!ALLOWED.has(file.type)) {
+    return NextResponse.json({ error: 'Only PNG, JPEG, WebP or GIF images are allowed' }, { status: 400 });
+  }
+  if (file.size > MAX_BYTES) {
+    return NextResponse.json({ error: 'Image too large (max 2 MB)' }, { status: 400 });
+  }
+
+  const data = Buffer.from(await file.arrayBuffer());
+  await prisma.avatarFile.upsert({
+    where: { userId: targetUserId },
+    create: { userId: targetUserId, contentType: file.type, size: file.size, data },
+    update: { contentType: file.type, size: file.size, data },
+  });
+  await prisma.user.update({ where: { id: targetUserId }, data: { avatarUrl: `/api/avatar/${targetUserId}` } });
+
+  return NextResponse.json({ ok: true, avatarUrl: `/api/avatar/${targetUserId}` });
+}

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -44,6 +44,7 @@ export async function GET() {
         graduationYear: true,
         skills: true,
         cvUrl: true,
+        avatarUrl: true,
         publicProfile: true,
         createdAt: true,
       },

--- a/src/app/company/layout.tsx
+++ b/src/app/company/layout.tsx
@@ -6,6 +6,8 @@ import { GraduationCap, LayoutDashboard, LogOut } from 'lucide-react';
 import { getServerDictionary } from '@/i18n/server';
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
 import { ResponsiveShell } from '@/components/ResponsiveShell';
+import { SidebarAvatar } from '@/components/SidebarAvatar';
+import { prisma } from '@/lib/prisma';
 
 export default async function CompanyLayout({ children }: { children: React.ReactNode }) {
   const session = await getServerSession(authOptions);
@@ -14,6 +16,7 @@ export default async function CompanyLayout({ children }: { children: React.Reac
   if (session.user.role !== 'COMPANY' && session.user.role !== 'ADMIN') redirect('/');
 
   const { locale, t } = await getServerDictionary();
+  const me = await prisma.user.findUnique({ where: { id: session.user.id }, select: { avatarUrl: true } });
 
   return (
     <ResponsiveShell
@@ -39,9 +42,7 @@ export default async function CompanyLayout({ children }: { children: React.Reac
 
           <div className="p-4 border-t border-gray-200">
             <Link href="/account" title={t.account.nav} className="flex items-center gap-3 mb-3 px-3 py-1.5 rounded-lg hover:bg-gray-50 transition-colors">
-              <div className="w-8 h-8 bg-indigo-100 rounded-full flex items-center justify-center">
-                <span className="text-indigo-700 font-semibold text-sm">{session.user.name?.[0] || 'C'}</span>
-              </div>
+              <SidebarAvatar avatarUrl={me?.avatarUrl} name={session.user.name} fallback="C" className="bg-indigo-100 text-indigo-700" />
               <div className="min-w-0">
                 <p className="text-sm font-medium text-gray-900 truncate">{session.user.name}</p>
                 <p className="text-xs text-gray-500 truncate">{session.user.email}</p>

--- a/src/app/mentor/layout.tsx
+++ b/src/app/mentor/layout.tsx
@@ -6,6 +6,8 @@ import { GraduationCap, LayoutDashboard, Columns3, Users, BookOpen, Mail, Calend
 import { getServerDictionary } from '@/i18n/server';
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
 import { ResponsiveShell } from '@/components/ResponsiveShell';
+import { SidebarAvatar } from '@/components/SidebarAvatar';
+import { prisma } from '@/lib/prisma';
 
 export default async function MentorLayout({ children }: { children: React.ReactNode }) {
   const session = await getServerSession(authOptions);
@@ -19,6 +21,7 @@ export default async function MentorLayout({ children }: { children: React.React
   }
 
   const { locale, t } = await getServerDictionary();
+  const me = await prisma.user.findUnique({ where: { id: session.user.id }, select: { avatarUrl: true } });
 
   return (
     <ResponsiveShell
@@ -79,11 +82,7 @@ export default async function MentorLayout({ children }: { children: React.React
 
         <div className="p-4 border-t border-gray-200">
           <Link href="/account" title={t.account.nav} className="flex items-center gap-3 mb-3 px-3 py-1.5 rounded-lg hover:bg-gray-50 transition-colors">
-            <div className="w-8 h-8 bg-green-100 rounded-full flex items-center justify-center">
-              <span className="text-green-700 font-semibold text-sm">
-                {session.user.name?.[0] || 'M'}
-              </span>
-            </div>
+            <SidebarAvatar avatarUrl={me?.avatarUrl} name={session.user.name} fallback="M" className="bg-green-100 text-green-700" />
             <div className="min-w-0">
               <p className="text-sm font-medium text-gray-900 truncate">{session.user.name}</p>
               <p className="text-xs text-gray-500 truncate">{session.user.email}</p>

--- a/src/app/p/[userId]/page.tsx
+++ b/src/app/p/[userId]/page.tsx
@@ -19,6 +19,7 @@ export default async function PublicProfilePage({ params }: { params: Promise<{ 
       graduationYear: true,
       city: true,
       skills: true,
+      avatarUrl: true,
     },
   });
 
@@ -31,9 +32,14 @@ export default async function PublicProfilePage({ params }: { params: Promise<{ 
       <div className="w-full max-w-lg">
         <div className="bg-white rounded-2xl shadow-sm border border-gray-200 p-8">
           <div className="flex items-center gap-4 mb-6">
-            <div className="w-16 h-16 bg-blue-100 rounded-2xl flex items-center justify-center">
-              <span className="text-blue-700 font-bold text-2xl">{user.fullName?.[0] ?? '?'}</span>
-            </div>
+            {user.avatarUrl ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={user.avatarUrl} alt="" className="w-16 h-16 rounded-2xl object-cover border border-gray-200" />
+            ) : (
+              <div className="w-16 h-16 bg-blue-100 rounded-2xl flex items-center justify-center">
+                <span className="text-blue-700 font-bold text-2xl">{user.fullName?.[0] ?? '?'}</span>
+              </div>
+            )}
             <div>
               <h1 className="text-2xl font-bold text-gray-900">{user.fullName}</h1>
               {user.city && <p className="text-gray-500">{user.city}</p>}

--- a/src/app/portal/layout.tsx
+++ b/src/app/portal/layout.tsx
@@ -6,6 +6,8 @@ import { GraduationCap, LayoutDashboard, User, BookOpen, LogOut } from 'lucide-r
 import { getServerDictionary } from '@/i18n/server';
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
 import { ResponsiveShell } from '@/components/ResponsiveShell';
+import { SidebarAvatar } from '@/components/SidebarAvatar';
+import { prisma } from '@/lib/prisma';
 
 export default async function PortalLayout({ children }: { children: React.ReactNode }) {
   const session = await getServerSession(authOptions);
@@ -27,6 +29,7 @@ export default async function PortalLayout({ children }: { children: React.React
   }
 
   const { locale, t } = await getServerDictionary();
+  const me = await prisma.user.findUnique({ where: { id: session.user.id }, select: { avatarUrl: true } });
 
   return (
     <ResponsiveShell
@@ -66,11 +69,7 @@ export default async function PortalLayout({ children }: { children: React.React
 
         <div className="p-4 border-t border-gray-200">
           <Link href="/account" title={t.account.nav} className="flex items-center gap-3 mb-3 px-3 py-1.5 rounded-lg hover:bg-gray-50 transition-colors">
-            <div className="w-8 h-8 bg-purple-100 rounded-full flex items-center justify-center">
-              <span className="text-purple-700 font-semibold text-sm">
-                {session.user.name?.[0] || 'M'}
-              </span>
-            </div>
+            <SidebarAvatar avatarUrl={me?.avatarUrl} name={session.user.name} fallback="M" className="bg-purple-100 text-purple-700" />
             <div className="min-w-0">
               <p className="text-sm font-medium text-gray-900 truncate">{session.user.name}</p>
               <p className="text-xs text-gray-500 truncate">{session.user.email}</p>

--- a/src/components/AccountSettings.tsx
+++ b/src/components/AccountSettings.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Input } from '@/components/ui/Input';
 import { Button } from '@/components/ui/Button';
+import { AvatarManager } from '@/components/AvatarManager';
 import { useT } from '@/i18n/client';
 
 // Universal account settings used by every role (admin/mentor/mentee/company):
@@ -24,11 +25,16 @@ export function AccountSettings() {
   const [savingPw, setSavingPw] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [me, setMe] = useState<{ id: string; fullName: string; avatarUrl: string | null } | null>(null);
 
   useEffect(() => {
     fetch('/api/profile')
       .then((r) => r.json())
-      .then(({ user }) => user && setEmail(user.email));
+      .then(({ user }) => {
+        if (!user) return;
+        setEmail(user.email);
+        setMe({ id: user.id, fullName: user.fullName, avatarUrl: user.avatarUrl ?? null });
+      });
   }, []);
 
   const flash = (m: string, isErr = false) => {
@@ -100,6 +106,13 @@ export function AccountSettings() {
 
       {msg && <div className="mb-4 p-3 bg-green-50 border border-green-200 rounded-lg text-green-700 text-sm">✓ {msg}</div>}
       {err && <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">{err}</div>}
+
+      {me && (
+        <Card className="mb-6 max-w-4xl">
+          <CardHeader><CardTitle>{t.avatar.section}</CardTitle></CardHeader>
+          <AvatarManager targetUserId={me.id} initialAvatarUrl={me.avatarUrl} name={me.fullName} />
+        </Card>
+      )}
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 max-w-4xl">
         <Card>

--- a/src/components/AvatarManager.tsx
+++ b/src/components/AvatarManager.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useSession } from 'next-auth/react';
+import { Upload, Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/Button';
+import { useT } from '@/i18n/client';
+
+// Upload / replace / remove a profile picture.
+export function AvatarManager({
+  targetUserId,
+  initialAvatarUrl,
+  name,
+}: {
+  targetUserId: string;
+  initialAvatarUrl?: string | null;
+  name?: string | null;
+}) {
+  const t = useT();
+  const router = useRouter();
+  const { update } = useSession();
+  const [avatarUrl, setAvatarUrl] = useState<string | null>(initialAvatarUrl ?? null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const refreshChrome = async () => {
+    await update();
+    router.refresh();
+  };
+
+  const upload = async (file: File) => {
+    setBusy(true);
+    setError('');
+    try {
+      const fd = new FormData();
+      fd.append('file', file);
+      fd.append('targetUserId', targetUserId);
+      const res = await fetch('/api/avatar', { method: 'POST', body: fd });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Upload failed');
+      setAvatarUrl(`/api/avatar/${targetUserId}?t=${Date.now()}`);
+      await refreshChrome();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Upload failed');
+    } finally {
+      setBusy(false);
+      if (fileRef.current) fileRef.current.value = '';
+    }
+  };
+
+  const remove = async () => {
+    setBusy(true);
+    try {
+      await fetch(`/api/avatar/${targetUserId}`, { method: 'DELETE' });
+      setAvatarUrl(null);
+      await refreshChrome();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-4">
+      {avatarUrl ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={avatarUrl} alt="" className="w-16 h-16 rounded-full object-cover border border-gray-200" />
+      ) : (
+        <div className="w-16 h-16 rounded-full bg-blue-100 flex items-center justify-center">
+          <span className="text-blue-700 font-bold text-2xl">{name?.[0] ?? '?'}</span>
+        </div>
+      )}
+      <div>
+        <p className="text-xs text-gray-500 mb-1">{t.avatar.title}</p>
+        {error && <p className="text-xs text-red-600 mb-1">{error}</p>}
+        <div className="flex gap-2">
+          <input
+            ref={fileRef}
+            type="file"
+            accept="image/png,image/jpeg,image/webp,image/gif"
+            className="hidden"
+            onChange={(e) => {
+              const f = e.target.files?.[0];
+              if (f) upload(f);
+            }}
+          />
+          <Button type="button" variant="outline" size="sm" loading={busy} onClick={() => fileRef.current?.click()}>
+            <Upload className="h-4 w-4 mr-1" />
+            {avatarUrl ? t.avatar.replace : t.avatar.upload}
+          </Button>
+          {avatarUrl && (
+            <Button type="button" variant="ghost" size="sm" disabled={busy} onClick={remove}>
+              <Trash2 className="h-4 w-4 mr-1" />
+              {t.avatar.remove}
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SidebarAvatar.tsx
+++ b/src/components/SidebarAvatar.tsx
@@ -1,0 +1,22 @@
+// Small avatar for sidebars/lists: shows the uploaded image or a colored initial.
+export function SidebarAvatar({
+  avatarUrl,
+  name,
+  fallback = '?',
+  className = 'bg-blue-100 text-blue-700',
+}: {
+  avatarUrl?: string | null;
+  name?: string | null;
+  fallback?: string;
+  className?: string;
+}) {
+  if (avatarUrl) {
+    // eslint-disable-next-line @next/next/no-img-element
+    return <img src={avatarUrl} alt="" className="w-8 h-8 rounded-full object-cover border border-gray-200" />;
+  }
+  return (
+    <div className={`w-8 h-8 rounded-full flex items-center justify-center ${className}`}>
+      <span className="font-semibold text-sm">{name?.[0] || fallback}</span>
+    </div>
+  );
+}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -280,6 +280,13 @@ const en = {
     none: 'No CV uploaded',
     hint: 'PDF or Word, up to 5 MB.',
   },
+  avatar: {
+    section: 'Profile picture',
+    title: 'Profile picture',
+    upload: 'Upload photo',
+    replace: 'Replace',
+    remove: 'Remove',
+  },
   apply: {
     title: 'Apply for mentorship',
     subtitle: 'Your application goes directly to {mentor}.',
@@ -659,6 +666,13 @@ const tr: Dict = {
     delete: 'Sil',
     none: 'CV yüklenmemiş',
     hint: 'PDF veya Word, en fazla 5 MB.',
+  },
+  avatar: {
+    section: 'Profil fotoğrafı',
+    title: 'Profil fotoğrafı',
+    upload: 'Fotoğraf yükle',
+    replace: 'Değiştir',
+    remove: 'Kaldır',
   },
   apply: {
     title: 'Mentorluk başvurusu',


### PR DESCRIPTION
## S13.3 · Profil fotoğrafı (EPIC 13 · #135)

- **schema**: `User.avatarUrl` + `AvatarFile` (görsel byte'ları DB'de).
- **POST /api/avatar** (multipart, görsel tipi + 2MB), **GET /api/avatar/[id]** (auth; anonim sadece public-profilli kullanıcılar için → /p/[id] gösterebilsin), **DELETE**.
- **AvatarManager** (yükle/değiştir/kaldır) hesap ayarlarında (her rol).
- **SidebarAvatar** dört panelin sidebar'ında fotoğrafı gösterir; public profilde de.
- i18n EN+TR.
- **e2e**: PNG yükle (kalıcı + avatarUrl) sonra kaldır.

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)