### PR TITLE
feat(documents): download access log (#290)

### DIFF
--- a/e2e/document-access-log.spec.ts
+++ b/e2e/document-access-log.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('downloading a document records an access-log entry', async ({ page }) => {
+  const adminEmail = uniqueEmail('dal-admin');
+  await seedUser(adminEmail, 'AdminPass123', 'ADMIN', 'DAL Admin');
+  let docId = '';
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', 'AdminPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    const up = await page.request.post('/api/documents', {
+      multipart: { file: { name: 'g.pdf', mimeType: 'application/pdf', buffer: Buffer.from('%PDF-1.4 x') }, isTemplate: 'true', title: 'Guide' },
+    });
+    expect(up.status()).toBe(201);
+    docId = (await up.json()).document.id;
+
+    const dl = await page.request.get(`/api/documents/${docId}`);
+    expect(dl.ok()).toBeTruthy();
+
+    await expect.poll(async () =>
+      prisma.activityLog.count({ where: { action: 'document.download', targetId: docId } })
+    , { timeout: 10_000 }).toBeGreaterThanOrEqual(1);
+  } finally {
+    await prisma.activityLog.deleteMany({ where: { targetId: docId } });
+    await prisma.document.deleteMany({ where: { id: docId } });
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/src/app/api/documents/[id]/route.ts
+++ b/src/app/api/documents/[id]/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { canAccessUserDocs } from '@/lib/documentAccess';
+import { logActivity } from '@/lib/activity';
 
 // GET — download a document (templates: any signed-in user; owned: access-controlled).
 export async function GET(_request: Request, { params }: { params: Promise<{ id: string }> }) {
@@ -18,6 +19,16 @@ export async function GET(_request: Request, { params }: { params: Promise<{ id:
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }
   }
+
+  // Access log: who downloaded which document (visible in the admin activity log).
+  await logActivity({
+    action: 'document.download',
+    actorId: session.user.id,
+    actorEmail: session.user.email ?? null,
+    targetType: 'document',
+    targetId: doc.id,
+    detail: doc.title,
+  });
 
   return new NextResponse(Buffer.from(doc.data), {
     headers: {


### PR DESCRIPTION
Closes #290 — document downloads recorded in the admin activity log. (Versioning shipped in EPIC 37; antivirus needs an external service, out of scope.)