### PR TITLE
feat(activity): per-user activity on profiles + inactivity flag (#345)

### DIFF
--- a/e2e/profile-activity.spec.ts
+++ b/e2e/profile-activity.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('a user\'s activity is visible to admin and to their mentor, but not to strangers', async ({ page }) => {
+  const adminEmail = uniqueEmail('pa-admin');
+  const mentorEmail = uniqueEmail('pa-mentor');
+  const strangerEmail = uniqueEmail('pa-stranger');
+  const menteeEmail = uniqueEmail('pa-mentee');
+  await seedUser(adminEmail, 'AdminPass123', 'ADMIN', 'PA Admin');
+  const mentor = await seedUser(mentorEmail, 'MentorPass123', 'MENTOR', 'PA Mentor');
+  await seedUser(strangerEmail, 'StrangerPass123', 'MENTOR', 'PA Stranger');
+  const mentee = await seedUser(menteeEmail, 'x', 'MENTEE', 'PA Mentee');
+  await prisma.mentorshipRelation.create({ data: { mentorId: mentor.id, menteeId: mentee.id } });
+  await prisma.activityLog.create({ data: { action: 'auth.login', level: 'INFO', actorId: mentee.id, actorEmail: menteeEmail } });
+
+  try {
+    // Admin can read it.
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', 'AdminPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+    const asAdmin = await (await page.request.get(`/api/users/${mentee.id}/activity`)).json();
+    expect(asAdmin.items.some((i: { action: string }) => i.action === 'auth.login')).toBeTruthy();
+
+    // The mentee's mentor can read it.
+    await page.context().clearCookies();
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', mentorEmail);
+    await page.fill('input[type="password"]', 'MentorPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/mentor'), { timeout: 20_000 });
+    const asMentor = await page.request.get(`/api/users/${mentee.id}/activity`);
+    expect(asMentor.ok()).toBeTruthy();
+
+    // An unrelated mentor cannot.
+    await page.context().clearCookies();
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', strangerEmail);
+    await page.fill('input[type="password"]', 'StrangerPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/mentor'), { timeout: 20_000 });
+    const asStranger = await page.request.get(`/api/users/${mentee.id}/activity`);
+    expect(asStranger.status()).toBe(403);
+  } finally {
+    await prisma.activityLog.deleteMany({ where: { actorId: mentee.id } });
+    await prisma.mentorshipRelation.deleteMany({ where: { menteeId: mentee.id } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(strangerEmail);
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/src/app/admin/candidates/[id]/page.tsx
+++ b/src/app/admin/candidates/[id]/page.tsx
@@ -14,6 +14,7 @@ import { nextAction } from '@/lib/matching';
 import { EvaluationPanel } from '@/components/EvaluationPanel';
 import { GoalsPanel } from '@/components/GoalsPanel';
 import { DocumentsManager } from '@/components/DocumentsManager';
+import { UserActivityPanel } from '@/components/UserActivityPanel';
 import { useT, useLocale } from '@/i18n/client';
 
 interface Interaction { id: string; date: string; notes: string; type: string }
@@ -443,6 +444,7 @@ export default function AdminMenteeDetailPage() {
         {rel && <EvaluationPanel relationId={rel.id} />}
         {rel && <GoalsPanel relationId={rel.id} />}
         <DocumentsManager targetUserId={id} />
+        <UserActivityPanel userId={id} />
       </div>
     </div>
   );

--- a/src/app/api/users/[id]/activity/route.ts
+++ b/src/app/api/users/[id]/activity/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+// GET — recent activity for a single user (as actor or target). Visible to the
+// user themselves, any admin, or a mentor who mentors that user. Also returns
+// lastActiveAt so callers can flag inactivity.
+export async function GET(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const { id } = await params;
+
+  let allowed = session.user.id === id || session.user.role === 'ADMIN';
+  if (!allowed && session.user.role === 'MENTOR') {
+    const rel = await prisma.mentorshipRelation.findFirst({ where: { mentorId: session.user.id, menteeId: id }, select: { id: true } });
+    allowed = !!rel;
+  }
+  if (!allowed) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+  const [items, lastActive] = await Promise.all([
+    prisma.activityLog.findMany({
+      where: { OR: [{ actorId: id }, { targetId: id }] },
+      orderBy: { createdAt: 'desc' },
+      take: 25,
+    }),
+    prisma.activityLog.findFirst({
+      where: { actorId: id },
+      orderBy: { createdAt: 'desc' },
+      select: { createdAt: true },
+    }),
+  ]);
+
+  return NextResponse.json({ items, lastActiveAt: lastActive?.createdAt ?? null });
+}

--- a/src/app/mentor/mentees/[id]/page.tsx
+++ b/src/app/mentor/mentees/[id]/page.tsx
@@ -16,6 +16,7 @@ import { GoalsPanel } from '@/components/GoalsPanel';
 import { MeetingRequestsPanel } from '@/components/MeetingRequestsPanel';
 import { QuestionsPanel } from '@/components/QuestionsPanel';
 import { ContactActions } from '@/components/ContactActions';
+import { UserActivityPanel } from '@/components/UserActivityPanel';
 import { DocumentsManager } from '@/components/DocumentsManager';
 
 interface InteractionLog {
@@ -389,6 +390,10 @@ export default function MenteeDetailPage() {
 
         <div className="lg:col-span-2">
           <DocumentsManager targetUserId={relation.mentee.id} />
+        </div>
+
+        <div className="lg:col-span-2">
+          <UserActivityPanel userId={relation.mentee.id} flagInactive />
         </div>
       </div>
     </div>

--- a/src/components/UserActivityPanel.tsx
+++ b/src/components/UserActivityPanel.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
+import { Badge } from '@/components/ui/Badge';
+import { useT, useLocale } from '@/i18n/client';
+
+interface Item {
+  id: string;
+  level: string;
+  action: string;
+  detail: string | null;
+  createdAt: string;
+}
+
+// Per-user activity feed. `flagInactive` (mentor view) shows a warning when the
+// user hasn't been active for a while.
+export function UserActivityPanel({ userId, flagInactive = false }: { userId: string; flagInactive?: boolean }) {
+  const t = useT();
+  const locale = useLocale();
+  const [items, setItems] = useState<Item[]>([]);
+  const [lastActiveAt, setLastActiveAt] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    const res = await fetch(`/api/users/${userId}/activity`);
+    if (res.ok) {
+      const d = await res.json();
+      setItems(d.items ?? []);
+      setLastActiveAt(d.lastActiveAt ?? null);
+    }
+    setLoading(false);
+  }, [userId]);
+  useEffect(() => { load(); }, [load]);
+
+  const daysSince = lastActiveAt ? Math.floor((Date.now() - new Date(lastActiveAt).getTime()) / 86_400_000) : null;
+  const inactive = flagInactive && (daysSince === null || daysSince >= 14);
+
+  return (
+    <Card>
+      <CardHeader><CardTitle>{t.activityFeed.title}</CardTitle></CardHeader>
+
+      {inactive && (
+        <div className="mb-3 rounded-lg bg-amber-50 border border-amber-200 px-3 py-2 text-sm text-amber-800">
+          {daysSince === null ? t.activityFeed.neverActive : t.activityFeed.inactiveDays.replace('{d}', String(daysSince))}
+        </div>
+      )}
+
+      {loading ? (
+        <p className="text-sm text-gray-400">{t.common.loading}</p>
+      ) : items.length === 0 ? (
+        <p className="text-sm text-gray-400">{t.activityFeed.none}</p>
+      ) : (
+        <div className="space-y-2 max-h-72 overflow-y-auto">
+          {items.map((i) => (
+            <div key={i.id} className="flex items-center gap-2 text-sm border-b border-gray-50 pb-1.5 last:border-0">
+              <Badge variant={i.level === 'WARNING' ? 'warning' : i.level === 'ERROR' ? 'danger' : 'info'} className="text-[10px]">{i.level}</Badge>
+              <span className="font-mono text-xs text-gray-700">{i.action}</span>
+              {i.detail && <span className="text-xs text-gray-400 truncate">· {i.detail}</span>}
+              <span className="ml-auto text-[11px] text-gray-400 flex-shrink-0">{new Date(i.createdAt).toLocaleDateString(locale)}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -574,6 +574,7 @@ const en = {
     overdue: 'Overdue',
     weekdays: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
   },
+  activityFeed: { title: 'Activity', none: 'No activity yet', neverActive: 'No recorded activity yet.', inactiveDays: 'Inactive for {d} days — consider reaching out.' },
   contact: {
     call: 'Call',
     reachedQ: 'Did you reach them?',
@@ -1486,6 +1487,7 @@ const tr: Dict = {
     overdue: 'Gecikmiş',
     weekdays: ['Pzt', 'Sal', 'Çar', 'Per', 'Cum', 'Cmt', 'Paz'],
   },
+  activityFeed: { title: 'Aktivite', none: 'Henüz aktivite yok', neverActive: 'Henüz kayıtlı aktivite yok.', inactiveDays: '{d} gündür pasif — iletişime geçmeyi düşün.' },
   contact: {
     call: 'Ara',
     reachedQ: 'Görüşebildin mi?',
@@ -2396,6 +2398,7 @@ const de: Dict = {
     overdue: 'Überfällig',
     weekdays: ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So'],
   },
+  activityFeed: { title: 'Aktivität', none: 'Noch keine Aktivität', neverActive: 'Noch keine Aktivität erfasst.', inactiveDays: 'Seit {d} Tagen inaktiv — kontaktiere sie.' },
   contact: {
     call: 'Anrufen',
     reachedQ: 'Hast du sie erreicht?',


### PR DESCRIPTION
Closes #345 — user activity on admin/mentor profile pages (access-controlled), with an inactivity warning for mentors. EN/TR/DE.