### PR TITLE
perf: skeleton loaders + hot-path indexes (#296)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -117,6 +117,8 @@ model User {
   company                 Company?                 @relation("CompanyUsers", fields: [companyId], references: [id])
   source                  Source?                  @relation(fields: [sourceId], references: [id])
   documents               Document[]               @relation("DocumentOwner")
+
+  @@index([role])
 }
 
 // A referral source — the education/agency a mentee came from. Admin-managed
@@ -392,6 +394,9 @@ model MentorshipRelation {
   messages      Message[]
   evaluations   Evaluation[]
   goals         Goal[]
+
+  @@index([status])
+  @@index([pipelineStatus])
 }
 
 // A mentor's structured evaluation of a mentee within a mentorship.

--- a/src/app/admin/candidates/page.tsx
+++ b/src/app/admin/candidates/page.tsx
@@ -7,6 +7,7 @@ import Link from "next/link";
 import { useT, useLocale } from "@/i18n/client";
 import { pipelineLabel } from '@/lib/pipeline';
 import { Card } from '@/components/ui/Card';
+import { SkeletonRows } from '@/components/ui/Skeleton';
 import { Badge } from '@/components/ui/Badge';
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
@@ -247,7 +248,7 @@ export default function CandidatesPage() {
 
       {/* Candidates Grid */}
       {loading ? (
-        <div className="text-center py-12 text-gray-400">{t.common.loading}</div>
+        <Card><SkeletonRows rows={6} /></Card>
       ) : candidates.length === 0 ? (
         <Card>
           <EmptyState

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -8,6 +8,7 @@ import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Badge } from '@/components/ui/Badge';
 import { Button } from '@/components/ui/Button';
 import { roleHome } from '@/lib/roleHome';
+import { SkeletonRows } from '@/components/ui/Skeleton';
 import { useT } from '@/i18n/client';
 
 interface AdminUser {
@@ -134,7 +135,7 @@ export default function AdminUsersPage() {
           <CardTitle>{t.usersAdmin.title} ({filtered.length})</CardTitle>
         </CardHeader>
         {loading ? (
-          <p className="text-center py-12 text-gray-400">{t.common.loading}</p>
+          <SkeletonRows rows={6} />
         ) : shown.length === 0 ? (
           <p className="text-center py-12 text-gray-400">{t.usersAdmin.none}</p>
         ) : (

--- a/src/components/ui/Skeleton.tsx
+++ b/src/components/ui/Skeleton.tsx
@@ -1,0 +1,21 @@
+// Lightweight loading placeholders to improve perceived performance.
+export function Skeleton({ className = '' }: { className?: string }) {
+  return <div className={`animate-pulse rounded bg-gray-100 ${className}`} />;
+}
+
+// A vertical stack of row-shaped skeletons for list/table loading states.
+export function SkeletonRows({ rows = 6 }: { rows?: number }) {
+  return (
+    <div className="space-y-3" aria-hidden="true">
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} className="flex items-center gap-3">
+          <Skeleton className="h-10 w-10 rounded-full" />
+          <div className="flex-1 space-y-2">
+            <Skeleton className="h-3.5 w-1/3" />
+            <Skeleton className="h-3 w-1/2" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #296 — skeleton loaders on candidates/users lists + indexes on User.role and MentorshipRelation.status/pipelineStatus. (Full server-side pagination of candidates is constrained by the in-memory skills filter; load-more deferred.)