### PR TITLE
feat(consent): reusable per-user consent framework (GDPR) (#362)

### DIFF
--- a/e2e/consent.spec.ts
+++ b/e2e/consent.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// EPIC B2 — reusable per-user consent. Off by default; grant/revoke persists.
+test('user can grant and revoke a consent', async ({ page }) => {
+  const email = uniqueEmail('consent-mentee');
+  await seedUser(email, 'MenteePass123', 'MENTEE', 'Consent Mentee');
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', email);
+    await page.fill('input[type="password"]', 'MenteePass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/portal'), { timeout: 20_000 });
+
+    // Off by default.
+    let got = await (await page.request.get('/api/consent')).json();
+    expect(got.consents.AI_CV_PARSING ?? false).toBe(false);
+
+    // Grant.
+    const grant = await page.request.post('/api/consent', { data: { type: 'AI_CV_PARSING', granted: true } });
+    expect(grant.ok()).toBeTruthy();
+    got = await (await page.request.get('/api/consent')).json();
+    expect(got.consents.AI_CV_PARSING).toBe(true);
+
+    // Revoke.
+    await page.request.post('/api/consent', { data: { type: 'AI_CV_PARSING', granted: false } });
+    got = await (await page.request.get('/api/consent')).json();
+    expect(got.consents.AI_CV_PARSING).toBe(false);
+  } finally {
+    await cleanupByEmail(email);
+  }
+});

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -122,8 +122,30 @@ model User {
   source                  Source?                  @relation(fields: [sourceId], references: [id])
   documents               Document[]               @relation("DocumentOwner")
   personalNotes           PersonalNote[]
+  consents                UserConsent[]
 
   @@index([role])
+}
+
+// Reusable, auditable per-user consent (GDPR). A consent is "active" when
+// grantedAt is set and revokedAt is null. Gates optional processing such as
+// sending CV text to an AI provider (see ConsentType).
+enum ConsentType {
+  AI_CV_PARSING
+}
+
+model UserConsent {
+  id        String      @id @default(cuid())
+  userId    String
+  type      ConsentType
+  grantedAt DateTime?
+  revokedAt DateTime?
+  updatedAt DateTime    @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, type])
+  @@index([userId])
 }
 
 // A referral source — the education/agency a mentee came from. Admin-managed

--- a/src/app/api/consent/route.ts
+++ b/src/app/api/consent/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { z } from 'zod';
+import { authOptions } from '@/lib/auth';
+import { getConsents, setConsent } from '@/lib/consent';
+import { logActivity } from '@/lib/activity';
+import type { ConsentType } from '@prisma/client';
+
+const CONSENT_TYPES = ['AI_CV_PARSING'] as const;
+
+const bodySchema = z.object({
+  type: z.enum(CONSENT_TYPES),
+  granted: z.boolean(),
+});
+
+// GET — the current user's consents as a { TYPE: boolean } map.
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  return NextResponse.json({ consents: await getConsents(session.user.id) });
+}
+
+// POST — grant or revoke a consent for the current user.
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+
+  await setConsent(session.user.id, parsed.data.type as ConsentType, parsed.data.granted);
+  await logActivity({
+    action: parsed.data.granted ? 'consent.grant' : 'consent.revoke',
+    actorId: session.user.id,
+    actorEmail: session.user.email ?? null,
+    targetType: 'consent',
+    targetId: parsed.data.type,
+  });
+  return NextResponse.json({ ok: true, consents: await getConsents(session.user.id) });
+}

--- a/src/components/AccountSettings.tsx
+++ b/src/components/AccountSettings.tsx
@@ -7,6 +7,7 @@ import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Input } from '@/components/ui/Input';
 import { Button } from '@/components/ui/Button';
 import { AvatarManager } from '@/components/AvatarManager';
+import { ConsentSettings } from '@/components/ConsentSettings';
 import { useT } from '@/i18n/client';
 import { locales, LOCALE_COOKIE } from '@/i18n/config';
 
