### PR TITLE
feat(profile): star-based skill self-assessment picker (#384)

### DIFF
--- a/e2e/skill-rating.spec.ts
+++ b/e2e/skill-rating.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// Skill self-assessment uses a 1–5 star picker; clicking a star persists that level.
+test('mentee sets a skill level with the star rating and it persists', async ({ page }) => {
+  const email = uniqueEmail('skillrate-mentee');
+  await seedUser(email, 'MenteePass123', 'MENTEE', 'Skill Rate Mentee');
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', email);
+    await page.fill('input[type="password"]', 'MenteePass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/portal'), { timeout: 20_000 });
+
+    await page.goto('/portal/profile');
+    // Enter a skill so its rating row appears.
+    const skills = page.locator('input[name="skills"]');
+    await skills.fill('React');
+    // React's rating group; click the 4/5 star.
+    const group = page.getByRole('radiogroup', { name: 'React' });
+    await expect(group).toBeVisible({ timeout: 10_000 });
+    await group.getByRole('radio', { name: '4/5' }).click();
+    await expect(group.getByRole('radio', { name: '4/5' })).toHaveAttribute('aria-checked', 'true');
+
+    // Save and confirm persistence.
+    await page.getByRole('button', { name: /^(Save|Save changes|Kaydet)/i }).first().click();
+    await expect(async () => {
+      const me = await (await page.request.get('/api/profile')).json();
+      expect(me.user.skillLevels?.React).toBe(4);
+    }).toPass({ timeout: 10_000 });
+  } finally {
+    await cleanupByEmail(email);
+  }
+});

--- a/src/app/portal/profile/page.tsx
+++ b/src/app/portal/profile/page.tsx
@@ -11,6 +11,7 @@ import { Button } from '@/components/ui/Button';
 import { Select } from '@/components/ui/Select';
 import { CvManager } from '@/components/CvManager';
 import { CvSuggestPanel } from '@/components/CvSuggestPanel';
+import { SkillRating } from '@/components/SkillRating';
 import { AvatarManager } from '@/components/AvatarManager';
 import { DocumentsManager } from '@/components/DocumentsManager';
 import { TemplatesLibrary } from '@/components/TemplatesLibrary';
@@ -315,17 +316,14 @@ export default function ProfilePage() {
                     <p className="text-xs font-medium text-gray-600 mb-2">{t.profileForm.skillLevels}</p>
                     <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
                       {list.map((s) => (
-                        <label key={s} className="flex items-center justify-between gap-2 text-sm bg-gray-50 rounded-lg px-3 py-1.5">
+                        <div key={s} className="flex items-center justify-between gap-2 text-sm bg-gray-50 rounded-lg px-3 py-1.5">
                           <span className="truncate text-gray-700">{s}</span>
-                          <select
-                            value={skillLevels[s] ?? ''}
-                            onChange={(e) => setSkillLevels((prev) => ({ ...prev, [s]: Number(e.target.value) }))}
-                            className="rounded border border-gray-300 px-2 py-1 text-sm"
-                          >
-                            <option value="">–</option>
-                            {[1, 2, 3, 4, 5].map((n) => <option key={n} value={n}>{n}</option>)}
-                          </select>
-                        </label>
+                          <SkillRating
+                            label={s}
+                            value={skillLevels[s] ?? 0}
+                            onChange={(v) => setSkillLevels((prev) => ({ ...prev, [s]: v }))}
+                          />
+                        </div>
                       ))}
                     </div>
                   </div>

--- a/src/components/SkillRating.tsx
+++ b/src/components/SkillRating.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useState } from 'react';
+import { Star } from 'lucide-react';
+
+// A 1–5 star self-assessment picker, replacing the old numeric <select>.
+// Click a star to set the level; click the current level again to clear it.
+// Keyboard-accessible (arrow keys) and dark-mode aware.
+export function SkillRating({
+  value,
+  onChange,
+  label,
+}: {
+  value: number;
+  onChange: (v: number) => void;
+  label?: string;
+}) {
+  const [hover, setHover] = useState(0);
+  const shown = hover || value;
+
+  return (
+    <div
+      className="flex items-center gap-0.5"
+      role="radiogroup"
+      aria-label={label}
+      onMouseLeave={() => setHover(0)}
+    >
+      {[1, 2, 3, 4, 5].map((n) => {
+        const active = n <= shown;
+        return (
+          <button
+            key={n}
+            type="button"
+            role="radio"
+            aria-checked={value === n}
+            aria-label={`${n}/5`}
+            onMouseEnter={() => setHover(n)}
+            onClick={() => onChange(value === n ? 0 : n)}
+            onKeyDown={(e) => {
+              if (e.key === 'ArrowRight') { e.preventDefault(); onChange(Math.min(5, value + 1)); }
+              if (e.key === 'ArrowLeft') { e.preventDefault(); onChange(Math.max(0, value - 1)); }
+            }}
+            className="p-0.5 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+          >
+            <Star
+              className={`h-5 w-5 transition-colors ${
+                active
+                  ? 'fill-amber-400 text-amber-400'
+                  : 'fill-transparent text-gray-300 dark:text-gray-600 hover:text-amber-300'
+              }`}
+            />
+          </button>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
Replaces the numeric 1–5 `<select>` dropdowns on the profile with an easy **click-to-set star rating** (`SkillRating`): click a star to set the level, click again to clear, arrow keys to adjust. Accessible (`radiogroup`/`radio`) and dark-mode aware.

e2e: setting a skill's star level persists to `skillLevels`. `tsc` clean.

Closes #384 · Refs #370
🤖 Generated with [Claude Code](https://claude.com/claude-code)