### PR TITLE
ci(deploy): aggressive image/cache prune to prevent disk-full

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -146,7 +146,8 @@ jobs:
             -e SMTP_FROM="\$SMTP_FROM" \
             "\$IMAGE"
 
-          docker image prune -f
+          docker image prune -af
+          docker builder prune -af --filter until=72h
           EOF
 
       # ── Preview deploy (pull_request) ───────────────────────────────────────
@@ -229,7 +230,8 @@ jobs:
             -e SMTP_FROM="\$SMTP_FROM" \
             "\$IMAGE"
 
-          docker image prune -f
+          docker image prune -af
+          docker builder prune -af --filter until=72h
           EOF
 
       - name: Post preview URL comment


### PR DESCRIPTION
Server hit 100% disk (stale images) → deploys failed with no space left. Post-deploy now runs docker image prune -af + builder prune (>72h). Manually reclaimed 99GB on the server already.