### PR TITLE
fix(auth): impersonated company session loads company data (#193)

### DIFF
--- a/e2e/impersonation.spec.ts
+++ b/e2e/impersonation.spec.ts
@@ -5,6 +5,47 @@ test.afterAll(async () => {
   await prisma.$disconnect();
 });
 
+test('impersonating a company user loads that company\'s candidates', async ({ page }) => {
+  const adminEmail = uniqueEmail('impco-admin');
+  const companyEmail = uniqueEmail('impco-company');
+  const mentorEmail = uniqueEmail('impco-mentor');
+  const menteeEmail = uniqueEmail('impco-mentee');
+  await seedUser(adminEmail, 'AdminPass123!', 'ADMIN', 'ImpCo Admin');
+  const companyUser = await seedUser(companyEmail, 'x', 'COMPANY', 'ImpCo Login');
+  const mentor = await seedUser(mentorEmail, 'x', 'MENTOR', 'ImpCo Mentor');
+  const mentee = await seedUser(menteeEmail, 'x', 'MENTEE', 'Zoltan Candidate');
+  const company = await prisma.company.create({ data: { name: 'ImpCo GmbH' } });
+  await prisma.user.update({ where: { id: companyUser.id }, data: { companyId: company.id } });
+  const rel = await prisma.mentorshipRelation.create({
+    data: { mentorId: mentor.id, menteeId: mentee.id, companyId: company.id },
+  });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', 'AdminPass123!');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    await page.goto('/admin/users');
+    const row = page.getByTestId(`user-row-${companyUser.id}`);
+    await expect(row).toBeVisible({ timeout: 10_000 });
+    await row.getByRole('button', { name: 'Login as' }).click();
+    await page.waitForURL((u) => u.pathname.startsWith('/company'), { timeout: 20_000 });
+
+    // The impersonated company session must carry companyId → candidates load.
+    await expect(page.getByText('Zoltan Candidate')).toBeVisible({ timeout: 10_000 });
+  } finally {
+    await prisma.auditLog.deleteMany({ where: { targetId: companyUser.id } });
+    await prisma.mentorshipRelation.deleteMany({ where: { id: rel.id } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(companyEmail);
+    await cleanupByEmail(adminEmail);
+    await prisma.company.deleteMany({ where: { id: company.id } });
+  }
+});
+
 test('admin can impersonate a user and return to their own account', async ({ page }) => {
   const adminEmail = uniqueEmail('impadmin');
   const menteeEmail = uniqueEmail('impmentee');

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -96,6 +96,9 @@ export const authOptions: NextAuthOptions = {
           name: user.fullName,
           role: user.role,
           emailVerified: user.emailVerified,
+          // Carry the impersonated user's company so the company portal (and any
+          // companyId-scoped data) loads correctly while impersonating.
+          companyId: user.companyId,
           impersonatorId: isStart ? grant.adminId : undefined,
           impersonatorName: isStart ? admin?.fullName ?? 'Admin' : undefined,
         };


### PR DESCRIPTION
## Sorun
Admin 'Login as' ile bir **COMPANY** kullanıcısına girince Company overview **0 aday** gösteriyordu; normal girişte 7 geliyordu.

## Sebep / Çözüm
Impersonate `authorize()` oturuma **companyId** koymuyordu (credentials provider koyuyor) → JWT/session'da companyId yok → `/api/mentorship` COMPANY scope'u (`companyId ?? '__none__'`) hiçbir şey eşleştirmiyordu. Impersonate provider artık `user.companyId` döndürüyor. Diğer alanlar (role/email/emailVerified/impersonator*) zaten taşınıyordu → **as login artık güvenilir**.

- e2e: bir company kullanıcısını impersonate edince o şirketin adayı görünüyor.

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)