### PR TITLE
feat(privacy): data export + consent/retention (#163 #164)

### DIFF
--- a/e2e/privacy.spec.ts
+++ b/e2e/privacy.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('a user can export their own data', async ({ page }) => {
+  const email = uniqueEmail('exp');
+  await seedUser(email, 'ExportPass123', 'MENTEE', 'Export Me');
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', email);
+    await page.fill('input[type="password"]', 'ExportPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/portal'), { timeout: 20_000 });
+
+    const res = await page.request.get('/api/account/export');
+    expect(res.ok()).toBeTruthy();
+    expect(res.headers()['content-type']).toContain('application/json');
+    const data = await res.json();
+    expect(data.user.email).toBe(email);
+    expect(data.exportedAt).toBeTruthy();
+  } finally {
+    await cleanupByEmail(email);
+  }
+});
+
+test('registration records consent and the privacy page is public', async ({ page }) => {
+  const email = uniqueEmail('consent');
+  try {
+    const res = await page.request.post('/api/register', {
+      data: { email, password: 'ConsentPass123', fullName: 'Consent User' },
+    });
+    expect(res.ok()).toBeTruthy();
+    const user = await prisma.user.findUnique({ where: { email } });
+    expect(user?.consentAt).not.toBeNull();
+
+    await page.goto('/privacy');
+    await expect(page.getByRole('heading', { name: /Privacy/i })).toBeVisible({ timeout: 10_000 });
+  } finally {
+    await cleanupByEmail(email);
+  }
+});

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -71,6 +71,8 @@ model User {
   companyId      String?
   // How many times this user's public profile has been viewed.
   profileViews   Int       @default(0)
+  // When the user accepted the privacy/data terms (consent).
+  consentAt      DateTime?
   createdAt      DateTime  @default(now())
   updatedAt      DateTime  @updatedAt
 

--- a/src/app/api/account/export/route.ts
+++ b/src/app/api/account/export/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { logActivity } from '@/lib/activity';
+
+// GET — the current user downloads all of their own data as JSON (GDPR-style).
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const id = session.user.id;
+
+  const user = await prisma.user.findUnique({
+    where: { id },
+    select: {
+      id: true, email: true, fullName: true, role: true, phone: true, whatsapp: true,
+      city: true, birthDate: true, university: true, department: true, graduationYear: true,
+      skills: true, cvUrl: true, publicProfile: true, profileViews: true, createdAt: true, consentAt: true,
+    },
+  });
+  if (!user) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+  const relationInclude = {
+    company: { select: { name: true } },
+    interactions: { select: { date: true, type: true, notes: true } },
+    meetings: { select: { title: true, scheduledAt: true, rsvp: true } },
+  };
+  const [asMentee, asMentor, notifications] = await Promise.all([
+    prisma.mentorshipRelation.findMany({
+      where: { menteeId: id },
+      include: { ...relationInclude, mentor: { select: { fullName: true } } },
+    }),
+    prisma.mentorshipRelation.findMany({
+      where: { mentorId: id },
+      include: { ...relationInclude, mentee: { select: { fullName: true } } },
+    }),
+    prisma.notification.findMany({ where: { userId: id }, select: { type: true, text: true, createdAt: true } }),
+  ]);
+
+  await logActivity({ action: 'account.export', actorId: id, actorEmail: user.email });
+
+  const payload = { exportedAt: new Date().toISOString(), user, mentorships: { asMentee, asMentor }, notifications };
+  return new NextResponse(JSON.stringify(payload, null, 2), {
+    headers: {
+      'Content-Type': 'application/json',
+      'Content-Disposition': `attachment; filename="my-data.json"`,
+    },
+  });
+}

