### PR TITLE
feat(notifications): in-app notification center (#156)

### DIFF
--- a/e2e/notifications.spec.ts
+++ b/e2e/notifications.spec.ts
@@ -28,7 +28,7 @@ test('a new application notifies the mentor in-app', async ({ page }) => {
     await page.click('button[type="submit"]');
     await page.waitForURL((u) => u.pathname.startsWith('/mentor'), { timeout: 20_000 });
 
-    await page.getByLabel('Notifications').first().click();
+    await page.getByLabel('Notifications').last().click();
     await expect(page.getByText(/applied to be your mentee/i)).toBeVisible({ timeout: 10_000 });
   } finally {
     await cleanupByEmail(applicantEmail);

--- a/e2e/notifications.spec.ts
+++ b/e2e/notifications.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('a new application notifies the mentor in-app', async ({ page }) => {
+  const mentorEmail = uniqueEmail('notementor');
+  const applicantEmail = uniqueEmail('noteapplicant');
+  const mentor = await seedUser(mentorEmail, 'MentorPass123', 'MENTOR', 'Note Mentor');
+
+  try {
+    // Anonymous public application → should create a notification for the mentor.
+    const res = await page.request.post('/api/apply', {
+      data: { mentorId: mentor.id, fullName: 'Note Applicant', email: applicantEmail },
+    });
+    expect(res.ok()).toBeTruthy();
+
+    await expect
+      .poll(async () => prisma.notification.count({ where: { userId: mentor.id } }), { timeout: 10_000 })
+      .toBeGreaterThan(0);
+
+    // Mentor signs in and sees the notification.
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', mentorEmail);
+    await page.fill('input[type="password"]', 'MentorPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/mentor'), { timeout: 20_000 });
+
+    await page.getByLabel('Notifications').first().click();
+    await expect(page.getByText(/applied to be your mentee/i)).toBeVisible({ timeout: 10_000 });
+  } finally {
+    await cleanupByEmail(applicantEmail);
+    await cleanupByEmail(mentorEmail);
+  }
+});

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -81,7 +81,23 @@ model User {
   emailVerificationTokens EmailVerificationToken[]
   cvFile                  CvFile?
   avatarFile              AvatarFile?
+  notifications           Notification[]
   company                 Company?                 @relation("CompanyUsers", fields: [companyId], references: [id])
+}
+
+// In-app notification for a user.
+model Notification {
+  id        String   @id @default(cuid())
+  userId    String
+  type      String
+  text      String
+  link      String?
+  read      Boolean  @default(false)
+  createdAt DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
 }
 
 // A user's profile picture, stored in the database (same approach as CvFile).

--- a/src/app/api/apply/route.ts
+++ b/src/app/api/apply/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { prisma } from '@/lib/prisma';
 import { createPasswordResetToken } from '@/lib/passwordReset';
 import { sendPasswordResetEmail, sendEmail } from '@/services/emailService';
+import { notify } from '@/lib/notify';
 
 // GET ?mentorId= — public: validate the link and return the mentor's name so
 // the application page can greet the applicant.
@@ -62,6 +63,7 @@ export async function POST(request: Request) {
   });
 
   await prisma.mentorshipRelation.create({ data: { mentorId: mentor.id, menteeId: mentee.id } });
+  await notify(mentor.id, 'application', `${fullName} applied to be your mentee.`, '/mentor/mentees');
 
   // Let the applicant set a password so they can sign in to the portal.
   const token = await createPasswordResetToken(mentee.id, 'SET_INITIAL');

--- a/src/app/api/mentorship/[id]/route.ts
+++ b/src/app/api/mentorship/[id]/route.ts
@@ -5,6 +5,7 @@ import { prisma } from '@/lib/prisma';
 import { Prisma } from '@prisma/client';
 import { z } from 'zod';
 import { logActivity } from '@/lib/activity';
+import { notify } from '@/lib/notify';
 import { PIPELINE_STATUSES } from '@/lib/pipeline';
 
 const updateRelationSchema = z.object({
@@ -133,6 +134,7 @@ export async function PUT(request: Request, { params }: { params: Promise<{ id: 
         targetId: id,
         detail: `${relation.pipelineStatus} → ${parsed.data.pipelineStatus}`,
       });
+      await notify(relation.menteeId, 'stage', 'Your pipeline stage was updated.', '/portal');
     }
 
     return NextResponse.json({ relation: updated });

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+// GET — the current user's recent notifications + unread count.
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const [items, unread] = await Promise.all([
+    prisma.notification.findMany({
+      where: { userId: session.user.id },
+      orderBy: { createdAt: 'desc' },
+      take: 20,
+    }),
+    prisma.notification.count({ where: { userId: session.user.id, read: false } }),
+  ]);
+  return NextResponse.json({ items, unread });
+}
+
+// POST — mark notifications read (all, or a single id via { id }).
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const body = await request.json().catch(() => ({}));
+  await prisma.notification.updateMany({
+    where: { userId: session.user.id, ...(body.id ? { id: body.id } : {}) },
+    data: { read: true },
+  });
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/rsvp/route.ts
+++ b/src/app/api/rsvp/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { prisma } from '@/lib/prisma';
+import { notify } from '@/lib/notify';
 
 // Public endpoint — the mentee responds to a meeting invite via the token in
 // their email. No auth: the unguessable token is the credential.
@@ -30,5 +31,11 @@ export async function POST(request: Request) {
     where: { id: meeting.id },
     data: { rsvp: response === 'yes' ? 'ACCEPTED' : 'DECLINED' },
   });
+  await notify(
+    meeting.createdById,
+    'rsvp',
+    `A mentee ${response === 'yes' ? 'accepted' : 'declined'} the meeting "${meeting.title}".`,
+    '/mentor/meetings'
+  );
   return NextResponse.json({ ok: true, rsvp: response === 'yes' ? 'ACCEPTED' : 'DECLINED' });
 }