@@ -362,6 +363,8 @@ export function AccountSettings() {
           </div>
         </div>
       </Card>
+
+      <ConsentSettings />
 
       <Card className="mt-6 max-w-4xl">
         <CardHeader><CardTitle>{t.account.dataSection}</CardTitle></CardHeader>

--- a/src/components/ConsentSettings.tsx
+++ b/src/components/ConsentSettings.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { ShieldCheck } from 'lucide-react';
+import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
+import { useT } from '@/i18n/client';
+
+// EPIC B2 — per-user consent toggles (GDPR). Reusable: each entry gates an
+// optional processing activity. Currently: AI-assisted CV parsing.
+const CONSENTS = [
+  { type: 'AI_CV_PARSING', key: 'aiCvParsing' as const },
+];
+
+export function ConsentSettings() {
+  const t = useT();
+  const c = t.consent;
+  const [state, setState] = useState<Record<string, boolean>>({});
+  const [busy, setBusy] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch('/api/consent').then((r) => r.json()).then((d) => setState(d.consents ?? {})).catch(() => {});
+  }, []);
+
+  const toggle = async (type: string, granted: boolean) => {
+    setBusy(type);
+    setState((s) => ({ ...s, [type]: granted })); // optimistic
+    try {
+      const res = await fetch('/api/consent', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type, granted }),
+      });
+      const d = await res.json();
+      if (res.ok) setState(d.consents ?? {});
+    } catch {
+      setState((s) => ({ ...s, [type]: !granted })); // revert
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  return (
+    <Card className="mt-6 max-w-4xl">
+      <CardHeader><CardTitle>{c.section}</CardTitle></CardHeader>
+      <p className="text-sm text-gray-600 dark:text-gray-300 mb-4 flex items-start gap-2">
+        <ShieldCheck className="h-4 w-4 mt-0.5 text-gray-400 flex-shrink-0" />
+        {c.intro}
+      </p>
+      <div className="divide-y divide-gray-100 dark:divide-gray-800">
+        {CONSENTS.map(({ type, key }) => {
+          const item = (c.items as Record<string, { title: string; desc: string }>)[key];
+          return (
+            <label key={type} className="flex items-start justify-between gap-4 py-3 cursor-pointer">
+              <div className="min-w-0">
+                <p className="text-sm font-medium text-gray-800 dark:text-gray-200">{item.title}</p>
+                <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{item.desc}</p>
+              </div>
+              <input
+                type="checkbox"
+                className="mt-1 h-4 w-4 flex-shrink-0"
+                checked={!!state[type]}
+                disabled={busy === type}
+                onChange={(e) => toggle(type, e.target.checked)}
+              />
+            </label>
+          );
+        })}
+      </div>
+    </Card>
+  );
+}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -650,6 +650,7 @@ const en = {
     sent: 'Sent to {n} users',
   },
   cvSuggest: { button: 'Suggest from CV', hint: 'Reads your uploaded CV locally to suggest contact links and skills. Nothing is sent anywhere.', apply: 'Apply', applyAll: 'Apply all', applied: 'Added', skills: 'Skills', none: 'No suggestions found in the CV.', failed: 'Could not read suggestions.', fields: { phone: 'Phone', linkedinUrl: 'LinkedIn', githubUrl: 'GitHub', portfolioUrl: 'Portfolio / website' } },
