### PR TITLE
feat(evaluation): skill self-assessment + mentor rubric (#214 #215)

### DIFF
--- a/e2e/evaluation.spec.ts
+++ b/e2e/evaluation.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('a mentor can record an evaluation for their mentee', async ({ page }) => {
+  const mentorEmail = uniqueEmail('ev-mentor');
+  const menteeEmail = uniqueEmail('ev-mentee');
+  const mentor = await seedUser(mentorEmail, 'MentorPass123', 'MENTOR', 'Ev Mentor');
+  const mentee = await seedUser(menteeEmail, 'x', 'MENTEE', 'Ev Mentee');
+  const rel = await prisma.mentorshipRelation.create({ data: { mentorId: mentor.id, menteeId: mentee.id } });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', mentorEmail);
+    await page.fill('input[type="password"]', 'MentorPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/mentor'), { timeout: 20_000 });
+
+    const res = await page.request.post('/api/evaluations', {
+      data: { relationId: rel.id, scores: { technical: 4, communication: 5 }, comment: 'Strong start.' },
+    });
+    expect(res.status()).toBe(201);
+    const ev = await prisma.evaluation.findFirst({ where: { relationId: rel.id } });
+    expect(ev?.authorId).toBe(mentor.id);
+    expect((ev?.scores as Record<string, number>).technical).toBe(4);
+  } finally {
+    await prisma.mentorshipRelation.deleteMany({ where: { id: rel.id } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+  }
+});
+
+test('a mentee can self-assess their skill levels', async ({ page }) => {
+  const email = uniqueEmail('sl-mentee');
+  const mentee = await seedUser(email, 'MenteePass123', 'MENTEE', 'SL Mentee');
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', email);
+    await page.fill('input[type="password"]', 'MenteePass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/portal'), { timeout: 20_000 });
+
+    const res = await page.request.put('/api/profile', {
+      data: { skills: ['React', 'Docker'], skillLevels: { React: 4, Docker: 2 } },
+    });
+    expect(res.ok()).toBeTruthy();
+    const u = await prisma.user.findUnique({ where: { id: mentee.id } });
+    expect((u?.skillLevels as Record<string, number>).React).toBe(4);
+  } finally {
+    await cleanupByEmail(email);
+  }
+});

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -54,6 +54,8 @@ model User {
   department     String?
   graduationYear Int?
   skills         Json      @default("[]")
+  // Mentee self-assessment: { "<skill>": 1..5 }
+  skillLevels    Json      @default("{}")
   cvUrl          String?
   avatarUrl      String?
   whatsapp       String?
@@ -231,6 +233,21 @@ model MentorshipRelation {
   statusChanges StatusChange[]
   meetings      Meeting[]
   messages      Message[]
+  evaluations   Evaluation[]
+}
+
+// A mentor's structured evaluation of a mentee within a mentorship.
+model Evaluation {
+  id         String   @id @default(cuid())
+  relationId String
+  authorId   String
+  scores     Json     @default("{}") // { criterion: 1..5 }
+  comment    String?  @db.Text
+  createdAt  DateTime @default(now())
+
+  relation MentorshipRelation @relation(fields: [relationId], references: [id], onDelete: Cascade)
+
+  @@index([relationId])
 }
 
 model InteractionLog {

--- a/src/app/admin/candidates/[id]/page.tsx
+++ b/src/app/admin/candidates/[id]/page.tsx
@@ -11,6 +11,7 @@ import { ArrowLeft, KeyRound, Trash2, Plus } from 'lucide-react';
 import { pipelineLabel, pipelineOptions, PIPELINE_STATUSES } from '@/lib/pipeline';
 import { CvManager } from '@/components/CvManager';
 import { nextAction } from '@/lib/matching';
+import { EvaluationPanel } from '@/components/EvaluationPanel';
 import { useT, useLocale } from '@/i18n/client';
 
 interface Interaction { id: string; date: string; notes: string; type: string }
@@ -365,6 +366,7 @@ export default function AdminMenteeDetailPage() {
             </div>
           )}
         </Card>
+        {rel && <EvaluationPanel relationId={rel.id} />}
       </div>
     </div>
   );

