### PR TITLE
fix(profile): accept internal /api/cv path as CV URL (#348)

### DIFF
--- a/e2e/cv-url-relative.spec.ts
+++ b/e2e/cv-url-relative.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('profile accepts an internal /api/cv path as the CV URL', async ({ page }) => {
+  const email = uniqueEmail('cvurl-mentee');
+  await seedUser(email, 'MenteePass123', 'MENTEE', 'CV Url Mentee');
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', email);
+    await page.fill('input[type="password"]', 'MenteePass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/portal'), { timeout: 20_000 });
+
+    // A relative internal path (as set by CV upload) must be accepted.
+    const put = await page.request.put('/api/profile', { data: { cvUrl: '/api/cv/abc123' } });
+    expect(put.ok()).toBeTruthy();
+    const me = await (await page.request.get('/api/profile')).json();
+    expect(me.user.cvUrl).toBe('/api/cv/abc123');
+
+    // A full URL still works.
+    const put2 = await page.request.put('/api/profile', { data: { cvUrl: 'https://example.com/cv.pdf' } });
+    expect(put2.ok()).toBeTruthy();
+  } finally {
+    await cleanupByEmail(email);
+  }
+});

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -17,7 +17,8 @@ const updateProfileSchema = z.object({
   graduationYear: z.number().int().nullable().optional(),
   skills: z.array(z.string()).optional(),
   skillLevels: z.record(z.string(), z.number().int().min(1).max(5)).optional(),
-  cvUrl: z.string().url().or(z.literal('')).nullable().optional(),
+  // Full URL or an internal path (/api/cv/<id> set on CV upload).
+  cvUrl: z.string().refine((v) => /^https?:\/\//.test(v) || v.startsWith('/'), 'Invalid URL').or(z.literal('')).nullable().optional(),
   publicProfile: z.boolean().optional(),
   // Extended profile fields (EPIC 32).
   displayName: z.string().max(120).optional(),

--- a/src/app/portal/profile/page.tsx
+++ b/src/app/portal/profile/page.tsx
@@ -23,7 +23,8 @@ const profileSchema = z.object({
   department: z.string().optional(),
   graduationYear: z.coerce.number().int().min(2010).max(new Date().getFullYear() + 5).optional().or(z.literal(0)),
   skills: z.string().optional(),
-  cvUrl: z.string().url('Please enter a valid URL').optional().or(z.literal('')),
+  // Accept a full URL or an internal path (e.g. /api/cv/<id> set on upload).
+  cvUrl: z.string().refine((v) => v === '' || /^https?:\/\//.test(v) || v.startsWith('/'), 'Please enter a valid URL').optional().or(z.literal('')),
   displayName: z.string().optional(),
   bio: z.string().optional(),
   country: z.string().optional(),
@@ -307,7 +308,8 @@ export default function ProfilePage() {
               })()}
               <Input
                 label={t.profileForm.cvUrl}
-                type="url"
+                type="text"
+                inputMode="url"
                 placeholder="https://drive.google.com/..."
                 hint="Link to your CV"
                 {...register('cvUrl')}


### PR DESCRIPTION
Closes #348 — CV URL field now accepts the relative /api/cv/<id> path set on upload (and full URLs); fixes the 'Please enter a URL' save block.