### PR TITLE
feat(board): Kanban search + hide-empty-stages (#284)

### DIFF
--- a/e2e/board-filter.spec.ts
+++ b/e2e/board-filter.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('admin board can search cards and hide empty stages', async ({ page }) => {
+  const adminEmail = uniqueEmail('bf-admin');
+  const mentorEmail = uniqueEmail('bf-mentor');
+  await seedUser(adminEmail, 'AdminPass123', 'ADMIN', 'BF Admin');
+  const mentor = await seedUser(mentorEmail, 'x', 'MENTOR', 'BF Mentor');
+  const mentee = await seedUser(uniqueEmail('bf-mentee'), 'x', 'MENTEE', 'Findable Mentee');
+  const rel = await prisma.mentorshipRelation.create({ data: { mentorId: mentor.id, menteeId: mentee.id, pipelineStatus: 'APPLICATION_100' } });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', 'AdminPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    await page.goto('/admin/board');
+    await expect(page.getByText('Findable Mentee')).toBeVisible({ timeout: 10_000 });
+
+    // Hide empty stages collapses columns without cards.
+    await page.getByLabel(/Hide empty stages/i).check();
+    await expect(page.getByText('Findable Mentee')).toBeVisible();
+
+    // Search filters cards out.
+    await page.getByPlaceholder(/Find a mentee or mentor/i).fill('zzz-no-match');
+    await expect(page.getByText('Findable Mentee')).toHaveCount(0);
+  } finally {
+    await prisma.mentorshipRelation.deleteMany({ where: { id: rel.id } });
+    await cleanupByEmail(mentee.email);
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/src/app/admin/board/page.tsx
+++ b/src/app/admin/board/page.tsx
@@ -23,6 +23,8 @@ export default function AdminBoardPage() {
   const [relations, setRelations] = useState<Relation[]>([]);
   const [loading, setLoading] = useState(true);
   const [dragOver, setDragOver] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [hideEmpty, setHideEmpty] = useState(false);
 
   const fetchRelations = useCallback(async () => {
     const res = await fetch('/api/mentorship');
@@ -59,9 +61,28 @@ export default function AdminBoardPage() {
         <p className="text-gray-500 mt-1">{t.adminBoard.subtitle}</p>
       </div>
 
+      <div className="flex flex-wrap items-center gap-3 mb-4">
+        <input
+          type="search"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder={t.adminBoard.searchPlaceholder}
+          className="flex-1 min-w-[180px] max-w-sm rounded-lg border border-gray-300 px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-100 focus:border-blue-400"
+        />
+        <label className="flex items-center gap-2 text-sm text-gray-600">
+          <input type="checkbox" checked={hideEmpty} onChange={(e) => setHideEmpty(e.target.checked)} />
+          {t.adminBoard.hideEmpty}
+        </label>
+      </div>
+
       <div className="flex gap-4 overflow-x-auto pb-4">
         {PIPELINE_STATUSES.map((status) => {
-          const items = relations.filter((r) => r.pipelineStatus === status);
+          const q = search.trim().toLowerCase();
+          const items = relations.filter(
+            (r) => r.pipelineStatus === status &&
+              (!q || r.mentee.fullName.toLowerCase().includes(q) || r.mentor.fullName.toLowerCase().includes(q))
+          );
+          if (hideEmpty && items.length === 0) return null;
           return (
             <div
               key={status}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -365,6 +365,8 @@ const en = {
   },
   adminBoard: {
     subtitle: 'All mentees across every mentor — drag a card to change its stage',
+    searchPlaceholder: 'Find a mentee or mentor...',
+    hideEmpty: 'Hide empty stages',
   },
   mentorEmail: {
     title: 'Email mentees',
@@ -1229,6 +1231,8 @@ const tr: Dict = {
   },
   adminBoard: {
     subtitle: 'Tüm mentorların tüm mentee’leri — aşamayı değiştirmek için kartı sürükle',
+    searchPlaceholder: 'Mentee veya mentor bul...',
+    hideEmpty: 'Boş aşamaları gizle',
   },
   mentorEmail: {
     title: 'Mentee’lere e-posta',
@@ -2091,6 +2095,8 @@ const de: Dict = {
   },
   adminBoard: {
     subtitle: 'Alle Mentees aller Mentoren — ziehe eine Karte, um die Phase zu ändern',
+    searchPlaceholder: 'Mentee oder Mentor finden...',
+    hideEmpty: 'Leere Phasen ausblenden',
   },
   mentorEmail: {
     title: 'Mentees per E-Mail erreichen',


### PR DESCRIPTION
Closes #283 — card search + hide empty columns on the admin board. EN/TR/DE.