### PR TITLE
feat(reporting): Excel export + printable analytics (#206 #207)

### DIFF
--- a/e2e/export.spec.ts
+++ b/e2e/export.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+async function adminLogin(page: import('@playwright/test').Page, email: string, pw: string) {
+  await page.goto('/auth/signin');
+  await page.fill('input[type="email"], input[name="email"]', email);
+  await page.fill('input[type="password"]', pw);
+  await page.click('button[type="submit"]');
+  await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+}
+
+test('candidates can be exported to Excel (.xlsx)', async ({ page }) => {
+  const adminEmail = uniqueEmail('xls-admin');
+  const mentorEmail = uniqueEmail('xls-mentor');
+  const menteeEmail = uniqueEmail('xls-mentee');
+  await seedUser(adminEmail, 'AdminPass123', 'ADMIN', 'Xls Admin');
+  const mentor = await seedUser(mentorEmail, 'x', 'MENTOR', 'Xls Mentor');
+  const mentee = await seedUser(menteeEmail, 'x', 'MENTEE', 'Xls Candidate');
+  const rel = await prisma.mentorshipRelation.create({ data: { mentorId: mentor.id, menteeId: mentee.id } });
+
+  try {
+    await adminLogin(page, adminEmail, 'AdminPass123');
+    await page.goto('/admin/candidates');
+    await expect(page.getByText('Xls Candidate')).toBeVisible({ timeout: 10_000 });
+
+    const [download] = await Promise.all([
+      page.waitForEvent('download'),
+      page.getByRole('button', { name: 'Export Excel' }).click(),
+    ]);
+    expect(download.suggestedFilename()).toMatch(/\.xlsx$/);
+  } finally {
+    await prisma.mentorshipRelation.deleteMany({ where: { id: rel.id } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});
+
+test('analytics page offers print and Excel export', async ({ page }) => {
+  const adminEmail = uniqueEmail('xls-an-admin');
+  await seedUser(adminEmail, 'AdminPass123', 'ADMIN', 'Xls An Admin');
+  try {
+    await adminLogin(page, adminEmail, 'AdminPass123');
+    await page.goto('/admin/analytics');
+    await expect(page.getByRole('button', { name: 'Print / PDF' })).toBeVisible({ timeout: 10_000 });
+    const [download] = await Promise.all([
+      page.waitForEvent('download'),
+      page.getByRole('button', { name: 'Export Excel' }).click(),
+    ]);
+    expect(download.suggestedFilename()).toMatch(/\.xlsx$/);
+  } finally {
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "react-dom": "^19.2.4",
         "react-hook-form": "^7.52.1",
         "tailwind-merge": "^2.4.0",
+        "xlsx": "^0.18.5",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -1716,6 +1717,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -2254,6 +2264,19 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2324,6 +2347,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2368,6 +2400,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/cross-spawn": {
@@ -3413,6 +3457,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fraction.js": {
@@ -5944,6 +5997,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
@@ -6684,6 +6749,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -6700,6 +6783,27 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/yallist": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-dom": "^19.2.4",
     "react-hook-form": "^7.52.1",
     "tailwind-merge": "^2.4.0",
+    "xlsx": "^0.18.5",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
+import { Button } from '@/components/ui/Button';
 import { PIPELINE_STATUSES, pipelineLabel } from '@/lib/pipeline';
 import { useT, useLocale } from '@/i18n/client';
 
@@ -41,11 +42,23 @@ export default function AdminAnalyticsPage() {
 
   const maxFunnel = Math.max(1, ...PIPELINE_STATUSES.map((s) => data.funnel[s] || 0));
 
+  const exportExcel = async () => {
+    const { exportXlsx } = await import('@/lib/excel');
+    const rows = PIPELINE_STATUSES.map((s) => [pipelineLabel(s, locale), data.funnel[s] || 0]);
+    await exportXlsx(`analytics-${new Date().toISOString().slice(0, 10)}`, ['Stage', 'Count'], rows, 'Funnel');
+  };
+
   return (
     <div>
-      <div className="mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">{t.analytics.title}</h1>
-        <p className="text-gray-500 mt-1">{t.analytics.subtitle}</p>
+      <div className="mb-6 flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">{t.analytics.title}</h1>
+          <p className="text-gray-500 mt-1">{t.analytics.subtitle}</p>
+        </div>
+        <div className="flex gap-2 no-print">
+          <Button variant="outline" size="sm" onClick={exportExcel}>{t.analytics.exportExcel}</Button>
+          <Button variant="outline" size="sm" onClick={() => window.print()}>{t.analytics.print}</Button>
+        </div>
       </div>
 
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-6">

--- a/src/app/admin/candidates/page.tsx
+++ b/src/app/admin/candidates/page.tsx
@@ -52,25 +52,32 @@ export default function CandidatesPage() {
   const [cityFilter, setCityFilter] = useState('');
   const [error, setError] = useState('');
 
+  const COLS = ['Name', 'Email', 'Phone', 'WhatsApp', 'City', 'University', 'Department', 'Graduation', 'Skills', 'Stage', 'Project', 'Mentor'];
+  const toRow = (c: Candidate) => {
+    const rel = c.menteeRelations[0];
+    return [
+      c.fullName, c.email, c.phone, c.whatsapp, c.city, c.university, c.department,
+      c.graduationYear, c.skills.join('; '),
+      rel?.pipelineStatus ? pipelineLabel(rel.pipelineStatus, locale) : '',
+      rel?.company?.name ?? '', rel?.mentor?.fullName ?? '',
+    ];
+  };
+
   const exportCsv = () => {
-    const cols = ['Name', 'Email', 'Phone', 'WhatsApp', 'City', 'University', 'Department', 'Graduation', 'Skills', 'Stage', 'Project', 'Mentor'];
     const esc = (v: unknown) => `"${String(v ?? '').replace(/"/g, '""')}"`;
-    const rows = candidates.map((c) => {
-      const rel = c.menteeRelations[0];
-      return [
-        c.fullName, c.email, c.phone, c.whatsapp, c.city, c.university, c.department,
-        c.graduationYear, c.skills.join('; '),
-        rel?.pipelineStatus ? pipelineLabel(rel.pipelineStatus, locale) : '',
-        rel?.company?.name ?? '', rel?.mentor?.fullName ?? '',
-      ].map(esc).join(',');
-    });
-    const csv = [cols.join(','), ...rows].join('\n');
+    const rows = candidates.map((c) => toRow(c).map(esc).join(','));
+    const csv = [COLS.join(','), ...rows].join('\n');
     const url = URL.createObjectURL(new Blob(['﻿' + csv], { type: 'text/csv;charset=utf-8' }));
     const a = document.createElement('a');
     a.href = url;
     a.download = `candidates-${new Date().toISOString().slice(0, 10)}.csv`;
     a.click();
     URL.revokeObjectURL(url);
+  };
+
+  const exportExcel = async () => {
+    const { exportXlsx } = await import('@/lib/excel');
+    await exportXlsx(`candidates-${new Date().toISOString().slice(0, 10)}`, COLS, candidates.map(toRow), 'Candidates');
   };
 
   // Read an optional ?status= filter from the URL (e.g. from dashboard pipeline bars)
@@ -126,10 +133,16 @@ export default function CandidatesPage() {
           </div>
         )}
         </div>
-        <Button variant="outline" onClick={exportCsv} disabled={candidates.length === 0}>
-          <Download className="h-4 w-4" />
-          {t.candidates.exportCsv}
-        </Button>
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={exportCsv} disabled={candidates.length === 0}>
+            <Download className="h-4 w-4" />
+            {t.candidates.exportCsv}
+          </Button>
+          <Button variant="outline" onClick={exportExcel} disabled={candidates.length === 0}>
+            <Download className="h-4 w-4" />
+            {t.candidates.exportExcel}
+          </Button>
+        </div>
       </div>
 
       {error && (

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -18,3 +18,15 @@
     @apply max-w-7xl mx-auto px-4 sm:px-6 lg:px-8;
   }
 }
+
+/* Print: hide app chrome so pages like analytics print as clean reports. */
+@media print {
+  aside,
+  header,
+  .no-print {
+    display: none !important;
+  }
+  main {
+    overflow: visible !important;
+  }
+}

--- a/src/components/ResponsiveShell.tsx
+++ b/src/components/ResponsiveShell.tsx
@@ -58,7 +58,7 @@ export function ResponsiveShell({
 
       <main className="flex-1 overflow-auto min-w-0">
         {/* Desktop-only top strip for search + notifications */}
-        <div className="hidden lg:flex items-center justify-end gap-3 px-8 pt-4">
+        <div className="hidden lg:flex items-center justify-end gap-3 px-8 pt-4 no-print">
           {headerExtra}
           <NotificationBell />
         </div>

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -68,6 +68,7 @@ const en = {
     viewCv: 'View CV',
     none: 'No candidates found',
     exportCsv: 'Export CSV',
+    exportExcel: 'Export Excel',
     cityPlaceholder: 'Filter by city',
     filters: 'Filters',
     searchPlaceholder: 'Search by name, email, university...',
@@ -408,6 +409,8 @@ const en = {
     mentorWorkload: 'Mentor workload & outcomes',
     active: 'active',
     hired: 'hired',
+    print: 'Print / PDF',
+    exportExcel: 'Export Excel',
   },
   apply: {
     title: 'Apply for mentorship',
@@ -590,6 +593,7 @@ const tr: Dict = {
     viewCv: 'CV’yi gör',
     none: 'Aday bulunamadı',
     exportCsv: 'CSV indir',
+    exportExcel: 'Excel indir',
     cityPlaceholder: 'Şehre göre filtrele',
     filters: 'Filtreler',
     searchPlaceholder: 'Ad, e-posta, üniversite ara...',
@@ -930,6 +934,8 @@ const tr: Dict = {
     mentorWorkload: 'Mentor yükü & çıktılar',
     active: 'aktif',
     hired: 'işe alındı',
+    print: 'Yazdır / PDF',
+    exportExcel: 'Excel indir',
   },
   apply: {
     title: 'Mentorluk başvurusu',

--- a/src/lib/excel.ts
+++ b/src/lib/excel.ts
@@ -1,0 +1,15 @@
+// Client-side Excel (.xlsx) export. SheetJS is imported dynamically so it is
+// code-split out of the main bundle and only loaded on demand.
+export async function exportXlsx(
+  filename: string,
+  columns: string[],
+  rows: (string | number | null | undefined)[][],
+  sheetName = 'Sheet1'
+) {
+  const XLSX = await import('xlsx');
+  const data = [columns, ...rows.map((r) => r.map((c) => (c == null ? '' : c)))];
+  const ws = XLSX.utils.aoa_to_sheet(data);
+  const wb = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(wb, ws, sheetName);
+  XLSX.writeFile(wb, filename.endsWith('.xlsx') ? filename : `${filename}.xlsx`);
+}


### PR DESCRIPTION
## EPIC 23 · Raporlama & dışa aktarma 2.0 (#198)

- **#206**: SheetJS ile `exportXlsx()` (`src/lib/excel.ts`, dinamik import → code-split). Aday listesi ve analitik sayfasında **Excel indir** (mevcut CSV'nin yanında).
- **#207**: Analitikte **Yazdır / PDF** (`window.print()`) + `globals.css` print kuralları (sidebar/üst bar/butonlar gizli → temiz rapor; `no-print` sınıfı).
- i18n EN+TR.
- e2e: aday + analitik Excel indirme .xlsx tetikler; print butonu görünür.

Closes #206
Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)