### PR TITLE
feat(search): global search + saved filter views (#159 #160)

### DIFF
--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('global search finds a mentee and saved views can be created', async ({ page }) => {
+  const adminEmail = uniqueEmail('srchadmin');
+  const menteeEmail = uniqueEmail('srchmentee');
+  await seedUser(adminEmail, 'AdminPass123', 'ADMIN', 'Search Admin');
+  const mentee = await seedUser(menteeEmail, 'x', 'MENTEE', 'Zephyrine Quanta');
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', 'AdminPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    // Global search API returns the mentee.
+    const res = await page.request.get('/api/search?q=Zephyrine');
+    expect(res.ok()).toBeTruthy();
+    const data = await res.json();
+    expect((data.users ?? []).some((u: { id: string }) => u.id === mentee.id)).toBeTruthy();
+
+    // Saved views: create one on the candidates page.
+    await page.goto('/admin/candidates');
+    page.once('dialog', (d) => d.accept('My View'));
+    await page.getByRole('button', { name: /Save view/i }).click();
+    await expect(page.getByText('My View')).toBeVisible({ timeout: 10_000 });
+  } finally {
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/src/app/admin/candidates/page.tsx
+++ b/src/app/admin/candidates/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
+import { SavedViews } from '@/components/SavedViews';
 import Link from "next/link";
 import { useT, useLocale } from "@/i18n/client";
 import { pipelineLabel } from '@/lib/pipeline';
@@ -186,6 +187,19 @@ export default function CandidatesPage() {
             Clear filters
           </Button>
         )}
+        <div className="mt-3 border-t border-gray-100 pt-3">
+          <SavedViews
+            storageKey="candidate-views"
+            current={{ search, skillFilter, yearFilter, statusFilter, cityFilter }}
+            onApply={(f) => {
+              setSearch(f.search || '');
+              setSkillFilter(f.skillFilter || '');
+              setYearFilter(f.yearFilter || '');
+              setStatusFilter(f.statusFilter || '');
+              setCityFilter(f.cityFilter || '');
+            }}
+          />
+        </div>
       </div>
 
       {/* Results count */}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -7,6 +7,7 @@ import { getServerDictionary } from '@/i18n/server';
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
 import { ResponsiveShell } from '@/components/ResponsiveShell';
 import { SidebarAvatar } from '@/components/SidebarAvatar';
+import { GlobalSearch } from '@/components/GlobalSearch';
 import { prisma } from '@/lib/prisma';
 
 export default async function AdminLayout({ children }: { children: React.ReactNode }) {
@@ -25,6 +26,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
 
   return (
     <ResponsiveShell
+      headerExtra={<GlobalSearch />}
       sidebar={
         <aside className="w-64 h-full bg-white border-r border-gray-200 flex flex-col">
         <div className="p-6 border-b border-gray-200">

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import type { Prisma } from '@prisma/client';
+
+// GET ?q= — global search over users (by name/email) and companies (by name).
+// Admins search everyone; mentors search their own mentees.
+export async function GET(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session || (session.user.role !== 'ADMIN' && session.user.role !== 'MENTOR')) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const q = (new URL(request.url).searchParams.get('q') || '').trim();
+  if (q.length < 2) return NextResponse.json({ users: [], companies: [] });
+
+  const userWhere: Prisma.UserWhereInput = {
+    OR: [{ fullName: { contains: q } }, { email: { contains: q } }],
+  };
+  if (session.user.role === 'MENTOR') {
+    userWhere.role = 'MENTEE';
+    userWhere.menteeRelations = { some: { mentorId: session.user.id } };
+  }
+
+  const [users, companies] = await Promise.all([
+    prisma.user.findMany({
+      where: userWhere,
+      select: { id: true, fullName: true, email: true, role: true },
+      take: 8,
+      orderBy: { fullName: 'asc' },
+    }),
+    session.user.role === 'ADMIN'
+      ? prisma.company.findMany({ where: { name: { contains: q } }, select: { id: true, name: true }, take: 5 })
+      : Promise.resolve([]),
+  ]);
+
+  return NextResponse.json({ users, companies });
+}

--- a/src/components/GlobalSearch.tsx
+++ b/src/components/GlobalSearch.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Search } from 'lucide-react';
+import { useT } from '@/i18n/client';
+
+interface UserHit { id: string; fullName: string; email: string; role: string }
+interface CompanyHit { id: string; name: string }
+
+export function GlobalSearch() {
+  const t = useT();
+  const router = useRouter();
+  const [q, setQ] = useState('');
+  const [users, setUsers] = useState<UserHit[]>([]);
+  const [companies, setCompanies] = useState<CompanyHit[]>([]);
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (q.trim().length < 2) {
+      setUsers([]); setCompanies([]);
+      return;
+    }
+    const id = setTimeout(async () => {
+      try {
+        const res = await fetch(`/api/search?q=${encodeURIComponent(q)}`);
+        const d = await res.json();
+        setUsers(d.users ?? []);
+        setCompanies(d.companies ?? []);
+        setOpen(true);
+      } catch {
+        /* ignore */
+      }
+    }, 250);
+    return () => clearTimeout(id);
+  }, [q]);
+
+  useEffect(() => {
+    const onClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', onClick);
+    return () => document.removeEventListener('mousedown', onClick);
+  }, []);
+
+  const go = (href: string) => {
+    setOpen(false);
+    setQ('');
+    router.push(href);
+  };
+
+  const userHref = (u: UserHit) => (u.role === 'MENTEE' ? `/admin/candidates/${u.id}` : `/admin/users`);
+
+  return (
+    <div className="relative w-56" ref={ref}>
+      <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-gray-200 bg-white">
+        <Search className="h-4 w-4 text-gray-400" />
+        <input
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          onFocus={() => q.trim().length >= 2 && setOpen(true)}
+          placeholder={t.search.placeholder}
+          className="flex-1 text-sm outline-none bg-transparent"
+        />
+      </div>
+      {open && (users.length > 0 || companies.length > 0) && (
+        <div className="absolute right-0 mt-2 w-72 max-h-96 overflow-y-auto rounded-xl border border-gray-200 bg-white shadow-lg z-50">
+          {users.map((u) => (
+            <button key={u.id} onClick={() => go(userHref(u))} className="block w-full text-left px-4 py-2.5 hover:bg-gray-50 text-sm">
+              <span className="font-medium text-gray-900">{u.fullName}</span>
+              <span className="text-xs text-gray-400 ml-2">{u.role}</span>
+              <span className="block text-xs text-gray-500 truncate">{u.email}</span>
+            </button>
+          ))}
+          {companies.map((c) => (
+            <button key={c.id} onClick={() => go('/admin/companies')} className="block w-full text-left px-4 py-2.5 hover:bg-gray-50 text-sm">
+              <span className="font-medium text-gray-900">{c.name}</span>
+              <span className="text-xs text-gray-400 ml-2">{t.search.company}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ResponsiveShell.tsx
+++ b/src/components/ResponsiveShell.tsx
@@ -11,9 +11,11 @@ import { NotificationBell } from '@/components/NotificationBell';
 export function ResponsiveShell({
   sidebar,
   children,
+  headerExtra,
 }: {
   sidebar: React.ReactNode;
   children: React.ReactNode;
+  headerExtra?: React.ReactNode;
 }) {
   const [open, setOpen] = useState(false);
 
@@ -55,8 +57,9 @@ export function ResponsiveShell({
       </div>
 
       <main className="flex-1 overflow-auto min-w-0">
-        {/* Desktop-only top strip for the notification bell */}
-        <div className="hidden lg:flex justify-end px-8 pt-4">
+        {/* Desktop-only top strip for search + notifications */}
+        <div className="hidden lg:flex items-center justify-end gap-3 px-8 pt-4">
+          {headerExtra}
           <NotificationBell />
         </div>
         <div className="p-4 lg:p-8 lg:pt-2">

--- a/src/components/SavedViews.tsx
+++ b/src/components/SavedViews.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Bookmark, X } from 'lucide-react';
+import { useT } from '@/i18n/client';
+
+type Filters = Record<string, string>;
+interface View { name: string; filters: Filters }
+
+// Named, client-stored filter presets for a list page (kept in localStorage).
+export function SavedViews({
+  storageKey,
+  current,
+  onApply,
+}: {
+  storageKey: string;
+  current: Filters;
+  onApply: (f: Filters) => void;
+}) {
+  const t = useT();
+  const [views, setViews] = useState<View[]>([]);
+
+  useEffect(() => {
+    try {
+      setViews(JSON.parse(localStorage.getItem(storageKey) || '[]'));
+    } catch {
+      setViews([]);
+    }
+  }, [storageKey]);
+
+  const persist = (next: View[]) => {
+    setViews(next);
+    localStorage.setItem(storageKey, JSON.stringify(next));
+  };
+
+  const save = () => {
+    const name = window.prompt(t.savedViews.namePrompt);
+    if (!name) return;
+    persist([...views.filter((v) => v.name !== name), { name, filters: current }]);
+  };
+
+  const remove = (name: string) => persist(views.filter((v) => v.name !== name));
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <button
+        onClick={save}
+        className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg border border-gray-200 bg-white text-sm text-gray-600 hover:bg-gray-50"
+      >
+        <Bookmark className="h-4 w-4" />
+        {t.savedViews.save}
+      </button>
+      {views.map((v) => (
+        <span key={v.name} className="inline-flex items-center gap-1 px-2.5 py-1.5 rounded-lg bg-blue-50 text-blue-700 text-sm">
+          <button onClick={() => onApply(v.filters)} className="font-medium hover:underline">{v.name}</button>
+          <button onClick={() => remove(v.name)} aria-label="remove" className="text-blue-400 hover:text-blue-700">
+            <X className="h-3 w-3" />
+          </button>
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -293,6 +293,16 @@ const en = {
     title: 'Notifications',
     none: 'No notifications',
   },
+  search: {
+    placeholder: 'Search people, companies…',
+    company: 'Company',
+  },
+  savedViews: {
+    save: 'Save view',
+    saved: 'Saved views',
+    namePrompt: 'Name this view',
+    none: 'No saved views',
+  },
   activity: {
     title: 'Activity log',
     subtitle: 'Auth events and key actions across the app',
@@ -706,6 +716,16 @@ const tr: Dict = {
   notifications: {
     title: 'Bildirimler',
     none: 'Bildirim yok',
+  },
+  search: {
+    placeholder: 'Kişi, şirket ara…',
+    company: 'Şirket',
+  },
+  savedViews: {
+    save: 'Görünümü kaydet',
+    saved: 'Kayıtlı görünümler',
+    namePrompt: 'Bu görünüme ad ver',
+    none: 'Kayıtlı görünüm yok',
   },
   activity: {
     title: 'Aktivite günlüğü',


### PR DESCRIPTION
## EPIC 17 · Arama & kayıtlı görünümler (#153)

- **#159**: `GET /api/search?q=` — kullanıcılar (ad/e-posta) + şirketler (admin) / kendi mentee'leri (mentor). Admin header'da **GlobalSearch** kutusu, canlı sonuç açılır listesi, detay sayfalarına link.
- **#160**: **SavedViews** — mevcut aday filtrelerini adlandırıp localStorage'a kaydet; chip'e tıkla uygula, × ile sil. Filtre çubuğuna eklendi.
- i18n EN+TR.
- e2e: arama mentee'yi bulur; kayıtlı görünüm oluşturulabilir.

Closes #159
Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)