### PR TITLE
feat(security): security HTTP headers (#185)

### DIFF
--- a/e2e/security-headers.spec.ts
+++ b/e2e/security-headers.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+
+test('responses carry the security headers', async ({ request }) => {
+  const res = await request.get('/');
+  const h = res.headers();
+  expect(h['x-frame-options']).toBe('DENY');
+  expect(h['x-content-type-options']).toBe('nosniff');
+  expect(h['referrer-policy']).toBe('strict-origin-when-cross-origin');
+  expect(h['content-security-policy']).toContain("default-src 'self'");
+  expect(h['content-security-policy']).toContain("frame-ancestors 'none'");
+  expect(h['permissions-policy']).toContain('camera=()');
+});
+
+test('home page still renders without console errors under CSP', async ({ page }) => {
+  const errors: string[] = [];
+  page.on('console', (m) => m.type() === 'error' && errors.push(m.text()));
+  await page.goto('/');
+  await expect(page.getByRole('heading', { name: /Connect Talent with/i })).toBeVisible();
+  expect(errors).toEqual([]);
+});

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,35 @@
 /** @type {import('next').NextConfig} */
+
+// Pragmatic CSP: same-origin by default; allow inline/eval for Next's runtime
+// and styles, data:/blob: images (avatars, CV object URLs, CSV downloads).
+const csp = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob:",
+  "font-src 'self'",
+  "connect-src 'self'",
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "object-src 'none'",
+].join('; ');
+
+const securityHeaders = [
+  { key: 'Content-Security-Policy', value: csp },
+  { key: 'X-Frame-Options', value: 'DENY' },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+  { key: 'Strict-Transport-Security', value: 'max-age=63072000; includeSubDomains; preload' },
+];
+
 const nextConfig = {
   reactStrictMode: true,
   serverExternalPackages: ['@prisma/client', 'bcryptjs'],
+  async headers() {
+    return [{ source: '/:path*', headers: securityHeaders }];
+  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## S21.3 (EPIC 21 · #182)

Tüm rotalara: **Content-Security-Policy** (varsayılan self; Next runtime için inline/eval, data:/blob: görseller), **X-Frame-Options: DENY**, **X-Content-Type-Options: nosniff**, **Referrer-Policy**, **Permissions-Policy**, **HSTS**.

- e2e: başlıklar yanıtlarda mevcut; CSP altında anasayfa konsol hatasız render olur.

> CSP bilinçli olarak `unsafe-inline`/`unsafe-eval` içeriyor (Next runtime + dev refresh); nonce tabanlı sıkılaştırma ileride yapılabilir.

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)