### PR TITLE
fix(ui): Install app button placement (#240)

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -109,6 +109,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
             <Mail className="h-5 w-5 text-gray-400 group-hover:text-blue-600" />
             {t.nav.invite}
           </Link>
+          <InstallAppButton />
         </nav>
 
         <div className="p-4 border-t border-gray-200">
@@ -130,8 +131,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
             <LogOut className="h-4 w-4" />
             {t.nav.signOut}
           </Link>
-          <div className="mt-3 px-3 space-y-1">
-            <InstallAppButton />
+          <div className="mt-3 px-3">
             <LanguageSwitcher current={locale} />
           </div>
         </div>

--- a/src/app/company/layout.tsx
+++ b/src/app/company/layout.tsx
@@ -39,7 +39,8 @@ export default async function CompanyLayout({ children }: { children: React.Reac
               <LayoutDashboard className="h-5 w-5 text-gray-400 group-hover:text-blue-600" />
               {t.nav.dashboard}
             </Link>
-          </nav>
+            <InstallAppButton />
+        </nav>
 
           <div className="p-4 border-t border-gray-200">
             <Link href="/account" title={t.account.nav} className="flex items-center gap-3 mb-3 px-3 py-1.5 rounded-lg hover:bg-gray-50 transition-colors">
@@ -56,8 +57,7 @@ export default async function CompanyLayout({ children }: { children: React.Reac
               <LogOut className="h-4 w-4" />
               {t.nav.signOut}
             </Link>
-            <div className="mt-3 px-3 space-y-1">
-              <InstallAppButton />
+            <div className="mt-3 px-3">
               <LanguageSwitcher current={locale} />
             </div>
           </div>

--- a/src/app/mentor/layout.tsx
+++ b/src/app/mentor/layout.tsx
@@ -79,6 +79,7 @@ export default async function MentorLayout({ children }: { children: React.React
             <CalendarClock className="h-5 w-5 text-gray-400 group-hover:text-blue-600" />
             {t.nav.meetings}
           </Link>
+          <InstallAppButton />
         </nav>
 
         <div className="p-4 border-t border-gray-200">
@@ -96,8 +97,7 @@ export default async function MentorLayout({ children }: { children: React.React
             <LogOut className="h-4 w-4" />
             {t.nav.signOut}
           </Link>
-          <div className="mt-3 px-3 space-y-1">
-            <InstallAppButton />
+          <div className="mt-3 px-3">
             <LanguageSwitcher current={locale} />
           </div>
         </div>

--- a/src/app/portal/layout.tsx
+++ b/src/app/portal/layout.tsx
@@ -73,6 +73,7 @@ export default async function PortalLayout({ children }: { children: React.React
             <BookOpen className="h-5 w-5 text-gray-400 group-hover:text-blue-600" />
             {t.nav.interactionLogs}
           </Link>
+          <InstallAppButton />
         </nav>
 
         <div className="p-4 border-t border-gray-200">
@@ -90,8 +91,7 @@ export default async function PortalLayout({ children }: { children: React.React
             <LogOut className="h-4 w-4" />
             {t.nav.signOut}
           </Link>
-          <div className="mt-3 px-3 space-y-1">
-            <InstallAppButton />
+          <div className="mt-3 px-3">
             <LanguageSwitcher current={locale} />
           </div>
         </div>


### PR DESCRIPTION
Install app butonu Sign Out'un altında kötü duruyordu; dört sidebar'da da **nav'ın en altına, profil bloğunun (border-t) üstüne** taşındı. Dil değiştirici footer'da kaldı.

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)