### PR TITLE
fix(portal): dark impersonation banner + active mentee nav (#380)

### DIFF
--- a/src/app/portal/layout.tsx
+++ b/src/app/portal/layout.tsx
@@ -2,8 +2,9 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
-import { GraduationCap, LayoutDashboard, User, BookOpen, MessageSquare, LogOut } from 'lucide-react';
+import { GraduationCap, LogOut } from 'lucide-react';
 import { getServerDictionary } from '@/i18n/server';
+import { PortalNav } from '@/components/PortalNav';
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
 import { ThemeToggle } from '@/components/ThemeToggle';
 import { ResponsiveShell } from '@/components/ResponsiveShell';
@@ -46,34 +47,7 @@ export default async function PortalLayout({ children }: { children: React.React
         </div>
 
         <nav className="flex-1 p-4 space-y-1 overflow-y-auto">
-          <Link
-            href="/portal"
-            className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-gray-700 hover:bg-blue-50 hover:text-blue-700 transition-colors group"
-          >
-            <LayoutDashboard className="h-5 w-5 text-gray-400 group-hover:text-blue-600" />
-            {t.nav.dashboard}
-          </Link>
-          <Link
-            href="/portal/profile"
-            className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-gray-700 hover:bg-blue-50 hover:text-blue-700 transition-colors group"
-          >
-            <User className="h-5 w-5 text-gray-400 group-hover:text-blue-600" />
-            {t.nav.myProfile}
-          </Link>
-          <Link
-            href="/portal/messages"
-            className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-gray-700 hover:bg-blue-50 hover:text-blue-700 transition-colors group"
-          >
-            <MessageSquare className="h-5 w-5 text-gray-400 group-hover:text-blue-600" />
-            {t.nav.messages}
-          </Link>
-          <Link
-            href="/portal/interactions"
-            className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-gray-700 hover:bg-blue-50 hover:text-blue-700 transition-colors group"
-          >
-            <BookOpen className="h-5 w-5 text-gray-400 group-hover:text-blue-600" />
-            {t.nav.interactionLogs}
-          </Link>
+          <PortalNav />
           <InstallAppButton />
         </nav>
 

--- a/src/components/ImpersonationBanner.tsx
+++ b/src/components/ImpersonationBanner.tsx
@@ -34,7 +34,7 @@ export function ImpersonationBanner() {
   };
 
   return (
-    <div className="mb-4 flex flex-wrap items-center gap-x-3 gap-y-1 rounded-lg border border-purple-300 bg-purple-100 px-4 py-3 text-sm text-purple-900">
+    <div className="mb-4 flex flex-wrap items-center gap-x-3 gap-y-1 rounded-lg border border-purple-300 dark:border-purple-700 bg-purple-100 dark:bg-purple-900/40 px-4 py-3 text-sm text-purple-900 dark:text-purple-100">
       <UserCog className="h-4 w-4 shrink-0" />
       <span className="flex-1 min-w-0">
         {t.impersonation.viewingAs.replace('{name}', session.user.name ?? '')}

--- a/src/components/PortalNav.tsx
+++ b/src/components/PortalNav.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { LayoutDashboard, User, BookOpen, MessageSquare } from 'lucide-react';
+import { useT } from '@/i18n/client';
+
+// Mentee portal sidebar navigation with active-route highlighting (mirrors the
+// admin/mentor navs). Client component so it can read the current pathname.
+export function PortalNav() {
+  const t = useT();
+  const pathname = usePathname();
+
+  const links = [
+    { href: '/portal', label: t.nav.dashboard, Icon: LayoutDashboard },
+    { href: '/portal/profile', label: t.nav.myProfile, Icon: User },
+    { href: '/portal/messages', label: t.nav.messages, Icon: MessageSquare },
+    { href: '/portal/interactions', label: t.nav.interactionLogs, Icon: BookOpen },
+  ];
+
+  const isActive = (href: string) =>
+    href === '/portal' ? pathname === '/portal' : pathname.startsWith(href);
+
+  return (
+    <>
+      {links.map(({ href, label, Icon }) => {
+        const active = isActive(href);
+        return (
+          <Link
+            key={href}
+            href={href}
+            aria-current={active ? 'page' : undefined}
+            className={`flex items-center gap-3 px-3 py-2.5 rounded-lg transition-colors group ${
+              active
+                ? 'bg-blue-50 text-blue-700 font-medium'
+                : 'text-gray-700 hover:bg-blue-50 hover:text-blue-700'
+            }`}
+          >
+            <Icon className={`h-5 w-5 ${active ? 'text-blue-600' : 'text-gray-400 group-hover:text-blue-600'}`} />
+            {label}
+          </Link>
+        );
+      })}
+    </>
+  );
+}


### PR DESCRIPTION
Two issues from the screenshots:

- **Impersonation banner** (`bg-purple-100 text-purple-900`) was unreadable in dark mode → added `dark:` variants (`dark:bg-purple-900/40 dark:text-purple-100`).
- **Mentee portal nav** didn't highlight the active page (static server links). Extracted a `PortalNav` client component with `usePathname` active-route highlighting, matching the admin/mentor navs.

`npx tsc --noEmit` clean.

Closes #380
🤖 Generated with [Claude Code](https://claude.com/claude-code)