### PR TITLE
docs(security): authz audit + SECURITY.md + IDOR test (#187)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security overview
+
+This document summarizes the security model of Internship CRM and the controls
+added in the security-hardening epic (#182).
+
+## Authentication
+- **NextAuth (Credentials)** with JWT sessions. Passwords hashed with **bcrypt** (cost 12).
+- **Password policy** (`src/lib/password.ts`): min 8 chars, at least one upper- and one lower-case letter. Enforced on register, reset and password change.
+- **No user enumeration**: sign-in returns a single generic *“Invalid email or password”* for both unknown email and wrong password.
+- **Brute-force throttle**: failed logins are counted per email (10 / 15 min); successful logins reset the counter. Failed attempts are written to the activity log (`auth.login_failed`).
+- **Email verification**: unverified accounts are read-only (write APIs blocked by `src/middleware.ts`).
+- **Deactivation**: admins can disable accounts; inactive users cannot sign in.
+
+## Re-authentication for sensitive actions
+- Changing **email**, changing **password**, and **deleting the account** all require the current password (`/api/account`).
+- Impersonation (`/api/admin/impersonate`) is ADMIN-only, single-use grant based, audited, and cannot be used to delete the impersonated account.
+
+## Authorization (RBAC + ownership)
+Every API route checks the session and the appropriate role; resource routes additionally verify ownership to prevent IDOR:
+
+| Area | Rule |
+|------|------|
+| `/api/admin/*`, `/api/users`, `/api/candidates`, `/api/search`, `/api/status-changes`, `/api/invite`, `/api/companies` | ADMIN only |
+| `/api/mentorship/[id]`, `/api/interactions[/id]`, `/api/meetings` | ADMIN **or** the mentor who owns the relation |
+| `/api/cv/[userId]`, `/api/avatar` | owner, ADMIN, or the mentee’s mentor (`src/lib/cvAccess.ts`) |
+| `/api/profile`, `/api/account[/export]`, `/api/notifications` | the authenticated user, scoped to their own data |
+| `/api/apply`, `/api/rsvp`, `/api/auth/*`, `/api/profile-view` | public by design (unguessable token or anti-enumeration) |
+
+## Rate limiting
+`src/lib/rateLimit.ts` (in-memory, per-process fixed window) guards auth and public endpoints: forgot, reset, register, apply, rsvp, and login. Returns **429** with `Retry-After` when exceeded. For a multi-instance deployment, back this with Redis.
+
+## HTTP security headers
+Set for all routes in `next.config.js`: Content-Security-Policy (self by default), `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy`, `Permissions-Policy`, and HSTS.
+
+## Auditing & privacy
+- **Activity log** (`ActivityLog`) records auth events, profile/stage changes, account email/password change and deletion, impersonation, and failed logins. Viewable by admins at `/admin/activity`.
+- **Data export** (`/api/account/export`) lets a user download all their own data; **consent** is recorded at registration; see `/privacy`.
+
+## Reporting a vulnerability
+Email the maintainer (see repository owner). Do not open public issues for sensitive reports.

--- a/e2e/authz-idor.spec.ts
+++ b/e2e/authz-idor.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('a mentee cannot access another user\'s CV or admin APIs (IDOR/RBAC)', async ({ page }) => {
+  const aEmail = uniqueEmail('idor-a');
+  const bEmail = uniqueEmail('idor-b');
+  await seedUser(aEmail, 'IdorPass123', 'MENTEE', 'Mentee A');
+  const b = await seedUser(bEmail, 'x', 'MENTEE', 'Mentee B');
+  // Give B a CV that A should not be able to read.
+  await prisma.cvFile.create({
+    data: { userId: b.id, filename: 'b.pdf', contentType: 'application/pdf', size: 3, data: Buffer.from('pdf') },
+  });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', aEmail);
+    await page.fill('input[type="password"]', 'IdorPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/portal'), { timeout: 20_000 });
+
+    // Cross-user CV access is forbidden.
+    expect((await page.request.get(`/api/cv/${b.id}`)).status()).toBe(403);
+    // Admin-only APIs are denied to a mentee.
+    expect((await page.request.get('/api/users')).status()).toBe(401);
+    expect((await page.request.get('/api/admin/analytics')).status()).toBe(401);
+    // The mentee can read their own CV endpoint (404, not 403 — no CV, but allowed).
+    expect((await page.request.get(`/api/cv/${(await prisma.user.findUnique({ where: { email: aEmail } }))!.id}`)).status()).toBe(404);
+  } finally {
+    await prisma.cvFile.deleteMany({ where: { userId: b.id } });
+    await cleanupByEmail(aEmail);
+    await cleanupByEmail(bEmail);
+  }
+});


### PR DESCRIPTION
## S21.5 (EPIC 21 · #182) — yetki & IDOR taraması

Tüm API route'ları denetlendi: hepsi session + rol kontrol ediyor; kaynak route'ları sahiplik doğruluyor (mentorship/interactions/meetings → ilişki sahibi veya admin; cv/avatar → owner/admin/mentor-of; profile/account/notifications → self). **IDOR açığı bulunamadı.**

- **SECURITY.md**: kimlik doğrulama modeli, RBAC + sahiplik tablosu, rate limit, başlıklar, audit ve gizlilik.
- e2e: mentee başka kullanıcının CV'sinde 403, admin API'lerinde 401 alır; kendi CV ucuna erişebilir.

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)