### PR TITLE
feat(pwa): installable app — manifest + install button (#195)

### DIFF
--- a/e2e/pwa.spec.ts
+++ b/e2e/pwa.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+
+test('web app manifest is served and installable-shaped', async ({ request }) => {
+  const res = await request.get('/manifest.webmanifest');
+  expect(res.ok()).toBeTruthy();
+  const m = await res.json();
+  expect(m.name).toBe('Internship CRM');
+  expect(m.display).toBe('standalone');
+  expect(m.start_url).toBe('/');
+  expect(Array.isArray(m.icons) && m.icons.length).toBeGreaterThan(0);
+});
+
+test('the service worker script is served', async ({ request }) => {
+  const res = await request.get('/sw.js');
+  expect(res.ok()).toBeTruthy();
+  expect(res.headers()['content-type']).toContain('javascript');
+});
+
+test('the home page links the manifest', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('link[rel="manifest"]')).toHaveCount(1);
+});

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,0 +1,8 @@
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Internship CRM">
+  <rect width="64" height="64" rx="14" fill="#1D4ED8"/>
+  <!-- graduation cap -->
+  <path d="M32 16 L52 25 L32 34 L12 25 Z" fill="#ffffff"/>
+  <path d="M22 30 L22 40 C22 43 41 43 41 40 L41 30 L32 34 Z" fill="#bfdbfe"/>
+  <path d="M52 25 L52 37" stroke="#ffffff" stroke-width="2.5" stroke-linecap="round"/>
+  <circle cx="52" cy="39" r="2.5" fill="#ffffff"/>
+</svg>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,31 @@
+// Minimal service worker — enables installability and an offline-friendly
+// shell. Network-first; falls back to cache when offline.
+const CACHE = 'internship-crm-v1';
+
+self.addEventListener('install', (event) => {
+  self.skipWaiting();
+  event.waitUntil(caches.open(CACHE));
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) => Promise.all(keys.filter((k) => k !== CACHE).map((k) => caches.delete(k))))
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+  const req = event.request;
+  // Only handle same-origin GET navigations/assets; let the rest pass through.
+  if (req.method !== 'GET' || new URL(req.url).origin !== self.location.origin) return;
+
+  event.respondWith(
+    fetch(req)
+      .then((res) => {
+        const copy = res.clone();
+        caches.open(CACHE).then((c) => c.put(req, copy)).catch(() => {});
+        return res;
+      })
+      .catch(() => caches.match(req))
+  );
+});

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -6,6 +6,7 @@ import { GraduationCap, LayoutDashboard, Columns3, Building2, Users, UserCheck, 
 import { getServerDictionary } from '@/i18n/server';
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
 import { ResponsiveShell } from '@/components/ResponsiveShell';
+import { InstallAppButton } from '@/components/InstallAppButton';
 import { SidebarAvatar } from '@/components/SidebarAvatar';
 import { GlobalSearch } from '@/components/GlobalSearch';
 import { prisma } from '@/lib/prisma';
@@ -129,7 +130,8 @@ export default async function AdminLayout({ children }: { children: React.ReactN
             <LogOut className="h-4 w-4" />
             {t.nav.signOut}
           </Link>
-          <div className="mt-3 px-3">
+          <div className="mt-3 px-3 space-y-1">
+            <InstallAppButton />
             <LanguageSwitcher current={locale} />
           </div>
         </div>

--- a/src/app/company/layout.tsx
+++ b/src/app/company/layout.tsx
@@ -6,6 +6,7 @@ import { GraduationCap, LayoutDashboard, LogOut } from 'lucide-react';
 import { getServerDictionary } from '@/i18n/server';
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
 import { ResponsiveShell } from '@/components/ResponsiveShell';
+import { InstallAppButton } from '@/components/InstallAppButton';
 import { SidebarAvatar } from '@/components/SidebarAvatar';
 import { prisma } from '@/lib/prisma';
 
@@ -55,7 +56,8 @@ export default async function CompanyLayout({ children }: { children: React.Reac
               <LogOut className="h-4 w-4" />
               {t.nav.signOut}
             </Link>
-            <div className="mt-3 px-3">
+            <div className="mt-3 px-3 space-y-1">
+              <InstallAppButton />
               <LanguageSwitcher current={locale} />
             </div>
           </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import './globals.css';
 import { Providers } from './providers';
 import { getLocale } from '@/i18n/server';
@@ -7,6 +7,12 @@ import { getDictionary } from '@/i18n/dictionaries';
 export const metadata: Metadata = {
   title: 'Internship CRM - Mentor-Mentee Management',
   description: 'A comprehensive CRM for managing mentor-mentee relationships and internship programs',
+  applicationName: 'Internship CRM',
+  appleWebApp: { capable: true, statusBarStyle: 'default', title: 'InternshipCRM' },
+};
+
+export const viewport: Viewport = {
+  themeColor: '#1D4ED8',
 };
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,0 +1,31 @@
+import type { MetadataRoute } from 'next';
+
+// Web app manifest (served at /manifest.webmanifest) — makes the app
+// installable on desktop and mobile.
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: 'Internship CRM',
+    short_name: 'InternshipCRM',
+    description: 'Mentor ↔ mentee CRM & internship pipeline',
+    start_url: '/',
+    scope: '/',
+    display: 'standalone',
+    background_color: '#ffffff',
+    theme_color: '#1D4ED8',
+    orientation: 'portrait-primary',
+    icons: [
+      {
+        src: '/icon.svg',
+        sizes: 'any',
+        type: 'image/svg+xml',
+        purpose: 'any',
+      },
+      {
+        src: '/icon.svg',
+        sizes: 'any',
+        type: 'image/svg+xml',
+        purpose: 'maskable',
+      },
+    ],
+  };
+}

--- a/src/app/mentor/layout.tsx
+++ b/src/app/mentor/layout.tsx
@@ -6,6 +6,7 @@ import { GraduationCap, LayoutDashboard, Columns3, Users, BookOpen, Mail, Calend
 import { getServerDictionary } from '@/i18n/server';
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
 import { ResponsiveShell } from '@/components/ResponsiveShell';
+import { InstallAppButton } from '@/components/InstallAppButton';
 import { SidebarAvatar } from '@/components/SidebarAvatar';
 import { prisma } from '@/lib/prisma';
 
@@ -95,7 +96,8 @@ export default async function MentorLayout({ children }: { children: React.React
             <LogOut className="h-4 w-4" />
             {t.nav.signOut}
           </Link>
-          <div className="mt-3 px-3">
+          <div className="mt-3 px-3 space-y-1">
+            <InstallAppButton />
             <LanguageSwitcher current={locale} />
           </div>
         </div>

--- a/src/app/portal/layout.tsx
+++ b/src/app/portal/layout.tsx
@@ -6,6 +6,7 @@ import { GraduationCap, LayoutDashboard, User, BookOpen, LogOut } from 'lucide-r
 import { getServerDictionary } from '@/i18n/server';
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
 import { ResponsiveShell } from '@/components/ResponsiveShell';
+import { InstallAppButton } from '@/components/InstallAppButton';
 import { SidebarAvatar } from '@/components/SidebarAvatar';
 import { prisma } from '@/lib/prisma';
 
@@ -82,7 +83,8 @@ export default async function PortalLayout({ children }: { children: React.React
             <LogOut className="h-4 w-4" />
             {t.nav.signOut}
           </Link>
-          <div className="mt-3 px-3">
+          <div className="mt-3 px-3 space-y-1">
+            <InstallAppButton />
             <LanguageSwitcher current={locale} />
           </div>
         </div>

--- a/src/components/InstallAppButton.tsx
+++ b/src/components/InstallAppButton.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Download, Share } from 'lucide-react';
+import { useT } from '@/i18n/client';
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
+}
+
+// "Install app" entry for the sidebar. Registers the service worker, then:
+// - Chrome/Edge/Android: shows a button wired to the install prompt.
+// - iOS Safari (no prompt API): shows a tappable "Add to Home Screen" hint.
+// - Already installed (standalone): renders nothing.
+export function InstallAppButton() {
+  const t = useT();
+  const [deferred, setDeferred] = useState<BeforeInstallPromptEvent | null>(null);
+  const [installed, setInstalled] = useState(false);
+  const [isIos, setIsIos] = useState(false);
+  const [showIosHint, setShowIosHint] = useState(false);
+
+  useEffect(() => {
+    // Register the service worker.
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('/sw.js').catch(() => {});
+    }
+
+    const standalone =
+      window.matchMedia('(display-mode: standalone)').matches ||
+      (window.navigator as unknown as { standalone?: boolean }).standalone === true;
+    if (standalone) {
+      setInstalled(true);
+      return;
+    }
+
+    const ua = window.navigator.userAgent.toLowerCase();
+    setIsIos(/iphone|ipad|ipod/.test(ua));
+
+    const onPrompt = (e: Event) => {
+      e.preventDefault();
+      setDeferred(e as BeforeInstallPromptEvent);
+    };
+    const onInstalled = () => {
+      setInstalled(true);
+      setDeferred(null);
+    };
+    window.addEventListener('beforeinstallprompt', onPrompt);
+    window.addEventListener('appinstalled', onInstalled);
+    return () => {
+      window.removeEventListener('beforeinstallprompt', onPrompt);
+      window.removeEventListener('appinstalled', onInstalled);
+    };
+  }, []);
+
+  const install = async () => {
+    if (!deferred) return;
+    await deferred.prompt();
+    const { outcome } = await deferred.userChoice;
+    if (outcome === 'accepted') setInstalled(true);
+    setDeferred(null);
+  };
+
+  if (installed) return null;
+
+  // iOS: no programmatic prompt — offer a hint.
+  if (isIos && !deferred) {
+    return (
+      <div>
+        <button
+          onClick={() => setShowIosHint((v) => !v)}
+          className="flex items-center gap-2 w-full px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 rounded-lg transition-colors"
+        >
+          <Download className="h-4 w-4" />
+          {t.pwa.install}
+        </button>
+        {showIosHint && (
+          <p className="px-3 py-2 text-xs text-gray-500 flex items-start gap-1">
+            <Share className="h-3.5 w-3.5 mt-0.5 flex-shrink-0" />
+            {t.pwa.iosHint}
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  if (!deferred) return null;
+
+  return (
+    <button
+      onClick={install}
+      className="flex items-center gap-2 w-full px-3 py-2 text-sm text-blue-600 hover:bg-blue-50 rounded-lg transition-colors font-medium"
+    >
+      <Download className="h-4 w-4" />
+      {t.pwa.install}
+    </button>
+  );
+}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -356,6 +356,10 @@ const en = {
     title: 'Notifications',
     none: 'No notifications',
   },
+  pwa: {
+    install: 'Install app',
+    iosHint: 'Tap the Share button, then “Add to Home Screen”.',
+  },
   search: {
     placeholder: 'Search people, companies…',
     company: 'Company',
@@ -854,6 +858,10 @@ const tr: Dict = {
   notifications: {
     title: 'Bildirimler',
     none: 'Bildirim yok',
+  },
+  pwa: {
+    install: 'Uygulamayı kur',
+    iosHint: 'Paylaş düğmesine, sonra “Ana Ekrana Ekle”ye dokun.',
   },
   search: {
     placeholder: 'Kişi, şirket ara…',


### PR DESCRIPTION
## #195 · Uygulama olarak kurulabilsin

- **app/manifest.ts** → `/manifest.webmanifest` (standalone, tema rengi, ikonlar); `public/icon.svg` + apple-web-app + theme-color metadata.
- **public/sw.js**: kurulabilirlik ve offline-dostu shell için minimal (network-first) service worker.
- **InstallAppButton** her sidebar'ın altında: SW'yi kaydeder; `beforeinstallprompt` ile **kur** butonu (Chrome/Edge/Android), iOS'ta **Ana Ekrana Ekle** ipucu; **zaten kuruluysa gizlenir** (display-mode: standalone) veya `appinstalled` sonrası. Mobile + desktop çalışır.
- i18n EN+TR.
- e2e: manifest + service worker servis ediliyor; anasayfa manifest'i linkliyor.

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)