### PR TITLE
feat(pwa): offline fallback page + SW handling (#297)

### DIFF
--- a/e2e/offline-page.spec.ts
+++ b/e2e/offline-page.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+
+test('offline fallback page renders and is public', async ({ page }) => {
+  await page.goto('/offline');
+  await expect(page.getByRole('heading', { name: /offline/i })).toBeVisible({ timeout: 10_000 });
+});
+
+test('the web manifest is served', async ({ page }) => {
+  const res = await page.request.get('/manifest.webmanifest');
+  expect(res.ok()).toBeTruthy();
+  const m = await res.json();
+  expect(m.name).toBeTruthy();
+  expect(m.display).toBe('standalone');
+});

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,10 +1,12 @@
 // Minimal service worker — enables installability and an offline-friendly
 // shell. Network-first; falls back to cache when offline.
-const CACHE = 'internship-crm-v1';
+const CACHE = 'internship-crm-v2';
+const OFFLINE_URL = '/offline';
 
 self.addEventListener('install', (event) => {
   self.skipWaiting();
-  event.waitUntil(caches.open(CACHE));
+  // Precache the offline fallback so even un-visited pages degrade gracefully.
+  event.waitUntil(caches.open(CACHE).then((c) => c.addAll([OFFLINE_URL, '/icon.svg']).catch(() => {})));
 });
 
 self.addEventListener('activate', (event) => {
@@ -26,6 +28,15 @@ self.addEventListener('fetch', (event) => {
         caches.open(CACHE).then((c) => c.put(req, copy)).catch(() => {});
         return res;
       })
-      .catch(() => caches.match(req))
+      .catch(async () => {
+        const cached = await caches.match(req);
+        if (cached) return cached;
+        // For navigations with nothing cached, show the offline page.
+        if (req.mode === 'navigate') {
+          const offline = await caches.match(OFFLINE_URL);
+          if (offline) return offline;
+        }
+        return new Response('Offline', { status: 503, statusText: 'Offline' });
+      })
   );
 });

--- a/src/app/offline/page.tsx
+++ b/src/app/offline/page.tsx
@@ -1,0 +1,19 @@
+import { WifiOff } from 'lucide-react';
+import { getServerDictionary } from '@/i18n/server';
+
+// Offline fallback shown by the service worker when a navigation fails with no
+// cached copy available.
+export default async function OfflinePage() {
+  const { t } = await getServerDictionary();
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 p-4">
+      <div className="text-center max-w-sm">
+        <div className="mx-auto w-14 h-14 rounded-2xl bg-gray-100 flex items-center justify-center mb-4">
+          <WifiOff className="h-7 w-7 text-gray-400" />
+        </div>
+        <h1 className="text-xl font-bold text-gray-900">{t.offline.title}</h1>
+        <p className="text-gray-500 text-sm mt-2">{t.offline.body}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -50,6 +50,7 @@ const en = {
     searchPlaceholder: 'Search by name or university...',
     allStages: 'All stages',
   },
+  offline: { title: 'You are offline', body: 'Check your connection and try again. Some pages you have visited may still work.' },
   common: {
     loading: 'Loading...',
     notFound: 'Not found',
@@ -921,6 +922,7 @@ const tr: Dict = {
     searchPlaceholder: 'Ad veya üniversiteye göre ara...',
     allStages: 'Tüm aşamalar',
   },
+  offline: { title: 'Çevrimdışısın', body: 'Bağlantını kontrol edip tekrar dene. Daha önce ziyaret ettiğin bazı sayfalar yine de çalışabilir.' },
   common: {
     loading: 'Yükleniyor...',
     notFound: 'Bulunamadı',
@@ -1790,6 +1792,7 @@ const de: Dict = {
     searchPlaceholder: 'Nach Name oder Universität suchen...',
     allStages: 'Alle Phasen',
   },
+  offline: { title: 'Du bist offline', body: 'Prüfe deine Verbindung und versuche es erneut. Bereits besuchte Seiten funktionieren womöglich weiter.' },
   common: {
     loading: 'Wird geladen...',
     notFound: 'Nicht gefunden',


### PR DESCRIPTION
Closes #297 — /offline page + SW serves it when offline. Manifest/install/SW + touch-friendly stage select already present; web-push deferred (needs VAPID key).