### PR TITLE
feat(mentor): needs-attention follow-up queue on the dashboard (#374)

### DIFF
--- a/e2e/mentor-attention-queue.spec.ts
+++ b/e2e/mentor-attention-queue.spec.ts
@@ -43,7 +43,7 @@ test('mentor dashboard surfaces a needs-attention queue for stale/overdue/unansw
     await page.waitForURL((u) => u.pathname.startsWith('/mentor'), { timeout: 20_000 });
 
     const queue = page.getByTestId('attention-queue');
-    await expect(queue.getByText(/Needs attention/i)).toBeVisible({ timeout: 10_000 });
+    await expect(queue.getByRole('heading', { name: /Needs attention/i })).toBeVisible({ timeout: 10_000 });
     const row = queue.getByRole('link', { name: /Needs Attention Mentee/ });
     await expect(row).toBeVisible();
     await expect(row.getByText(/No recent contact/i)).toBeVisible();

--- a/e2e/mentor-attention-queue.spec.ts
+++ b/e2e/mentor-attention-queue.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('mentor dashboard surfaces a needs-attention queue for stale/overdue/unanswered mentees', async ({ page }) => {
+  const mentorEmail = uniqueEmail('attn-mentor');
+  const menteeEmail = uniqueEmail('attn-mentee');
+  const okMenteeEmail = uniqueEmail('attn-ok-mentee');
+  const mentor = await seedUser(mentorEmail, 'MentorPass123', 'MENTOR', 'Attention Mentor');
+  const mentee = await seedUser(menteeEmail, 'x', 'MENTEE', 'Needs Attention Mentee');
+  const okMentee = await seedUser(okMenteeEmail, 'x', 'MENTEE', 'Fine Mentee');
+
+  // Overdue stage deadline + unanswered question + pending meeting request, no interactions logged.
+  const rel = await prisma.mentorshipRelation.create({
+    data: {
+      mentorId: mentor.id,
+      menteeId: mentee.id,
+      status: 'ACTIVE',
+      stageDeadline: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000),
+    },
+  });
+  await prisma.mentorQuestion.create({
+    data: { relationId: rel.id, askedById: mentee.id, question: 'What should I prepare for the interview?' },
+  });
+  await prisma.meetingRequest.create({
+    data: { relationId: rel.id, requestedById: mentee.id, topic: 'Check-in', proposedAt: new Date(Date.now() + 86_400_000) },
+  });
+
+  // A fine relation with a recent interaction and nothing pending — should NOT appear.
+  const okRel = await prisma.mentorshipRelation.create({ data: { mentorId: mentor.id, menteeId: okMentee.id, status: 'ACTIVE' } });
+  await prisma.interactionLog.create({
+    data: { relationId: okRel.id, type: 'Meeting', notes: 'Recent sync', date: new Date() },
+  });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', mentorEmail);
+    await page.fill('input[type="password"]', 'MentorPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/mentor'), { timeout: 20_000 });
+
+    const queue = page.getByTestId('attention-queue');
+    await expect(queue.getByText(/Needs attention/i)).toBeVisible({ timeout: 10_000 });
+    const row = queue.getByRole('link', { name: /Needs Attention Mentee/ });
+    await expect(row).toBeVisible();
+    await expect(row.getByText(/No recent contact/i)).toBeVisible();
+    await expect(row.getByText(/Stage overdue/i)).toBeVisible();
+    await expect(row.getByText(/Unanswered question/i)).toBeVisible();
+    await expect(row.getByText(/Pending meeting request/i)).toBeVisible();
+
+    // The healthy relation is not in the attention queue (it may still
+    // legitimately appear elsewhere on the dashboard, e.g. "My mentees").
+    await expect(queue.getByText('Fine Mentee')).toHaveCount(0);
+  } finally {
+    await prisma.meetingRequest.deleteMany({ where: { relationId: rel.id } });
+    await prisma.mentorQuestion.deleteMany({ where: { relationId: rel.id } });
+    await prisma.mentorshipRelation.deleteMany({ where: { id: { in: [rel.id, okRel.id] } } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(okMenteeEmail);
+    await cleanupByEmail(mentorEmail);
+  }
+});

--- a/src/app/mentor/page.tsx
+++ b/src/app/mentor/page.tsx
@@ -1,8 +1,10 @@
 import { getServerSession } from 'next-auth';
 import { OnboardingChecklist } from '@/components/OnboardingChecklist';
+import { MentorAttentionQueue } from '@/components/MentorAttentionQueue';
 import { getServerDictionary } from "@/i18n/server";
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { getAttentionItems } from '@/lib/mentorAttention';
 import { Card, CardHeader, CardTitle, CardDescription } from '@/components/ui/Card';
 import { Badge, StatusBadge } from '@/components/ui/Badge';
 import { Users, BookOpen, MessageSquare, Calendar } from 'lucide-react';
@@ -55,6 +57,7 @@ export default async function MentorDashboard() {
   const session = await getServerSession(authOptions);
   const { t } = await getServerDictionary();
   const { relations, recentInteractions } = await getMentorData(session!.user.id);
+  const attentionItems = await getAttentionItems(session!.user.id);
 
   const activeRelations = relations.filter((r) => r.status === 'ACTIVE');
 
@@ -67,6 +70,8 @@ export default async function MentorDashboard() {
         </h1>
         <p className="text-gray-500 mt-1">{t.mentor.dashSubtitle}</p>
       </div>
+
+      <MentorAttentionQueue items={attentionItems} t={t} />
 
       {/* Stats */}
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-6 mb-8">

--- a/src/components/MentorAttentionQueue.tsx
+++ b/src/components/MentorAttentionQueue.tsx
@@ -1,0 +1,62 @@
+import Link from 'next/link';
+import { AlertTriangle } from 'lucide-react';
+import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
+import { Badge } from '@/components/ui/Badge';
+import type { AttentionItem, AttentionReason } from '@/lib/mentorAttention';
+import type { Dictionary } from '@/i18n/dictionaries';
+
+const REASON_VARIANT: Record<AttentionReason, 'warning' | 'danger' | 'info' | 'purple'> = {
+  inactive: 'warning',
+  overdue: 'danger',
+  unanswered_question: 'info',
+  pending_meeting: 'purple',
+};
+
+// Ranked "needs attention" widget on the mentor dashboard (EPIC: mentor
+// attention queue). Hides itself when nothing needs attention.
+export function MentorAttentionQueue({ items, t }: { items: AttentionItem[]; t: Dictionary }) {
+  if (items.length === 0) return null;
+  const labels = t.mentor.attention;
+  const reasonLabel: Record<AttentionReason, string> = {
+    inactive: labels.inactive,
+    overdue: labels.overdue,
+    unanswered_question: labels.unansweredQuestion,
+    pending_meeting: labels.pendingMeeting,
+  };
+
+  return (
+    <Card className="mb-6 border-amber-200 dark:border-amber-800" data-testid="attention-queue">
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <AlertTriangle className="h-5 w-5 text-amber-500" />
+          <CardTitle>{labels.title} ({items.length})</CardTitle>
+        </div>
+      </CardHeader>
+      <div className="divide-y divide-gray-50 dark:divide-gray-800">
+        {items.map((item) => (
+          <Link
+            key={item.relationId}
+            href={`/mentor/mentees/${item.relationId}`}
+            className="flex flex-wrap items-center justify-between gap-2 py-2.5 hover:bg-gray-50 dark:hover:bg-gray-800/60 -mx-2 px-2 rounded-lg transition-colors"
+          >
+            <div className="min-w-0">
+              <p className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">{item.menteeName}</p>
+              {item.daysSinceLastInteraction !== null && item.reasons.includes('inactive') && (
+                <p className="text-xs text-gray-500 dark:text-gray-400">
+                  {labels.daysAgo.replace('{d}', String(item.daysSinceLastInteraction))}
+                </p>
+              )}
+            </div>
+            <div className="flex flex-wrap gap-1">
+              {item.reasons.map((r) => (
+                <Badge key={r} variant={REASON_VARIANT[r]} className="text-xs">
+                  {reasonLabel[r]}
+                </Badge>
+              ))}
+            </div>
+          </Link>
+        ))}
+      </div>
+    </Card>
+  );
+}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -218,6 +218,14 @@ const en = {
     companyHintLink: 'Companies →',
   },
   mentor: {
+    attention: {
+      title: 'Needs attention',
+      inactive: 'No recent contact',
+      overdue: 'Stage overdue',
+      unansweredQuestion: 'Unanswered question',
+      pendingMeeting: 'Pending meeting request',
+      daysAgo: '{d} days since last interaction',
+    },
     welcomeBack: 'Welcome back',
     dashSubtitle: "Here's an overview of your mentees and interactions",
     activeMentees: 'Active Mentees',
@@ -1150,6 +1158,14 @@ const tr: Dict = {
     companyHintLink: 'Şirketler →',
   },
   mentor: {
+    attention: {
+      title: 'Dikkat gerektiriyor',
+      inactive: 'Yakın zamanda temas yok',
+      overdue: 'Aşama süresi geçti',
+      unansweredQuestion: 'Yanıtsız soru',
+      pendingMeeting: 'Bekleyen toplantı talebi',
+      daysAgo: 'Son etkileşimden bu yana {d} gün',
+    },
     welcomeBack: 'Tekrar hoş geldin',
     dashSubtitle: 'Mentee’lerine ve etkileşimlerine genel bakış',
     activeMentees: 'Aktif Mentee',
@@ -2080,6 +2096,14 @@ const de: Dict = {
     companyHintLink: 'Unternehmen →',
   },
   mentor: {
+    attention: {
+      title: 'Braucht Aufmerksamkeit',
+      inactive: 'Kein aktueller Kontakt',
+      overdue: 'Phase überfällig',
+      unansweredQuestion: 'Unbeantwortete Frage',
+      pendingMeeting: 'Ausstehende Terminanfrage',
+      daysAgo: '{d} Tage seit der letzten Interaktion',
+    },
     welcomeBack: 'Willkommen zurück',
     dashSubtitle: 'Hier ist ein Überblick über deine Mentees und Interaktionen',
     activeMentees: 'Aktive Mentees',

--- a/src/lib/mentorAttention.ts
+++ b/src/lib/mentorAttention.ts
@@ -1,0 +1,64 @@
+import { prisma } from '@/lib/prisma';
+import { getSetting } from '@/lib/settings';
+
+export type AttentionReason = 'inactive' | 'overdue' | 'unanswered_question' | 'pending_meeting';
+
+export interface AttentionItem {
+  relationId: string;
+  menteeId: string;
+  menteeName: string;
+  reasons: AttentionReason[];
+  daysSinceLastInteraction: number | null;
+}
+
+// A ranked "needs attention" list for a mentor's active mentees (EPIC: mentor
+// attention queue). Reuses the same inactivity threshold as the weekly email
+// digest (Setting.reminderDays, default 14) so the in-app view and the email
+// agree on what "stale" means.
+export async function getAttentionItems(mentorId: string): Promise<AttentionItem[]> {
+  const reminderDays = parseInt(await getSetting('reminderDays'), 10) || 14;
+  const now = Date.now();
+  const staleCutoff = new Date(now - reminderDays * 24 * 60 * 60 * 1000);
+
+  const relations = await prisma.mentorshipRelation.findMany({
+    where: { mentorId, status: 'ACTIVE' },
+    select: {
+      id: true,
+      stageDeadline: true,
+      mentee: { select: { id: true, fullName: true } },
+      interactions: { orderBy: { date: 'desc' }, take: 1, select: { date: true } },
+      questions: { where: { answer: null }, select: { id: true } },
+      meetingRequests: { where: { status: 'PENDING' }, select: { id: true } },
+    },
+  });
+
+  const items: AttentionItem[] = [];
+  for (const r of relations) {
+    const reasons: AttentionReason[] = [];
+    const last = r.interactions[0]?.date ?? null;
+    const daysSince = last ? Math.floor((now - last.getTime()) / (24 * 60 * 60 * 1000)) : null;
+
+    if (!last || last < staleCutoff) reasons.push('inactive');
+    if (r.stageDeadline && r.stageDeadline.getTime() < now) reasons.push('overdue');
+    if (r.questions.length > 0) reasons.push('unanswered_question');
+    if (r.meetingRequests.length > 0) reasons.push('pending_meeting');
+
+    if (reasons.length > 0) {
+      items.push({
+        relationId: r.id,
+        menteeId: r.mentee.id,
+        menteeName: r.mentee.fullName,
+        reasons,
+        daysSinceLastInteraction: daysSince,
+      });
+    }
+  }
+
+  // Most reasons first, then longest-inactive first.
+  items.sort((a, b) => {
+    if (b.reasons.length !== a.reasons.length) return b.reasons.length - a.reasons.length;
+    return (b.daysSinceLastInteraction ?? Infinity) - (a.daysSinceLastInteraction ?? Infinity);
+  });
+
+  return items;
+}


### PR DESCRIPTION
The mentor dashboard showed raw counts and per-mentee last-interaction days, but no actionable triage of who's falling behind. The underlying signals were already computed for email reminders but never surfaced in-app.

### What's included
- **`getAttentionItems(mentorId)`** (`lib/mentorAttention.ts`) — ranks active relations by:
  - No interaction in `reminderDays` (same `Setting` the weekly email digest already uses, default 14 — so the in-app view and the email agree on "stale")
  - Overdue `stageDeadline`
  - Unanswered `MentorQuestion`
  - Pending `MeetingRequest`

  Sorted most-reasons-first, then longest-inactive-first.
- **`MentorAttentionQueue`**: dashboard widget — hides itself when nothing needs attention, otherwise lists each mentee with color-coded reason badges, linking to their detail page.
- i18n: `mentor.attention.*` (EN/TR/DE).

### Verification
- `npx tsc --noEmit` and `next lint` clean.
- e2e (`e2e/mentor-attention-queue.spec.ts`): a relation with an overdue deadline + unanswered question + pending meeting request (no interactions logged) appears with all three badges; a healthy relation with a recent interaction does not appear in the queue.

Closes #374 · Refs #370
🤖 Generated with [Claude Code](https://claude.com/claude-code)