### PR TITLE
fix(dark): polish — hover, native inputs, header, role cards, toggle (#364)

### DIFF
--- a/e2e/dark-mode.spec.ts
+++ b/e2e/dark-mode.spec.ts
@@ -32,3 +32,20 @@ test('theme toggle switches dark mode and persists across reload', async ({ page
   await page.getByRole('button', { name: /toggle theme/i }).first().click();
   await expect(html).not.toHaveClass(/\bdark\b/);
 });
+
+// The sticky landing header uses bg-white/80; in dark mode it must not stay a
+// light bar (regression from the utility remap missing opacity variants).
+test('dark mode retints the translucent landing header (not a light bar)', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: /toggle theme/i }).first().click();
+  await expect(page.locator('html')).toHaveClass(/\bdark\b/);
+
+  const headerBg = await page.locator('header').first().evaluate(
+    (el) => getComputedStyle(el).backgroundColor,
+  );
+  // Parse "rgb(a)(r, g, b[, a])" and assert it is a dark surface, not near-white.
+  const [r, g, b] = headerBg.match(/\d+(\.\d+)?/g)!.map(Number);
+  expect(r).toBeLessThan(60);
+  expect(g).toBeLessThan(60);
+  expect(b).toBeLessThan(70);
+});

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -60,7 +60,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
             <LogOut className="h-4 w-4" />
             {t.nav.signOut}
           </Link>
-          <div className="mt-3 px-3">
+          <div className="mt-3 px-3 flex flex-col gap-2 items-start">
             <LanguageSwitcher current={locale} />
             <ThemeToggle />
           </div>

--- a/src/app/company/layout.tsx
+++ b/src/app/company/layout.tsx
@@ -58,9 +58,9 @@ export default async function CompanyLayout({ children }: { children: React.Reac
               <LogOut className="h-4 w-4" />
               {t.nav.signOut}
             </Link>
-            <div className="mt-3 px-3">
+            <div className="mt-3 px-3 flex flex-col gap-2 items-start">
               <LanguageSwitcher current={locale} />
-            <ThemeToggle />
+              <ThemeToggle />
             </div>
           </div>
         </aside>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -52,6 +52,45 @@ html.dark .border-gray-300 { border-color: #4b5563; }
 html.dark .divide-gray-50 > :not([hidden]) ~ :not([hidden]) { border-color: #1f2937; }
 html.dark .divide-gray-100 > :not([hidden]) ~ :not([hidden]) { border-color: #374151; }
 
+/* Translucent white surfaces (e.g. the sticky landing header bg-white/80). */
+html.dark .bg-white\/80 { background-color: rgba(17,24,39,0.85); }
+html.dark .bg-white\/70 { background-color: rgba(17,24,39,0.80); }
+
+/*
+ * Variant utilities (hover:/focus:) can't be reached by the base-name remaps
+ * above — the class is e.g. `hover:bg-blue-50`, not `bg-blue-50`. Re-tint the
+ * ones the app actually uses (nav items, list rows, danger actions).
+ */
+html.dark .hover\:bg-blue-50:hover { background-color: rgba(30,58,138,0.35); }
+html.dark .hover\:bg-gray-50:hover { background-color: #1f2937; }
+html.dark .hover\:bg-gray-100:hover { background-color: #374151; }
+html.dark .hover\:bg-red-50:hover { background-color: rgba(127,29,29,0.35); }
+
+/* Colored heading text used on tinted cards → lighter for contrast on dark. */
+html.dark .text-red-900 { color: #fca5a5; }
+html.dark .text-blue-900 { color: #bfdbfe; }
+html.dark .text-green-900 { color: #bbf7d0; }
+html.dark .text-indigo-900 { color: #c7d2fe; }
+html.dark .text-purple-900 { color: #e9d5ff; }
+html.dark .text-amber-900 { color: #fde68a; }
+
+/*
+ * Native form controls. Inline <input>/<select>/<textarea> scattered through
+ * pages don't all use the themed UI primitives, so default them to dark here.
+ * The UI primitives carry their own dark: classes in the same palette, so the
+ * two never visibly disagree. Checkboxes/radios keep their accent.
+ */
+html.dark input:not([type='checkbox']):not([type='radio']):not([type='range']),
+html.dark select,
+html.dark textarea {
+  background-color: #111827;
+  color: #f3f4f6;
+  border-color: #374151;
+}
+html.dark input::placeholder,
+html.dark textarea::placeholder { color: #6b7280; }
+html.dark option { background-color: #111827; color: #f3f4f6; }
+
 @layer components {
   .container-page {
     @apply max-w-7xl mx-auto px-4 sm:px-6 lg:px-8;

--- a/src/app/mentor/layout.tsx
+++ b/src/app/mentor/layout.tsx
@@ -119,7 +119,7 @@ export default async function MentorLayout({ children }: { children: React.React
             <LogOut className="h-4 w-4" />
             {t.nav.signOut}
           </Link>
-          <div className="mt-3 px-3">
+          <div className="mt-3 px-3 flex flex-col gap-2 items-start">
             <LanguageSwitcher current={locale} />
             <ThemeToggle />
           </div>

--- a/src/app/portal/layout.tsx
+++ b/src/app/portal/layout.tsx
@@ -92,7 +92,7 @@ export default async function PortalLayout({ children }: { children: React.React
             <LogOut className="h-4 w-4" />
             {t.nav.signOut}
           </Link>
-          <div className="mt-3 px-3">
+          <div className="mt-3 px-3 flex flex-col gap-2 items-start">
             <LanguageSwitcher current={locale} />
             <ThemeToggle />
           </div>

--- a/src/app/source/layout.tsx
+++ b/src/app/source/layout.tsx
@@ -58,9 +58,9 @@ export default async function SourceLayout({ children }: { children: React.React
               <LogOut className="h-4 w-4" />
               {t.nav.signOut}
             </Link>
-            <div className="mt-3 px-3">
+            <div className="mt-3 px-3 flex flex-col gap-2 items-start">
               <LanguageSwitcher current={locale} />
-            <ThemeToggle />
+              <ThemeToggle />
             </div>
           </div>
         </aside>


### PR DESCRIPTION
Follow-up dark-mode fixes for bugs reported after #343 (with screenshots):

| Issue | Fix |
|-------|-----|
| Nav **hover** stayed light | retint `hover:bg-blue-50 / gray-50 / gray-100 / red-50` (variant utilities the base-name remap can't reach) |
| **Inputs/selects** rendered white | default native `<input>/<select>/<textarea>/<option>` to the dark palette; primitives' own `dark:` classes use the same palette so they never disagree |
| **Header** was a light bar | retint translucent `bg-white/80` (+`/70`) |
| **Role cards** dark-on-dark text | lighten `text-{red,blue,green,indigo,purple,amber}-900` |
| **Toggle placement** cramped | sidebar toggle in its own row (flex-col) under the language switcher |

### Verification
- Landing header + role-card colors verified in the browser (dark): header `rgba(17,24,39,0.85)`, role title `rgb(252,165,165)`.
- e2e extended: asserts the landing header is a dark surface (not near-white) in dark mode. Both dark-mode specs pass locally.
- `npx tsc --noEmit` clean.

Closes #364 · Refs #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)