### PR TITLE
feat(a11y): skip link + visible focus rings (#216)

### DIFF
--- a/e2e/a11y.spec.ts
+++ b/e2e/a11y.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('a skip-to-content link targets the main landmark', async ({ page }) => {
+  const email = uniqueEmail('a11y');
+  await seedUser(email, 'AdminPass123', 'ADMIN', 'A11y Admin');
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', email);
+    await page.fill('input[type="password"]', 'AdminPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    const skip = page.locator('a[href="#main-content"]');
+    await expect(skip).toHaveCount(1);
+    await expect(page.locator('#main-content')).toHaveCount(1);
+    // It becomes visible on keyboard focus.
+    await skip.focus();
+    await expect(skip).toBeVisible();
+  } finally {
+    await cleanupByEmail(email);
+  }
+});

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -30,3 +30,14 @@
     overflow: visible !important;
   }
 }
+
+/* a11y: a clear, consistent keyboard focus ring for interactive elements. */
+a:focus-visible,
+button:focus-visible,
+[role='button']:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,6 +21,12 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   return (
     <html lang={locale}>
       <body>
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:absolute focus:z-[100] focus:top-2 focus:left-2 focus:rounded-lg focus:bg-blue-600 focus:px-4 focus:py-2 focus:text-white"
+        >
+          {dict.a11y.skipToContent}
+        </a>
         <Providers locale={locale} dict={dict}>
           {children}
         </Providers>

--- a/src/components/ResponsiveShell.tsx
+++ b/src/components/ResponsiveShell.tsx
@@ -56,7 +56,7 @@ export function ResponsiveShell({
         </div>
       </div>
 
-      <main className="flex-1 overflow-auto min-w-0">
+      <main id="main-content" className="flex-1 overflow-auto min-w-0">
         {/* Desktop-only top strip for search + notifications */}
         <div className="hidden lg:flex items-center justify-end gap-3 px-8 pt-4 no-print">
           {headerExtra}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -33,6 +33,7 @@ const en = {
     company: 'Company Portal',
   },
   lang: { en: 'English', tr: 'Türkçe', label: 'Language' },
+  a11y: { skipToContent: 'Skip to content' },
   company: {
     title: 'Company overview',
     subtitle: 'Candidates linked to your company (read-only)',
@@ -668,6 +669,7 @@ const tr: Dict = {
     company: 'Şirket Portalı',
   },
   lang: { en: 'English', tr: 'Türkçe', label: 'Dil' },
+  a11y: { skipToContent: 'İçeriğe geç' },
   company: {
     title: 'Şirket genel görünümü',
     subtitle: 'Şirketinize bağlı adaylar (salt-okunur)',


### PR DESCRIPTION
## EPIC 28 · Erişilebilirlik

- **Skip-to-content** linki (odakta görünür) → `#main-content` landmark.
- Global `:focus-visible` çerçevesi (link/buton/input/select/textarea) — klavye gezintisi her zaman görünür.
- i18n EN+TR.
- e2e: skip link var, `#main-content`'i hedefler, odakta görünür.

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)