### PR TITLE
docs(changelog): log onboarding-checklist dark fix under Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [Unreleased]
 
+### Fixed
+- Onboarding checklist card on the dashboard was nearly unreadable in dark mode (#389).
+
 ## [0.2.0] - 2026-07-01
 
 ### Added


### PR DESCRIPTION
Small follow-up: record the #389/#390 dark-mode fix (merged after 0.2.0) under the `Unreleased` section per Keep a Changelog convention.
🤖 Generated with [Claude Code](https://claude.com/claude-code)