### PR TITLE
feat(theme): OS-aware dark mode with per-user persistence (#343)

### DIFF
--- a/e2e/dark-mode.spec.ts
+++ b/e2e/dark-mode.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test';
+
+// Dark mode (EPIC D1). The toggle on the public landing header flips the
+// `dark` class on <html>, persists a `theme` cookie, and survives reload.
+test('theme toggle switches dark mode and persists across reload', async ({ page }) => {
+  await page.goto('/');
+
+  const html = page.locator('html');
+  // Start from a known light baseline regardless of the runner's OS preference.
+  await page.emulateMedia({ colorScheme: 'light' });
+  await page.evaluate(() => {
+    document.documentElement.classList.remove('dark');
+    document.cookie = 'theme=light; path=/; max-age=0';
+    try { localStorage.removeItem('theme'); } catch { /* ignore */ }
+  });
+  await expect(html).not.toHaveClass(/\bdark\b/);
+
+  // Toggle → dark.
+  const toggle = page.getByRole('button', { name: /toggle theme/i }).first();
+  await toggle.click();
+  await expect(html).toHaveClass(/\bdark\b/);
+
+  // Cookie was written so SSR + the no-flash script agree on the next load.
+  const cookies = await page.context().cookies();
+  expect(cookies.find((c) => c.name === 'theme')?.value).toBe('dark');
+
+  // Survives a full reload (no flash back to light).
+  await page.reload();
+  await expect(html).toHaveClass(/\bdark\b/);
+
+  // Toggle back → light.
+  await page.getByRole('button', { name: /toggle theme/i }).first().click();
+  await expect(html).not.toHaveClass(/\bdark\b/);
+});

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -103,6 +103,8 @@ model User {
   twoFactorSecret    String?
   // Preferred UI language ('en' | 'tr' | 'de'); applied at sign-in.
   preferredLanguage  String?
+  // UI theme preference ('light' | 'dark' | 'system'); applied at sign-in.
+  theme              String?
   createdAt          DateTime  @default(now())
   updatedAt          DateTime  @updatedAt
 

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { GraduationCap, LogOut } from 'lucide-react';
 import { getServerDictionary } from '@/i18n/server';
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
+import { ThemeToggle } from '@/components/ThemeToggle';
 import { ResponsiveShell } from '@/components/ResponsiveShell';
 import { AdminNav } from '@/components/AdminNav';
 import { SidebarAvatar } from '@/components/SidebarAvatar';
@@ -29,7 +30,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
     <ResponsiveShell
       headerExtra={<GlobalSearch />}
       sidebar={
-        <aside className="w-64 h-full bg-white border-r border-gray-200 flex flex-col">
+        <aside className="w-64 h-full bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-800 flex flex-col">
         <div className="p-6 border-b border-gray-200">
           <div className="flex items-center gap-2">
             <GraduationCap className="h-7 w-7 text-blue-600" />
@@ -61,6 +62,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
           </Link>
           <div className="mt-3 px-3">
             <LanguageSwitcher current={locale} />
+            <ThemeToggle />
           </div>
         </div>
         </aside>

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -34,6 +34,7 @@ const updateProfileSchema = z.object({
   emailNotifications: z.boolean().optional(),
   notificationPrefs: z.record(z.string(), z.boolean()).optional(),
   preferredLanguage: z.enum(['en', 'tr', 'de']).optional(),
+  theme: z.enum(['light', 'dark', 'system']).optional(),
 });
 
 // Profile fields surfaced by both GET and PUT responses.
@@ -69,6 +70,7 @@ const PROFILE_SELECT = {
   emailNotifications: true,
   notificationPrefs: true,
   preferredLanguage: true,
+  theme: true,
   createdAt: true,
 } as const;
 

--- a/src/app/company/layout.tsx
+++ b/src/app/company/layout.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { GraduationCap, LayoutDashboard, LogOut } from 'lucide-react';
 import { getServerDictionary } from '@/i18n/server';
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
+import { ThemeToggle } from '@/components/ThemeToggle';
 import { ResponsiveShell } from '@/components/ResponsiveShell';
 import { InstallAppButton } from '@/components/InstallAppButton';
 import { SidebarAvatar } from '@/components/SidebarAvatar';
@@ -22,7 +23,7 @@ export default async function CompanyLayout({ children }: { children: React.Reac
   return (
     <ResponsiveShell
       sidebar={
-        <aside className="w-64 h-full bg-white border-r border-gray-200 flex flex-col">
+        <aside className="w-64 h-full bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-800 flex flex-col">
           <div className="p-6 border-b border-gray-200">
             <div className="flex items-center gap-2">
               <GraduationCap className="h-7 w-7 text-blue-600" />
@@ -59,6 +60,7 @@ export default async function CompanyLayout({ children }: { children: React.Reac
             </Link>
             <div className="mt-3 px-3">
               <LanguageSwitcher current={locale} />
+            <ThemeToggle />
             </div>
           </div>
         </aside>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13,6 +13,45 @@
   }
 }
 
+/* Dark mode base surfaces (class strategy); primitives add their own dark: */
+html.dark body { background-color: #030712; color: #f3f4f6; }
+
+/*
+ * Dark theme — broad neutral/accent remap.
+ * Components are built from a small set of Tailwind utilities (white/gray
+ * surfaces, gray text, *-50 accent boxes). Rather than annotate every element,
+ * we retint those utilities under html.dark. Flat (non-nested) selectors so no
+ * CSS-nesting plugin is required. Specificity (0,2,0) beats a bare utility
+ * (0,1,0), so these win without !important; primitives carrying explicit dark:
+ * classes resolve to the same dark values.
+ */
+/* Surfaces */
+html.dark .bg-white { background-color: #111827; }      /* gray-900 */
+html.dark .bg-gray-50 { background-color: #1f2937; }    /* gray-800 */
+html.dark .bg-gray-100 { background-color: #374151; }   /* gray-700 */
+html.dark .bg-gray-900 { background-color: #030712; }   /* keep deep */
+/* Soft accent boxes → dark tints (keep light text readable) */
+html.dark .bg-blue-50 { background-color: rgba(30,58,138,0.25); }
+html.dark .bg-green-50 { background-color: rgba(20,83,45,0.25); }
+html.dark .bg-yellow-50 { background-color: rgba(113,63,18,0.25); }
+html.dark .bg-amber-50 { background-color: rgba(120,53,15,0.25); }
+html.dark .bg-red-50 { background-color: rgba(127,29,29,0.25); }
+html.dark .bg-purple-50 { background-color: rgba(88,28,135,0.25); }
+html.dark .bg-indigo-50 { background-color: rgba(49,46,129,0.25); }
+html.dark .bg-gradient-to-br { background-image: none; background-color: #030712; }
+/* Text */
+html.dark .text-gray-900 { color: #f3f4f6; }
+html.dark .text-gray-800 { color: #e5e7eb; }
+html.dark .text-gray-700 { color: #d1d5db; }
+html.dark .text-gray-600 { color: #9ca3af; }
+html.dark .text-gray-500 { color: #9ca3af; }
+/* Borders */
+html.dark .border-gray-100 { border-color: #1f2937; }
+html.dark .border-gray-200 { border-color: #374151; }
+html.dark .border-gray-300 { border-color: #4b5563; }
+html.dark .divide-gray-50 > :not([hidden]) ~ :not([hidden]) { border-color: #1f2937; }
+html.dark .divide-gray-100 > :not([hidden]) ~ :not([hidden]) { border-color: #374151; }
+
 @layer components {
   .container-page {
     @apply max-w-7xl mx-auto px-4 sm:px-6 lg:px-8;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,12 @@
 import type { Metadata, Viewport } from 'next';
+import { cookies } from 'next/headers';
+import { getServerSession } from 'next-auth';
 import './globals.css';
 import { Providers } from './providers';
 import { getLocale } from '@/i18n/server';
 import { getDictionary } from '@/i18n/dictionaries';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
 
 export const metadata: Metadata = {
   title: 'Internship CRM - Mentor-Mentee Management',
@@ -15,11 +19,31 @@ export const viewport: Viewport = {
   themeColor: '#1D4ED8',
 };
 
+// Runs before paint to set the dark class from the saved preference or the OS,
+// so there's no light flash. Mirrors the server-side cookie read below.
+const NO_FLASH = `(function(){try{var m=document.cookie.match(/(?:^|; )theme=([^;]+)/);var e=m?decodeURIComponent(m[1]):localStorage.getItem('theme');var h=document.documentElement;if(e==='dark')h.classList.add('dark');else if(e==='light')h.classList.remove('dark');else if(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches)h.classList.add('dark');}catch(e){}})();`;
+
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const locale = await getLocale();
   const dict = getDictionary(locale);
+  let theme = (await cookies()).get('theme')?.value;
+  // No device cookie yet? Fall back to the signed-in user's saved theme so it
+  // follows them across devices (the no-flash script still handles OS default).
+  if (!theme) {
+    try {
+      const session = await getServerSession(authOptions);
+      if (session?.user?.id) {
+        const u = await prisma.user.findUnique({ where: { id: session.user.id }, select: { theme: true } });
+        if (u?.theme) theme = u.theme;
+      }
+    } catch { /* ignore */ }
+  }
+
   return (
-    <html lang={locale}>
+    <html lang={locale} className={theme === 'dark' ? 'dark' : undefined} suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: NO_FLASH }} />
+      </head>
       <body>
         <a
           href="#main-content"

--- a/src/app/mentor/layout.tsx
+++ b/src/app/mentor/layout.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { GraduationCap, LayoutDashboard, Columns3, Users, BookOpen, Mail, CalendarClock, CalendarRange, CalendarDays, FolderGit2, LogOut } from 'lucide-react';
 import { getServerDictionary } from '@/i18n/server';
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
+import { ThemeToggle } from '@/components/ThemeToggle';
 import { ResponsiveShell } from '@/components/ResponsiveShell';
 import { InstallAppButton } from '@/components/InstallAppButton';
 import { SidebarAvatar } from '@/components/SidebarAvatar';
@@ -27,7 +28,7 @@ export default async function MentorLayout({ children }: { children: React.React
   return (
     <ResponsiveShell
       sidebar={
-        <aside className="w-64 h-full bg-white border-r border-gray-200 flex flex-col">
+        <aside className="w-64 h-full bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-800 flex flex-col">
         <div className="p-6 border-b border-gray-200">
           <div className="flex items-center gap-2">
             <GraduationCap className="h-7 w-7 text-blue-600" />
@@ -120,6 +121,7 @@ export default async function MentorLayout({ children }: { children: React.React
           </Link>
           <div className="mt-3 px-3">
             <LanguageSwitcher current={locale} />
+            <ThemeToggle />
           </div>
         </div>
         </aside>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,7 @@ import { authOptions } from '@/lib/auth';
 import { roleHome } from '@/lib/roleHome';
 import { getServerDictionary } from '@/i18n/server';
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
+import { ThemeToggle } from '@/components/ThemeToggle';
 
 export default async function HomePage() {
   const session = await getServerSession(authOptions);
@@ -52,6 +53,7 @@ export default async function HomePage() {
             </div>
             <div className="flex items-center gap-2 sm:gap-4 flex-shrink-0">
               <LanguageSwitcher current={locale} />
+            <ThemeToggle />
               <Link href="/auth/signin" className="text-gray-600 hover:text-gray-900 font-medium transition-colors whitespace-nowrap text-sm sm:text-base">
                 {L.signIn}
               </Link>
@@ -106,7 +108,7 @@ export default async function HomePage() {
                     <rect x={x} y={50} width="180" height="60" rx="14" fill="none" stroke="#6366f1" strokeWidth="1.5" />
                     <circle cx={x + 30} cy={80} r="14" fill="#6366f1" />
                     <text x={x + 30} y={85} textAnchor="middle" fill="#fff" fontSize="13" fontWeight="700">{i + 1}</text>
-                    <text x={x + 58} y={85} fill="#1e293b" fontSize="15" fontWeight="600">{label}</text>
+                    <text x={x + 58} y={85} className="fill-slate-800 dark:fill-slate-100" fontSize="15" fontWeight="600">{label}</text>
                     {i < stages.length - 1 && (
                       <g>
                         <line x1={x + 180} y1={80} x2={x + 218} y2={80} stroke="#94a3b8" strokeWidth="2" />

--- a/src/app/portal/layout.tsx
+++ b/src/app/portal/layout.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { GraduationCap, LayoutDashboard, User, BookOpen, MessageSquare, LogOut } from 'lucide-react';
 import { getServerDictionary } from '@/i18n/server';
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
+import { ThemeToggle } from '@/components/ThemeToggle';
 import { ResponsiveShell } from '@/components/ResponsiveShell';
 import { InstallAppButton } from '@/components/InstallAppButton';
 import { SidebarAvatar } from '@/components/SidebarAvatar';
@@ -35,7 +36,7 @@ export default async function PortalLayout({ children }: { children: React.React
   return (
     <ResponsiveShell
       sidebar={
-        <aside className="w-64 h-full bg-white border-r border-gray-200 flex flex-col">
+        <aside className="w-64 h-full bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-800 flex flex-col">
         <div className="p-6 border-b border-gray-200">
           <div className="flex items-center gap-2">
             <GraduationCap className="h-7 w-7 text-blue-600" />
@@ -93,6 +94,7 @@ export default async function PortalLayout({ children }: { children: React.React
           </Link>
           <div className="mt-3 px-3">
             <LanguageSwitcher current={locale} />
+            <ThemeToggle />
           </div>
         </div>
         </aside>

--- a/src/app/source/layout.tsx
+++ b/src/app/source/layout.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { GraduationCap, LayoutDashboard, LogOut } from 'lucide-react';
 import { getServerDictionary } from '@/i18n/server';
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
+import { ThemeToggle } from '@/components/ThemeToggle';
 import { ResponsiveShell } from '@/components/ResponsiveShell';
 import { InstallAppButton } from '@/components/InstallAppButton';
 import { SidebarAvatar } from '@/components/SidebarAvatar';
@@ -22,7 +23,7 @@ export default async function SourceLayout({ children }: { children: React.React
   return (
     <ResponsiveShell
       sidebar={
-        <aside className="w-64 h-full bg-white border-r border-gray-200 flex flex-col">
+        <aside className="w-64 h-full bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-800 flex flex-col">
           <div className="p-6 border-b border-gray-200">
             <div className="flex items-center gap-2">
               <GraduationCap className="h-7 w-7 text-blue-600" />
@@ -59,6 +60,7 @@ export default async function SourceLayout({ children }: { children: React.React
             </Link>
             <div className="mt-3 px-3">
               <LanguageSwitcher current={locale} />
+            <ThemeToggle />
             </div>
           </div>
         </aside>

--- a/src/components/AccountSettings.tsx
+++ b/src/components/AccountSettings.tsx
@@ -37,6 +37,7 @@ export function AccountSettings() {
   const [twoFaCode, setTwoFaCode] = useState('');
   const [twoFaBusy, setTwoFaBusy] = useState(false);
   const [language, setLanguage] = useState('en');
+  const [theme, setTheme] = useState('system');
   const [role, setRole] = useState('');
   const [skills, setSkills] = useState('');
   const [capacity, setCapacity] = useState('');
@@ -51,6 +52,7 @@ export function AccountSettings() {
         setEmailNotifications(user.emailNotifications !== false);
         setNotifPrefs((user.notificationPrefs && typeof user.notificationPrefs === 'object') ? user.notificationPrefs : {});
         setLanguage(user.preferredLanguage ?? 'en');
+        setTheme(user.theme ?? 'system');
         setRole(user.role ?? '');
         setSkills(Array.isArray(user.skills) ? user.skills.join(', ') : '');
         setCapacity(user.mentorCapacity != null ? String(user.mentorCapacity) : '');
@@ -76,6 +78,24 @@ export function AccountSettings() {
     } finally {
       setTwoFaBusy(false);
     }
+  };
+
+  const changeTheme = async (next: string) => {
+    setTheme(next);
+    const root = document.documentElement;
+    if (next === 'system') {
+      try { localStorage.removeItem('theme'); } catch { /* ignore */ }
+      document.cookie = 'theme=; path=/; max-age=0';
+      const osDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+      root.classList.toggle('dark', !!osDark);
+    } else {
+      try { localStorage.setItem('theme', next); } catch { /* ignore */ }
+      document.cookie = `theme=${next}; path=/; max-age=${60 * 60 * 24 * 365}; samesite=lax`;
+      root.classList.toggle('dark', next === 'dark');
+    }
+    try {
+      await fetch('/api/profile', { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ theme: next }) });
+    } catch { /* ignore */ }
   };
 
   const changeLanguage = async (next: string) => {
@@ -315,17 +335,31 @@ export function AccountSettings() {
           ))}
         </div>
 
-        <div className="mt-4 pt-4 border-t border-gray-100 max-w-xs">
-          <label className="block text-sm font-medium text-gray-700 mb-1.5">{t.account.language}</label>
-          <select
-            value={language}
-            onChange={(e) => changeLanguage(e.target.value)}
-            className="block w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
-          >
-            {locales.map((l) => (
-              <option key={l} value={l}>{(t.account.languages as Record<string, string>)[l] ?? l.toUpperCase()}</option>
-            ))}
-          </select>
+        <div className="mt-4 pt-4 border-t border-gray-100 grid grid-cols-1 sm:grid-cols-2 gap-4 max-w-md">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1.5">{t.account.language}</label>
+            <select
+              value={language}
+              onChange={(e) => changeLanguage(e.target.value)}
+              className="block w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+            >
+              {locales.map((l) => (
+                <option key={l} value={l}>{(t.account.languages as Record<string, string>)[l] ?? l.toUpperCase()}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1.5">{t.account.themeLabel}</label>
+            <select
+              value={theme}
+              onChange={(e) => changeTheme(e.target.value)}
+              className="block w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+            >
+              <option value="system">{t.theme.system}</option>
+              <option value="light">{t.theme.light}</option>
+              <option value="dark">{t.theme.dark}</option>
+            </select>
+          </div>
         </div>
       </Card>
 

--- a/src/components/ResponsiveShell.tsx
+++ b/src/components/ResponsiveShell.tsx
@@ -20,10 +20,10 @@ export function ResponsiveShell({
   const [open, setOpen] = useState(false);
 
   return (
-    <div className="min-h-screen bg-gray-50 lg:flex">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-950 lg:flex">
       {/* Mobile top bar */}
-      <div className="lg:hidden sticky top-0 z-30 flex items-center justify-between bg-white border-b border-gray-200 h-14 px-4">
-        <span className="font-bold text-gray-900">InternshipCRM</span>
+      <div className="lg:hidden sticky top-0 z-30 flex items-center justify-between bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-800 h-14 px-4">
+        <span className="font-bold text-gray-900 dark:text-gray-100">InternshipCRM</span>
         <div className="flex items-center gap-1">
           <NotificationBell />
           <button onClick={() => setOpen(true)} aria-label="Open menu" className="p-2 -mr-2 text-gray-600 hover:text-gray-900">

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Sun, Moon } from 'lucide-react';
+import { useT } from '@/i18n/client';
+
+type Theme = 'light' | 'dark';
+
+// Light/dark toggle. Persists to localStorage + a cookie (so SSR + the no-flash
+// script agree) and, when signed in, to the user's saved preference.
+export function ThemeToggle() {
+  const t = useT();
+  const [theme, setTheme] = useState<Theme>('light');
+
+  useEffect(() => {
+    setTheme(document.documentElement.classList.contains('dark') ? 'dark' : 'light');
+  }, []);
+
+  const apply = (next: Theme) => {
+    setTheme(next);
+    document.documentElement.classList.toggle('dark', next === 'dark');
+    try { localStorage.setItem('theme', next); } catch { /* ignore */ }
+    document.cookie = `theme=${next}; path=/; max-age=${60 * 60 * 24 * 365}; samesite=lax`;
+    // Best-effort persist to the account (ignored / 401 when signed out).
+    fetch('/api/profile', {
+      method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ theme: next }),
+    }).catch(() => {});
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={() => apply(theme === 'dark' ? 'light' : 'dark')}
+      aria-label={t.theme.toggle}
+      title={t.theme.toggle}
+      className="inline-flex items-center gap-1.5 rounded-lg px-2 py-1 text-xs text-gray-500 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-100 transition-colors"
+    >
+      {theme === 'dark' ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+      <span>{theme === 'dark' ? t.theme.light : t.theme.dark}</span>
+    </button>
+  );
+}

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -12,12 +12,12 @@ interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
 
 export function Badge({ className, variant = 'default', children, ...props }: BadgeProps) {
   const variants = {
-    default: 'bg-gray-100 text-gray-700',
-    success: 'bg-green-100 text-green-700',
-    warning: 'bg-yellow-100 text-yellow-700',
-    danger: 'bg-red-100 text-red-700',
-    info: 'bg-blue-100 text-blue-700',
-    purple: 'bg-purple-100 text-purple-700',
+    default: 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200',
+    success: 'bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300',
+    warning: 'bg-yellow-100 dark:bg-yellow-900/40 text-yellow-700 dark:text-yellow-300',
+    danger: 'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300',
+    info: 'bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300',
+    purple: 'bg-purple-100 dark:bg-purple-900/40 text-purple-700 dark:text-purple-300',
   };
 
   return (

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -23,7 +23,7 @@ export const Card = forwardRef<HTMLDivElement, CardProps>(
       <div
         ref={ref}
         className={cn(
-          'bg-white rounded-xl border border-gray-200 shadow-sm',
+          'bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-800 shadow-sm',
           paddings[padding],
           className
         )}
@@ -39,7 +39,7 @@ Card.displayName = 'Card';
 
 export function CardHeader({ className, children, ...props }: HTMLAttributes<HTMLDivElement>) {
   return (
-    <div className={cn('mb-4 pb-4 border-b border-gray-100', className)} {...props}>
+    <div className={cn('mb-4 pb-4 border-b border-gray-100 dark:border-gray-800', className)} {...props}>
       {children}
     </div>
   );
@@ -47,7 +47,7 @@ export function CardHeader({ className, children, ...props }: HTMLAttributes<HTM
 
 export function CardTitle({ className, children, ...props }: HTMLAttributes<HTMLHeadingElement>) {
   return (
-    <h3 className={cn('text-lg font-semibold text-gray-900', className)} {...props}>
+    <h3 className={cn('text-lg font-semibold text-gray-900 dark:text-gray-100', className)} {...props}>
       {children}
     </h3>
   );
@@ -55,7 +55,7 @@ export function CardTitle({ className, children, ...props }: HTMLAttributes<HTML
 
 export function CardDescription({ className, children, ...props }: HTMLAttributes<HTMLParagraphElement>) {
   return (
-    <p className={cn('text-sm text-gray-500 mt-1', className)} {...props}>
+    <p className={cn('text-sm text-gray-500 dark:text-gray-400 mt-1', className)} {...props}>
       {children}
     </p>
   );
@@ -63,7 +63,7 @@ export function CardDescription({ className, children, ...props }: HTMLAttribute
 
 export function CardFooter({ className, children, ...props }: HTMLAttributes<HTMLDivElement>) {
   return (
-    <div className={cn('mt-4 pt-4 border-t border-gray-100 flex items-center gap-2', className)} {...props}>
+    <div className={cn('mt-4 pt-4 border-t border-gray-100 dark:border-gray-800 flex items-center gap-2', className)} {...props}>
       {children}
     </div>
   );

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -21,7 +21,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
         {label && (
           <label
             htmlFor={inputId}
-            className="block text-sm font-medium text-gray-700 mb-1.5"
+            className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5"
           >
             {label}
             {props.required && <span className="text-red-500 ml-1">*</span>}
@@ -31,13 +31,13 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
           ref={ref}
           id={inputId}
           className={cn(
-            'block w-full rounded-lg border px-3.5 py-2.5 text-sm text-gray-900',
+            'block w-full rounded-lg border px-3.5 py-2.5 text-sm text-gray-900 dark:text-gray-100',
             'placeholder:text-gray-400',
             'focus:outline-none focus:ring-2 focus:ring-offset-0',
             'transition-colors duration-150',
             error
               ? 'border-red-300 focus:border-red-400 focus:ring-red-200 bg-red-50'
-              : 'border-gray-300 focus:border-blue-400 focus:ring-blue-100 bg-white',
+              : 'border-gray-300 dark:border-gray-700 focus:border-blue-400 focus:ring-blue-100 bg-white dark:bg-gray-800',
             'disabled:bg-gray-50 disabled:text-gray-500 disabled:cursor-not-allowed',
             className
           )}

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -23,7 +23,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
         {label && (
           <label
             htmlFor={selectId}
-            className="block text-sm font-medium text-gray-700 mb-1.5"
+            className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5"
           >
             {label}
             {props.required && <span className="text-red-500 ml-1">*</span>}
@@ -33,12 +33,12 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
           ref={ref}
           id={selectId}
           className={cn(
-            'block w-full rounded-lg border px-3.5 py-2.5 text-sm text-gray-900',
+            'block w-full rounded-lg border px-3.5 py-2.5 text-sm text-gray-900 dark:text-gray-100',
             'focus:outline-none focus:ring-2 focus:ring-offset-0',
-            'transition-colors duration-150 bg-white',
+            'transition-colors duration-150 bg-white dark:bg-gray-800',
             error
               ? 'border-red-300 focus:border-red-400 focus:ring-red-200'
-              : 'border-gray-300 focus:border-blue-400 focus:ring-blue-100',
+              : 'border-gray-300 dark:border-gray-700 focus:border-blue-400 focus:ring-blue-100',
             'disabled:bg-gray-50 disabled:text-gray-500 disabled:cursor-not-allowed',
             className
           )}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -575,6 +575,7 @@ const en = {
     weekdays: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
   },
   activityFeed: { title: 'Activity', none: 'No activity yet', neverActive: 'No recorded activity yet.', inactiveDays: 'Inactive for {d} days — consider reaching out.' },
+  theme: { toggle: 'Toggle theme', light: 'Light', dark: 'Dark', system: 'System' },
   contact: {
     call: 'Call',
     reachedQ: 'Did you reach them?',
@@ -909,6 +910,7 @@ const en = {
     emailNotificationsHint: 'In-app notifications are always shown regardless of this setting.',
     notifCategories: { messages: 'Messages', announcements: 'Announcements', deadlines: 'Stage deadlines', digest: 'Weekly digest' },
     language: 'Language',
+    themeLabel: 'Theme',
     languages: { en: 'English', tr: 'Türkçe', de: 'Deutsch' },
   },
 };
@@ -1488,6 +1490,7 @@ const tr: Dict = {
     weekdays: ['Pzt', 'Sal', 'Çar', 'Per', 'Cum', 'Cmt', 'Paz'],
   },
   activityFeed: { title: 'Aktivite', none: 'Henüz aktivite yok', neverActive: 'Henüz kayıtlı aktivite yok.', inactiveDays: '{d} gündür pasif — iletişime geçmeyi düşün.' },
+  theme: { toggle: 'Temayı değiştir', light: 'Açık', dark: 'Koyu', system: 'Sistem' },
   contact: {
     call: 'Ara',
     reachedQ: 'Görüşebildin mi?',
@@ -1822,6 +1825,7 @@ const tr: Dict = {
     emailNotificationsHint: 'Uygulama içi bildirimler bu ayardan bağımsız olarak her zaman gösterilir.',
     notifCategories: { messages: 'Mesajlar', announcements: 'Duyurular', deadlines: 'Aşama son tarihleri', digest: 'Haftalık özet' },
     language: 'Dil',
+    themeLabel: 'Tema',
     languages: { en: 'English', tr: 'Türkçe', de: 'Deutsch' },
   },
 };
@@ -2399,6 +2403,7 @@ const de: Dict = {
     weekdays: ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So'],
   },
   activityFeed: { title: 'Aktivität', none: 'Noch keine Aktivität', neverActive: 'Noch keine Aktivität erfasst.', inactiveDays: 'Seit {d} Tagen inaktiv — kontaktiere sie.' },
+  theme: { toggle: 'Theme wechseln', light: 'Hell', dark: 'Dunkel', system: 'System' },
   contact: {
     call: 'Anrufen',
     reachedQ: 'Hast du sie erreicht?',
@@ -2733,6 +2738,7 @@ const de: Dict = {
     emailNotificationsHint: 'In-App-Benachrichtigungen werden unabhängig von dieser Einstellung immer angezeigt.',
     notifCategories: { messages: 'Nachrichten', announcements: 'Ankündigungen', deadlines: 'Phasen-Fristen', digest: 'Wochenübersicht' },
     language: 'Sprache',
+    themeLabel: 'Theme',
     languages: { en: 'English', tr: 'Türkçe', de: 'Deutsch' },
   },
 };

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from 'tailwindcss';
 
 const config: Config = {
+  darkMode: 'class',
   content: [
     './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',


### PR DESCRIPTION
## EPIC D1 · Dark mode

OS-aware dark mode that users can toggle, persisted per-user and remembered across sessions/devices.

### What's included
- **Tailwind class strategy** (`darkMode: 'class'`) + a **no-flash inline script** that sets the `dark` class from cookie → localStorage → OS preference before first paint.
- **SSR-aware**: the root layout reads the `theme` cookie and, when absent, falls back to the signed-in user's saved `User.theme` so the first render already matches (no flash).
- **ThemeToggle** in all five role sidebars (admin/mentor/portal/company/source) and the landing header. Persists to localStorage + cookie + `User.theme` via `/api/profile`.
- **AccountSettings**: Light / Dark / **System** selector.
- **Theming**: `globals.css` retints neutral/accent utilities under `html.dark` (flat, non-nested selectors — no CSS-nesting plugin needed); UI primitives (`Card`, `Input`, `Select`, `Badge`, `ResponsiveShell`) and role layouts carry explicit `dark:` variants.
- **i18n**: `theme` block (toggle/light/dark/system) in EN/TR/DE.

### Verification
- `npx tsc --noEmit` clean.
- Manual preview: landing renders correctly in dark; toggle visible in header.
- **e2e** (`e2e/dark-mode.spec.ts`): toggle flips `html.dark`, writes the `theme` cookie, and the choice survives a full reload.

### Future-proofing
The class-strategy + utility-remap approach leaves room for additional accessibility modes (e.g. high-contrast) as future `html.*` variants without per-element rework.

Closes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)