### PR TITLE
feat(templates): multilingual document templates with preview + PDF/TXT/MD (#357)

### DIFF
--- a/e2e/templates-library.spec.ts
+++ b/e2e/templates-library.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// EPIC #357: multilingual document templates with in-app preview.
+test('mentee can preview a template and switch its language', async ({ page }) => {
+  const email = uniqueEmail('tpl-mentee');
+  await seedUser(email, 'MenteePass123', 'MENTEE', 'Template Mentee');
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', email);
+    await page.fill('input[type="password"]', 'MenteePass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/portal'), { timeout: 20_000 });
+
+    await page.goto('/portal/profile');
+
+    // Open the CV template preview.
+    const row = page.getByTestId('tpl-cv');
+    await expect(row).toBeVisible({ timeout: 10_000 });
+    await row.getByRole('button').click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    // Default locale is EN in the test runner → English heading rendered.
+    await expect(dialog.getByRole('heading', { name: /Curriculum Vitae/i })).toBeVisible();
+
+    // Switch to German and confirm the content re-renders.
+    await dialog.getByRole('button', { name: 'DE', exact: true }).click();
+    await expect(dialog.getByRole('heading', { name: /Lebenslauf/i })).toBeVisible();
+
+    // Export actions are present (PDF / TXT / MD).
+    await expect(dialog.getByRole('button', { name: /Save as PDF|PDF/i })).toBeVisible();
+    await expect(dialog.getByRole('button', { name: '.txt' })).toBeVisible();
+    await expect(dialog.getByRole('button', { name: '.md' })).toBeVisible();
+  } finally {
+    await cleanupByEmail(email);
+  }
+});

