### PR TITLE
feat(company): candidate detail view + CV access (#372)

### DIFF
--- a/e2e/company-candidate-detail.spec.ts
+++ b/e2e/company-candidate-detail.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from '@playwright/test';
+import bcrypt from 'bcryptjs';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('a COMPANY user can open a linked candidate\'s detail page but not an unlinked one', async ({ page }) => {
+  const companyEmail = uniqueEmail('co-detail');
+  const mentorEmail = uniqueEmail('co-detail-mentor');
+  const menteeEmail = uniqueEmail('co-detail-mentee');
+  const outsiderEmail = uniqueEmail('co-detail-outsider');
+  const pw = 'CompanyPass123!';
+
+  const company = await prisma.company.create({ data: { name: `Detail Co ${Date.now()}` } });
+  const companyUser = await prisma.user.create({
+    data: {
+      email: companyEmail,
+      password: await bcrypt.hash(pw, 10),
+      role: 'COMPANY',
+      fullName: 'Detail Co Observer',
+      companyId: company.id,
+      skills: [],
+    },
+  });
+  const mentor = await seedUser(mentorEmail, 'x', 'MENTOR', 'Detail Mentor');
+  const mentee = await seedUser(menteeEmail, 'x', 'MENTEE', 'Detail Candidate');
+  const outsider = await seedUser(outsiderEmail, 'x', 'MENTEE', 'Outsider Candidate');
+  await prisma.user.update({
+    where: { id: mentee.id },
+    data: { university: 'TU Berlin', skills: ['React', 'SQL'], skillLevels: { React: 4 }, targetPosition: 'Backend Intern' },
+  });
+  const rel = await prisma.mentorshipRelation.create({
+    data: { mentorId: mentor.id, menteeId: mentee.id, companyId: company.id, pipelineStatus: 'INTERVIEW_PENDING_250' },
+  });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', companyEmail);
+    await page.fill('input[type="password"]', pw);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/company'), { timeout: 20_000 });
+
+    // Click through from the list into the candidate detail page.
+    await page.getByText('Detail Candidate').click();
+    await page.waitForURL(`**/company/candidates/${mentee.id}`);
+    await expect(page.getByRole('heading', { name: 'Detail Candidate' })).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('TU Berlin')).toBeVisible();
+    await expect(page.getByText('React · 4/5')).toBeVisible();
+    await expect(page.getByText('Backend Intern')).toBeVisible();
+
+    // IDOR check: a candidate not linked to this company is not accessible.
+    const res = await page.request.get(`/api/company/candidates/${outsider.id}`);
+    expect(res.status()).toBe(404);
+  } finally {
+    await prisma.mentorshipRelation.deleteMany({ where: { id: rel.id } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(outsiderEmail);
+    await prisma.user.deleteMany({ where: { id: companyUser.id } });
+    await prisma.company.deleteMany({ where: { id: company.id } });
+  }
+});

--- a/src/app/api/company/candidates/[id]/route.ts
+++ b/src/app/api/company/candidates/[id]/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+// GET — read-only candidate detail for a COMPANY user (EPIC: company
+// candidate detail). Authorized only when a mentorship relation links this
+// candidate to the requester's company. Exposes the fields a company needs to
+// evaluate a candidate — no email/phone (those stay mentor/admin-only, as in
+// the existing company candidates list).
+export async function GET(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  if (session.user.role !== 'COMPANY' || !session.user.companyId) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const { id } = await params;
+  const relation = await prisma.mentorshipRelation.findFirst({
+    where: { companyId: session.user.companyId, menteeId: id },
+    select: {
+      pipelineStatus: true,
+      mentor: { select: { fullName: true } },
+    },
+  });
+  if (!relation) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+  const candidate = await prisma.user.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      fullName: true,
+      avatarUrl: true,
+      university: true,
+      department: true,
+      graduationYear: true,
+      city: true,
+      bio: true,
+      targetPosition: true,
+      skills: true,
+      skillLevels: true,
+      cvUrl: true,
+      linkedinUrl: true,
+      githubUrl: true,
+      portfolioUrl: true,
+    },
+  });
+  if (!candidate) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+  return NextResponse.json({
+    candidate: { ...candidate, pipelineStatus: relation.pipelineStatus, mentorName: relation.mentor.fullName },
+  });
+}

