### PR TITLE
feat(messaging): secure reply-by-email inbound (#225)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,3 +38,14 @@ Set for all routes in `next.config.js`: Content-Security-Policy (self by default
 
 ## Reporting a vulnerability
 Email the maintainer (see repository owner). Do not open public issues for sensitive reports.
+
+## Inbound email (reply-by-email)
+Mentor↔mentee threads accept replies by email. Outgoing thread emails set
+`Reply-To: reply+<relationId>.<hmac>@<domain>` where the HMAC is signed with
+`NEXTAUTH_SECRET` (unguessable, tamper-evident). A mail bridge (IMAP poller or
+provider inbound webhook) POSTs parsed mail to `POST /api/inbound-email`
+(`{to, from, text}`). The endpoint accepts a message **only if** the reply
+token's HMAC verifies **and** the sender address is a participant of that
+thread; quoted history is stripped. Set `INBOUND_SECRET` (and have the bridge
+send it as `X-Inbound-Secret`) for defense-in-depth, and `INBOUND_EMAIL_DOMAIN`
+to your mail domain. Ideally the mail server enforces SPF/DKIM before forwarding.

--- a/e2e/inbound-email.spec.ts
+++ b/e2e/inbound-email.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test';
+import { createHmac } from 'crypto';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// Mirror src/lib/replyToken.ts so the test can craft valid/invalid tokens.
+const secret = () => process.env.NEXTAUTH_SECRET || 'dev-secret';
+const makeToken = (relationId: string) =>
+  `${relationId}.${createHmac('sha256', secret()).update(relationId).digest('hex').slice(0, 32)}`;
+
+test('inbound email reply is routed to the thread (token + sender verified)', async ({ request }) => {
+  const mentorEmail = uniqueEmail('inb-mentor');
+  const menteeEmail = uniqueEmail('inb-mentee');
+  const mentor = await seedUser(mentorEmail, 'x', 'MENTOR', 'Inb Mentor');
+  const mentee = await seedUser(menteeEmail, 'x', 'MENTEE', 'Inb Mentee');
+  const rel = await prisma.mentorshipRelation.create({ data: { mentorId: mentor.id, menteeId: mentee.id } });
+  const token = makeToken(rel.id);
+
+  try {
+    // Valid: correct token + participant sender → message created, quoted text stripped.
+    const ok = await request.post('/api/inbound-email', {
+      data: { to: `reply+${token}@crm.ersah.in`, from: `Inb Mentee <${menteeEmail}>`, text: 'Thanks, see you then!\n\nOn Mon someone wrote:\n> earlier message' },
+    });
+    expect(ok.status()).toBe(200);
+    await expect.poll(async () => prisma.message.count({ where: { relationId: rel.id, channel: 'EMAIL', senderId: mentee.id } })).toBeGreaterThan(0);
+    const msg = await prisma.message.findFirst({ where: { relationId: rel.id, senderId: mentee.id } });
+    expect(msg?.body).toBe('Thanks, see you then!');
+    await expect.poll(async () => prisma.notification.count({ where: { userId: mentor.id, type: 'message' } })).toBeGreaterThan(0);
+
+    // Tampered token → rejected.
+    const bad = await request.post('/api/inbound-email', {
+      data: { to: `reply+${rel.id}.deadbeefdeadbeefdeadbeefdeadbeef@crm.ersah.in`, from: menteeEmail, text: 'hack' },
+    });
+    expect(bad.status()).toBe(400);
+
+    // Valid token but sender is not a participant → rejected.
+    const stranger = await request.post('/api/inbound-email', {
+      data: { to: `reply+${token}@crm.ersah.in`, from: 'stranger@evil.com', text: 'spoof' },
+    });
+    expect(stranger.status()).toBe(403);
+
+    // Still only one message from the mentee.
+    expect(await prisma.message.count({ where: { relationId: rel.id } })).toBe(1);
+  } finally {
+    await prisma.message.deleteMany({ where: { relationId: rel.id } });
+    await prisma.notification.deleteMany({ where: { userId: { in: [mentor.id, mentee.id] } } });
+    await prisma.mentorshipRelation.deleteMany({ where: { id: rel.id } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+  }
+});

--- a/src/app/api/inbound-email/route.ts
+++ b/src/app/api/inbound-email/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from 'next/server';
+import { timingSafeEqual } from 'crypto';
+import { z } from 'zod';
+import { prisma } from '@/lib/prisma';
+import { verifyReplyToken, extractReplyToken } from '@/lib/replyToken';
+import { notify } from '@/lib/notify';
+import { logger } from '@/lib/logger';
+
+const schema = z.object({
+  to: z.string().min(1),
+  from: z.string().min(1),
+  text: z.string().max(20000).optional().default(''),
+});
+
+const emailOf = (s: string) => (s.match(/[^<>\s]+@[^<>\s]+/)?.[0] || s).trim().toLowerCase();
+
+// Strip a quoted reply history (best-effort) so only the new text is kept.
+function stripQuoted(text: string): string {
+  const cut = text.search(/^\s*(On .+ wrote:|-{2,} ?Original Message|>)/m);
+  return (cut > 0 ? text.slice(0, cut) : text).trim();
+}
+
+function secretOk(request: Request): boolean {
+  const expected = process.env.INBOUND_SECRET;
+  if (!expected) return true; // not configured (dev/CI) — rely on the HMAC token gate
+  const got = request.headers.get('x-inbound-secret') || '';
+  try {
+    return got.length === expected.length && timingSafeEqual(Buffer.from(got), Buffer.from(expected));
+  } catch {
+    return false;
+  }
+}
+
+// POST — receive a parsed inbound email from the mail bridge (IMAP poller or
+// provider webhook). Routes it to a thread only when the HMAC reply token
+// verifies AND the sender is a participant of that thread.
+export async function POST(request: Request) {
+  if (!secretOk(request)) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const parsed = schema.safeParse(await request.json().catch(() => ({})));
+  if (!parsed.success) return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+
+  const token = extractReplyToken(parsed.data.to);
+  const relationId = token && verifyReplyToken(token);
+  if (!relationId) return NextResponse.json({ error: 'No valid reply token' }, { status: 400 });
+
+  const rel = await prisma.mentorshipRelation.findUnique({
+    where: { id: relationId },
+    include: { mentor: { select: { id: true, email: true } }, mentee: { select: { id: true, email: true } } },
+  });
+  if (!rel) return NextResponse.json({ error: 'Thread not found' }, { status: 404 });
+
+  // The sender must be a participant of this thread.
+  const from = emailOf(parsed.data.from);
+  const senderId = from === rel.mentor.email.toLowerCase() ? rel.mentor.id
+    : from === rel.mentee.email.toLowerCase() ? rel.mentee.id
+    : null;
+  if (!senderId) {
+    logger.warning('Inbound email from non-participant rejected', { relationId, from });
+    return NextResponse.json({ error: 'Sender is not a participant' }, { status: 403 });
+  }
+
+  const body = stripQuoted(parsed.data.text) || '(empty message)';
+  await prisma.message.create({ data: { relationId, senderId, channel: 'EMAIL', body } });
+  const recipient = senderId === rel.mentor.id ? rel.mentee.id : rel.mentor.id;
+  await notify(recipient, 'message', 'New message (by email).', `/messages/${relationId}`);
+
+  return NextResponse.json({ ok: true, created: true });
+}

--- a/src/app/api/mentor/email/route.ts
+++ b/src/app/api/mentor/email/route.ts
@@ -5,6 +5,7 @@ import { prisma } from '@/lib/prisma';
 import { z } from 'zod';
 import { sendEmail } from '@/services/emailService';
 import { notify } from '@/lib/notify';
+import { replyAddress } from '@/lib/replyToken';
 
 const schema = z.object({
   relationIds: z.array(z.string().min(1)).min(1),
@@ -46,7 +47,8 @@ export async function POST(request: Request) {
   let sent = 0;
   for (const rel of relations) {
     try {
-      await sendEmail({ to: rel.mentee.email, subject, html });
+      // Reply-To routes mentee replies back into this thread (inbound email).
+      await sendEmail({ to: rel.mentee.email, subject, html, replyTo: replyAddress(rel.id) });
     } catch (e) {
       console.error('Mentor email failed for', rel.mentee.email, e);
     }

--- a/src/lib/replyToken.ts
+++ b/src/lib/replyToken.ts
@@ -1,0 +1,42 @@
+import { createHmac, timingSafeEqual } from 'crypto';
+
+// Per-thread reply token used in email Reply-To addresses
+// (reply+<relationId>.<sig>@domain). The signature is an HMAC of the relation
+// id with the server secret, so tokens are unguessable and tamper-evident —
+// an inbound email can only be routed to a thread if its token verifies.
+const secret = () => process.env.NEXTAUTH_SECRET || 'dev-secret';
+
+function sign(relationId: string): string {
+  return createHmac('sha256', secret()).update(relationId).digest('hex').slice(0, 32);
+}
+
+export function makeReplyToken(relationId: string): string {
+  return `${relationId}.${sign(relationId)}`;
+}
+
+export function verifyReplyToken(token: string): string | null {
+  const dot = token.lastIndexOf('.');
+  if (dot <= 0) return null;
+  const relationId = token.slice(0, dot);
+  const sig = token.slice(dot + 1);
+  const expected = sign(relationId);
+  if (sig.length !== expected.length) return null;
+  try {
+    if (!timingSafeEqual(Buffer.from(sig), Buffer.from(expected))) return null;
+  } catch {
+    return null;
+  }
+  return relationId;
+}
+
+export function replyAddress(relationId: string): string {
+  const domain = process.env.INBOUND_EMAIL_DOMAIN || 'crm.ersah.in';
+  return `reply+${makeReplyToken(relationId)}@${domain}`;
+}
+
+// Extract the reply token from a recipient address like
+// "reply+<token>@domain" (handles display-name wrapped addresses too).
+export function extractReplyToken(recipient: string): string | null {
+  const m = recipient.match(/reply\+([^@>\s]+)@/i);
+  return m ? m[1] : null;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -19,7 +19,9 @@ function isAllowlisted(pathname: string) {
     // Public mentee application form.
     pathname === '/api/apply' ||
     // Public profile view counter.
-    pathname === '/api/profile-view'
+    pathname === '/api/profile-view' ||
+    // Inbound email bridge (authenticated by HMAC reply token + shared secret).
+    pathname === '/api/inbound-email'
   );
 }
 

--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -17,10 +17,12 @@ export async function sendEmail({
   to,
   subject,
   html,
+  replyTo,
 }: {
   to: string;
   subject: string;
   html: string;
+  replyTo?: string;
 }) {
   if (!process.env.SMTP_USER) {
     console.log(`[Email skipped - no SMTP config] To: ${to}, Subject: ${subject}`);
@@ -32,6 +34,7 @@ export async function sendEmail({
     to,
     subject,
     html,
+    ...(replyTo ? { replyTo } : {}),
   });
 }
 


### PR DESCRIPTION
## S29.3 · Email ile cevap → otomatik thread (güvenli inbound)

- `src/lib/replyToken.ts`: thread başına **HMAC reply token** (NEXTAUTH_SECRET ile imzalı) → `Reply-To: reply+<relationId>.<sig>@domain`.
- `sendEmail()` artık `replyTo` alıyor; mentor thread e-postaları reply adresini set ediyor.
- `POST /api/inbound-email`: mail köprüsü `{to,from,text}` post eder; mesaj thread'e **yalnızca** token HMAC doğrulanır **ve** gönderen o thread'in katılımcısıysa eklenir; alıntı geçmişi temizlenir; opsiyonel `X-Inbound-Secret`. Karşı tarafa bildirim.
- middleware allowlist + SECURITY.md köprü dokümantasyonu.
- e2e: geçerli cevap mesaj oluşturur (alıntı temizli) + bildirir; bozuk token → 400; katılımcı olmayan gönderen → 403.

> Mail sunucusu → endpoint köprüsü (IMAP poll veya provider webhook) bir **ops adımı**; `INBOUND_SECRET`/`INBOUND_EMAIL_DOMAIN` env ile.

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)