--- a/src/app/api/evaluations/route.ts
+++ b/src/app/api/evaluations/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { z } from 'zod';
+import { EVAL_CRITERIA } from '@/lib/evaluation';
+
+// GET ?relationId= — evaluations for a relation (participants/admin).
+export async function GET(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const relationId = new URL(request.url).searchParams.get('relationId') || '';
+
+  const rel = await prisma.mentorshipRelation.findUnique({ where: { id: relationId } });
+  if (!rel) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  const allowed = session.user.role === 'ADMIN' || rel.mentorId === session.user.id || rel.menteeId === session.user.id;
+  if (!allowed) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+  const evaluations = await prisma.evaluation.findMany({ where: { relationId }, orderBy: { createdAt: 'desc' } });
+  return NextResponse.json({ evaluations });
+}
+
+const scoreSchema = z.record(z.enum(EVAL_CRITERIA), z.number().int().min(1).max(5));
+const schema = z.object({
+  relationId: z.string().min(1),
+  scores: scoreSchema,
+  comment: z.string().max(2000).optional().nullable(),
+});
+
+// POST — the mentor (or an admin) records an evaluation for the mentee.
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const parsed = schema.safeParse(await request.json());
+  if (!parsed.success) return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 });
+
+  const rel = await prisma.mentorshipRelation.findUnique({ where: { id: parsed.data.relationId } });
+  if (!rel) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  if (session.user.role !== 'ADMIN' && rel.mentorId !== session.user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const evaluation = await prisma.evaluation.create({
+    data: { relationId: rel.id, authorId: session.user.id, scores: parsed.data.scores, comment: parsed.data.comment || null },
+  });
+  return NextResponse.json({ evaluation }, { status: 201 });
+}

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -16,6 +16,7 @@ const updateProfileSchema = z.object({
   department: z.string().optional(),
   graduationYear: z.number().int().nullable().optional(),
   skills: z.array(z.string()).optional(),
+  skillLevels: z.record(z.string(), z.number().int().min(1).max(5)).optional(),
   cvUrl: z.string().url().or(z.literal('')).nullable().optional(),
   publicProfile: z.boolean().optional(),
 });
@@ -44,6 +45,7 @@ export async function GET() {
         department: true,
         graduationYear: true,
         skills: true,
+        skillLevels: true,
         cvUrl: true,
         avatarUrl: true,
         publicProfile: true,
@@ -106,6 +108,7 @@ export async function PUT(request: Request) {
         department: true,
         graduationYear: true,
         skills: true,
+        skillLevels: true,
         cvUrl: true,
         publicProfile: true,
         updatedAt: true,

--- a/src/app/mentor/mentees/[id]/page.tsx
+++ b/src/app/mentor/mentees/[id]/page.tsx
@@ -11,6 +11,7 @@ import { ArrowLeft, Plus, Trash2, ExternalLink } from 'lucide-react';
 import Link from 'next/link';
 import { pipelineOptions, pipelineLabel } from '@/lib/pipeline';
 import { useT, useLocale } from '@/i18n/client';
+import { EvaluationPanel } from '@/components/EvaluationPanel';
 
 interface InteractionLog {
   id: string;
@@ -356,6 +357,10 @@ export default function MenteeDetailPage() {
             ))}
           </div>
         </Card>
+
+        <div className="lg:col-span-2">
+          <EvaluationPanel relationId={id} />
+        </div>
       </div>
     </div>
   );