--- a/e2e/templates-library.spec.ts
+++ b/e2e/templates-library.spec.ts
@@ -26,12 +26,13 @@ test('mentee can preview a template and switch its language', async ({ page }) =
 
     const dialog = page.getByRole('dialog');
     await expect(dialog).toBeVisible();
-    // Default locale is EN in the test runner → English heading rendered.
-    await expect(dialog.getByRole('heading', { name: /Curriculum Vitae/i })).toBeVisible();
+    // Default locale is EN in the test runner → English body heading rendered.
+    // Target the rendered body H1 (level 1); the modal title is a separate H2.
+    await expect(dialog.getByRole('heading', { level: 1, name: 'Curriculum Vitae' })).toBeVisible();
 
     // Switch to German and confirm the content re-renders.
     await dialog.getByRole('button', { name: 'DE', exact: true }).click();
-    await expect(dialog.getByRole('heading', { name: /Lebenslauf/i })).toBeVisible();
+    await expect(dialog.getByRole('heading', { level: 1, name: 'Lebenslauf' })).toBeVisible();
 
     // Export actions are present (PDF / TXT / MD).
     await expect(dialog.getByRole('button', { name: /Save as PDF|PDF/i })).toBeVisible();

--- a/src/app/admin/documents/page.tsx
+++ b/src/app/admin/documents/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { DocumentsManager } from '@/components/DocumentsManager';
+import { TemplatesLibrary } from '@/components/TemplatesLibrary';
 import { useT } from '@/i18n/client';
 
 export default function AdminDocumentsPage() {
@@ -11,7 +12,10 @@ export default function AdminDocumentsPage() {
         <h1 className="text-2xl font-bold text-gray-900">{t.documents.templates}</h1>
         <p className="text-gray-500 mt-1">{t.documents.templatesSubtitle}</p>
       </div>
-      <div className="max-w-2xl">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 max-w-4xl">
+        {/* Curated, multilingual templates with preview + PDF/TXT/MD export. */}
+        <TemplatesLibrary />
+        {/* Custom uploaded templates (admin-managed). */}
         <DocumentsManager templates canUpload canDelete />
       </div>
     </div>

--- a/src/app/portal/profile/page.tsx
+++ b/src/app/portal/profile/page.tsx
@@ -12,6 +12,7 @@ import { Select } from '@/components/ui/Select';
 import { CvManager } from '@/components/CvManager';
 import { AvatarManager } from '@/components/AvatarManager';
 import { DocumentsManager } from '@/components/DocumentsManager';
+import { TemplatesLibrary } from '@/components/TemplatesLibrary';
 
 const profileSchema = z.object({
   fullName: z.string().min(1, 'Full name is required'),
@@ -376,7 +377,7 @@ export default function ProfilePage() {
       {userId && (
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 max-w-4xl mt-6">
           <DocumentsManager targetUserId={userId} />
-          <DocumentsManager templates canUpload={false} canDelete={false} />
+          <TemplatesLibrary />
         </div>
       )}
     </div>

--- a/src/components/TemplatesLibrary.tsx
+++ b/src/components/TemplatesLibrary.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { useState } from 'react';
+import { FileText, Mail, ClipboardList, CheckSquare, Eye, Download, Printer, X } from 'lucide-react';
+import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
+import { useT, useLocale } from '@/i18n/client';
+import { TEMPLATES, type DocTemplate, type TemplateLocale } from '@/lib/templates';
+import { templateToHtml, templateToText } from '@/lib/renderTemplate';
+
+const ICONS: Record<string, typeof FileText> = { FileText, Mail, ClipboardList, CheckSquare };
+const LOCALES: TemplateLocale[] = ['en', 'tr', 'de'];
+const LOCALE_LABEL: Record<TemplateLocale, string> = { en: 'EN', tr: 'TR', de: 'DE' };
+
+// Print-optimised stylesheet for the "Save as PDF" window. Inlined so the popup
+// is fully self-contained (no app CSS, no external requests — Docker-safe PDF).
+const PRINT_CSS = `
+  * { box-sizing: border-box; }
+  body { font-family: -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; color: #111827; margin: 0; }
+  main { max-width: 720px; margin: 0 auto; padding: 48px 40px; line-height: 1.55; }
+  h1 { font-size: 24px; margin: 0 0 12px; }
+  h2 { font-size: 16px; margin: 22px 0 6px; border-bottom: 1px solid #e5e7eb; padding-bottom: 4px; }
+  h3 { font-size: 14px; margin: 16px 0 4px; }
+  p { margin: 6px 0; }
+  ul { margin: 6px 0; padding-left: 22px; }
+  li { margin: 3px 0; }
+  li.task { list-style: none; margin-left: -22px; }
+  .cb { display: inline-block; width: 16px; }
+  @page { margin: 18mm; }
+`;
+
+function download(filename: string, text: string, mime: string) {
+  const blob = new Blob([text], { type: mime });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+function printPdf(title: string, bodyHtml: string) {
+  const w = window.open('', '_blank', 'width=820,height=1040');
+  if (!w) return;
+  w.document.write(
+    `<!doctype html><html><head><meta charset="utf-8"><title>${title}</title>` +
+    `<style>${PRINT_CSS}</style></head><body><main>${bodyHtml}</main>` +
+    `<script>window.onload=function(){setTimeout(function(){window.focus();window.print();},150);};<\/script>` +
+    `</body></html>`,
+  );
+  w.document.close();
+}
+
+// Multilingual document templates with in-app preview and PDF / TXT / Markdown
+// export. Replaces the old single-language, download-only template list.
+export function TemplatesLibrary() {
+  const t = useT();
+  const locale = useLocale() as TemplateLocale;
+  const base: TemplateLocale = (['en', 'tr', 'de'].includes(locale) ? locale : 'en') as TemplateLocale;
+  const [active, setActive] = useState<DocTemplate | null>(null);
+  const [lang, setLang] = useState<TemplateLocale>(base);
+
+  const open = (tpl: DocTemplate) => { setLang(base); setActive(tpl); };
+  const tl = t.templatesLib;
+
+  return (
+    <Card>
+      <CardHeader><CardTitle>{t.documents.templates}</CardTitle></CardHeader>
+
+      <div className="divide-y divide-gray-50">
+        {TEMPLATES.map((tpl) => {
+          const Icon = ICONS[tpl.icon] ?? FileText;
+          return (
+            <div key={tpl.id} data-testid={`tpl-${tpl.id}`} className="flex items-center gap-3 py-2.5">
+              <Icon className="h-5 w-5 text-gray-400 flex-shrink-0" />
+              <div className="min-w-0 flex-1">
+                <p className="text-sm text-gray-800 truncate">{tpl.title[base]}</p>
+                <p className="text-xs text-gray-400 truncate">{tpl.summary[base]}</p>
+              </div>
+              <button
+                type="button"
+                onClick={() => open(tpl)}
+                className="inline-flex items-center gap-1 rounded-lg border border-gray-200 dark:border-gray-700 px-2.5 py-1.5 text-xs text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800"
+              >
+                <Eye className="h-4 w-4" /> {tl.preview}
+              </button>
+            </div>
+          );
+        })}
+      </div>
+
+      {active && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-label={active.title[lang]}
+          onClick={() => setActive(null)}
+        >
+          <div
+            className="bg-white dark:bg-gray-900 rounded-2xl shadow-xl w-full max-w-2xl max-h-[90vh] flex flex-col"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center gap-3 border-b border-gray-100 dark:border-gray-800 p-4">
+              <h2 className="text-base font-semibold text-gray-900 dark:text-gray-100 flex-1 truncate">{active.title[lang]}</h2>
+              <div className="flex items-center gap-1 rounded-lg bg-gray-100 dark:bg-gray-800 p-0.5">
+                {LOCALES.map((l) => (
+                  <button
+                    key={l}
+                    type="button"
+                    onClick={() => setLang(l)}
+                    aria-pressed={lang === l}
+                    className={`px-2 py-1 text-xs rounded-md ${lang === l ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm' : 'text-gray-500 dark:text-gray-400'}`}
+                  >
+                    {LOCALE_LABEL[l]}
+                  </button>
+                ))}
+              </div>
+              <button type="button" onClick={() => setActive(null)} aria-label={tl.close} className="text-gray-400 hover:text-gray-700 dark:hover:text-gray-200">
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+
+            <div className="overflow-y-auto p-6">
+              <div
+                className="tpl-preview text-sm text-gray-800 dark:text-gray-200 leading-relaxed [&_h1]:text-xl [&_h1]:font-bold [&_h1]:mb-2 [&_h2]:text-base [&_h2]:font-semibold [&_h2]:mt-5 [&_h2]:mb-1 [&_h2]:border-b [&_h2]:border-gray-100 dark:[&_h2]:border-gray-800 [&_h2]:pb-1 [&_h3]:font-semibold [&_h3]:mt-3 [&_ul]:list-disc [&_ul]:pl-6 [&_ul]:my-1.5 [&_li]:my-0.5 [&_li.task]:list-none [&_li.task]:-ml-6 [&_p]:my-1.5"
+                dangerouslySetInnerHTML={{ __html: templateToHtml(active.body[lang]) }}
+              />
+            </div>
+
+            <div className="flex flex-wrap items-center justify-end gap-2 border-t border-gray-100 dark:border-gray-800 p-4">
+              <button
+                type="button"
+                onClick={() => download(`${active.id}-${lang}.txt`, templateToText(active.body[lang]), 'text/plain;charset=utf-8')}
+                className="inline-flex items-center gap-1 rounded-lg border border-gray-200 dark:border-gray-700 px-3 py-1.5 text-xs text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800"
+              >
+                <Download className="h-4 w-4" /> {tl.txt}
+              </button>
+              <button
+                type="button"
+                onClick={() => download(`${active.id}-${lang}.md`, active.body[lang], 'text/markdown;charset=utf-8')}
+                className="inline-flex items-center gap-1 rounded-lg border border-gray-200 dark:border-gray-700 px-3 py-1.5 text-xs text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800"
+              >
+                <Download className="h-4 w-4" /> {tl.md}
+              </button>
+              <button
+                type="button"
+                onClick={() => printPdf(active.title[lang], templateToHtml(active.body[lang]))}
+                className="inline-flex items-center gap-1 rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700"
+              >
+                <Printer className="h-4 w-4" /> {tl.pdf}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -649,6 +649,7 @@ const en = {
     send: 'Broadcast',
     sent: 'Sent to {n} users',
   },
+  templatesLib: { preview: 'Preview', close: 'Close', pdf: 'Save as PDF', txt: '.txt', md: '.md' },
   documents: {
     title: 'Documents',
     templates: 'Document templates',
@@ -1565,6 +1566,7 @@ const tr: Dict = {
     send: 'Yayınla',
     sent: '{n} kullanıcıya gönderildi',
   },
+  templatesLib: { preview: 'Önizle', close: 'Kapat', pdf: 'PDF kaydet', txt: '.txt', md: '.md' },
   documents: {
     title: 'Dokümanlar',
     templates: 'Doküman şablonları',
@@ -2479,6 +2481,7 @@ const de: Dict = {
     send: 'Senden',
     sent: 'An {n} Benutzer gesendet',
   },
+  templatesLib: { preview: 'Vorschau', close: 'Schließen', pdf: 'Als PDF speichern', txt: '.txt', md: '.md' },
   documents: {
     title: 'Dokumente',
     templates: 'Dokumentvorlagen',

--- a/src/lib/renderTemplate.ts
+++ b/src/lib/renderTemplate.ts
@@ -1,0 +1,66 @@
+// Minimal, dependency-free renderer for the constrained markdown used by our
+// document templates: #/##/### headings, **bold**, "- " bullets, "[ ]/[x]"
+// checkboxes, and paragraphs. Input is escaped first, so it is safe to inject.
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function inline(s: string): string {
+  // **bold** → <strong>. Run after escaping.
+  return escapeHtml(s).replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+}
+
+/** Render the template markdown subset to an HTML string. */
+export function templateToHtml(md: string): string {
+  const lines = md.replace(/\r\n/g, '\n').split('\n');
+  const out: string[] = [];
+  let listOpen = false;
+  const closeList = () => { if (listOpen) { out.push('</ul>'); listOpen = false; } };
+
+  for (const raw of lines) {
+    const line = raw.replace(/\s+$/, '');
+    if (line === '') { closeList(); continue; }
+
+    const h = /^(#{1,3})\s+(.*)$/.exec(line);
+    if (h) { closeList(); const lvl = h[1].length; out.push(`<h${lvl}>${inline(h[2])}</h${lvl}>`); continue; }
+
+    // Bullet (optionally indented) with optional checkbox.
+    const b = /^(\s*)-\s+(.*)$/.exec(line);
+    if (b) {
+      if (!listOpen) { out.push('<ul>'); listOpen = true; }
+      let item = b[2];
+      const cb = /^\[( |x|X)\]\s+(.*)$/.exec(item);
+      if (cb) {
+        const checked = cb[1].toLowerCase() === 'x';
+        item = `<span class="cb" aria-hidden="true">${checked ? '☑' : '☐'}</span> ${inline(cb[2])}`;
+        out.push(`<li class="task">${item}</li>`);
+      } else {
+        out.push(`<li>${inline(item)}</li>`);
+      }
+      continue;
+    }
+
+    // Numbered list item → keep as a paragraph with the number preserved.
+    closeList();
+    out.push(`<p>${inline(line)}</p>`);
+  }
+  closeList();
+  return out.join('\n');
+}
+
+/** Strip markdown markers to a plain-text rendering (for .txt export). */
+export function templateToText(md: string): string {
+  return md
+    .replace(/\r\n/g, '\n')
+    .split('\n')
+    .map((l) => l
+      .replace(/^(#{1,3})\s+/, '')
+      .replace(/\*\*(.+?)\*\*/g, '$1')
+      .replace(/^(\s*)-\s+\[( |x|X)\]\s+/, '$1• ')
+      .replace(/^(\s*)-\s+/, '$1• '))
+    .join('\n');
+}

--- a/src/lib/templates.ts
+++ b/src/lib/templates.ts
@@ -1,0 +1,405 @@
+// Document templates v2 — a localized, code-owned catalog (EN/TR/DE).
+//
+// Templates used to live as single-language markdown blobs in the DB and were
+// only downloadable. Here they are structured per-locale so the UI can switch
+// language, preview the rendered content, and export to PDF / TXT / Markdown
+// without any server-side binary generation (PDF is produced via the browser's
+// print pipeline from styled HTML — Docker-safe, no headless Chromium).
+
+export type TemplateLocale = 'en' | 'tr' | 'de';
+
+export interface DocTemplate {
+  id: string;
+  /** lucide-react icon name, resolved in the UI. */
+  icon: string;
+  title: Record<TemplateLocale, string>;
+  /** One-line description shown in the list. */
+  summary: Record<TemplateLocale, string>;
+  /** Markdown body (constrained subset: #/##/### headings, **bold**, - bullets, [ ] checkboxes, paragraphs). */
+  body: Record<TemplateLocale, string>;
+}
+
+const CV: DocTemplate = {
+  id: 'cv',
+  icon: 'FileText',
+  title: { en: 'CV (sample)', tr: 'Özgeçmiş (örnek)', de: 'Lebenslauf (Muster)' },
+  summary: {
+    en: 'A clean, recruiter-friendly CV structure.',
+    tr: 'Sade, işe alımcı dostu bir özgeçmiş yapısı.',
+    de: 'Eine klare, recruiter-freundliche Lebenslauf-Struktur.',
+  },
+  body: {
+    en: `# Curriculum Vitae
+
+## Personal details
+- Name: [First and last name]
+- Address: [Street, ZIP City]
+- Phone: [Number]
+- E-mail: [E-mail]
+- LinkedIn / GitHub: [Links]
+
+## Profile
+[2–3 sentences: who you are, your focus, your goal.]
+
+## Experience / Internships
+- **[Position]**, [Company] — [City] ([Mon/Year – Mon/Year])
+  - [Achievement or task with a measurable result]
+  - [Achievement or task]
+
+## Education
+- **[Degree]**, [University] — [City] ([Year – Year])
+  - Focus areas: [Subjects]
+
+## Skills
+- Technical: [e.g. React, Python, SQL]
+- Languages: [English C1, German B2, …]
+
+## Projects
+- **[Project name]** — [short description + link]
+`,
+    tr: `# Özgeçmiş
+
+## Kişisel bilgiler
+- Ad Soyad: [Ad ve soyad]
+- Adres: [Sokak, Posta Kodu, Şehir]
+- Telefon: [Numara]
+- E-posta: [E-posta]
+- LinkedIn / GitHub: [Bağlantılar]
+
+## Kısa profil
+[2–3 cümle: kim olduğun, uzmanlık alanın, hedefin.]
+
+## Deneyim / Stajlar
+- **[Pozisyon]**, [Şirket] — [Şehir] ([Ay/Yıl – Ay/Yıl])
+  - [Ölçülebilir sonucu olan başarı veya görev]
+  - [Başarı veya görev]
+
+## Eğitim
+- **[Derece]**, [Üniversite] — [Şehir] ([Yıl – Yıl])
+  - Odak alanları: [Dersler]
+
+## Yetkinlikler
+- Teknik: [örn. React, Python, SQL]
+- Diller: [İngilizce C1, Almanca B2, …]
+
+## Projeler
+- **[Proje adı]** — [kısa açıklama + bağlantı]
+`,
+    de: `# Lebenslauf
+
+## Persönliche Daten
+- Name: [Vor- und Nachname]
+- Adresse: [Straße, PLZ Ort]
+- Telefon: [Nummer]
+- E-Mail: [E-Mail]
+- LinkedIn / GitHub: [Links]
+
+## Kurzprofil
+[2–3 Sätze: wer du bist, dein Schwerpunkt, dein Ziel.]
+
+## Berufserfahrung / Praktika
+- **[Position]**, [Firma] — [Ort] ([Monat/Jahr – Monat/Jahr])
+  - [Erfolg/Aufgabe mit messbarem Ergebnis]
+  - [Erfolg/Aufgabe]
+
+## Ausbildung
+- **[Abschluss]**, [Universität] — [Ort] ([Jahr – Jahr])
+  - Schwerpunkte: [Fächer]
+
+## Kenntnisse
+- Technisch: [z. B. React, Python, SQL]
+- Sprachen: [Deutsch C1, Englisch B2, …]
+
+## Projekte
+- **[Projektname]** — [kurze Beschreibung + Link]
+`,
+  },
+};
+
+const COVER_LETTER: DocTemplate = {
+  id: 'cover-letter',
+  icon: 'Mail',
+  title: { en: 'Cover letter (sample)', tr: 'Ön yazı (örnek)', de: 'Anschreiben (Muster)' },
+  summary: {
+    en: 'A persuasive application cover letter.',
+    tr: 'İkna edici bir başvuru ön yazısı.',
+    de: 'Ein überzeugendes Bewerbungsanschreiben.',
+  },
+  body: {
+    en: `[Your name]
+[Address] · [Phone] · [E-mail]
+
+[Company]
+[Contact person]
+[Address]
+
+[City, date]
+
+**Application for [Position]**
+
+Dear [Mr./Ms. Last name],
+
+I read your posting for [Position] with great interest.
+[1–2 sentences: why this company / this role excites you.]
+
+During [studies/internship/project] I gained [relevant skill/achievement].
+[A concrete example with a result.] This is the value I would bring to your team.
+
+I would welcome the opportunity to discuss my application in person.
+
+Kind regards,
+[Your name]
+`,
+    tr: `[Adınız]
+[Adres] · [Telefon] · [E-posta]
+
+[Şirket]
+[İlgili kişi]
+[Adres]
+
+[Şehir, tarih]
+
+**[Pozisyon] başvurusu**
+
+Sayın [Bay/Bayan Soyad],
+
+[Pozisyon] ilanınızı büyük bir ilgiyle okudum.
+[1–2 cümle: bu şirket / bu rol sizi neden heyecanlandırıyor.]
+
+[Eğitim/staj/proje] sırasında [ilgili beceri/başarı] kazandım.
+[Sonucu olan somut bir örnek.] Bu değeri ekibinize katacağıma inanıyorum.
+
+Başvurumu yüz yüze görüşme fırsatından memnuniyet duyarım.
+
+Saygılarımla,
+[Adınız]
+`,
+    de: `[Dein Name]
+[Adresse] · [Telefon] · [E-Mail]
+
+[Firma]
+[Ansprechpartner]
+[Adresse]
+
+[Ort, Datum]
+
+**Bewerbung als [Position]**
+
+Sehr geehrte/r [Frau/Herr Nachname],
+
+mit großem Interesse habe ich Ihre Ausschreibung für [Position] gelesen.
+[1–2 Sätze: warum diese Firma / diese Rolle dich begeistert.]
+
+Während [Studium/Praktikum/Projekt] habe ich [relevante Fähigkeit/Erfolg]
+gesammelt. [Konkretes Beispiel mit Ergebnis.] Dadurch bringe ich [Mehrwert]
+für Ihr Team mit.
+
+Über die Möglichkeit eines persönlichen Gesprächs freue ich mich sehr.
+
+Mit freundlichen Grüßen
+[Dein Name]
+`,
+  },
+};
+
+const REFERENCE_REQUEST: DocTemplate = {
+  id: 'reference-request',
+  icon: 'Mail',
+  title: { en: 'Reference request (e-mail)', tr: 'Referans talebi (e-posta)', de: 'Referenzanfrage (E-Mail)' },
+  summary: {
+    en: 'Politely ask someone to be your reference.',
+    tr: 'Birinden kibarca referansınız olmasını isteyin.',
+    de: 'Bitte jemanden höflich, deine Referenz zu sein.',
+  },
+  body: {
+    en: `Subject: Reference request for [position / program]
+
+Hi [Name],
+
+I hope you're well. I'm applying for [position/program] at [company] and
+would be grateful if you'd act as a reference.
+
+A few details to help you:
+- Role/relationship: [how we worked together]
+- Timeframe: [dates]
+- What to highlight: [skills/achievements relevant to the role]
+- Deadline: [date]
+
+Thank you so much — happy to share my CV and the job description.
+
+Best regards,
+[Your name]
+`,
+    tr: `Konu: [pozisyon / program] için referans talebi
+
+Merhaba [İsim],
+
+Umarım iyisinizdir. [Şirket] firmasındaki [pozisyon/program] için başvuruyorum
+ve referansım olmanız beni çok mutlu eder.
+
+Yardımcı olması için birkaç ayrıntı:
+- Rol/ilişki: [birlikte nasıl çalıştık]
+- Zaman aralığı: [tarihler]
+- Öne çıkarılacaklar: [role uygun beceriler/başarılar]
+- Son tarih: [tarih]
+
+Çok teşekkürler — özgeçmişimi ve iş tanımını memnuniyetle paylaşırım.
+
+Saygılarımla,
+[Adınız]
+`,
+    de: `Betreff: Referenzanfrage für [Position / Programm]
+
+Hallo [Name],
+
+ich hoffe, es geht dir gut. Ich bewerbe mich für [Position/Programm] bei
+[Firma] und würde mich sehr freuen, wenn du als Referenz fungieren würdest.
+
+Ein paar Details zur Hilfe:
+- Rolle/Beziehung: [wie wir zusammengearbeitet haben]
+- Zeitraum: [Daten]
+- Was hervorzuheben ist: [relevante Fähigkeiten/Erfolge]
+- Frist: [Datum]
+
+Vielen Dank — ich teile gern meinen Lebenslauf und die Stellenbeschreibung.
+
+Viele Grüße
+[Dein Name]
+`,
+  },
+};
+
+const INTERNSHIP_REPORT: DocTemplate = {
+  id: 'internship-report',
+  icon: 'ClipboardList',
+  title: { en: 'Internship report (outline)', tr: 'Staj raporu (taslak)', de: 'Praktikumsbericht (Gliederung)' },
+  summary: {
+    en: 'A structure for your internship report.',
+    tr: 'Staj raporunuz için bir yapı.',
+    de: 'Eine Struktur für deinen Praktikumsbericht.',
+  },
+  body: {
+    en: `# Internship report — outline
+
+1. **Cover page** — name, company, period, supervisor
+2. **Introduction** — why this internship? expectations.
+3. **The company** — industry, size, department.
+4. **My tasks** — weekly overview, concrete projects.
+5. **Skills learned** — technical & personal.
+6. **Challenges & solutions**
+7. **Conclusion** — were expectations met? next steps.
+8. **Appendix** — evidence, screenshots, certificate.
+`,
+    tr: `# Staj raporu — taslak
+
+1. **Kapak sayfası** — ad, şirket, dönem, danışman
+2. **Giriş** — neden bu staj? beklentiler.
+3. **Şirket** — sektör, büyüklük, departman.
+4. **Görevlerim** — haftalık genel bakış, somut projeler.
+5. **Kazanılan beceriler** — teknik ve kişisel.
+6. **Zorluklar ve çözümler**
+7. **Sonuç** — beklentiler karşılandı mı? sonraki adımlar.
+8. **Ek** — belgeler, ekran görüntüleri, staj belgesi.
+`,
+    de: `# Praktikumsbericht — Gliederung
+
+1. **Deckblatt** — Name, Firma, Zeitraum, Betreuer
+2. **Einleitung** — Warum dieses Praktikum? Erwartungen.
+3. **Das Unternehmen** — Branche, Größe, Abteilung.
+4. **Meine Aufgaben** — Wochenüberblick, konkrete Projekte.
+5. **Gelernte Fähigkeiten** — fachlich & persönlich.
+6. **Herausforderungen & Lösungen**
+7. **Fazit** — Wurden die Erwartungen erfüllt? Nächste Schritte.
+8. **Anhang** — Belege, Screenshots, Bescheinigung.
+`,
+  },
+};
+
+const INTERVIEW_PREP: DocTemplate = {
+  id: 'interview-prep',
+  icon: 'CheckSquare',
+  title: { en: 'Interview prep checklist', tr: 'Mülakat hazırlık listesi', de: 'Interview-Vorbereitungs-Checkliste' },
+  summary: {
+    en: 'Be ready before, during and after an interview.',
+    tr: 'Mülakat öncesi, sırası ve sonrası için hazır olun.',
+    de: 'Sei vor, während und nach dem Interview bereit.',
+  },
+  body: {
+    en: `# Interview prep checklist
+
+## Before
+- [ ] Research the company (product, mission, recent news)
+- [ ] Re-read the job description; map your experience to each requirement
+- [ ] Prepare 3–5 STAR stories (Situation, Task, Action, Result)
+- [ ] Prepare questions to ask them
+- [ ] Test your camera/mic and link (for remote)
+
+## Common questions
+- [ ] Tell me about yourself (2-minute pitch)
+- [ ] Why this role / company?
+- [ ] A challenge you overcame
+- [ ] A conflict and how you handled it
+- [ ] Where do you see yourself in 2–3 years?
+
+## After
+- [ ] Send a short thank-you note
+- [ ] Note what went well / to improve
+`,
+    tr: `# Mülakat hazırlık listesi
+
+## Öncesi
+- [ ] Şirketi araştır (ürün, misyon, güncel haberler)
+- [ ] İş tanımını tekrar oku; deneyimini her gereksinimle eşleştir
+- [ ] 3–5 STAR hikâyesi hazırla (Durum, Görev, Eylem, Sonuç)
+- [ ] Onlara soracağın sorular hazırla
+- [ ] Kamera/mikrofon ve bağlantını test et (uzaktan için)
+
+## Sık sorulan sorular
+- [ ] Kendinizden bahseder misiniz (2 dakikalık tanıtım)
+- [ ] Neden bu rol / şirket?
+- [ ] Üstesinden geldiğin bir zorluk
+- [ ] Bir anlaşmazlık ve nasıl yönettiğin
+- [ ] Kendini 2–3 yıl sonra nerede görüyorsun?
+
+## Sonrası
+- [ ] Kısa bir teşekkür notu gönder
+- [ ] Neyin iyi gittiğini / nelerin geliştirileceğini not et
+`,
+    de: `# Interview-Vorbereitungs-Checkliste
+
+## Davor
+- [ ] Unternehmen recherchieren (Produkt, Mission, aktuelle News)
+- [ ] Stellenbeschreibung erneut lesen; Erfahrung jeder Anforderung zuordnen
+- [ ] 3–5 STAR-Geschichten vorbereiten (Situation, Task, Action, Result)
+- [ ] Eigene Fragen vorbereiten
+- [ ] Kamera/Mikro und Link testen (für Remote)
+
+## Häufige Fragen
+- [ ] Erzählen Sie etwas über sich (2-Minuten-Pitch)
+- [ ] Warum diese Rolle / dieses Unternehmen?
+- [ ] Eine gemeisterte Herausforderung
+- [ ] Ein Konflikt und wie du ihn gelöst hast
+- [ ] Wo siehst du dich in 2–3 Jahren?
+
+## Danach
+- [ ] Eine kurze Dankesnachricht senden
+- [ ] Notieren, was gut lief / verbessert werden kann
+`,
+  },
+};
+
+export const TEMPLATES: DocTemplate[] = [
+  CV,
+  COVER_LETTER,
+  REFERENCE_REQUEST,
+  INTERNSHIP_REPORT,
+  INTERVIEW_PREP,
+];
+
+export function getTemplate(id: string): DocTemplate | undefined {
+  return TEMPLATES.find((t) => t.id === id);
+}
+
+export function isTemplateLocale(v: string): v is TemplateLocale {
+  return v === 'en' || v === 'tr' || v === 'de';
+}


### PR DESCRIPTION
## EPIC C · Document templates v2

Replaces the single-language, download-only template list with a **localized, code-owned catalog** and a real **in-app preview** (the hard requirement).

### What's included
- **Localized catalog** (`src/lib/templates.ts`): CV, cover letter, reference request, internship report, interview-prep checklist — each in **EN / TR / DE** (title, summary, body).
- **Dependency-free renderer** (`src/lib/renderTemplate.ts`): markdown→HTML and →plain-text for the constrained template subset (escaped, injection-safe).
- **`TemplatesLibrary`**: list → **preview modal** with **EN/TR/DE language tabs**, plus export to:
  - **PDF** via the browser print pipeline (no headless Chromium — Docker-safe), styled for print.
  - **.txt** and **.md** (one-click downloads).
  - Dark-mode aware.
- Wired into the **portal profile** (replaces the old read-only template manager) and the **admin documents** page (next to custom uploads).
- i18n: `templatesLib` block in EN/TR/DE.

### Verification
- `npx tsc --noEmit` clean; renderer output verified in isolation (headings, checkbox task lists, bold; txt stripped to bullets).
- e2e (`e2e/templates-library.spec.ts`): preview opens, **language switch re-renders** (EN→DE), export actions present.
- Visible on **preview & production** with no DB seeding required (catalog is code-owned).

### Deferred (the "optional / nice-to-have" parts, per the issue)
- Server-generated **binary PDF** and **.docx** export. The current PDF path (print-to-PDF) yields well-formatted output with zero heavy dependencies; a binary generator can follow if needed.
- Legacy DB-seeded templates now appear only under admin "custom uploads" and can be retired in a follow-up.

Closes #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)