--- a/src/app/company/candidates/[id]/page.tsx
+++ b/src/app/company/candidates/[id]/page.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import { ArrowLeft, FileText, ExternalLink } from 'lucide-react';
+import { Card } from '@/components/ui/Card';
+import { Badge } from '@/components/ui/Badge';
+import { pipelineLabel } from '@/lib/pipeline';
+import { useT, useLocale } from '@/i18n/client';
+
+interface Candidate {
+  id: string;
+  fullName: string;
+  avatarUrl?: string | null;
+  university?: string | null;
+  department?: string | null;
+  graduationYear?: number | null;
+  city?: string | null;
+  bio?: string | null;
+  targetPosition?: string | null;
+  skills: string[];
+  skillLevels?: Record<string, number> | null;
+  cvUrl?: string | null;
+  linkedinUrl?: string | null;
+  githubUrl?: string | null;
+  portfolioUrl?: string | null;
+  pipelineStatus: string;
+  mentorName: string;
+}
+
+// Read-only candidate detail for a COMPANY user (EPIC: company candidate
+// detail). Authorized server-side by a mentorship relation to this company.
+export default function CompanyCandidateDetailPage() {
+  const t = useT();
+  const locale = useLocale();
+  const { id } = useParams<{ id: string }>();
+  const [candidate, setCandidate] = useState<Candidate | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    fetch(`/api/company/candidates/${id}`)
+      .then(async (r) => {
+        const body = await r.json();
+        if (!r.ok) throw new Error(body.error || t.common.error);
+        setCandidate(body.candidate);
+      })
+      .catch((e) => setError(e instanceof Error ? e.message : t.common.error))
+      .finally(() => setLoading(false));
+  }, [id, t.common.error]);
+
+  if (loading) return <p className="text-center py-12 text-gray-400">{t.common.loading}</p>;
+  if (error || !candidate) return <p className="text-center py-12 text-gray-400">{error || t.common.notFound}</p>;
+
+  const links = [
+    { label: 'LinkedIn', url: candidate.linkedinUrl },
+    { label: 'GitHub', url: candidate.githubUrl },
+    { label: t.profileForm.portfolio, url: candidate.portfolioUrl },
+  ].filter((l) => l.url);
+
+  return (
+    <div>
+      <Link href="/company" className="inline-flex items-center gap-1.5 text-sm text-blue-600 hover:underline mb-4">
+        <ArrowLeft className="h-4 w-4" /> {t.company.back}
+      </Link>
+
+      <Card>
+        <div className="flex items-start gap-4 mb-4">
+          {candidate.avatarUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={candidate.avatarUrl} alt="" className="w-16 h-16 rounded-2xl object-cover border border-gray-200 dark:border-gray-700" />
+          ) : (
+            <div className="w-16 h-16 bg-blue-100 dark:bg-blue-900/40 rounded-2xl flex items-center justify-center flex-shrink-0">
+              <span className="text-blue-700 dark:text-blue-300 font-bold text-2xl">{candidate.fullName?.[0] ?? '?'}</span>
+            </div>
+          )}
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100">{candidate.fullName}</h1>
+              <Badge variant="info">{pipelineLabel(candidate.pipelineStatus, locale)}</Badge>
+            </div>
+            {candidate.targetPosition && <p className="text-blue-600 dark:text-blue-400 text-sm font-medium mt-0.5">{candidate.targetPosition}</p>}
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{t.company.mentor}: {candidate.mentorName}</p>
+          </div>
+        </div>
+
+        {candidate.bio && <p className="text-sm text-gray-700 dark:text-gray-300 mb-4 whitespace-pre-line">{candidate.bio}</p>}
+
+        <dl className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm mb-4">
+          {candidate.university && (
+            <div>
+              <dt className="text-gray-500 dark:text-gray-400">{t.profileForm.university}</dt>
+              <dd className="text-gray-900 dark:text-gray-100">{candidate.university}</dd>
+            </div>
+          )}
+          {candidate.department && (
+            <div>
+              <dt className="text-gray-500 dark:text-gray-400">{t.profileForm.department}</dt>
+              <dd className="text-gray-900 dark:text-gray-100">{candidate.department}</dd>
+            </div>
+          )}
+          {candidate.graduationYear && (
+            <div>
+              <dt className="text-gray-500 dark:text-gray-400">{t.profileForm.graduationYear}</dt>
+              <dd className="text-gray-900 dark:text-gray-100">{candidate.graduationYear}</dd>
+            </div>
+          )}
+          {candidate.city && (
+            <div>
+              <dt className="text-gray-500 dark:text-gray-400">{t.profileForm.city}</dt>
+              <dd className="text-gray-900 dark:text-gray-100">{candidate.city}</dd>
+            </div>
+          )}
+        </dl>
+
+        {candidate.skills.length > 0 && (
+          <div className="mb-4">
+            <p className="text-xs text-gray-500 dark:text-gray-400 mb-1.5">{t.profileForm.skills}</p>
+            <div className="flex flex-wrap gap-1.5">
+              {candidate.skills.map((s) => (
+                <Badge key={s} variant="info" className="text-xs">
+                  {s}{candidate.skillLevels?.[s] ? ` · ${candidate.skillLevels[s]}/5` : ''}
+                </Badge>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <div className="flex flex-wrap items-center gap-2 pt-3 border-t border-gray-100 dark:border-gray-800">
+          {candidate.cvUrl && (
+            <a href={candidate.cvUrl} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 text-sm text-blue-600 dark:text-blue-400 hover:underline">
+              <FileText className="h-4 w-4" /> {t.cv.view}
+            </a>
+          )}
+          {links.map((l) => (
+            <a key={l.label} href={l.url!} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 text-sm text-gray-600 dark:text-gray-300 hover:underline">
+              <ExternalLink className="h-4 w-4" /> {l.label}
+            </a>
+          ))}
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/company/page.tsx
+++ b/src/app/company/page.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { ChevronRight } from 'lucide-react';
 import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Badge } from '@/components/ui/Badge';
 import { Select } from '@/components/ui/Select';
@@ -10,7 +12,7 @@ import { useT, useLocale } from '@/i18n/client';
 interface Relation {
   id: string;
   pipelineStatus: string;
-  mentee: { fullName: string; university?: string };
+  mentee: { id: string; fullName: string; university?: string };
   mentor: { fullName: string };
 }
 
@@ -69,20 +71,25 @@ export default function CompanyOverviewPage() {
         ) : shown.length === 0 ? (
           <p className="text-center py-12 text-gray-400">{t.company.none}</p>
         ) : (
-          <div className="divide-y divide-gray-50">
+          <div className="divide-y divide-gray-50 dark:divide-gray-800">
             {shown.map((r) => (
-              <div key={r.id} className="flex items-center justify-between gap-3 py-3">
+              <Link
+                key={r.id}
+                href={`/company/candidates/${r.mentee.id}`}
+                className="flex items-center justify-between gap-3 py-3 hover:bg-gray-50 dark:hover:bg-gray-800/60 -mx-2 px-2 rounded-lg transition-colors"
+              >
                 <div className="min-w-0">
-                  <p className="text-sm font-medium text-gray-900 truncate">{r.mentee.fullName}</p>
-                  <p className="text-xs text-gray-500 truncate">
+                  <p className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">{r.mentee.fullName}</p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
                     {r.mentee.university ? `${r.mentee.university} · ` : ''}
                     {t.company.mentor}: {r.mentor.fullName}
                   </p>
                 </div>
-                <Badge variant="info" className="flex-shrink-0">
-                  {pipelineLabel(r.pipelineStatus, locale)}
-                </Badge>
-              </div>
+                <div className="flex items-center gap-2 flex-shrink-0">
+                  <Badge variant="info">{pipelineLabel(r.pipelineStatus, locale)}</Badge>
+                  <ChevronRight className="h-4 w-4 text-gray-300 dark:text-gray-600" />
+                </div>
+              </Link>
             ))}
           </div>
         )}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -49,6 +49,8 @@ const en = {
     none: 'No candidates linked yet',
     searchPlaceholder: 'Search by name or university...',
     allStages: 'All stages',
+    back: 'Back to candidates',
+    viewProfile: 'View profile',
   },
   offline: { title: 'You are offline', body: 'Check your connection and try again. Some pages you have visited may still work.' },
   common: {
@@ -971,6 +973,8 @@ const tr: Dict = {
     none: 'Henüz bağlı aday yok',
     searchPlaceholder: 'Ad veya üniversiteye göre ara...',
     allStages: 'Tüm aşamalar',
+    back: 'Adaylara dön',
+    viewProfile: 'Profili gör',
   },
   offline: { title: 'Çevrimdışısın', body: 'Bağlantını kontrol edip tekrar dene. Daha önce ziyaret ettiğin bazı sayfalar yine de çalışabilir.' },
   common: {
@@ -1891,6 +1895,8 @@ const de: Dict = {
     none: 'Noch keine Kandidaten verknüpft',
     searchPlaceholder: 'Nach Name oder Universität suchen...',
     allStages: 'Alle Phasen',
+    back: 'Zurück zu den Kandidaten',
+    viewProfile: 'Profil ansehen',
   },
   offline: { title: 'Du bist offline', body: 'Prüfe deine Verbindung und versuche es erneut. Bereits besuchte Seiten funktionieren womöglich weiter.' },
   common: {

--- a/src/lib/cvAccess.ts
+++ b/src/lib/cvAccess.ts
@@ -3,15 +3,24 @@ import { prisma } from '@/lib/prisma';
 interface SessionUser {
   id: string;
   role: string;
+  companyId?: string | null;
 }
 
-// A CV is accessible to the owner, any admin, or a mentor who mentors that user.
+// A CV is accessible to the owner, any admin, a mentor who mentors that user,
+// or a company the user has a mentorship relation with.
 export async function canAccessCv(user: SessionUser, targetUserId: string) {
   if (user.id === targetUserId) return true;
   if (user.role === 'ADMIN') return true;
   if (user.role === 'MENTOR') {
     const rel = await prisma.mentorshipRelation.findFirst({
       where: { mentorId: user.id, menteeId: targetUserId },
+      select: { id: true },
+    });
+    return !!rel;
+  }
+  if (user.role === 'COMPANY' && user.companyId) {
+    const rel = await prisma.mentorshipRelation.findFirst({
+      where: { companyId: user.companyId, menteeId: targetUserId },
       select: { id: true },
     });
     return !!rel;


### PR DESCRIPTION
Companies previously saw only a one-line candidate row (name/university/mentor/stage) with no way to actually evaluate a candidate. This is the foundational piece the rest of the company-lens roadmap (shortlist, feedback, matching) builds on.

### What's included
- **`canAccessCv`** now also authorizes a **COMPANY** user when a mentorship relation links the target mentee to their company — companies can finally download a linked candidate's CV via the existing `/api/cv/[userId]` route (previously company was not in the allow-list at all).
- **`GET /api/company/candidates/[id]`**: read-only detail — skills (+ self-assessed levels), university, department, graduation year, city, bio, target position, CV/LinkedIn/GitHub/portfolio links, pipeline stage, mentor name. Authorized only via an existing mentorship relation to the requester's company — deliberately **no email/phone**, matching what the list view already withholds.
- **`/company/candidates/[id]`** page; each row in the company candidate list now links there instead of being a static row.
- i18n: `company.back` / `company.viewProfile` (EN/TR/DE).

### Verification
- `npx tsc --noEmit` and `next lint` clean.
- e2e (`e2e/company-candidate-detail.spec.ts`): a company can click through to a linked candidate's detail and see skills/university/target position; requesting an **unlinked** candidate's detail returns 404 (IDOR check).

Closes #372 · Refs #370
🤖 Generated with [Claude Code](https://claude.com/claude-code)