### PR TITLE
feat(messaging): in-app threads + reply + profile avatar (#221 #223 #224)

### DIFF
--- a/e2e/cv-upload.spec.ts
+++ b/e2e/cv-upload.spec.ts
@@ -24,7 +24,7 @@ test('mentee can upload, view and delete their CV', async ({ page }) => {
     const uploaded = page.waitForResponse(
       (r) => r.url().endsWith('/api/cv') && r.request().method() === 'POST'
     );
-    await page.locator('input[type="file"]').setInputFiles({
+    await page.locator('input[type="file"][accept*="pdf"]').setInputFiles({
       name: 'cv.pdf',
       mimeType: 'application/pdf',
       buffer: PDF,

--- a/e2e/messaging.spec.ts
+++ b/e2e/messaging.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+async function signIn(page: import('@playwright/test').Page, email: string, pw: string, home: string) {
+  await page.goto('/auth/signin');
+  await page.fill('input[type="email"], input[name="email"]', email);
+  await page.fill('input[type="password"]', pw);
+  await page.click('button[type="submit"]');
+  await page.waitForURL((u) => u.pathname.startsWith(home), { timeout: 20_000 });
+}
+
+test('mentor email lands in the thread and notifies the mentee', async ({ page }) => {
+  const mentorEmail = uniqueEmail('msg-mentor');
+  const menteeEmail = uniqueEmail('msg-mentee');
+  const mentor = await seedUser(mentorEmail, 'MentorPass123', 'MENTOR', 'Msg Mentor');
+  const mentee = await seedUser(menteeEmail, 'MenteePass123', 'MENTEE', 'Msg Mentee');
+  const rel = await prisma.mentorshipRelation.create({ data: { mentorId: mentor.id, menteeId: mentee.id } });
+
+  try {
+    await signIn(page, mentorEmail, 'MentorPass123', '/mentor');
+    const res = await page.request.post('/api/mentor/email', {
+      data: { relationIds: [rel.id], subject: 'Welcome', body: 'Glad to mentor you.' },
+    });
+    expect(res.ok()).toBeTruthy();
+
+    await expect.poll(async () =>
+      prisma.message.count({ where: { relationId: rel.id, channel: 'EMAIL' } })
+    ).toBeGreaterThan(0);
+    await expect.poll(async () =>
+      prisma.notification.count({ where: { userId: mentee.id, type: 'message' } })
+    ).toBeGreaterThan(0);
+  } finally {
+    await prisma.message.deleteMany({ where: { relationId: rel.id } });
+    await prisma.notification.deleteMany({ where: { userId: { in: [mentor.id, mentee.id] } } });
+    await prisma.mentorshipRelation.deleteMany({ where: { id: rel.id } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+  }
+});
+
+test('mentee can reply in the thread and the mentor is notified', async ({ page }) => {
+  const mentorEmail = uniqueEmail('rep-mentor');
+  const menteeEmail = uniqueEmail('rep-mentee');
+  const mentor = await seedUser(mentorEmail, 'MentorPass123', 'MENTOR', 'Rep Mentor');
+  const mentee = await seedUser(menteeEmail, 'MenteePass123', 'MENTEE', 'Rep Mentee');
+  const rel = await prisma.mentorshipRelation.create({ data: { mentorId: mentor.id, menteeId: mentee.id } });
+  await prisma.message.create({ data: { relationId: rel.id, senderId: mentor.id, channel: 'EMAIL', body: 'How is it going?' } });
+
+  try {
+    await signIn(page, menteeEmail, 'MenteePass123', '/portal');
+    await page.goto(`/messages/${rel.id}`);
+    await expect(page.getByText('How is it going?')).toBeVisible({ timeout: 10_000 });
+
+    await page.locator('textarea').fill('Going great, thanks!');
+    const done = page.waitForResponse((r) => r.url().includes('/api/messages') && r.request().method() === 'POST');
+    await page.getByRole('button', { name: 'Send' }).click();
+    await done;
+
+    await expect.poll(async () =>
+      prisma.message.count({ where: { relationId: rel.id, senderId: mentee.id } })
+    ).toBeGreaterThan(0);
+    await expect.poll(async () =>
+      prisma.notification.count({ where: { userId: mentor.id, type: 'message' } })
+    ).toBeGreaterThan(0);
+  } finally {
+    await prisma.message.deleteMany({ where: { relationId: rel.id } });
+    await prisma.notification.deleteMany({ where: { userId: { in: [mentor.id, mentee.id] } } });
+    await prisma.mentorshipRelation.deleteMany({ where: { id: rel.id } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+  }
+});

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -87,6 +87,26 @@ model User {
   company                 Company?                 @relation("CompanyUsers", fields: [companyId], references: [id])
 }
 
+enum MessageChannel {
+  IN_APP
+  EMAIL
+}
+
+// A message in a mentorship thread (the thread is the MentorshipRelation).
+// Sent in-app or mirrored from an email; powers mentor ↔ mentee conversations.
+model Message {
+  id         String         @id @default(cuid())
+  relationId String
+  senderId   String
+  body       String         @db.Text
+  channel    MessageChannel @default(IN_APP)
+  createdAt  DateTime       @default(now())
+
+  relation MentorshipRelation @relation(fields: [relationId], references: [id], onDelete: Cascade)
+
+  @@index([relationId])
+}
+
 // In-app notification for a user.
 model Notification {
   id        String   @id @default(cuid())
@@ -167,6 +187,7 @@ model MentorshipRelation {
   interactions  InteractionLog[]
   statusChanges StatusChange[]
   meetings      Meeting[]
+  messages      Message[]
 }
 
 model InteractionLog {

--- a/src/app/api/mentor/email/route.ts
+++ b/src/app/api/mentor/email/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { z } from 'zod';
 import { sendEmail } from '@/services/emailService';
+import { notify } from '@/lib/notify';
 
 const schema = z.object({
   relationIds: z.array(z.string().min(1)).min(1),
@@ -52,6 +53,11 @@ export async function POST(request: Request) {
     await prisma.interactionLog.create({
       data: { relationId: rel.id, date: new Date(), type: 'Email', notes: `${subject} — ${body}` },
     });
+    // Mirror the email into the conversation thread + notify the mentee in-app.
+    await prisma.message.create({
+      data: { relationId: rel.id, senderId: session.user.id, channel: 'EMAIL', body: `${subject}\n\n${body}` },
+    });
+    await notify(rel.menteeId, 'message', `New message from ${session.user.name ?? 'your mentor'}.`, `/messages/${rel.id}`);
     sent++;
   }
 

--- a/src/app/api/messages/route.ts
+++ b/src/app/api/messages/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { z } from 'zod';
+import { getThreadIfAllowed, otherParticipant } from '@/lib/messaging';
+import { notify } from '@/lib/notify';
+
+// GET ?relationId= — messages in a thread (participants/admin only).
+export async function GET(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const relationId = new URL(request.url).searchParams.get('relationId') || '';
+  const rel = await getThreadIfAllowed(session.user, relationId);
+  if (!rel) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+  const messages = await prisma.message.findMany({
+    where: { relationId },
+    orderBy: { createdAt: 'asc' },
+  });
+  return NextResponse.json({
+    relationId,
+    mentor: rel.mentor,
+    mentee: rel.mentee,
+    messages,
+  });
+}
+
+const schema = z.object({ relationId: z.string().min(1), body: z.string().min(1).max(5000) });
+
+// POST — post a message to a thread (participants/admin). Notifies the other party.
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const parsed = schema.safeParse(await request.json());
+  if (!parsed.success) return NextResponse.json({ error: 'Validation failed' }, { status: 400 });
+
+  const rel = await getThreadIfAllowed(session.user, parsed.data.relationId);
+  if (!rel) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+  const message = await prisma.message.create({
+    data: { relationId: rel.id, senderId: session.user.id, body: parsed.data.body, channel: 'IN_APP' },
+  });
+
+  // Notify the other participant (unless an admin is posting to someone else's thread).
+  const recipient = otherParticipant(rel, session.user.id);
+  if (recipient && recipient !== session.user.id) {
+    await notify(recipient, 'message', `New message from ${session.user.name ?? 'your mentor'}.`, `/messages/${rel.id}`);
+  }
+
+  return NextResponse.json({ message }, { status: 201 });
+}

--- a/src/app/messages/[relationId]/page.tsx
+++ b/src/app/messages/[relationId]/page.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { use, useCallback, useEffect, useRef, useState } from 'react';
+import { useSession } from 'next-auth/react';
+import { Card } from '@/components/ui/Card';
+import { Button } from '@/components/ui/Button';
+import { useT } from '@/i18n/client';
+
+interface Msg {
+  id: string;
+  senderId: string;
+  body: string;
+  channel: 'IN_APP' | 'EMAIL';
+  createdAt: string;
+}
+interface Party { id: string; fullName: string }
+
+export default function ThreadPage({ params }: { params: Promise<{ relationId: string }> }) {
+  const { relationId } = use(params);
+  const t = useT();
+  const { data: session } = useSession();
+  const myId = session?.user?.id;
+  const [messages, setMessages] = useState<Msg[]>([]);
+  const [mentor, setMentor] = useState<Party | null>(null);
+  const [mentee, setMentee] = useState<Party | null>(null);
+  const [body, setBody] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [sending, setSending] = useState(false);
+  const [forbidden, setForbidden] = useState(false);
+  const endRef = useRef<HTMLDivElement>(null);
+
+  const load = useCallback(async () => {
+    const res = await fetch(`/api/messages?relationId=${relationId}`);
+    if (res.status === 403) { setForbidden(true); setLoading(false); return; }
+    const d = await res.json();
+    setMessages(d.messages ?? []);
+    setMentor(d.mentor ?? null);
+    setMentee(d.mentee ?? null);
+    setLoading(false);
+  }, [relationId]);
+
+  useEffect(() => { load(); }, [load]);
+  useEffect(() => { endRef.current?.scrollIntoView({ behavior: 'smooth' }); }, [messages]);
+
+  const send = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!body.trim()) return;
+    setSending(true);
+    try {
+      const res = await fetch('/api/messages', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ relationId, body }),
+      });
+      if (res.ok) { setBody(''); await load(); }
+    } finally {
+      setSending(false);
+    }
+  };
+
+  if (loading) return <p className="text-center py-12 text-gray-400">{t.common.loading}</p>;
+  if (forbidden) return <p className="text-center py-12 text-gray-400">{t.common.notFound}</p>;
+
+  const nameFor = (id: string) =>
+    id === mentor?.id ? mentor?.fullName : id === mentee?.id ? mentee?.fullName : '—';
+  const other = myId === mentor?.id ? mentee : mentor;
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold text-gray-900 mb-1">{t.messages.title}</h1>
+      <p className="text-gray-500 mb-6">{other?.fullName}</p>
+
+      <Card className="mb-4">
+        {messages.length === 0 ? (
+          <p className="text-center py-10 text-gray-400 text-sm">{t.messages.empty}</p>
+        ) : (
+          <div className="space-y-3 max-h-[55vh] overflow-y-auto">
+            {messages.map((m) => {
+              const mine = m.senderId === myId;
+              return (
+                <div key={m.id} className={`flex ${mine ? 'justify-end' : 'justify-start'}`}>
+                  <div className={`max-w-[80%] rounded-2xl px-4 py-2 text-sm ${mine ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-900'}`}>
+                    {!mine && <p className="text-xs font-medium mb-0.5 opacity-70">{nameFor(m.senderId)}</p>}
+                    <p className="whitespace-pre-wrap break-words">{m.body}</p>
+                    <p className={`text-[10px] mt-1 ${mine ? 'text-blue-100' : 'text-gray-400'}`}>
+                      {m.channel === 'EMAIL' ? '✉ ' : ''}{new Date(m.createdAt).toLocaleString()}
+                    </p>
+                  </div>
+                </div>
+              );
+            })}
+            <div ref={endRef} />
+          </div>
+        )}
+      </Card>
+
+      <form onSubmit={send} className="flex gap-2">
+        <textarea
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          rows={2}
+          placeholder={t.messages.replyPlaceholder}
+          className="flex-1 rounded-lg border border-gray-300 px-3.5 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-100 focus:border-blue-400 resize-none"
+        />
+        <Button type="submit" loading={sending} disabled={!body.trim()}>{t.messages.send}</Button>
+      </form>
+    </div>
+  );
+}

--- a/src/app/messages/layout.tsx
+++ b/src/app/messages/layout.tsx
@@ -1,0 +1,27 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { redirect } from 'next/navigation';
+import Link from 'next/link';
+import { ArrowLeft } from 'lucide-react';
+import { roleHome } from '@/lib/roleHome';
+
+// Conversation threads are available to any authenticated participant.
+export default async function MessagesLayout({ children }: { children: React.ReactNode }) {
+  const session = await getServerSession(authOptions);
+  if (!session) redirect('/auth/signin');
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-3xl mx-auto p-4 lg:p-8">
+        <Link
+          href={roleHome(session.user.role)}
+          className="inline-flex items-center gap-2 text-sm text-gray-500 hover:text-gray-700 mb-6"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          {session.user.name ?? 'Back'}
+        </Link>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/app/portal/layout.tsx
+++ b/src/app/portal/layout.tsx
@@ -2,7 +2,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
-import { GraduationCap, LayoutDashboard, User, BookOpen, LogOut } from 'lucide-react';
+import { GraduationCap, LayoutDashboard, User, BookOpen, MessageSquare, LogOut } from 'lucide-react';
 import { getServerDictionary } from '@/i18n/server';
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
 import { ResponsiveShell } from '@/components/ResponsiveShell';
@@ -58,6 +58,13 @@ export default async function PortalLayout({ children }: { children: React.React
           >
             <User className="h-5 w-5 text-gray-400 group-hover:text-blue-600" />
             {t.nav.myProfile}
+          </Link>
+          <Link
+            href="/portal/messages"
+            className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-gray-700 hover:bg-blue-50 hover:text-blue-700 transition-colors group"
+          >
+            <MessageSquare className="h-5 w-5 text-gray-400 group-hover:text-blue-600" />
+            {t.nav.messages}
           </Link>
           <Link
             href="/portal/interactions"

--- a/src/app/portal/messages/page.tsx
+++ b/src/app/portal/messages/page.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
+import { MessageSquare } from 'lucide-react';
+import { useT } from '@/i18n/client';
+
+interface Relation {
+  id: string;
+  mentor: { fullName: string };
+}
+
+// Mentee view: list of conversation threads (one per mentorship).
+export default function PortalMessagesPage() {
+  const t = useT();
+  const [relations, setRelations] = useState<Relation[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch('/api/mentorship')
+      .then((r) => r.json())
+      .then((d) => setRelations(d.relations ?? []))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900">{t.messages.title}</h1>
+        <p className="text-gray-500 mt-1">{t.messages.listSubtitle}</p>
+      </div>
+      <Card>
+        <CardHeader><CardTitle>{t.messages.threads}</CardTitle></CardHeader>
+        {loading ? (
+          <p className="text-center py-10 text-gray-400">{t.common.loading}</p>
+        ) : relations.length === 0 ? (
+          <p className="text-center py-10 text-gray-400">{t.messages.noThreads}</p>
+        ) : (
+          <div className="divide-y divide-gray-50">
+            {relations.map((r) => (
+              <Link key={r.id} href={`/messages/${r.id}`} className="flex items-center gap-3 py-3 hover:bg-gray-50 rounded-lg px-2">
+                <div className="w-9 h-9 rounded-full bg-blue-100 flex items-center justify-center">
+                  <MessageSquare className="h-4 w-4 text-blue-600" />
+                </div>
+                <span className="text-sm font-medium text-gray-900">{r.mentor?.fullName ?? '—'}</span>
+              </Link>
+            ))}
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/src/app/portal/profile/page.tsx
+++ b/src/app/portal/profile/page.tsx
@@ -10,6 +10,7 @@ import { Input } from '@/components/ui/Input';
 import { Button } from '@/components/ui/Button';
 import { Select } from '@/components/ui/Select';
 import { CvManager } from '@/components/CvManager';
+import { AvatarManager } from '@/components/AvatarManager';
 
 const profileSchema = z.object({
   fullName: z.string().min(1, 'Full name is required'),
@@ -46,6 +47,8 @@ export default function ProfilePage() {
   const [initialCv, setInitialCv] = useState<string | null>(null);
   const [publicProfile, setPublicProfile] = useState(false);
   const [profileViews, setProfileViews] = useState(0);
+  const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
+  const [fullName, setFullName] = useState('');
 
   const {
     register,
@@ -65,6 +68,8 @@ export default function ProfilePage() {
           setInitialCv(user.cvUrl || null);
           setPublicProfile(!!user.publicProfile);
           setProfileViews(user.profileViews || 0);
+          setAvatarUrl(user.avatarUrl || null);
+          setFullName(user.fullName || '');
           reset({
             fullName: user.fullName,
             phone: user.phone || '',
@@ -118,7 +123,7 @@ export default function ProfilePage() {
     }
   });
 
-  if (loading) return <div className="text-center py-12 text-gray-400">Loading...</div>;
+  if (loading) return <div className="text-center py-12 text-gray-400">{t.common.loading}</div>;
 
   return (
     <div>
@@ -126,6 +131,13 @@ export default function ProfilePage() {
         <h1 className="text-2xl font-bold text-gray-900">{t.profileForm.title}</h1>
         <p className="text-gray-500 mt-1">{t.profileForm.subtitle}</p>
       </div>
+
+      {userId && (
+        <Card className="max-w-2xl mb-6">
+          <CardHeader><CardTitle>{t.avatar.section}</CardTitle></CardHeader>
+          <AvatarManager targetUserId={userId} initialAvatarUrl={avatarUrl} name={fullName} />
+        </Card>
+      )}
 
       <Card className="max-w-2xl">
         <CardHeader>

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -16,6 +16,7 @@ const en = {
     myMentees: 'My Mentees',
     board: 'Board',
     interactionLogs: 'Interaction Logs',
+    messages: 'Messages',
     email: 'Email',
     meetings: 'Meetings',
     myProfile: 'My Profile',
@@ -363,6 +364,15 @@ const en = {
     install: 'Install app',
     iosHint: 'Tap the Share button, then “Add to Home Screen”.',
   },
+  messages: {
+    title: 'Messages',
+    listSubtitle: 'Your conversations with your mentor',
+    threads: 'Conversations',
+    noThreads: 'No conversations yet',
+    empty: 'No messages yet. Say hello!',
+    replyPlaceholder: 'Write a reply…',
+    send: 'Send',
+  },
   checklist: {
     title: 'Get started',
     dismiss: 'Dismiss',
@@ -543,6 +553,7 @@ const tr: Dict = {
     myMentees: 'Mentee’lerim',
     board: 'Pano',
     interactionLogs: 'Etkileşim Kayıtları',
+    messages: 'Mesajlar',
     email: 'E-posta',
     meetings: 'Toplantılar',
     myProfile: 'Profilim',
@@ -889,6 +900,15 @@ const tr: Dict = {
   pwa: {
     install: 'Uygulamayı kur',
     iosHint: 'Paylaş düğmesine, sonra “Ana Ekrana Ekle”ye dokun.',
+  },
+  messages: {
+    title: 'Mesajlar',
+    listSubtitle: 'Mentorunla yazışmaların',
+    threads: 'Görüşmeler',
+    noThreads: 'Henüz görüşme yok',
+    empty: 'Henüz mesaj yok. Merhaba de!',
+    replyPlaceholder: 'Bir cevap yaz…',
+    send: 'Gönder',
   },
   checklist: {
     title: 'Başlayalım',

--- a/src/lib/messaging.ts
+++ b/src/lib/messaging.ts
@@ -1,0 +1,27 @@
+import { prisma } from '@/lib/prisma';
+
+interface SessionUser {
+  id: string;
+  role: string;
+}
+
+// A mentorship thread is accessible to its mentor, its mentee, or any admin.
+// Returns the relation (with participant ids/names) when allowed, else null.
+export async function getThreadIfAllowed(user: SessionUser, relationId: string) {
+  const rel = await prisma.mentorshipRelation.findUnique({
+    where: { id: relationId },
+    include: {
+      mentor: { select: { id: true, fullName: true } },
+      mentee: { select: { id: true, fullName: true } },
+    },
+  });
+  if (!rel) return null;
+  const isParticipant = rel.mentorId === user.id || rel.menteeId === user.id;
+  if (!isParticipant && user.role !== 'ADMIN') return null;
+  return rel;
+}
+
+// The "other" participant to notify when someone posts to a thread.
+export function otherParticipant(rel: { mentorId: string; menteeId: string }, senderId: string) {
+  return senderId === rel.mentorId ? rel.menteeId : rel.mentorId;
+}


### PR DESCRIPTION
## EPIC 29 (uygulama-içi kısım)

- **#221**: Mentee profil sayfasına **avatar** yükleme (önceden sadece /account).
- **#223**: `Message` modeli (thread = mentorship ilişkisi); katılımcı/admin korumalı `GET/POST /api/messages`. Sohbet sayfası `/messages/[relationId]` (mesajlar + cevap kutusu); mentee `/portal/messages` listesi + nav. Mesaj atınca karşı tarafa **bildirim** (thread linki).
- **#224**: Mentor e-postası artık thread'e `Message(EMAIL)` olarak da düşüyor + mentee'ye bildirim → mentee bildirimde görüp **cevaplıyor**, cevap o thread'e bağlı.
- i18n EN+TR.
- e2e: mentor email → thread mesajı + mentee bildirimi; mentee cevabı → kalıcı + mentor bildirimi.

Closes #221
Closes #223
Closes #224

> #225 (email ile cevap → otomatik thread, HMAC token'lı güvenli inbound) ayrı PR'da gelecek.

🤖 Generated with [Claude Code](https://claude.com/claude-code)