### PR TITLE
fix(mentorship): admins selectable + valid as mentors

### DIFF
--- a/e2e/admin-as-mentor.spec.ts
+++ b/e2e/admin-as-mentor.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('an admin can be assigned as a mentee\'s mentor', async ({ page }) => {
+  const adminEmail = uniqueEmail('aam-admin');
+  const admin = await seedUser(adminEmail, 'AdminPass123', 'ADMIN', 'AAM Admin');
+  const mentee = await seedUser(uniqueEmail('aam-mentee'), 'x', 'MENTEE', 'AAM Mentee');
+  let relId = '';
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', 'AdminPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    // Assigning an ADMIN as the mentor succeeds (admins can mentor).
+    const res = await page.request.post('/api/mentorship', { data: { mentorId: admin.id, menteeId: mentee.id } });
+    expect(res.status()).toBe(201);
+    relId = (await res.json()).relation.id;
+
+    // The mentorship assign form lists the admin as a selectable mentor.
+    await page.goto('/admin/mentorship');
+    const data = await (await page.request.get('/api/users')).json();
+    expect(data.users.some((u: { id: string; role: string }) => u.id === admin.id && u.role === 'ADMIN')).toBeTruthy();
+  } finally {
+    if (relId) await prisma.mentorshipRelation.deleteMany({ where: { id: relId } });
+    await cleanupByEmail(mentee.email);
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/src/app/admin/mentorship/page.tsx
+++ b/src/app/admin/mentorship/page.tsx
@@ -62,7 +62,8 @@ export default function MentorshipPage() {
         companiesRes.json(),
       ]);
       setRelations(relData.relations || []);
-      setMentors((usersData.users || []).filter((u: User & { role: string }) => u.role === 'MENTOR'));
+      // Admins can mentor too, so include them in the mentor picker.
+      setMentors((usersData.users || []).filter((u: User & { role: string }) => u.role === 'MENTOR' || u.role === 'ADMIN'));
       setMentees((usersData.users || []).filter((u: User & { role: string }) => u.role === 'MENTEE'));
       setCompanies(companiesData.companies || []);
     } catch {

--- a/src/app/api/mentorship/route.ts
+++ b/src/app/api/mentorship/route.ts
@@ -91,7 +91,8 @@ export async function POST(request: Request) {
       prisma.user.findUnique({ where: { id: menteeId } }),
     ]);
 
-    if (!mentor || mentor.role !== 'MENTOR') {
+    // Admins can also mentor, so they're valid mentors too.
+    if (!mentor || (mentor.role !== 'MENTOR' && mentor.role !== 'ADMIN')) {
       return NextResponse.json({ error: 'Invalid mentor' }, { status: 400 });
     }
 


### PR DESCRIPTION
Admins can mentor too — added to the assign-mentorship picker and accepted by the API.