### PR TITLE
feat(onboarding): first-run checklist + empty states (#204 #205)

### DIFF
--- a/e2e/onboarding-checklist.spec.ts
+++ b/e2e/onboarding-checklist.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('a fresh mentee sees the first-run checklist on the dashboard', async ({ page }) => {
+  const email = uniqueEmail('checklist');
+  await seedUser(email, 'CheckPass123', 'MENTEE', 'Checklist Mentee');
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', email);
+    await page.fill('input[type="password"]', 'CheckPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/portal'), { timeout: 20_000 });
+
+    await expect(page.getByRole('heading', { name: 'Get started' })).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('Complete your profile')).toBeVisible();
+    await expect(page.getByText('Upload your CV')).toBeVisible();
+  } finally {
+    await cleanupByEmail(email);
+  }
+});

--- a/e2e/onboarding-checklist.spec.ts
+++ b/e2e/onboarding-checklist.spec.ts
@@ -17,8 +17,9 @@ test('a fresh mentee sees the first-run checklist on the dashboard', async ({ pa
     await page.waitForURL((u) => u.pathname.startsWith('/portal'), { timeout: 20_000 });
 
     await expect(page.getByRole('heading', { name: 'Get started' })).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByText('Complete your profile')).toBeVisible();
+    // Steps unique to the checklist (the portal also has a generic "Complete your profile" prompt).
     await expect(page.getByText('Upload your CV')).toBeVisible();
+    await expect(page.getByText('Make your profile public')).toBeVisible();
   } finally {
     await cleanupByEmail(email);
   }

--- a/src/app/admin/candidates/page.tsx
+++ b/src/app/admin/candidates/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { SavedViews } from '@/components/SavedViews';
+import { EmptyState } from '@/components/EmptyState';
 import Link from "next/link";
 import { useT, useLocale } from "@/i18n/client";
 import { pipelineLabel } from '@/lib/pipeline';
@@ -210,9 +211,14 @@ export default function CandidatesPage() {
       {loading ? (
         <div className="text-center py-12 text-gray-400">{t.common.loading}</div>
       ) : candidates.length === 0 ? (
-        <Card className="text-center py-12">
-          <Users className="h-12 w-12 text-gray-300 mx-auto mb-4" />
-          <p className="text-gray-500">{t.candidates.none}</p>
+        <Card>
+          <EmptyState
+            icon={Users}
+            title={t.candidates.none}
+            description={t.emptyState.candidates}
+            actionLabel={t.emptyState.inviteCta}
+            actionHref="/admin/invite"
+          />
         </Card>
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,4 +1,5 @@
 import { getServerSession } from 'next-auth';
+import { OnboardingChecklist } from '@/components/OnboardingChecklist';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { Card, CardHeader, CardTitle, CardDescription } from '@/components/ui/Card';
@@ -66,6 +67,7 @@ export default async function AdminDashboard() {
 
   return (
     <div>
+      <OnboardingChecklist />
       <div className="mb-8">
         <h1 className="text-2xl font-bold text-gray-900">{t.dashboard.title}</h1>
         <p className="text-gray-500 mt-1">{t.dashboard.subtitle}</p>

--- a/src/app/api/onboarding/route.ts
+++ b/src/app/api/onboarding/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+// GET — role-aware first-run checklist state for the current user.
+// Returns ordered steps with { key, done, href }.
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const { id, role } = session.user;
+
+  if (role === 'MENTEE') {
+    const user = await prisma.user.findUnique({
+      where: { id },
+      select: { university: true, skills: true, publicProfile: true, cvFile: { select: { id: true } } },
+    });
+    const skills = Array.isArray(user?.skills) ? (user!.skills as unknown[]) : [];
+    return NextResponse.json({
+      role,
+      steps: [
+        { key: 'profile', done: !!(user?.university && skills.length > 0), href: '/portal/profile' },
+        { key: 'cv', done: !!user?.cvFile, href: '/portal/profile' },
+        { key: 'public', done: !!user?.publicProfile, href: '/portal/profile' },
+      ],
+    });
+  }
+
+  if (role === 'MENTOR') {
+    const [mentees, interactions] = await Promise.all([
+      prisma.mentorshipRelation.count({ where: { mentorId: id } }),
+      prisma.interactionLog.count({ where: { relation: { mentorId: id } } }),
+    ]);
+    return NextResponse.json({
+      role,
+      steps: [
+        { key: 'addMentee', done: mentees > 0, href: '/mentor/mentees/new' },
+        { key: 'logInteraction', done: interactions > 0, href: '/mentor/mentees' },
+        { key: 'scheduleMeeting', done: false, href: '/mentor/meetings', optional: true },
+      ].slice(0, mentees > 0 ? 3 : 2),
+    });
+  }
+
+  if (role === 'ADMIN') {
+    const [companies, nonAdmins, relations] = await Promise.all([
+      prisma.company.count(),
+      prisma.user.count({ where: { role: { not: 'ADMIN' } } }),
+      prisma.mentorshipRelation.count(),
+    ]);
+    return NextResponse.json({
+      role,
+      steps: [
+        { key: 'addCompany', done: companies > 0, href: '/admin/companies' },
+        { key: 'inviteUser', done: nonAdmins > 0, href: '/admin/invite' },
+        { key: 'assignMentorship', done: relations > 0, href: '/admin/mentorship' },
+      ],
+    });
+  }
+
+  return NextResponse.json({ role, steps: [] });
+}

--- a/src/app/mentor/page.tsx
+++ b/src/app/mentor/page.tsx
@@ -1,4 +1,5 @@
 import { getServerSession } from 'next-auth';
+import { OnboardingChecklist } from '@/components/OnboardingChecklist';
 import { getServerDictionary } from "@/i18n/server";
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
@@ -59,6 +60,7 @@ export default async function MentorDashboard() {
 
   return (
     <div>
+      <OnboardingChecklist />
       <div className="mb-8">
         <h1 className="text-2xl font-bold text-gray-900">
           {t.mentor.welcomeBack}, {session!.user.name}

--- a/src/app/portal/page.tsx
+++ b/src/app/portal/page.tsx
@@ -1,4 +1,5 @@
 import { getServerSession } from 'next-auth';
+import { OnboardingChecklist } from '@/components/OnboardingChecklist';
 import { getServerDictionary } from "@/i18n/server";
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
@@ -51,6 +52,7 @@ export default async function PortalDashboard() {
 
   return (
     <div>
+      <OnboardingChecklist />
       <div className="mb-8">
         <h1 className="text-2xl font-bold text-gray-900">
           {t.portal.welcome}, {session!.user.name}!

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -1,0 +1,36 @@
+import Link from 'next/link';
+import type { LucideIcon } from 'lucide-react';
+import { Inbox } from 'lucide-react';
+
+// Friendly empty-state with an optional primary action.
+export function EmptyState({
+  icon: Icon = Inbox,
+  title,
+  description,
+  actionLabel,
+  actionHref,
+}: {
+  icon?: LucideIcon;
+  title: string;
+  description?: string;
+  actionLabel?: string;
+  actionHref?: string;
+}) {
+  return (
+    <div className="text-center py-14 px-4">
+      <div className="mx-auto w-12 h-12 rounded-2xl bg-gray-100 flex items-center justify-center mb-4">
+        <Icon className="h-6 w-6 text-gray-400" />
+      </div>
+      <p className="text-gray-900 font-medium">{title}</p>
+      {description && <p className="text-gray-500 text-sm mt-1 max-w-sm mx-auto">{description}</p>}
+      {actionLabel && actionHref && (
+        <Link
+          href={actionHref}
+          className="inline-flex items-center mt-4 px-4 py-2 rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700 transition-colors"
+        >
+          {actionLabel}
+        </Link>
+      )}
+    </div>
+  );
+}

--- a/src/components/OnboardingChecklist.tsx
+++ b/src/components/OnboardingChecklist.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { CheckCircle2, Circle, X, Rocket } from 'lucide-react';
+import { useT } from '@/i18n/client';
+
+interface Step { key: string; done: boolean; href: string }
+
+// Role-aware first-run checklist shown on the dashboard. Hides itself when all
+// steps are done or the user dismisses it (remembered per role in localStorage).
+export function OnboardingChecklist() {
+  const t = useT();
+  const [steps, setSteps] = useState<Step[] | null>(null);
+  const [role, setRole] = useState('');
+  const [dismissed, setDismissed] = useState(true);
+
+  useEffect(() => {
+    fetch('/api/onboarding')
+      .then((r) => r.json())
+      .then((d) => {
+        setSteps(d.steps ?? []);
+        setRole(d.role ?? '');
+        setDismissed(localStorage.getItem(`onboarding-dismissed-${d.role}`) === '1');
+      })
+      .catch(() => setSteps([]));
+  }, []);
+
+  if (!steps || steps.length === 0 || dismissed) return null;
+  const allDone = steps.every((s) => s.done);
+  if (allDone) return null;
+
+  const labels = t.checklist.steps as Record<string, string>;
+  const dismiss = () => {
+    localStorage.setItem(`onboarding-dismissed-${role}`, '1');
+    setDismissed(true);
+  };
+
+  return (
+    <div className="mb-6 rounded-2xl border border-blue-200 bg-blue-50/60 p-5">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <Rocket className="h-5 w-5 text-blue-600" />
+          <h2 className="font-semibold text-gray-900">{t.checklist.title}</h2>
+        </div>
+        <button onClick={dismiss} aria-label={t.checklist.dismiss} className="text-gray-400 hover:text-gray-700">
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+      <ul className="mt-3 space-y-1.5">
+        {steps.map((s) => (
+          <li key={s.key}>
+            <Link
+              href={s.href}
+              className={`flex items-center gap-2 rounded-lg px-2 py-1.5 text-sm transition-colors hover:bg-white ${
+                s.done ? 'text-gray-400' : 'text-gray-800'
+              }`}
+            >
+              {s.done ? (
+                <CheckCircle2 className="h-4 w-4 text-green-500 flex-shrink-0" />
+              ) : (
+                <Circle className="h-4 w-4 text-gray-300 flex-shrink-0" />
+              )}
+              <span className={s.done ? 'line-through' : ''}>{labels[s.key] ?? s.key}</span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -360,6 +360,25 @@ const en = {
     install: 'Install app',
     iosHint: 'Tap the Share button, then “Add to Home Screen”.',
   },
+  checklist: {
+    title: 'Get started',
+    dismiss: 'Dismiss',
+    steps: {
+      profile: 'Complete your profile',
+      cv: 'Upload your CV',
+      public: 'Make your profile public',
+      addMentee: 'Add your first mentee',
+      logInteraction: 'Log an interaction',
+      scheduleMeeting: 'Schedule a meeting',
+      addCompany: 'Add a company',
+      inviteUser: 'Invite a user',
+      assignMentorship: 'Assign a mentorship',
+    },
+  },
+  emptyState: {
+    candidates: 'No mentees match yet. Invite people or share a public application link.',
+    inviteCta: 'Send an invitation',
+  },
   search: {
     placeholder: 'Search people, companies…',
     company: 'Company',
@@ -862,6 +881,25 @@ const tr: Dict = {
   pwa: {
     install: 'Uygulamayı kur',
     iosHint: 'Paylaş düğmesine, sonra “Ana Ekrana Ekle”ye dokun.',
+  },
+  checklist: {
+    title: 'Başlayalım',
+    dismiss: 'Kapat',
+    steps: {
+      profile: 'Profilini tamamla',
+      cv: 'CV’ni yükle',
+      public: 'Profilini herkese açık yap',
+      addMentee: 'İlk mentee’ni ekle',
+      logInteraction: 'Bir etkileşim kaydet',
+      scheduleMeeting: 'Toplantı planla',
+      addCompany: 'Şirket ekle',
+      inviteUser: 'Kullanıcı davet et',
+      assignMentorship: 'Mentorluk ata',
+    },
+  },
+  emptyState: {
+    candidates: 'Henüz eşleşen mentee yok. Kişileri davet et veya public başvuru linki paylaş.',
+    inviteCta: 'Davet gönder',
   },
   search: {
     placeholder: 'Kişi, şirket ara…',


### PR DESCRIPTION
## EPIC 22 · Onboarding & ilk-giriş (#197)

- **#204**: `GET /api/onboarding` role'e göre checklist durumu döndürür (mentee: profil/CV/public; mentor: mentee ekle/etkileşim; admin: şirket/davet/mentorluk). Her dashboard'da **OnboardingChecklist** kartı; adımlar aksiyona linkli; role bazlı kapatılabilir; tüm adımlar bitince gizlenir.
- **#205**: yeniden kullanılabilir **EmptyState**; aday listesi artık dostça boş-durum + davet CTA'sı gösteriyor.
- i18n EN+TR.
- e2e: yeni mentee checklist'i (profil/CV adımları) görür.

Closes #204
Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)