### PR TITLE
fix(admin): responsive Users page (#248)

### DIFF
--- a/e2e/users-responsive.spec.ts
+++ b/e2e/users-responsive.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('the users page is usable on a mobile viewport (Login as reachable)', async ({ page }) => {
+  const adminEmail = uniqueEmail('resp-admin');
+  const menteeEmail = uniqueEmail('resp-mentee');
+  await seedUser(adminEmail, 'AdminPass123', 'ADMIN', 'Resp Admin');
+  const mentee = await seedUser(menteeEmail, 'x', 'MENTEE', 'Resp Mentee');
+
+  try {
+    await page.setViewportSize({ width: 390, height: 820 });
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', 'AdminPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    await page.goto('/admin/users');
+    const row = page.getByTestId(`user-row-${mentee.id}`);
+    await expect(row).toBeVisible({ timeout: 10_000 });
+    // The action button is reachable (not clipped off-screen) on mobile.
+    const loginAs = row.getByRole('button', { name: 'Login as' });
+    await expect(loginAs).toBeInViewport();
+  } finally {
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -120,8 +120,8 @@ export default function AdminUsersPage() {
         ) : (
           <div className="divide-y divide-gray-50">
             {shown.map((u) => (
-              <div key={u.id} data-testid={`user-row-${u.id}`} className="flex items-center justify-between gap-3 py-3">
-                <div className="min-w-0">
+              <div key={u.id} data-testid={`user-row-${u.id}`} className="flex flex-col items-start gap-2 py-3 sm:flex-row sm:items-center sm:justify-between sm:gap-3">
+                <div className="min-w-0 w-full sm:w-auto">
                   {u.role === 'MENTEE' ? (
                     <Link href={`/admin/candidates/${u.id}`} className="text-sm font-medium text-gray-900 hover:text-blue-600 truncate block">
                       {u.fullName}
@@ -131,7 +131,7 @@ export default function AdminUsersPage() {
                   )}
                   <p className="text-xs text-gray-500 truncate">{u.email}</p>
                 </div>
-                <div className="flex items-center gap-2 flex-shrink-0">
+                <div className="flex flex-wrap items-center gap-2">
                   <Badge variant={ROLE_VARIANT[u.role]}>{t.usersAdmin[u.role.toLowerCase() as RoleLabel]}</Badge>
                   <Badge variant={u.isActive ? 'success' : 'warning'}>
                     {u.isActive ? t.usersAdmin.active : t.usersAdmin.inactive}


### PR DESCRIPTION
## #248 · Users sayfası mobilde responsive değil
Satırlar tek `justify-between` kullanıyordu; dar ekranda aksiyon kümesi (rozetler + Login as) taşıyor ve **Login as butonu ekran dışında** kalıyordu. Satırlar artık mobilde dikey yığılıyor (ad üstte, aksiyonlar altta sarmalanıyor), `sm:` ve üstünde yatay düzene geçiyor.

- e2e: 390px viewport'ta Login as butonu görünür.

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)