### PR TITLE
feat(a11y): keyboard stage change on Kanban (#295)

### DIFF
--- a/e2e/board-a11y.spec.ts
+++ b/e2e/board-a11y.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('board card has a keyboard-accessible stage select that moves the relation', async ({ page }) => {
+  const adminEmail = uniqueEmail('ba-admin');
+  const mentorEmail = uniqueEmail('ba-mentor');
+  await seedUser(adminEmail, 'AdminPass123', 'ADMIN', 'BA Admin');
+  const mentor = await seedUser(mentorEmail, 'x', 'MENTOR', 'BA Mentor');
+  const mentee = await seedUser(uniqueEmail('ba-mentee'), 'x', 'MENTEE', 'BA Mentee');
+  const rel = await prisma.mentorshipRelation.create({ data: { mentorId: mentor.id, menteeId: mentee.id, pipelineStatus: 'APPLICATION_100' } });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', 'AdminPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    await page.goto('/admin/board');
+    await expect(page.getByText('BA Mentee')).toBeVisible({ timeout: 10_000 });
+
+    await page.getByLabel('Move to stage').selectOption('INTERVIEW_PENDING_250');
+
+    await expect.poll(async () => {
+      const r = await prisma.mentorshipRelation.findUnique({ where: { id: rel.id } });
+      return r?.pipelineStatus;
+    }, { timeout: 10_000 }).toBe('INTERVIEW_PENDING_250');
+  } finally {
+    await prisma.mentorshipRelation.deleteMany({ where: { id: rel.id } });
+    await cleanupByEmail(mentee.email);
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/src/app/admin/board/page.tsx
+++ b/src/app/admin/board/page.tsx
@@ -131,6 +131,18 @@ export default function AdminBoardPage() {
                         {r._count.interactions}
                       </span>
                     </div>
+                    {/* Keyboard-accessible alternative to drag-and-drop. */}
+                    <select
+                      aria-label={t.adminBoard.moveTo}
+                      value={status}
+                      onClick={(e) => e.stopPropagation()}
+                      onChange={(e) => { e.stopPropagation(); moveTo(r.id, e.target.value); }}
+                      className="mt-2 w-full rounded border border-gray-200 px-1.5 py-1 text-xs text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-100"
+                    >
+                      {PIPELINE_STATUSES.map((sv) => (
+                        <option key={sv} value={sv}>{pipelineLabel(sv, locale)}</option>
+                      ))}
+                    </select>
                   </div>
                 ))}
               </div>

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -367,6 +367,7 @@ const en = {
     subtitle: 'All mentees across every mentor — drag a card to change its stage',
     searchPlaceholder: 'Find a mentee or mentor...',
     hideEmpty: 'Hide empty stages',
+    moveTo: 'Move to stage',
   },
   mentorEmail: {
     title: 'Email mentees',
@@ -1236,6 +1237,7 @@ const tr: Dict = {
     subtitle: 'Tüm mentorların tüm mentee’leri — aşamayı değiştirmek için kartı sürükle',
     searchPlaceholder: 'Mentee veya mentor bul...',
     hideEmpty: 'Boş aşamaları gizle',
+    moveTo: 'Aşamaya taşı',
   },
   mentorEmail: {
     title: 'Mentee’lere e-posta',
@@ -2103,6 +2105,7 @@ const de: Dict = {
     subtitle: 'Alle Mentees aller Mentoren — ziehe eine Karte, um die Phase zu ändern',
     searchPlaceholder: 'Mentee oder Mentor finden...',
     hideEmpty: 'Leere Phasen ausblenden',
+    moveTo: 'In Phase verschieben',
   },
   mentorEmail: {
     title: 'Mentees per E-Mail erreichen',


### PR DESCRIPTION
Closes #295 — labelled per-card stage select as a keyboard/screen-reader alternative to drag-and-drop. EN/TR/DE.