--- a/src/components/NotificationBell.tsx
+++ b/src/components/NotificationBell.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useSession } from 'next-auth/react';
+import Link from 'next/link';
+import { Bell } from 'lucide-react';
+import { useT } from '@/i18n/client';
+
+interface Note {
+  id: string;
+  text: string;
+  link?: string | null;
+  read: boolean;
+  createdAt: string;
+}
+
+export function NotificationBell() {
+  const t = useT();
+  const { status } = useSession();
+  const [items, setItems] = useState<Note[]>([]);
+  const [unread, setUnread] = useState(0);
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch('/api/notifications');
+      if (!res.ok) return;
+      const d = await res.json();
+      setItems(d.items ?? []);
+      setUnread(d.unread ?? 0);
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  useEffect(() => {
+    if (status !== 'authenticated') return;
+    load();
+    const id = setInterval(load, 60_000);
+    return () => clearInterval(id);
+  }, [status, load]);
+
+  useEffect(() => {
+    const onClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', onClick);
+    return () => document.removeEventListener('mousedown', onClick);
+  }, []);
+
+  if (status !== 'authenticated') return null;
+
+  const toggle = async () => {
+    const next = !open;
+    setOpen(next);
+    if (next && unread > 0) {
+      await fetch('/api/notifications', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' });
+      setUnread(0);
+      setItems((prev) => prev.map((n) => ({ ...n, read: true })));
+    }
+  };
+
+  return (
+    <div className="relative" ref={ref}>
+      <button onClick={toggle} aria-label="Notifications" className="relative p-2 text-gray-600 hover:text-gray-900">
+        <Bell className="h-5 w-5" />
+        {unread > 0 && (
+          <span className="absolute -top-0.5 -right-0.5 min-w-[18px] h-[18px] px-1 rounded-full bg-red-500 text-white text-[10px] font-bold flex items-center justify-center">
+            {unread > 9 ? '9+' : unread}
+          </span>
+        )}
+      </button>
+      {open && (
+        <div className="absolute right-0 mt-2 w-80 max-h-96 overflow-y-auto rounded-xl border border-gray-200 bg-white shadow-lg z-50">
+          <div className="px-4 py-2 border-b border-gray-100 text-sm font-semibold text-gray-700">{t.notifications.title}</div>
+          {items.length === 0 ? (
+            <p className="px-4 py-6 text-sm text-gray-400 text-center">{t.notifications.none}</p>
+          ) : (
+            items.map((n) => {
+              const inner = (
+                <div className={`px-4 py-3 border-b border-gray-50 text-sm ${n.read ? 'text-gray-500' : 'text-gray-900 bg-blue-50/40'}`}>
+                  <p>{n.text}</p>
+                  <p className="text-xs text-gray-400 mt-0.5">{new Date(n.createdAt).toLocaleString()}</p>
+                </div>
+              );
+              return n.link ? (
+                <Link key={n.id} href={n.link} onClick={() => setOpen(false)} className="block hover:bg-gray-50">
+                  {inner}
+                </Link>
+              ) : (
+                <div key={n.id}>{inner}</div>
+              );
+            })
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ResponsiveShell.tsx
+++ b/src/components/ResponsiveShell.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { Menu, X } from 'lucide-react';
 import { EmailVerificationBanner } from '@/components/EmailVerificationBanner';
 import { ImpersonationBanner } from '@/components/ImpersonationBanner';
+import { NotificationBell } from '@/components/NotificationBell';
 
 // App shell: sidebar is a static column on desktop and an off-canvas drawer
 // (with a hamburger top bar) on mobile.
@@ -21,9 +22,12 @@ export function ResponsiveShell({
       {/* Mobile top bar */}
       <div className="lg:hidden sticky top-0 z-30 flex items-center justify-between bg-white border-b border-gray-200 h-14 px-4">
         <span className="font-bold text-gray-900">InternshipCRM</span>
-        <button onClick={() => setOpen(true)} aria-label="Open menu" className="p-2 -mr-2 text-gray-600 hover:text-gray-900">
-          <Menu className="h-6 w-6" />
-        </button>
+        <div className="flex items-center gap-1">
+          <NotificationBell />
+          <button onClick={() => setOpen(true)} aria-label="Open menu" className="p-2 -mr-2 text-gray-600 hover:text-gray-900">
+            <Menu className="h-6 w-6" />
+          </button>
+        </div>
       </div>
 
       {/* Overlay (mobile only) */}
@@ -51,7 +55,11 @@ export function ResponsiveShell({
       </div>
 
       <main className="flex-1 overflow-auto min-w-0">
-        <div className="p-4 lg:p-8">
+        {/* Desktop-only top strip for the notification bell */}
+        <div className="hidden lg:flex justify-end px-8 pt-4">
+          <NotificationBell />
+        </div>
+        <div className="p-4 lg:p-8 lg:pt-2">
           <ImpersonationBanner />
           <EmailVerificationBanner />
           {children}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -289,6 +289,10 @@ const en = {
     replace: 'Replace',
     remove: 'Remove',
   },
+  notifications: {
+    title: 'Notifications',
+    none: 'No notifications',
+  },
   activity: {
     title: 'Activity log',
     subtitle: 'Auth events and key actions across the app',
@@ -698,6 +702,10 @@ const tr: Dict = {
     upload: 'Fotoğraf yükle',
     replace: 'Değiştir',
     remove: 'Kaldır',
+  },
+  notifications: {
+    title: 'Bildirimler',
+    none: 'Bildirim yok',
   },
   activity: {
     title: 'Aktivite günlüğü',

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -1,0 +1,12 @@
+import { prisma } from '@/lib/prisma';
+import { logger } from '@/lib/logger';
+
+// Create an in-app notification for a user. Never throws — a failed
+// notification must not break the action that triggered it.
+export async function notify(userId: string, type: string, text: string, link?: string) {
+  try {
+    await prisma.notification.create({ data: { userId, type, text, link: link ?? null } });
+  } catch (e) {
+    logger.error('Failed to create notification', { userId, type, error: String(e) });
+  }
+}


### PR DESCRIPTION
## S16.1 · Uygulama içi bildirim merkezi (EPIC 16 · #152)

- **schema**: `Notification` (kullanıcı başına, okundu bayrağı).
- `src/lib/notify.ts` `notify()` (throw etmez).
- **GET /api/notifications** (son + okunmamış sayısı), **POST** (okundu işaretle).
- App shell'de **NotificationBell** (çan + okunmamış rozeti + açılır liste, 60sn poll, açınca okundu) — mobil üst bar + masaüstü şerit.
- Bağlandı: yeni başvuru → mentor, RSVP yanıtı → toplantı sahibi, aşama değişimi → mentee.
- i18n EN+TR.
- **e2e**: public başvuru mentora bildirir, çanda görünür.

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)