### PR TITLE
feat(invite): explain company logins + link to Companies (#219)

### DIFF
--- a/e2e/invite-company-hint.spec.ts
+++ b/e2e/invite-company-hint.spec.ts
@@ -17,7 +17,7 @@ test('invite page links to Companies for company logins and omits Company role',
 
     await page.goto('/admin/invite');
     // Hint links to the Companies page.
-    const link = page.getByRole('link', { name: /Companies/i });
+    const link = page.getByRole('link', { name: 'Companies →' });
     await expect(link).toBeVisible({ timeout: 10_000 });
     await expect(link).toHaveAttribute('href', '/admin/companies');
 

--- a/e2e/invite-company-hint.spec.ts
+++ b/e2e/invite-company-hint.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('invite page links to Companies for company logins and omits Company role', async ({ page }) => {
+  const email = uniqueEmail('invhint');
+  await seedUser(email, 'AdminPass123', 'ADMIN', 'Invite Admin');
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', email);
+    await page.fill('input[type="password"]', 'AdminPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    await page.goto('/admin/invite');
+    // Hint links to the Companies page.
+    const link = page.getByRole('link', { name: /Companies/i });
+    await expect(link).toBeVisible({ timeout: 10_000 });
+    await expect(link).toHaveAttribute('href', '/admin/companies');
+
+    // The role select offers Mentee/Mentor/Admin but not Company.
+    const roleSelect = page.getByLabel(/Role/);
+    await expect(roleSelect.locator('option', { hasText: 'Mentor' })).toHaveCount(1);
+    await expect(roleSelect.locator('option', { hasText: 'Company' })).toHaveCount(0);
+  } finally {
+    await cleanupByEmail(email);
+  }
+});

--- a/src/app/admin/invite/page.tsx
+++ b/src/app/admin/invite/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -144,6 +145,13 @@ export default function InvitePage() {
               {t.invite.send}
             </Button>
           </form>
+
+          <p className="mt-4 text-xs text-gray-500">
+            {t.invite.companyHint}{' '}
+            <Link href="/admin/companies" className="text-blue-600 hover:underline font-medium">
+              {t.invite.companyHintLink}
+            </Link>
+          </p>
 
           <div className="mt-6 p-4 bg-blue-50 rounded-xl">
             <p className="text-sm font-medium text-blue-800 mb-2">{t.invite.howItWorks}</p>

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -150,6 +150,8 @@ const en = {
     notEmailed: 'not emailed',
     copy: 'Copy',
     copied: 'Copied',
+    companyHint: 'Need a company login? Companies are read-only accounts linked to a company — create one from',
+    companyHintLink: 'Companies →',
   },
   mentor: {
     welcomeBack: 'Welcome back',
@@ -675,6 +677,8 @@ const tr: Dict = {
     notEmailed: 'e-posta gönderilmedi',
     copy: 'Kopyala',
     copied: 'Kopyalandı',
+    companyHint: 'Şirket girişi mi lazım? Şirket hesapları bir şirkete bağlı salt-okunur hesaplardır — şuradan oluştur:',
+    companyHintLink: 'Şirketler →',
   },
   mentor: {
     welcomeBack: 'Tekrar hoş geldin',


### PR DESCRIPTION
## Soru: davet gönderirken company yok — engel mi?
**Tasarım gereği**, bug değil. Company hesapları bir **şirkete bağlı** salt-okunur girişlerdir; generic davet token'ı companyId taşımadığından **Admin → Companies → 'Add a company login'** akışından oluşturulur (companyId set eder + parola-oluşturma e-postası gönderir).

## Yapılan
Invite sayfasına bunu açıklayan, **Companies →**'e yönlendiren bir ipucu eklendi (i18n EN+TR). Rol menüsü bilinçli olarak Mentee/Mentor/Admin.

- e2e: ipucu /admin/companies'e linkli; rol menüsünde Company yok.

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)