--- a/src/app/portal/profile/page.tsx
+++ b/src/app/portal/profile/page.tsx
@@ -50,10 +50,13 @@ export default function ProfilePage() {
   const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
   const [fullName, setFullName] = useState('');
 
+  const [skillLevels, setSkillLevels] = useState<Record<string, number>>({});
+
   const {
     register,
     handleSubmit,
     reset,
+    watch,
     formState: { errors },
   } = useForm<ProfileFormData>({
     resolver: zodResolver(profileSchema),
@@ -70,6 +73,7 @@ export default function ProfilePage() {
           setProfileViews(user.profileViews || 0);
           setAvatarUrl(user.avatarUrl || null);
           setFullName(user.fullName || '');
+          setSkillLevels((user.skillLevels && typeof user.skillLevels === 'object') ? user.skillLevels : {});
           reset({
             fullName: user.fullName,
             phone: user.phone || '',
@@ -96,6 +100,10 @@ export default function ProfilePage() {
       const skillsArray = data.skills
         ? data.skills.split(',').map((s) => s.trim()).filter(Boolean)
         : [];
+      // Keep levels only for skills the user still lists.
+      const levels = Object.fromEntries(
+        skillsArray.filter((s) => skillLevels[s]).map((s) => [s, skillLevels[s]])
+      );
 
       const res = await fetch('/api/profile', {
         method: 'PUT',
@@ -103,6 +111,7 @@ export default function ProfilePage() {
         body: JSON.stringify({
           ...data,
           skills: skillsArray,
+          skillLevels: levels,
           graduationYear: data.graduationYear || null,
           cvUrl: data.cvUrl || null,
           publicProfile,
@@ -214,6 +223,30 @@ export default function ProfilePage() {
                 {...register('skills')}
                 error={errors.skills?.message}
               />
+              {(() => {
+                const list = (watch('skills') || '').split(',').map((s) => s.trim()).filter(Boolean);
+                if (list.length === 0) return null;
+                return (
+                  <div>
+                    <p className="text-xs font-medium text-gray-600 mb-2">{t.profileForm.skillLevels}</p>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                      {list.map((s) => (
+                        <label key={s} className="flex items-center justify-between gap-2 text-sm bg-gray-50 rounded-lg px-3 py-1.5">
+                          <span className="truncate text-gray-700">{s}</span>
+                          <select
+                            value={skillLevels[s] ?? ''}
+                            onChange={(e) => setSkillLevels((prev) => ({ ...prev, [s]: Number(e.target.value) }))}
+                            className="rounded border border-gray-300 px-2 py-1 text-sm"
+                          >
+                            <option value="">–</option>
+                            {[1, 2, 3, 4, 5].map((n) => <option key={n} value={n}>{n}</option>)}
+                          </select>
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+                );
+              })()}
               <Input
                 label={t.profileForm.cvUrl}
                 type="url"

--- a/src/components/EvaluationPanel.tsx
+++ b/src/components/EvaluationPanel.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
+import { Button } from '@/components/ui/Button';
+import { EVAL_CRITERIA } from '@/lib/evaluation';
+import { useT } from '@/i18n/client';
+
+interface Evaluation {
+  id: string;
+  scores: Record<string, number>;
+  comment: string | null;
+  createdAt: string;
+}
+
+// Shows a mentee's evaluation history; mentors/admins can add a new one.
+export function EvaluationPanel({ relationId, readOnly = false }: { relationId: string; readOnly?: boolean }) {
+  const t = useT();
+  const [items, setItems] = useState<Evaluation[]>([]);
+  const [scores, setScores] = useState<Record<string, number>>({});
+  const [comment, setComment] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const load = useCallback(async () => {
+    const res = await fetch(`/api/evaluations?relationId=${relationId}`);
+    if (res.ok) setItems((await res.json()).evaluations ?? []);
+  }, [relationId]);
+  useEffect(() => { load(); }, [load]);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    try {
+      const res = await fetch('/api/evaluations', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ relationId, scores, comment }),
+      });
+      if (res.ok) { setScores({}); setComment(''); await load(); }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const label = (c: string) => (t.evaluation.criteria as Record<string, string>)[c] ?? c;
+
+  return (
+    <Card>
+      <CardHeader><CardTitle>{t.evaluation.title}</CardTitle></CardHeader>
+
+      {!readOnly && (
+        <form onSubmit={submit} className="space-y-3 mb-5">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            {EVAL_CRITERIA.map((c) => (
+              <label key={c} className="flex items-center justify-between gap-2 text-sm">
+                <span className="text-gray-700">{label(c)}</span>
+                <select
+                  value={scores[c] ?? ''}
+                  onChange={(e) => setScores({ ...scores, [c]: Number(e.target.value) })}
+                  className="rounded-lg border border-gray-300 px-2 py-1 text-sm"
+                >
+                  <option value="">–</option>
+                  {[1, 2, 3, 4, 5].map((n) => <option key={n} value={n}>{n}</option>)}
+                </select>
+              </label>
+            ))}
+          </div>
+          <textarea
+            value={comment}
+            onChange={(e) => setComment(e.target.value)}
+            rows={2}
+            placeholder={t.evaluation.comment}
+            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+          />
+          <Button type="submit" size="sm" loading={saving} disabled={Object.keys(scores).length === 0}>
+            {t.evaluation.add}
+          </Button>
+        </form>
+      )}
+
+      {items.length === 0 ? (
+        <p className="text-sm text-gray-400">{t.evaluation.none}</p>
+      ) : (
+        <div className="space-y-3">
+          {items.map((ev) => (
+            <div key={ev.id} className="rounded-lg border border-gray-100 p-3">
+              <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm">
+                {EVAL_CRITERIA.filter((c) => ev.scores[c]).map((c) => (
+                  <span key={c} className="text-gray-700">{label(c)}: <strong>{ev.scores[c]}/5</strong></span>
+                ))}
+              </div>
+              {ev.comment && <p className="text-sm text-gray-600 mt-1.5 whitespace-pre-wrap">{ev.comment}</p>}
+              <p className="text-xs text-gray-400 mt-1">{new Date(ev.createdAt).toLocaleString()}</p>
+            </div>
+          ))}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -404,6 +404,13 @@ const en = {
     noPublic: 'No public projects yet.',
     by: 'by',
   },
+  evaluation: {
+    title: 'Evaluation',
+    criteria: { technical: 'Technical', communication: 'Communication', reliability: 'Reliability', growth: 'Growth' },
+    comment: 'Comment (optional)',
+    add: 'Add evaluation',
+    none: 'No evaluations yet',
+  },
   messages: {
     title: 'Messages',
     listSubtitle: 'Your conversations with your mentor',
@@ -527,6 +534,7 @@ const en = {
     skills: 'Skills',
     cvUrl: 'CV URL',
     profileViews: 'Profile views',
+    skillLevels: 'Self-assess your skills (1–5)',
     makePublic: 'Make my profile public',
     makePublicHint: 'Shows a PII-free public profile (no email/phone) at a shareable link.',
     save: 'Save Changes',
@@ -983,6 +991,13 @@ const tr: Dict = {
     noPublic: 'Henüz herkese açık proje yok.',
     by: '·',
   },
+  evaluation: {
+    title: 'Değerlendirme',
+    criteria: { technical: 'Teknik', communication: 'İletişim', reliability: 'Güvenilirlik', growth: 'Gelişim' },
+    comment: 'Yorum (opsiyonel)',
+    add: 'Değerlendirme ekle',
+    none: 'Henüz değerlendirme yok',
+  },
   messages: {
     title: 'Mesajlar',
     listSubtitle: 'Mentorunla yazışmaların',
@@ -1106,6 +1121,7 @@ const tr: Dict = {
     skills: 'Yetenekler',
     cvUrl: 'CV Bağlantısı',
     profileViews: 'Profil görüntülenme',
+    skillLevels: 'Yeteneklerini öz-değerlendir (1–5)',
     makePublic: 'Profilimi herkese açık yap',
     makePublicHint: 'Paylaşılabilir bir bağlantıda PII içermeyen (e-posta/telefon yok) bir profil gösterir.',
     save: 'Değişiklikleri Kaydet',

--- a/src/lib/evaluation.ts
+++ b/src/lib/evaluation.ts
@@ -1,0 +1,3 @@
+// Fixed evaluation rubric criteria (labels are localized in the UI).
+export const EVAL_CRITERIA = ['technical', 'communication', 'reliability', 'growth'] as const;
+export type EvalCriterion = (typeof EVAL_CRITERIA)[number];


### PR DESCRIPTION
## EPIC 27 · Yetenek & değerlendirme

- **#214**: `User.skillLevels` (JSON skill→1..5); portal profilinde mentee her yeteneğini puanlar; `/api/profile` saklar.
- **#215**: `Evaluation` modeli + `/api/evaluations` (mentor/admin yazar; katılımcı/admin okur). **EvaluationPanel** (rubrik: teknik/iletişim/güvenilirlik/gelişim + yorum, geçmişle) mentor mentee detayında ve admin aday detayında.
- i18n EN+TR.
- e2e: mentor değerlendirme kaydeder; mentee skill seviyelerini öz-değerlendirir.

Closes #214
Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)