### PR TITLE
fix(deploy): preview db push via docker gateway (#252)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -202,10 +202,12 @@ jobs:
           # can reach MySQL running on the host (works on Linux with --add-host).
           CONTAINER_DB=\$(echo "\$DATABASE_URL" | sed 's|localhost|host.docker.internal|g; s|127\.0\.0\.1|host.docker.internal|g')
 
-          # Apply schema changes using host networking so localhost MySQL is reachable.
+          # Apply schema changes. The preview DB user (crm-preview) is only granted
+          # from the docker gateway, not localhost, so push via host.docker.internal
+          # (the same connection the app container uses) rather than --network=host.
           docker run --rm \
-            --network=host \
-            -e DATABASE_URL="\$DATABASE_URL" \
+            --add-host=host.docker.internal:host-gateway \
+            -e DATABASE_URL="\$CONTAINER_DB" \
             "\$IMAGE" \
             npx prisma db push --accept-data-loss
 


### PR DESCRIPTION
## #252 · Preview'da login olunamıyor — kök neden
Preview deploy'ları **`prisma db push` P1000 `crm-preview@localhost`** ile patlıyordu: preview MySQL kullanıcısı yalnızca docker gateway'den yetkili, localhost'tan değil. App container'ı zaten `host.docker.internal` ile sorunsuz bağlanıyor. Bu yüzden db-push'u da aynı yoldan (`--add-host` + `CONTAINER_DB`) çalıştırıyorum (`--network=host` + localhost yerine).

Sonuç: preview deploy'ları tekrar yeşile döner → preview **güncel imaj + şema** ile yeniden kurulur → preview login düzelir (ortam, şema push'ları başarısız olduğu için bayat/drift olmuştu).

Refs #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)