### PR TITLE
feat(release): app version display, CHANGELOG.md, user-facing release notes (#387)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,6 +46,8 @@ jobs:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tag }}
+          build-args: |
+            GIT_SHA=${{ github.sha }}
           # No build-time secrets — all real values are injected at `docker run`
 
       # ── SSH key setup (shared by both deploy steps) ──────────────────────────

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project uses [Semantic Versioning](https://semver.org/). The app
+version is shown in the sidebar footer of every page (links to the
+[user-facing release notes](src/lib/releaseNotes.ts), rendered at
+`/release-notes`) and in the landing-page footer.
+
+## [Unreleased]
+
+## [0.2.0] - 2026-07-01
+
+### Added
+- **Dark mode** — OS-aware by default, user-togglable, preference persisted per-user (#343).
+- **CV tools**:
+  - Local, no-AI parsing of an uploaded CV → suggests contact links and skills for the profile (#361).
+  - Reusable per-user consent framework (GDPR) gating optional data processing (#362).
+  - Optional AI-assisted CV extraction (name, city, university, department, target position), gated behind explicit consent and only active when configured (#363).
+- **Document templates v2** — multilingual (EN/TR/DE) catalog with an in-app preview and export to PDF / TXT / Markdown (#357).
+- **Public profile**: language + theme toggles, a link back to the product, and a spam-protected contact form that notifies the profile owner (#382).
+- **Skill self-assessment** — replaced the 1–5 numeric dropdown with a click-to-set star rating (#384).
+- **App version display** + this changelog + a user-facing "What's new" page at `/release-notes`.
+- Secure local-dev database setup docs (Docker MySQL, no shared-DB exposure) (#366).
+
+### Fixed
+- CV URL field no longer shows the internal upload path; hidden once a file CV exists (#355).
+- Dark-mode contrast/visibility issues: hover states, native `<input>`/`<select>`, the translucent landing header, role cards, and the impersonation banner (#364, #380).
+- Mentee portal sidebar now highlights the active page (#380).
+- Public contact form's honeypot no longer leaks the anti-spam trap via a validation error.
+
+## [0.1.0] - 2026-01-01
+
+Initial platform baseline (predates formal changelog tracking): mentor↔mentee
+pipeline tracking, role-scoped dashboards (admin/mentor/mentee/company/source),
+interaction logging, Kanban board, calendar & reminders, analytics, document
+uploads with versioning, two-factor authentication, invitation-based
+registration, and English/Turkish/German localization.
+
+[Unreleased]: https://github.com/mersahin/Internship/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/mersahin/Internship/releases/tag/v0.2.0
+[0.1.0]: https://github.com/mersahin/Internship/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,3 +128,9 @@ SMTP_* for email. Seeder: `SEED_ADMIN_EMAIL` / `SEED_ADMIN_PASSWORD` / `SEED_ADM
 - **Work is tracked on a GitHub Project board** (Epics #5–#11, stories #12+). Move the issue
   to the matching column as you work.
 - Co-author trailer on commits: `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+- **Versioning**: on a notable batch of merged features (not every PR), bump `package.json`
+  `version` (semver), add an entry to `CHANGELOG.md` (developer-facing, Keep a Changelog
+  format), and add a matching entry to `src/lib/releaseNotes.ts` (user-facing, EN/TR/DE,
+  rendered at `/release-notes`, linked from the sidebar version footer). The app version is
+  read from `package.json` at build time (`src/lib/version.ts`); the git SHA is baked into the
+  Docker image via a build arg — no other wiring is needed.

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,12 @@ RUN npm run build
 # ---- runner ----
 FROM node:20-slim AS runner
 WORKDIR /app
+# Commit SHA baked in at build time (CI passes --build-arg GIT_SHA), surfaced
+# in the UI footer so a running deployment can be traced back to its commit.
+ARG GIT_SHA=dev
 ENV NODE_ENV=production \
-    NEXT_TELEMETRY_DISABLED=1
+    NEXT_TELEMETRY_DISABLED=1 \
+    GIT_SHA=$GIT_SHA
 
 # OpenSSL is required by the Prisma schema engine (used at runtime for `prisma db push`)
 RUN apt-get update -y && apt-get install -y --no-install-recommends openssl && rm -rf /var/lib/apt/lists/*

--- a/e2e/version-release-notes.spec.ts
+++ b/e2e/version-release-notes.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+import { readFileSync } from 'fs';
+import path from 'path';
+
+const pkg = JSON.parse(readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'));
+
+test('landing footer shows the app version linking to release notes', async ({ page }) => {
+  await page.goto('/');
+  const link = page.getByRole('link', { name: new RegExp(`^v${pkg.version.replace(/\./g, '\\.')}`) });
+  await expect(link).toBeVisible();
+  await link.click();
+  await page.waitForURL('**/release-notes');
+  await expect(page.getByRole('heading', { name: /What.s new|Yenilikler|Neuigkeiten/ })).toBeVisible();
+  // Latest entry matches the running package.json version.
+  await expect(page.getByRole('heading', { name: `v${pkg.version}` })).toBeVisible();
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "prisma": {
     "seed": "node prisma/seed.mjs"

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -6,6 +6,8 @@ import { GraduationCap, LogOut } from 'lucide-react';
 import { getServerDictionary } from '@/i18n/server';
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
 import { ThemeToggle } from '@/components/ThemeToggle';
+import { VersionFooter } from '@/components/VersionFooter';
+import { APP_VERSION } from '@/lib/version';
 import { ResponsiveShell } from '@/components/ResponsiveShell';
 import { AdminNav } from '@/components/AdminNav';
 import { SidebarAvatar } from '@/components/SidebarAvatar';
@@ -63,6 +65,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
           <div className="mt-3 px-3 flex flex-col gap-2 items-start">
             <LanguageSwitcher current={locale} />
             <ThemeToggle />
+            <VersionFooter version={APP_VERSION} />
           </div>
         </div>
         </aside>

--- a/src/app/company/layout.tsx
+++ b/src/app/company/layout.tsx
@@ -6,6 +6,8 @@ import { GraduationCap, LayoutDashboard, LogOut } from 'lucide-react';
 import { getServerDictionary } from '@/i18n/server';
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
 import { ThemeToggle } from '@/components/ThemeToggle';
+import { VersionFooter } from '@/components/VersionFooter';
+import { APP_VERSION } from '@/lib/version';
 import { ResponsiveShell } from '@/components/ResponsiveShell';
 import { InstallAppButton } from '@/components/InstallAppButton';
 import { SidebarAvatar } from '@/components/SidebarAvatar';
@@ -61,6 +63,7 @@ export default async function CompanyLayout({ children }: { children: React.Reac
             <div className="mt-3 px-3 flex flex-col gap-2 items-start">
               <LanguageSwitcher current={locale} />
               <ThemeToggle />
+            <VersionFooter version={APP_VERSION} />
             </div>
           </div>
         </aside>

--- a/src/app/mentor/layout.tsx
+++ b/src/app/mentor/layout.tsx
@@ -6,6 +6,8 @@ import { GraduationCap, LayoutDashboard, Columns3, Users, BookOpen, Mail, Calend
 import { getServerDictionary } from '@/i18n/server';
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
 import { ThemeToggle } from '@/components/ThemeToggle';
+import { VersionFooter } from '@/components/VersionFooter';
+import { APP_VERSION } from '@/lib/version';
 import { ResponsiveShell } from '@/components/ResponsiveShell';
 import { InstallAppButton } from '@/components/InstallAppButton';
 import { SidebarAvatar } from '@/components/SidebarAvatar';
@@ -122,6 +124,7 @@ export default async function MentorLayout({ children }: { children: React.React
           <div className="mt-3 px-3 flex flex-col gap-2 items-start">
             <LanguageSwitcher current={locale} />
             <ThemeToggle />
+            <VersionFooter version={APP_VERSION} />
           </div>
         </div>
         </aside>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,8 @@ import { roleHome } from '@/lib/roleHome';
 import { getServerDictionary } from '@/i18n/server';
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
 import { ThemeToggle } from '@/components/ThemeToggle';
+import { VersionFooter } from '@/components/VersionFooter';
+import { APP_VERSION } from '@/lib/version';
 
 export default async function HomePage() {
   const session = await getServerSession(authOptions);
@@ -192,6 +194,7 @@ export default async function HomePage() {
           <div className="flex items-center gap-4">
             <Link href="/privacy" className="hover:text-gray-700">{t.privacy.title}</Link>
             <Link href="/terms" className="hover:text-gray-700">{t.terms.title}</Link>
+            <VersionFooter version={APP_VERSION} />
           </div>
         </div>
       </footer>

--- a/src/app/portal/layout.tsx
+++ b/src/app/portal/layout.tsx
@@ -7,6 +7,8 @@ import { getServerDictionary } from '@/i18n/server';
 import { PortalNav } from '@/components/PortalNav';
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
 import { ThemeToggle } from '@/components/ThemeToggle';
+import { VersionFooter } from '@/components/VersionFooter';
+import { APP_VERSION } from '@/lib/version';
 import { ResponsiveShell } from '@/components/ResponsiveShell';
 import { InstallAppButton } from '@/components/InstallAppButton';
 import { SidebarAvatar } from '@/components/SidebarAvatar';
@@ -69,6 +71,7 @@ export default async function PortalLayout({ children }: { children: React.React
           <div className="mt-3 px-3 flex flex-col gap-2 items-start">
             <LanguageSwitcher current={locale} />
             <ThemeToggle />
+            <VersionFooter version={APP_VERSION} />
           </div>
         </div>
         </aside>

--- a/src/app/release-notes/page.tsx
+++ b/src/app/release-notes/page.tsx
@@ -1,0 +1,44 @@
+import Link from 'next/link';
+import { GraduationCap, Sparkles } from 'lucide-react';
+import { getServerDictionary } from '@/i18n/server';
+import { RELEASE_NOTES } from '@/lib/releaseNotes';
+import { APP_VERSION, GIT_SHA } from '@/lib/version';
+
+// Public, user-facing "what's new" page — friendly feature highlights per
+// release, localized. Distinct from CHANGELOG.md (developer-facing, in the repo).
+export default async function ReleaseNotesPage() {
+  const { locale, t } = await getServerDictionary();
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-950 py-12 px-4">
+      <div className="max-w-2xl mx-auto">
+        <div className="flex items-center justify-between mb-6">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 flex items-center gap-2">
+            <Sparkles className="h-6 w-6 text-blue-600" /> {t.releaseNotes.title}
+          </h1>
+          <span className="text-xs text-gray-400">v{APP_VERSION} · {GIT_SHA}</span>
+        </div>
+
+        <div className="space-y-6">
+          {RELEASE_NOTES.map((r) => (
+            <div key={r.version} className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-800 p-6">
+              <div className="flex items-baseline justify-between mb-3">
+                <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">v{r.version}</h2>
+                <span className="text-xs text-gray-400">{r.date}</span>
+              </div>
+              <ul className="space-y-2 text-sm text-gray-700 dark:text-gray-300 list-disc list-inside">
+                {r.highlights[locale].map((h, i) => (
+                  <li key={i}>{h}</li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+
+        <Link href="/" className="inline-flex items-center gap-1.5 mt-8 text-sm text-blue-600 hover:underline">
+          <GraduationCap className="h-4 w-4" /> {t.releaseNotes.back}
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/source/layout.tsx
+++ b/src/app/source/layout.tsx
@@ -6,6 +6,8 @@ import { GraduationCap, LayoutDashboard, LogOut } from 'lucide-react';
 import { getServerDictionary } from '@/i18n/server';
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
 import { ThemeToggle } from '@/components/ThemeToggle';
+import { VersionFooter } from '@/components/VersionFooter';
+import { APP_VERSION } from '@/lib/version';
 import { ResponsiveShell } from '@/components/ResponsiveShell';
 import { InstallAppButton } from '@/components/InstallAppButton';
 import { SidebarAvatar } from '@/components/SidebarAvatar';
@@ -61,6 +63,7 @@ export default async function SourceLayout({ children }: { children: React.React
             <div className="mt-3 px-3 flex flex-col gap-2 items-start">
               <LanguageSwitcher current={locale} />
               <ThemeToggle />
+            <VersionFooter version={APP_VERSION} />
             </div>
           </div>
         </aside>

--- a/src/components/VersionFooter.tsx
+++ b/src/components/VersionFooter.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useT } from '@/i18n/client';
+
+const LAST_SEEN_KEY = 'lastSeenReleaseVersion';
+
+// Small sidebar footer: app version + a link to /release-notes. Shows a dot
+// when the current version hasn't been seen yet (per-browser, localStorage);
+// visiting the page (or this footer once) marks it seen.
+export function VersionFooter({ version }: { version: string }) {
+  const t = useT();
+  const [isNew, setIsNew] = useState(false);
+
+  useEffect(() => {
+    try {
+      const lastSeen = localStorage.getItem(LAST_SEEN_KEY);
+      if (lastSeen !== version) setIsNew(true);
+    } catch { /* ignore */ }
+  }, [version]);
+
+  const markSeen = () => {
+    try { localStorage.setItem(LAST_SEEN_KEY, version); } catch { /* ignore */ }
+    setIsNew(false);
+  };
+
+  return (
+    <Link
+      href="/release-notes"
+      onClick={markSeen}
+      className="relative inline-flex items-center gap-1 text-xs text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+      title={t.releaseNotes.title}
+    >
+      v{version}
+      {isNew && <span className="h-1.5 w-1.5 rounded-full bg-blue-500" aria-label={t.releaseNotes.title} />}
+    </Link>
+  );
+}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -768,6 +768,7 @@ const en = {
     portfolio: 'Portfolio',
     poweredBy: 'InternshipCRM',
   },
+  releaseNotes: { title: 'What’s new', back: 'Back to home' },
   privacy: {
     title: 'Privacy & data',
     intro: 'We store the information you provide to manage mentorships and internships.',
@@ -1689,6 +1690,7 @@ const tr: Dict = {
     portfolio: 'Portfolyo',
     poweredBy: 'InternshipCRM',
   },
+  releaseNotes: { title: 'Yenilikler', back: 'Ana sayfaya dön' },
   privacy: {
     title: 'Gizlilik & veri',
     intro: 'Mentorluk ve staj sürecini yönetmek için sağladığın bilgileri saklarız.',
@@ -2608,6 +2610,7 @@ const de: Dict = {
     portfolio: 'Portfolio',
     poweredBy: 'InternshipCRM',
   },
+  releaseNotes: { title: 'Neuigkeiten', back: 'Zurück zur Startseite' },
   privacy: {
     title: 'Datenschutz & Daten',
     intro: 'Wir speichern die von dir bereitgestellten Informationen, um Mentorings und Praktika zu verwalten.',

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -1,0 +1,65 @@
+// User-facing release notes (EN/TR/DE) — friendly, feature-level summaries for
+// end users. Distinct from CHANGELOG.md, which is the developer-facing,
+// commit-level record. Add a new entry here (newest first) alongside each
+// notable release; bump APP_VERSION in package.json to match.
+
+import type { Locale } from '@/i18n/config';
+
+export interface ReleaseNote {
+  version: string;
+  date: string; // ISO date (release day)
+  highlights: Record<Locale, string[]>;
+}
+
+export const RELEASE_NOTES: ReleaseNote[] = [
+  {
+    version: '0.2.0',
+    date: '2026-07-01',
+    highlights: {
+      en: [
+        'Dark mode — follows your system by default, or switch it yourself from any sidebar. Your choice is remembered on your account.',
+        'CV tools — upload your CV and get one-click suggestions for your profile fields and skills, parsed locally on our server (nothing sent anywhere). An optional AI-assisted mode can fill in more fields once you turn it on in Account → Privacy.',
+        'Document templates — CV, cover letter, interview-prep checklist and more, now with an in-app preview and export to PDF, Word-friendly text, or Markdown, in your language.',
+        'Public profile upgrades — visitors can switch language and theme, get a link back to InternshipCRM, and send you a message directly (spam-protected).',
+        'Skill ratings — self-assess your skills with a simple 1–5 star picker instead of a dropdown.',
+        'A number of dark-mode and navigation polish fixes across the app.',
+      ],
+      tr: [
+        'Karanlık mod — varsayılan olarak işletim sisteminizi takip eder, dilerseniz herhangi bir kenar çubuğundan değiştirebilirsiniz. Tercihiniz hesabınızda hatırlanır.',
+        'CV araçları — CV\'nizi yükleyin, profil alanlarınız ve becerileriniz için tek tıkla öneriler alın; işlem sunucumuzda yerel olarak yapılır (hiçbir yere gönderilmez). Hesap → Gizlilik\'ten açtığınızda isteğe bağlı AI destekli mod daha fazla alanı doldurabilir.',
+        'Doküman şablonları — CV, ön yazı, mülakat hazırlık listesi ve daha fazlası; artık uygulama içi önizleme ve dilinizde PDF, Word-uyumlu metin veya Markdown olarak dışa aktarma ile.',
+        'Herkese açık profil geliştirmeleri — ziyaretçiler dil ve temayı değiştirebilir, InternshipCRM\'e geri dönen bir bağlantı görebilir ve size doğrudan mesaj gönderebilir (spam korumalı).',
+        'Yetenek değerlendirmesi — becerilerinizi açılır menü yerine basit bir 1–5 yıldız seçiciyle değerlendirin.',
+        'Uygulama genelinde çok sayıda karanlık mod ve gezinme iyileştirmesi.',
+      ],
+      de: [
+        'Dunkelmodus — folgt standardmäßig deinem System, oder wechsle ihn selbst über jede Seitenleiste. Deine Wahl wird für dein Konto gespeichert.',
+        'Lebenslauf-Tools — lade deinen Lebenslauf hoch und erhalte mit einem Klick Vorschläge für deine Profilfelder und Fähigkeiten, lokal auf unserem Server verarbeitet (nichts wird irgendwohin gesendet). Ein optionaler KI-gestützter Modus kann weitere Felder ausfüllen, sobald du ihn unter Konto → Datenschutz aktivierst.',
+        'Dokumentvorlagen — Lebenslauf, Anschreiben, Interview-Checkliste und mehr, jetzt mit Vorschau in der App und Export als PDF, Word-freundlicher Text oder Markdown, in deiner Sprache.',
+        'Verbessertes öffentliches Profil — Besucher können Sprache und Theme wechseln, finden einen Link zurück zu InternshipCRM und können dir direkt eine Nachricht senden (spamgeschützt).',
+        'Fähigkeitsbewertung — bewerte deine Fähigkeiten mit einer einfachen 1–5-Sterne-Auswahl statt eines Dropdowns.',
+        'Zahlreiche Verbesserungen am Dunkelmodus und an der Navigation in der gesamten App.',
+      ],
+    },
+  },
+  {
+    version: '0.1.0',
+    date: '2026-01-01',
+    highlights: {
+      en: [
+        'The original platform: mentor–mentee pipeline tracking, role-based dashboards for admins, mentors, mentees and companies, interaction logging, analytics, document uploads, two-factor authentication, and multi-language support (EN/TR/DE).',
+        'This is a retroactive summary — detailed release notes start with 0.2.0.',
+      ],
+      tr: [
+        'Orijinal platform: mentor–mentee süreç takibi, admin/mentör/mentee/şirket için rol bazlı panolar, etkileşim kaydı, analitik, doküman yükleme, iki faktörlü kimlik doğrulama ve çok dilli destek (EN/TR/DE).',
+        'Bu geriye dönük bir özettir — detaylı sürüm notları 0.2.0 ile başlar.',
+      ],
+      de: [
+        'Die ursprüngliche Plattform: Mentor-Mentee-Pipeline-Tracking, rollenbasierte Dashboards für Admins, Mentoren, Mentees und Unternehmen, Interaktionsprotokolle, Analysen, Dokument-Uploads, Zwei-Faktor-Authentifizierung und mehrsprachige Unterstützung (EN/TR/DE).',
+        'Dies ist eine rückwirkende Zusammenfassung — detaillierte Versionshinweise beginnen mit 0.2.0.',
+      ],
+    },
+  },
+];
+
+export const LATEST_RELEASE_VERSION = RELEASE_NOTES[0]?.version ?? '0.0.0';

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,0 +1,8 @@
+import pkg from '../../package.json';
+
+// package.json is a static JSON import — Next.js inlines its contents into
+// the compiled server bundle at build time, so this needs no runtime file
+// access. GIT_SHA is baked into the Docker image at build time (see
+// Dockerfile / .github/workflows/deploy.yml); 'dev' locally.
+export const APP_VERSION: string = pkg.version;
+export const GIT_SHA: string = (process.env.GIT_SHA || 'dev').slice(0, 7);


### PR DESCRIPTION
Fills a real gap: no version was visible anywhere, no changelog was kept, and users had no "what's new". Adds all three.

### What's included
- **Version bump**: `package.json` → `0.2.0` (first formally-tracked version).
- **`src/lib/version.ts`**: `APP_VERSION` (inlined from `package.json` at build) + `GIT_SHA` baked into the Docker image via a build arg (`Dockerfile` ARG/ENV + `deploy.yml` `build-args`) — a running deployment can be traced to its exact commit.
- **`VersionFooter`**: small `v{version}` link to `/release-notes` in every sidebar (admin/mentor/portal/company/source) and the landing footer; shows a dot for an unseen new version (localStorage).
- **`/release-notes`**: localized (EN/TR/DE) user-facing "what's new" page — friendly feature highlights, content in `src/lib/releaseNotes.ts`. Distinct from the dev-facing changelog.
- **`CHANGELOG.md`**: Keep a Changelog format — a retroactive `0.1.0` baseline plus a full `0.2.0` entry covering this session's shipped work (dark mode, CV tools incl. consent + optional AI, templates v2, public profile, star rating, dark-mode/nav fixes).
- **`CLAUDE.md`**: documents the versioning convention (bump + changelog + release notes together) for future work.

### Verification
- `npx tsc --noEmit` and `next lint` clean.
- e2e (`e2e/version-release-notes.spec.ts`): landing footer version link → `/release-notes` renders and matches the running `package.json` version.

Closes #387
🤖 Generated with [Claude Code](https://claude.com/claude-code)