### PR TITLE
feat(matching): mentor suggestions + next-action (#161 #162)

### DIFF
--- a/e2e/matching.spec.ts
+++ b/e2e/matching.spec.ts
@@ -17,7 +17,6 @@ test('mentor suggestions rank by skill overlap; candidate detail shows next acti
   await prisma.user.update({ where: { id: mentee.id }, data: { skills: ['React', 'Node.js'] } });
   await prisma.user.update({ where: { id: mentorA.id }, data: { skills: ['React', 'Node.js', 'AWS'] } });
   await prisma.user.update({ where: { id: mentorB.id }, data: { skills: ['Java'] } });
-  await prisma.mentorshipRelation.create({ data: { mentorId: mentorA.id, menteeId: mentee.id } });
 
   try {
     await page.goto('/auth/signin');
@@ -31,6 +30,8 @@ test('mentor suggestions rank by skill overlap; candidate detail shows next acti
     const { suggestions } = await res.json();
     expect(suggestions[0].id).toBe(mentorA.id); // higher skill overlap ranks first
 
+    // Assign a mentor, then the candidate detail shows the next-action hint.
+    await prisma.mentorshipRelation.create({ data: { mentorId: mentorA.id, menteeId: mentee.id } });
     await page.goto(`/admin/candidates/${mentee.id}`);
     await expect(page.getByText('Next action:')).toBeVisible({ timeout: 10_000 });
   } finally {

--- a/e2e/matching.spec.ts
+++ b/e2e/matching.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('mentor suggestions rank by skill overlap; candidate detail shows next action', async ({ page }) => {
+  const adminEmail = uniqueEmail('matchadmin');
+  const menteeEmail = uniqueEmail('matchmentee');
+  const mAEmail = uniqueEmail('mentorA');
+  const mBEmail = uniqueEmail('mentorB');
+  await seedUser(adminEmail, 'AdminPass123', 'ADMIN', 'Match Admin');
+  const mentee = await seedUser(menteeEmail, 'x', 'MENTEE', 'Match Mentee');
+  const mentorA = await seedUser(mAEmail, 'x', 'MENTOR', 'Overlap Mentor');
+  const mentorB = await seedUser(mBEmail, 'x', 'MENTOR', 'Other Mentor');
+  await prisma.user.update({ where: { id: mentee.id }, data: { skills: ['React', 'Node.js'] } });
+  await prisma.user.update({ where: { id: mentorA.id }, data: { skills: ['React', 'Node.js', 'AWS'] } });
+  await prisma.user.update({ where: { id: mentorB.id }, data: { skills: ['Java'] } });
+  await prisma.mentorshipRelation.create({ data: { mentorId: mentorA.id, menteeId: mentee.id } });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', 'AdminPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    const res = await page.request.get(`/api/admin/suggest-mentors?menteeId=${mentee.id}`);
+    expect(res.ok()).toBeTruthy();
+    const { suggestions } = await res.json();
+    expect(suggestions[0].id).toBe(mentorA.id); // higher skill overlap ranks first
+
+    await page.goto(`/admin/candidates/${mentee.id}`);
+    await expect(page.getByText('Next action:')).toBeVisible({ timeout: 10_000 });
+  } finally {
+    await prisma.mentorshipRelation.deleteMany({ where: { menteeId: mentee.id } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mAEmail);
+    await cleanupByEmail(mBEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/src/app/admin/candidates/[id]/page.tsx
+++ b/src/app/admin/candidates/[id]/page.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/components/ui/Button';
 import { ArrowLeft, KeyRound, Trash2, Plus } from 'lucide-react';
 import { pipelineLabel, pipelineOptions, PIPELINE_STATUSES } from '@/lib/pipeline';
 import { CvManager } from '@/components/CvManager';
+import { nextAction } from '@/lib/matching';
 import { useT, useLocale } from '@/i18n/client';
 
 interface Interaction { id: string; date: string; notes: string; type: string }
@@ -60,6 +61,7 @@ export default function AdminMenteeDetailPage() {
   const [saving, setSaving] = useState(false);
   const [resetting, setResetting] = useState(false);
   const [resetUrl, setResetUrl] = useState<string | null>(null);
+  const [suggestions, setSuggestions] = useState<{ id: string; fullName: string; overlap: number; activeCount: number }[]>([]);
 
   const load = useCallback(async () => {
     const res = await fetch(`/api/users/${id}`);
@@ -138,6 +140,13 @@ export default function AdminMenteeDetailPage() {
   useEffect(() => {
     load();
   }, [load]);
+
+  useEffect(() => {
+    fetch(`/api/admin/suggest-mentors?menteeId=${id}`)
+      .then((r) => (r.ok ? r.json() : { suggestions: [] }))
+      .then((d) => setSuggestions(d.suggestions ?? []))
+      .catch(() => {});
+  }, [id]);
 
   if (loading) return <div className="text-center py-12 text-gray-400">{t.common.loading}</div>;
   if (!user) return <div className="text-center py-12 text-gray-400">{t.common.notFound}</div>;
@@ -230,6 +239,30 @@ export default function AdminMenteeDetailPage() {
                   onChange={(e) => changeStage(rel.id, e.target.value)}
                 />
               </div>
+
+              {(() => {
+                const na = nextAction({ pipelineStatus: rel.pipelineStatus, lastInteractionAt: rel.interactions[0]?.date });
+                const color = na.level === 'urgent' ? 'text-red-700 bg-red-50 border-red-200' : na.level === 'warn' ? 'text-amber-700 bg-amber-50 border-amber-200' : 'text-green-700 bg-green-50 border-green-200';
+                return (
+                  <div className={`inline-flex items-center gap-2 text-sm rounded-lg border px-3 py-1.5 ${color}`}>
+                    <span className="font-medium">{t.candidateDetail.nextAction}:</span> {na.text}
+                  </div>
+                );
+              })()}
+
+              {suggestions.length > 0 && (
+                <div>
+                  <p className="text-sm font-semibold text-gray-700 mb-2">{t.candidateDetail.suggestedMentors}</p>
+                  <div className="flex flex-wrap gap-2">
+                    {suggestions.map((s) => (
+                      <span key={s.id} className="inline-flex items-center gap-1 px-2.5 py-1 rounded-lg bg-gray-50 border border-gray-200 text-sm">
+                        {s.fullName}
+                        <span className="text-xs text-gray-400">· {s.overlap} {t.candidateDetail.matchSkills} · {s.activeCount}</span>
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
 
               <div>
                 <p className="text-sm font-semibold text-gray-700 mb-2">{t.candidateDetail.stageHistory} ({rel.statusChanges.length})</p>

--- a/src/app/api/admin/suggest-mentors/route.ts
+++ b/src/app/api/admin/suggest-mentors/route.ts
@@ -17,7 +17,8 @@ export async function GET(request: Request) {
   if (!mentee) return NextResponse.json({ error: 'Mentee not found' }, { status: 404 });
 
   const mentors = await prisma.user.findMany({
-    where: { role: 'MENTOR', isActive: true },
+    // Exclude mentors already mentoring this mentee.
+    where: { role: 'MENTOR', isActive: true, NOT: { mentorRelations: { some: { menteeId } } } },
     select: { id: true, fullName: true, skills: true, _count: { select: { mentorRelations: true } } },
   });
 

--- a/src/app/api/admin/suggest-mentors/route.ts
+++ b/src/app/api/admin/suggest-mentors/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { scoreMentors } from '@/lib/matching';
+
+// GET ?menteeId= — admin: ranked mentor suggestions for a mentee by skill
+// overlap and current load.
+export async function GET(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const menteeId = new URL(request.url).searchParams.get('menteeId') || '';
+  const mentee = await prisma.user.findUnique({ where: { id: menteeId }, select: { skills: true } });
+  if (!mentee) return NextResponse.json({ error: 'Mentee not found' }, { status: 404 });
+
+  const mentors = await prisma.user.findMany({
+    where: { role: 'MENTOR', isActive: true },
+    select: { id: true, fullName: true, skills: true, _count: { select: { mentorRelations: true } } },
+  });
+
+  const menteeSkills = Array.isArray(mentee.skills) ? (mentee.skills as string[]) : [];
+  const ranked = scoreMentors(
+    menteeSkills,
+    mentors.map((m) => ({
+      id: m.id,
+      fullName: m.fullName,
+      skills: Array.isArray(m.skills) ? (m.skills as string[]) : [],
+      activeCount: m._count.mentorRelations,
+    }))
+  );
+
+  return NextResponse.json({ suggestions: ranked.slice(0, 5) });
+}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -98,6 +98,9 @@ const en = {
     date: 'Date',
     addEntry: 'Add entry',
     deleteEntry: 'Delete entry',
+    nextAction: 'Next action',
+    suggestedMentors: 'Suggested mentors',
+    matchSkills: 'matching skills',
   },
   mentors: {
     title: 'Mentors',
@@ -522,6 +525,9 @@ const tr: Dict = {
     date: 'Tarih',
     addEntry: 'Kayıt ekle',
     deleteEntry: 'Kaydı sil',
+    nextAction: 'Sonraki aksiyon',
+    suggestedMentors: 'Önerilen mentorlar',
+    matchSkills: 'eşleşen yetenek',
   },
   mentors: {
     title: 'Mentorlar',

--- a/src/lib/matching.ts
+++ b/src/lib/matching.ts
@@ -1,0 +1,45 @@
+// Lightweight, deterministic heuristics for mentor suggestions and the
+// "next action" hint. No ML — just skill overlap + capacity + recency.
+
+export interface MentorCandidate {
+  id: string;
+  fullName: string;
+  skills: string[];
+  activeCount: number;
+}
+
+const norm = (s: string) => s.trim().toLowerCase();
+
+export function scoreMentors(menteeSkills: string[], mentors: MentorCandidate[]) {
+  const want = new Set(menteeSkills.map(norm).filter(Boolean));
+  return mentors
+    .map((m) => {
+      const overlap = m.skills.map(norm).filter((s) => want.has(s)).length;
+      // Skill overlap dominates; lighter load breaks ties (capacity).
+      const score = overlap * 10 - m.activeCount;
+      return { id: m.id, fullName: m.fullName, overlap, activeCount: m.activeCount, score };
+    })
+    .sort((a, b) => b.score - a.score);
+}
+
+export interface NextActionInput {
+  pipelineStatus: string;
+  lastInteractionAt?: Date | string | null;
+}
+
+// Returns a short suggested next action + a severity level.
+export function nextAction({ pipelineStatus, lastInteractionAt }: NextActionInput): {
+  text: string;
+  level: 'ok' | 'warn' | 'urgent';
+} {
+  const last = lastInteractionAt ? new Date(lastInteractionAt) : null;
+  const days = last ? Math.floor((Date.now() - last.getTime()) / 86_400_000) : null;
+
+  if (days === null) return { text: 'Log a first interaction', level: 'warn' };
+  if (days >= 21) return { text: `No contact in ${days} days — reach out`, level: 'urgent' };
+  if (days >= 14) return { text: `Last contact ${days} days ago — follow up`, level: 'warn' };
+
+  const ending = ['INTERNSHIP_COMPLETED_490', 'JOB_SEEKING_500', 'HIREABLE_600'];
+  if (ending.includes(pipelineStatus)) return { text: 'Push toward hiring', level: 'warn' };
+  return { text: 'On track', level: 'ok' };
+}


### PR DESCRIPTION
## EPIC 18 · Akıllı eşleştirme & öneriler (#154)

- **#161**: `src/lib/matching.ts` `scoreMentors()` — yetenek örtüşmesine göre sıralar, kapasite eşitlik bozucu; `GET /api/admin/suggest-mentors?menteeId`. Admin aday detayında **önerilen mentorlar**.
- **#162**: `nextAction()` — durağanlık (son etkileşim) + aşamadan **önerilen sonraki aksiyon**; aday detayında renkli ipucu.
- i18n EN+TR.
- e2e: öneriler daha yüksek örtüşmeli mentoru öne çıkarır; next-action ipucu görünür.

Closes #161
Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)