### PR TITLE
feat(comms): weekly digest + meeting reminders (#157 #158)

### DIFF
--- a/e2e/cron-jobs.spec.ts
+++ b/e2e/cron-jobs.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test';
+import { randomBytes } from 'crypto';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('admin cron run sends meeting reminders and stamps reminderSentAt', async ({ page }) => {
+  const adminEmail = uniqueEmail('cronadmin');
+  const mentorEmail = uniqueEmail('cronmentor');
+  const menteeEmail = uniqueEmail('cronmentee');
+  await seedUser(adminEmail, 'AdminPass123', 'ADMIN', 'Cron Admin');
+  const mentor = await seedUser(mentorEmail, 'x', 'MENTOR', 'Cron Mentor');
+  const mentee = await seedUser(menteeEmail, 'x', 'MENTEE', 'Cron Mentee');
+  const rel = await prisma.mentorshipRelation.create({ data: { mentorId: mentor.id, menteeId: mentee.id } });
+  const meeting = await prisma.meeting.create({
+    data: {
+      relationId: rel.id,
+      title: 'Soon Meeting',
+      scheduledAt: new Date(Date.now() + 2 * 60 * 60 * 1000),
+      rsvpToken: randomBytes(12).toString('hex'),
+      createdById: mentor.id,
+    },
+  });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', 'AdminPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    const res = await page.request.get('/api/cron');
+    expect(res.ok()).toBeTruthy();
+    const body = await res.json();
+    expect(body.meetings.reminded).toBeGreaterThanOrEqual(1);
+
+    const after = await prisma.meeting.findUnique({ where: { id: meeting.id } });
+    expect(after!.reminderSentAt).not.toBeNull();
+  } finally {
+    await prisma.meeting.deleteMany({ where: { relationId: rel.id } });
+    await prisma.mentorshipRelation.deleteMany({ where: { id: rel.id } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -186,15 +186,16 @@ enum RsvpStatus {
 // A scheduled meeting between a mentor and a mentee, with a Google Meet link
 // and an emailed RSVP (responded to via a public token link).
 model Meeting {
-  id          String     @id @default(cuid())
-  relationId  String
-  title       String
-  scheduledAt DateTime
-  meetLink    String?
-  rsvp        RsvpStatus @default(PENDING)
-  rsvpToken   String     @unique
-  createdById String
-  createdAt   DateTime   @default(now())
+  id             String     @id @default(cuid())
+  relationId     String
+  title          String
+  scheduledAt    DateTime
+  meetLink       String?
+  rsvp           RsvpStatus @default(PENDING)
+  rsvpToken      String     @unique
+  createdById    String
+  reminderSentAt DateTime?
+  createdAt      DateTime   @default(now())
 
   relation MentorshipRelation @relation(fields: [relationId], references: [id], onDelete: Cascade)
 

--- a/src/app/api/cron/route.ts
+++ b/src/app/api/cron/route.ts
@@ -1,7 +1,11 @@
 import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
-import { checkMentorInteractionReminders } from '@/services/emailService';
+import {
+  checkMentorInteractionReminders,
+  sendMeetingReminders,
+  sendWeeklyMentorDigests,
+} from '@/services/emailService';
 
 export async function GET() {
   try {
@@ -11,11 +15,17 @@ export async function GET() {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const result = await checkMentorInteractionReminders();
+    const [interactions, meetings, digests] = await Promise.all([
+      checkMentorInteractionReminders(),
+      sendMeetingReminders(),
+      sendWeeklyMentorDigests(),
+    ]);
 
     return NextResponse.json({
-      message: 'Reminder check completed',
-      ...result,
+      message: 'Scheduled jobs ran',
+      interactions,
+      meetings,
+      digests,
     });
   } catch (error) {
     console.error('Cron error:', error);

--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -277,6 +277,92 @@ export async function checkMentorInteractionReminders() {
   };
 }
 
+// Email reminders for meetings happening within the next 24h that haven't been
+// reminded yet.
+export async function sendMeetingReminders() {
+  const now = new Date();
+  const in24h = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+  const meetings = await prisma.meeting.findMany({
+    where: { scheduledAt: { gt: now, lte: in24h }, reminderSentAt: null },
+    include: { relation: { include: { mentee: { select: { email: true, fullName: true } } } } },
+  });
+
+  let reminded = 0;
+  for (const m of meetings) {
+    try {
+      await sendEmail({
+        to: m.relation.mentee.email,
+        subject: `Reminder: ${m.title}`,
+        html: `<div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+          <h2 style="color:#2563eb;">Upcoming meeting</h2>
+          <p>Hi ${m.relation.mentee.fullName}, this is a reminder for <strong>${m.title}</strong> at ${m.scheduledAt.toLocaleString('en-GB')}.</p>
+          ${m.meetLink ? `<p><a href="${m.meetLink}">${m.meetLink}</a></p>` : ''}
+        </div>`,
+      });
+    } catch (e) {
+      console.error('Meeting reminder failed:', e);
+    }
+    await prisma.meeting.update({ where: { id: m.id }, data: { reminderSentAt: new Date() } });
+    reminded++;
+  }
+  return { checked: meetings.length, reminded };
+}
+
+// Weekly per-mentor digest: stale mentees, upcoming meetings, new applications.
+export async function sendWeeklyMentorDigests() {
+  const now = new Date();
+  const weekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+  const fourteenDaysAgo = new Date(now.getTime() - 14 * 24 * 60 * 60 * 1000);
+  const in7d = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
+
+  const mentors = await prisma.user.findMany({
+    where: { role: 'MENTOR', isActive: true },
+    select: {
+      id: true,
+      email: true,
+      fullName: true,
+      mentorRelations: {
+        select: {
+          startDate: true,
+          interactions: { orderBy: { date: 'desc' }, take: 1, select: { date: true } },
+          meetings: { where: { scheduledAt: { gt: now, lte: in7d } }, select: { id: true } },
+        },
+      },
+    },
+  });
+
+  let sent = 0;
+  for (const m of mentors) {
+    if (m.mentorRelations.length === 0) continue;
+    const stale = m.mentorRelations.filter(
+      (r) => !r.interactions[0] || r.interactions[0].date < fourteenDaysAgo
+    ).length;
+    const upcoming = m.mentorRelations.reduce((n, r) => n + r.meetings.length, 0);
+    const newApplications = m.mentorRelations.filter((r) => r.startDate >= weekAgo).length;
+
+    try {
+      await sendEmail({
+        to: m.email,
+        subject: 'Your weekly mentoring summary',
+        html: `<div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+          <h2 style="color:#2563eb;">Weekly summary</h2>
+          <p>Hi ${m.fullName}, here's your week at a glance:</p>
+          <ul>
+            <li><strong>${stale}</strong> mentee(s) with no interaction in 14+ days</li>
+            <li><strong>${upcoming}</strong> meeting(s) coming up this week</li>
+            <li><strong>${newApplications}</strong> new application(s) in the last 7 days</li>
+          </ul>
+          <a href="${process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'}/mentor" style="display:inline-block;background:#2563eb;color:#fff;padding:10px 20px;text-decoration:none;border-radius:6px;">Open dashboard</a>
+        </div>`,
+      });
+      sent++;
+    } catch (e) {
+      console.error('Mentor digest failed:', e);
+    }
+  }
+  return { mentors: mentors.length, sent };
+}
+
 const scheduledTasks = new Map<string, ReturnType<typeof cron.schedule>>();
 
 export function initCronJobs() {
@@ -294,5 +380,28 @@ export function initCronJobs() {
   });
 
   scheduledTasks.set('mentor-reminders', task);
+
+  // Meeting reminders — hourly.
+  const meetingTask = cron.schedule('0 * * * *', async () => {
+    try {
+      const r = await sendMeetingReminders();
+      console.log(`[Cron] Meeting reminders. Reminded: ${r.reminded}`);
+    } catch (e) {
+      console.error('[Cron] Meeting reminder error:', e);
+    }
+  });
+  scheduledTasks.set('meeting-reminders', meetingTask);
+
+  // Weekly mentor digest — Mondays 8:00.
+  const digestTask = cron.schedule('0 8 * * 1', async () => {
+    try {
+      const r = await sendWeeklyMentorDigests();
+      console.log(`[Cron] Weekly digests sent: ${r.sent}`);
+    } catch (e) {
+      console.error('[Cron] Digest error:', e);
+    }
+  });
+  scheduledTasks.set('weekly-digest', digestTask);
+
   console.log('[Cron] Scheduled jobs initialized');
 }


### PR DESCRIPTION
## S16.2 + S16.3 (EPIC 16 · #152)

- **#158**: `Meeting.reminderSentAt`; `sendMeetingReminders()` 24s içindeki toplantılar için mentee'ye hatırlatma + `reminderSentAt` damgalar (tekrar yok).
- **#157**: `sendWeeklyMentorDigests()` her mentora özet (durağan mentee, yaklaşan toplantı, yeni başvuru).
- ikisi de `initCronJobs`'a eklendi (saatlik hatırlatma, Pazartesi 08:00 özet) ve `GET /api/cron` (admin) ile elle çalıştırılabilir — artık tüm işleri koşar.
- e2e: admin /api/cron tetikler → yakın toplantı hatırlatılır + damgalanır.

Closes #157
Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)