### PR TITLE
fix(projects): transfer mentor→admin no longer 'Invalid owner'

### DIFF
--- a/e2e/project-transfer.spec.ts
+++ b/e2e/project-transfer.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('a mentor-owned project can be transferred back to the admin without error', async ({ page }) => {
+  const adminEmail = uniqueEmail('pt-admin');
+  const mentorEmail = uniqueEmail('pt-mentor');
+  const admin = await seedUser(adminEmail, 'AdminPass123', 'ADMIN', 'PT Admin');
+  const mentor = await seedUser(mentorEmail, 'x', 'MENTOR', 'PT Mentor');
+  const project = await prisma.project.create({
+    data: { name: 'Transfer Me', ownerType: 'MENTOR', ownerUserId: mentor.id },
+  });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', 'AdminPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    // Transfer mentor-owned -> admin, omitting ownerUserId (as the UI does for
+    // "Admin (me)"). Must succeed, not 400 "Invalid owner".
+    const res = await page.request.put(`/api/projects/${project.id}`, { data: { ownerType: 'ADMIN' } });
+    expect(res.ok()).toBeTruthy();
+    const body = await res.json();
+    expect(body.project.ownerType).toBe('ADMIN');
+    expect(body.project.ownerUserId).toBe(admin.id);
+  } finally {
+    await prisma.project.deleteMany({ where: { id: project.id } });
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -69,7 +69,11 @@ export async function PUT(request: Request, { params }: { params: Promise<{ id: 
   // Transfer (admin only): change the owner, preserving the invariant.
   let transferred: string | null = null;
   if (d.ownerType && session.user.role === 'ADMIN') {
-    const owner = await resolveOwner({ ownerType: d.ownerType, ownerUserId: d.ownerUserId, ownerCompanyId: d.ownerCompanyId });
+    // For ADMIN ownership default to the acting admin when no specific user is
+    // given (the UI has no admin picker), so a transfer to "Admin (me)" works
+    // even if the client didn't send an id.
+    const ownerUserId = d.ownerType === 'ADMIN' ? d.ownerUserId || session.user.id : d.ownerUserId;
+    const owner = await resolveOwner({ ownerType: d.ownerType, ownerUserId, ownerCompanyId: d.ownerCompanyId });
     if (!owner) return NextResponse.json({ error: 'Invalid owner' }, { status: 400 });
     Object.assign(data, owner);
     transferred = `${project.ownerType} → ${owner.ownerType}`;

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -59,7 +59,9 @@ export async function POST(request: Request) {
   if (session.user.role === 'MENTOR') {
     owner = { ownerType: 'MENTOR' as const, ownerUserId: session.user.id, ownerCompanyId: null };
   } else {
-    owner = await resolveOwner({ ownerType: d.ownerType, ownerUserId: d.ownerUserId, ownerCompanyId: d.ownerCompanyId });
+    // ADMIN ownership defaults to the acting admin when no user id is supplied.
+    const ownerUserId = d.ownerType === 'ADMIN' ? d.ownerUserId || session.user.id : d.ownerUserId;
+    owner = await resolveOwner({ ownerType: d.ownerType, ownerUserId, ownerCompanyId: d.ownerCompanyId });
     if (!owner) return NextResponse.json({ error: 'A valid owner (admin, mentor or company) is required' }, { status: 400 });
   }
 

--- a/src/components/ProjectsManager.tsx
+++ b/src/components/ProjectsManager.tsx
@@ -89,9 +89,12 @@ export function ProjectsManager({ isAdmin }: { isAdmin: boolean }) {
       // the "exactly one owner" invariant.
       if (isAdmin) {
         payload.ownerType = ownerType;
+        // ADMIN ownership is always the acting admin (no admin picker in this UI);
+        // using a stale ownerUserId from a previous MENTOR owner would fail
+        // server validation ("Invalid owner").
         if (ownerType === 'COMPANY') payload.ownerCompanyId = ownerCompanyId;
         else if (ownerType === 'MENTOR') payload.ownerUserId = ownerUserId;
-        else payload.ownerUserId = ownerUserId || meId; // ADMIN → self by default
+        else payload.ownerUserId = meId; // ADMIN → acting admin
       }
       const url = editingId ? `/api/projects/${editingId}` : '/api/projects';
       const res = await fetch(url, {
@@ -204,7 +207,7 @@ export function ProjectsManager({ isAdmin }: { isAdmin: boolean }) {
           {isAdmin && (
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 border-t border-gray-100 pt-3">
               {editingId && <p className="sm:col-span-2 text-xs text-gray-500">{t.projects.transferHint}</p>}
-              <Select label={t.projects.owner} value={ownerType} onChange={(e) => setOwnerType(e.target.value)}
+              <Select label={t.projects.owner} value={ownerType} onChange={(e) => { setOwnerType(e.target.value); setOwnerUserId(''); setOwnerCompanyId(''); }}
                 options={[{ value: 'ADMIN', label: t.projects.ownerAdmin }, { value: 'MENTOR', label: t.projects.ownerMentor }, { value: 'COMPANY', label: t.projects.ownerCompany }]} />
               {ownerType === 'MENTOR' && (
                 <Select label={t.projects.ownerMentor} value={ownerUserId} onChange={(e) => setOwnerUserId(e.target.value)}


### PR DESCRIPTION
Owner selector cleared stale id; ADMIN ownership uses the acting admin (client + server default). Fixes the reported transfer error.