--- a/src/app/api/register/route.ts
+++ b/src/app/api/register/route.ts
@@ -61,7 +61,7 @@ export async function POST(request: Request) {
     const emailVerified = !!token;
 
     const user = await prisma.user.create({
-      data: { email, password: hashedPassword, fullName, role, skills: [], emailVerified },
+      data: { email, password: hashedPassword, fullName, role, skills: [], emailVerified, consentAt: new Date() },
       select: { id: true, email: true, fullName: true, role: true, createdAt: true },
     });
 

--- a/src/app/auth/register/page.tsx
+++ b/src/app/auth/register/page.tsx
@@ -138,6 +138,10 @@ function RegisterForm() {
             <Button type="submit" className="w-full" size="lg" loading={loading}>
               {t.auth.createAccount}
             </Button>
+            <p className="text-xs text-gray-400 text-center">
+              {t.auth.consentNote}{' '}
+              <Link href="/privacy" className="text-blue-600 hover:underline">{t.auth.privacyLink}</Link>
+            </p>
           </form>
 
           <p className="text-center text-sm text-gray-500 mt-6">

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link';
+import { getServerDictionary } from '@/i18n/server';
+
+// Public privacy & data-retention notice.
+export default async function PrivacyPage() {
+  const { t } = await getServerDictionary();
+  return (
+    <div className="min-h-screen bg-gray-50 py-12 px-4">
+      <div className="max-w-2xl mx-auto bg-white rounded-2xl border border-gray-200 p-8">
+        <h1 className="text-2xl font-bold text-gray-900 mb-4">{t.privacy.title}</h1>
+        <div className="space-y-3 text-sm text-gray-600">
+          <p>{t.privacy.intro}</p>
+          <p>{t.privacy.use}</p>
+          <p>{t.privacy.retention}</p>
+          <p>{t.privacy.rights}</p>
+        </div>
+        <Link href="/" className="inline-block mt-6 text-sm text-blue-600 hover:underline">
+          ← {t.privacy.back}
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/components/AccountSettings.tsx
+++ b/src/components/AccountSettings.tsx
@@ -134,6 +134,17 @@ export function AccountSettings() {
         </Card>
       </div>
 
+      <Card className="mt-6 max-w-4xl">
+        <CardHeader><CardTitle>{t.account.dataSection}</CardTitle></CardHeader>
+        <p className="text-sm text-gray-600 mb-4">{t.account.dataHint}</p>
+        <a
+          href="/api/account/export"
+          className="inline-flex items-center px-4 py-2 rounded-lg border border-gray-300 text-sm text-gray-700 hover:bg-gray-50"
+        >
+          {t.account.exportData}
+        </a>
+      </Card>
+
       <Card className="mt-6 max-w-4xl border-red-200">
         <CardHeader><CardTitle>{t.account.deleteSection}</CardTitle></CardHeader>
         <p className="text-sm text-gray-600 mb-4">{t.account.deleteWarning}</p>

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -221,6 +221,8 @@ const en = {
     unverifiedBanner: 'Your email isn’t verified yet — your account is read-only until you confirm it.',
     verifyResend: 'Resend verification email',
     verifyResent: 'Verification email sent.',
+    consentNote: 'By registering you accept our',
+    privacyLink: 'privacy terms',
   },
   usersAdmin: {
     title: 'Users',
@@ -354,6 +356,14 @@ const en = {
     skills: 'Skills',
     poweredBy: 'InternshipCRM',
   },
+  privacy: {
+    title: 'Privacy & data',
+    intro: 'We store the information you provide to manage mentorships and internships.',
+    use: 'Your data is used only to operate the platform — matching, tracking and communication.',
+    retention: 'We keep your data while your account is active. You can delete your account anytime from settings.',
+    rights: 'You can download all your data from your account settings at any time.',
+    back: 'Back to home',
+  },
   portal: {
     welcome: 'Welcome',
     dashSubtitle: 'Your internship dashboard',
@@ -424,6 +434,9 @@ const en = {
     deleteConfirm: 'Are you sure?',
     deleteYes: 'Yes, delete',
     deleteCancel: 'Cancel',
+    dataSection: 'Your data',
+    dataHint: 'Download a copy of all the data we hold about you.',
+    exportData: 'Download my data',
   },
 };
 
@@ -648,6 +661,8 @@ const tr: Dict = {
     unverifiedBanner: 'E-postan henüz doğrulanmadı — onaylayana kadar hesabın salt-okunur.',
     verifyResend: 'Doğrulama e-postasını yeniden gönder',
     verifyResent: 'Doğrulama e-postası gönderildi.',
+    consentNote: 'Kaydolarak şunu kabul edersin:',
+    privacyLink: 'gizlilik koşulları',
   },
   usersAdmin: {
     title: 'Kullanıcılar',
@@ -781,6 +796,14 @@ const tr: Dict = {
     skills: 'Yetenekler',
     poweredBy: 'InternshipCRM',
   },
+  privacy: {
+    title: 'Gizlilik & veri',
+    intro: 'Mentorluk ve staj sürecini yönetmek için sağladığın bilgileri saklarız.',
+    use: 'Verilerin yalnızca platformu işletmek için kullanılır — eşleştirme, takip ve iletişim.',
+    retention: 'Verilerini hesabın aktif olduğu sürece tutarız. Hesabını ayarlardan istediğin zaman silebilirsin.',
+    rights: 'Tüm verini istediğin zaman hesap ayarlarından indirebilirsin.',
+    back: 'Ana sayfaya dön',
+  },
   portal: {
     welcome: 'Hoş geldin',
     dashSubtitle: 'Staj panonuz',
@@ -851,6 +874,9 @@ const tr: Dict = {
     deleteConfirm: 'Emin misin?',
     deleteYes: 'Evet, sil',
     deleteCancel: 'Vazgeç',
+    dataSection: 'Verilerin',
+    dataHint: 'Hakkında tuttuğumuz tüm verinin bir kopyasını indir.',
+    exportData: 'Verimi indir',
   },
 };
 


### PR DESCRIPTION
## EPIC 19 · Veri & gizlilik (GDPR) (#155) — round-3 backlog'u tamamlar

- **#163**: `GET /api/account/export` kullanıcının kendi verisini (profil, mentorluklar, etkileşimler, toplantılar, bildirimler) JSON olarak indirir; hesap ayarlarında **Verimi indir**. `account.export` olarak loglanır.
- **#164**: `User.consentAt` kayıtta set edilir; public **/privacy** notu (veri kullanımı + saklama + haklar), register formundan linkli.
- i18n EN+TR.
- e2e: kullanıcı verisini export eder; kayıt consent kaydeder; /privacy public.

Closes #163
Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)