### PR TITLE
fix(filters): partial skill matching (#228)

### DIFF
--- a/e2e/skill-filter.spec.ts
+++ b/e2e/skill-filter.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('skill filter matches a partial, case-insensitive term', async ({ page }) => {
+  const adminEmail = uniqueEmail('skf-admin');
+  const menteeEmail = uniqueEmail('skf-mentee');
+  await seedUser(adminEmail, 'AdminPass123', 'ADMIN', 'Skf Admin');
+  const mentee = await seedUser(menteeEmail, 'x', 'MENTEE', 'Docker Person');
+  await prisma.user.update({ where: { id: mentee.id }, data: { skills: ['Docker', 'Linux'] } });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', 'AdminPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    // Partial term via the API the page uses.
+    const res = await page.request.get('/api/candidates?skills=docke');
+    expect(res.ok()).toBeTruthy();
+    const data = await res.json();
+    expect(data.candidates.some((c: { id: string }) => c.id === mentee.id)).toBeTruthy();
+  } finally {
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/src/app/api/candidates/route.ts
+++ b/src/app/api/candidates/route.ts
@@ -79,11 +79,13 @@ export async function GET(request: Request) {
     // Normalise skills (stored as JSON array) and apply optional skill filter
     const candidates = rawCandidates
       .map((c) => ({ ...c, skills: (c.skills ?? []) as string[] }))
-      .filter((c) =>
-        skillList.length === 0
-          ? true
-          : skillList.some((s) => c.skills.map((k) => k.toLowerCase()).includes(s))
-      );
+      .filter((c) => {
+        if (skillList.length === 0) return true;
+        const owned = c.skills.map((k) => k.toLowerCase());
+        // Every typed term must be a substring of at least one of the candidate's
+        // skills (so "docke" matches "Docker"), case-insensitive.
+        return skillList.every((term) => owned.some((k) => k.includes(term)));
+      });
 
     return NextResponse.json({ candidates });
   } catch (error) {


### PR DESCRIPTION
## EPIC 30 · Gelişmiş filtreleme — S30.1

Skill filtresi tam token istiyordu ('docke' → 0). Artık her terim, adayın bir skill'inde **substring** olarak (case-insensitive, çoklu terim AND) aranıyor → 'docke' → Docker eşleşir.

- e2e: kısmi skill terimi adayı buluyor.

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)