+  consent: { section: 'Privacy & consent', intro: 'You control optional data processing. These are off by default and you can change them anytime.', items: { aiCvParsing: { title: 'AI-assisted CV reading', desc: 'Allow sending your CV text to an AI provider to suggest profile fields more accurately. Without this, only on-device parsing is used. Your CV file is never shared; only extracted text is sent when you trigger a suggestion.' } } },
   templatesLib: { preview: 'Preview', close: 'Close', pdf: 'Save as PDF', txt: '.txt', md: '.md' },
   documents: {
     title: 'Documents',
@@ -1568,6 +1569,7 @@ const tr: Dict = {
     sent: '{n} kullanıcıya gönderildi',
   },
   cvSuggest: { button: 'CV’den öner', hint: 'Yüklediğin CV’yi yerel olarak okuyup iletişim bağlantıları ve becerileri önerir. Hiçbir yere gönderilmez.', apply: 'Uygula', applyAll: 'Tümünü uygula', applied: 'Eklendi', skills: 'Beceriler', none: 'CV’de öneri bulunamadı.', failed: 'Öneriler okunamadı.', fields: { phone: 'Telefon', linkedinUrl: 'LinkedIn', githubUrl: 'GitHub', portfolioUrl: 'Portfolyo / web sitesi' } },
+  consent: { section: 'Gizlilik ve onay', intro: 'İsteğe bağlı veri işlemeyi sen kontrol edersin. Bunlar varsayılan olarak kapalıdır ve istediğin zaman değiştirebilirsin.', items: { aiCvParsing: { title: 'AI destekli CV okuma', desc: 'Profil alanlarını daha doğru önermek için CV metninin bir AI sağlayıcısına gönderilmesine izin ver. Bu olmadan yalnızca cihaz üzerinde ayrıştırma kullanılır. CV dosyan asla paylaşılmaz; yalnızca öneri istediğinde çıkarılan metin gönderilir.' } } },
   templatesLib: { preview: 'Önizle', close: 'Kapat', pdf: 'PDF kaydet', txt: '.txt', md: '.md' },
   documents: {
     title: 'Dokümanlar',
@@ -2484,6 +2486,7 @@ const de: Dict = {
     sent: 'An {n} Benutzer gesendet',
   },
   cvSuggest: { button: 'Aus Lebenslauf vorschlagen', hint: 'Liest deinen hochgeladenen Lebenslauf lokal und schlägt Kontaktlinks und Fähigkeiten vor. Es wird nichts gesendet.', apply: 'Übernehmen', applyAll: 'Alle übernehmen', applied: 'Hinzugefügt', skills: 'Fähigkeiten', none: 'Keine Vorschläge im Lebenslauf gefunden.', failed: 'Vorschläge konnten nicht gelesen werden.', fields: { phone: 'Telefon', linkedinUrl: 'LinkedIn', githubUrl: 'GitHub', portfolioUrl: 'Portfolio / Website' } },
+  consent: { section: 'Datenschutz & Einwilligung', intro: 'Du steuerst die optionale Datenverarbeitung. Diese ist standardmäßig aus und jederzeit änderbar.', items: { aiCvParsing: { title: 'KI-gestütztes Lesen des Lebenslaufs', desc: 'Erlaube, den Text deines Lebenslaufs an einen KI-Anbieter zu senden, um Profilfelder genauer vorzuschlagen. Ohne dies wird nur die Verarbeitung auf dem Gerät genutzt. Deine Lebenslauf-Datei wird nie geteilt; nur der extrahierte Text wird gesendet, wenn du einen Vorschlag auslöst.' } } },
   templatesLib: { preview: 'Vorschau', close: 'Schließen', pdf: 'Als PDF speichern', txt: '.txt', md: '.md' },
   documents: {
     title: 'Dokumente',

--- a/src/lib/consent.ts
+++ b/src/lib/consent.ts
@@ -1,0 +1,37 @@
+import { prisma } from '@/lib/prisma';
+import type { ConsentType } from '@prisma/client';
+
+// Reusable consent helpers (EPIC B2). A consent is active when it has been
+// granted and not since revoked. Gates optional processing (e.g. AI CV parsing).
+
+export async function hasConsent(userId: string, type: ConsentType): Promise<boolean> {
+  const c = await prisma.userConsent.findUnique({
+    where: { userId_type: { userId, type } },
+    select: { grantedAt: true, revokedAt: true },
+  });
+  return !!c?.grantedAt && !c.revokedAt;
+}
+
+export async function setConsent(userId: string, type: ConsentType, granted: boolean) {
+  const now = new Date();
+  return prisma.userConsent.upsert({
+    where: { userId_type: { userId, type } },
+    create: {
+      userId,
+      type,
+      grantedAt: granted ? now : null,
+      revokedAt: granted ? null : now,
+    },
+    update: granted ? { grantedAt: now, revokedAt: null } : { revokedAt: now },
+  });
+}
+
+export async function getConsents(userId: string): Promise<Record<string, boolean>> {
+  const rows = await prisma.userConsent.findMany({
+    where: { userId },
+    select: { type: true, grantedAt: true, revokedAt: true },
+  });
+  const out: Record<string, boolean> = {};
+  for (const r of rows) out[r.type] = !!r.grantedAt && !r.revokedAt;
+  return out;
+}


### PR DESCRIPTION
## EPIC B2 · Consent framework

A revocable, auditable per-user consent that gates optional data processing — the prerequisite for AI CV extraction (#363).

- **schema**: `UserConsent` + `ConsentType` (active = granted & not revoked).
- **`lib/consent.ts`**: `hasConsent` / `setConsent` / `getConsents`.
- **`GET/POST /api/consent`**: read + grant/revoke for the current user, written to the activity trail.
- **`ConsentSettings`**: a privacy card in account settings with a clear data-handling note; **off by default**, toggle anytime; dark-mode aware.
- i18n: `consent` block (EN/TR/DE).

### Verification
- `npx tsc --noEmit` clean (source); e2e (`e2e/consent.spec.ts`): grant → persists → revoke.
- No PII is transmitted by this PR — it only records consent.

Closes #362 · Refs #356
🤖 Generated with [Claude Code](https://claude.com/claude-code)