### PR TITLE
feat(mentor): private notes on a mentee (#375)

### DIFF
--- a/e2e/relation-notes.spec.ts
+++ b/e2e/relation-notes.spec.ts
@@ -23,10 +23,13 @@ test('mentor can add a private note on a mentee; the note stays mentor-only', as
     await page.waitForURL((u) => u.pathname.startsWith('/mentor'), { timeout: 20_000 });
 
     await page.goto(`/mentor/mentees/${rel.id}`);
-    await expect(page.getByText(/Private notes/i)).toBeVisible({ timeout: 10_000 });
-    await page.fill('textarea', 'Strong technical fit, a bit shy in meetings — check in 1:1.');
-    await page.getByRole('button', { name: /^Add note$/i }).click();
-    await expect(page.getByText('Strong technical fit, a bit shy in meetings — check in 1:1.')).toBeVisible({ timeout: 10_000 });
+    const panel = page.getByTestId('relation-notes-panel');
+    await expect(panel.getByText(/Private notes/i)).toBeVisible({ timeout: 10_000 });
+    // Scoped to this panel — the page has several other <textarea> fields
+    // (interaction log, evaluation, Q&A) an unscoped fill would hit instead.
+    await panel.locator('textarea').fill('Strong technical fit, a bit shy in meetings — check in 1:1.');
+    await panel.getByRole('button', { name: /^Add note$/i }).click();
+    await expect(panel.getByText('Strong technical fit, a bit shy in meetings — check in 1:1.')).toBeVisible({ timeout: 10_000 });
 
     // IDOR: an unrelated mentor cannot read notes on this relation.
     await page.context().clearCookies();

--- a/e2e/relation-notes.spec.ts
+++ b/e2e/relation-notes.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('mentor can add a private note on a mentee; the note stays mentor-only', async ({ page }) => {
+  const mentorEmail = uniqueEmail('note-mentor');
+  const menteeEmail = uniqueEmail('note-mentee');
+  const outsiderMentorEmail = uniqueEmail('note-outsider-mentor');
+  const mentor = await seedUser(mentorEmail, 'MentorPass123', 'MENTOR', 'Note Mentor');
+  const mentee = await seedUser(menteeEmail, 'MenteePass123', 'MENTEE', 'Note Mentee');
+  const outsiderMentor = await seedUser(outsiderMentorEmail, 'x', 'MENTOR', 'Outsider Mentor');
+  const rel = await prisma.mentorshipRelation.create({ data: { mentorId: mentor.id, menteeId: mentee.id, status: 'ACTIVE' } });
+
+  try {
+    // Mentor adds a private note.
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', mentorEmail);
+    await page.fill('input[type="password"]', 'MentorPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/mentor'), { timeout: 20_000 });
+
+    await page.goto(`/mentor/mentees/${rel.id}`);
+    await expect(page.getByText(/Private notes/i)).toBeVisible({ timeout: 10_000 });
+    await page.fill('textarea', 'Strong technical fit, a bit shy in meetings — check in 1:1.');
+    await page.getByRole('button', { name: /^Add note$/i }).click();
+    await expect(page.getByText('Strong technical fit, a bit shy in meetings — check in 1:1.')).toBeVisible({ timeout: 10_000 });
+
+    // IDOR: an unrelated mentor cannot read notes on this relation.
+    await page.context().clearCookies();
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', outsiderMentorEmail);
+    await page.fill('input[type="password"]', 'x');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/mentor'), { timeout: 20_000 });
+    const outsiderRes = await page.request.get(`/api/relation-notes?relationId=${rel.id}`);
+    expect(outsiderRes.status()).toBe(403);
+
+    // The mentee is never exposed to the note, even via the API directly.
+    await page.context().clearCookies();
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', menteeEmail);
+    await page.fill('input[type="password"]', 'MenteePass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/portal'), { timeout: 20_000 });
+    const menteeApiRes = await page.request.get(`/api/relation-notes?relationId=${rel.id}`);
+    expect(menteeApiRes.status()).toBe(403);
+  } finally {
+    await prisma.relationNote.deleteMany({ where: { relationId: rel.id } });
+    await prisma.mentorshipRelation.deleteMany({ where: { id: rel.id } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(outsiderMentorEmail);
+  }
+});

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -124,6 +124,7 @@ model User {
   personalNotes           PersonalNote[]
   consents                UserConsent[]
   companyInterests        CompanyInterest[]        @relation("CompanyInterestMentee")
+  authoredRelationNotes   RelationNote[]           @relation("RelationNoteAuthor")
 
   @@index([role])
 }
@@ -451,6 +452,7 @@ model MentorshipRelation {
   goals           Goal[]
   meetingRequests MeetingRequest[]
   questions       MentorQuestion[]
+  relationNotes   RelationNote[]
 
   @@index([status])
   @@index([pipelineStatus])
@@ -530,6 +532,23 @@ model PersonalNote {
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId])
+}
+
+// A mentor-private note on a mentorship relation (impressions, prep notes,
+// red flags) — visible only to the authoring mentor and admins, never the
+// mentee (EPIC: mentor private notes).
+model RelationNote {
+  id         String   @id @default(cuid())
+  relationId String
+  authorId   String
+  body       String   @db.Text
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  relation MentorshipRelation @relation(fields: [relationId], references: [id], onDelete: Cascade)
+  author   User               @relation("RelationNoteAuthor", fields: [authorId], references: [id], onDelete: Cascade)
+
+  @@index([relationId])
 }
 
 // A goal set within a mentorship — supports goal setting + tracking (checklist 7).

--- a/src/app/api/relation-notes/[id]/route.ts
+++ b/src/app/api/relation-notes/[id]/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+// DELETE — only the note's own author (or an admin) may remove it.
+export async function DELETE(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { id } = await params;
+  const note = await prisma.relationNote.findUnique({ where: { id }, select: { authorId: true } });
+  if (!note) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  if (note.authorId !== session.user.id && session.user.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  await prisma.relationNote.delete({ where: { id } });
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/relation-notes/route.ts
+++ b/src/app/api/relation-notes/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { z } from 'zod';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+const bodySchema = z.object({
+  relationId: z.string().min(1),
+  body: z.string().min(1).max(5000),
+});
+
+// A note is visible/writable only to the mentor of that relation, or an admin.
+async function canAccessRelation(userId: string, role: string, relationId: string) {
+  if (role === 'ADMIN') return true;
+  if (role !== 'MENTOR') return false;
+  const rel = await prisma.mentorshipRelation.findFirst({ where: { id: relationId, mentorId: userId }, select: { id: true } });
+  return !!rel;
+}
+
+// GET ?relationId=... — mentor-private notes on a mentorship relation
+// (EPIC: mentor private notes). Never exposed to the mentee.
+export async function GET(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const relationId = new URL(request.url).searchParams.get('relationId');
+  if (!relationId) return NextResponse.json({ error: 'relationId is required' }, { status: 400 });
+  if (!(await canAccessRelation(session.user.id, session.user.role, relationId))) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const notes = await prisma.relationNote.findMany({
+    where: { relationId },
+    orderBy: { createdAt: 'desc' },
+    include: { author: { select: { fullName: true } } },
+  });
+  return NextResponse.json({ notes });
+}
+
+// POST — add a note.
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+  const { relationId, body } = parsed.data;
+
+  if (!(await canAccessRelation(session.user.id, session.user.role, relationId))) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const note = await prisma.relationNote.create({
+    data: { relationId, authorId: session.user.id, body },
+    include: { author: { select: { fullName: true } } },
+  });
+  return NextResponse.json({ note }, { status: 201 });
+}

--- a/src/app/mentor/mentees/[id]/page.tsx
+++ b/src/app/mentor/mentees/[id]/page.tsx
@@ -15,6 +15,7 @@ import { EvaluationPanel } from '@/components/EvaluationPanel';
 import { GoalsPanel } from '@/components/GoalsPanel';
 import { MeetingRequestsPanel } from '@/components/MeetingRequestsPanel';
 import { QuestionsPanel } from '@/components/QuestionsPanel';
+import { RelationNotesPanel } from '@/components/RelationNotesPanel';
 import { ContactActions } from '@/components/ContactActions';
 import { UserActivityPanel } from '@/components/UserActivityPanel';
 import { DocumentsManager } from '@/components/DocumentsManager';
@@ -405,6 +406,10 @@ export default function MenteeDetailPage() {
 
         <div className="lg:col-span-2">
           <UserActivityPanel userId={relation.mentee.id} flagInactive />
+        </div>
+
+        <div className="lg:col-span-2">
+          <RelationNotesPanel relationId={id} />
         </div>
       </div>
     </div>

--- a/src/components/RelationNotesPanel.tsx
+++ b/src/components/RelationNotesPanel.tsx
@@ -51,7 +51,7 @@ export function RelationNotesPanel({ relationId }: { relationId: string }) {
   };
 
   return (
-    <Card>
+    <Card data-testid="relation-notes-panel">
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <Lock className="h-4 w-4 text-gray-400" /> {c.title}

--- a/src/components/RelationNotesPanel.tsx
+++ b/src/components/RelationNotesPanel.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Trash2, Lock } from 'lucide-react';
+import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
+import { Button } from '@/components/ui/Button';
+import { useT } from '@/i18n/client';
+
+interface Note {
+  id: string;
+  body: string;
+  createdAt: string;
+  author: { fullName: string };
+}
+
+// Mentor-private notes on a mentorship relation — impressions, prep notes,
+// red flags. Visible only to the authoring mentor (and admins); the mentee
+// never sees this panel or its data (EPIC: mentor private notes).
+export function RelationNotesPanel({ relationId }: { relationId: string }) {
+  const t = useT();
+  const c = t.relationNotes;
+  const [notes, setNotes] = useState<Note[]>([]);
+  const [body, setBody] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const load = useCallback(async () => {
+    const res = await fetch(`/api/relation-notes?relationId=${relationId}`);
+    if (res.ok) setNotes((await res.json()).notes ?? []);
+  }, [relationId]);
+  useEffect(() => { load(); }, [load]);
+
+  const add = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!body.trim()) return;
+    setSaving(true);
+    try {
+      const res = await fetch('/api/relation-notes', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ relationId, body }),
+      });
+      if (res.ok) { setBody(''); await load(); }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const remove = async (id: string) => {
+    await fetch(`/api/relation-notes/${id}`, { method: 'DELETE' });
+    await load();
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Lock className="h-4 w-4 text-gray-400" /> {c.title}
+        </CardTitle>
+      </CardHeader>
+      <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">{c.hint}</p>
+
+      <form onSubmit={add} className="mb-4">
+        <textarea
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          placeholder={c.placeholder}
+          rows={3}
+          className="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2 text-sm mb-2"
+        />
+        <Button type="submit" size="sm" loading={saving} disabled={!body.trim()}>{c.add}</Button>
+      </form>
+
+      {notes.length === 0 ? (
+        <p className="text-sm text-gray-400 text-center py-4">{c.none}</p>
+      ) : (
+        <div className="space-y-3">
+          {notes.map((n) => (
+            <div key={n.id} className="rounded-lg border border-gray-100 dark:border-gray-800 p-3">
+              <p className="text-sm text-gray-800 dark:text-gray-200 whitespace-pre-line">{n.body}</p>
+              <div className="flex items-center justify-between mt-2">
+                <p className="text-xs text-gray-400">
+                  {n.author.fullName} · {new Date(n.createdAt).toLocaleDateString()}
+                </p>
+                <button onClick={() => remove(n.id)} aria-label={t.common.delete} className="text-gray-300 hover:text-red-600 dark:text-gray-600 dark:hover:text-red-400">
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -41,6 +41,7 @@ const en = {
   },
   lang: { en: 'English', tr: 'Türkçe', label: 'Language' },
   a11y: { skipToContent: 'Skip to content' },
+  relationNotes: { title: 'Private notes', hint: 'Only you (and admins) can see these — never the mentee.', placeholder: 'Impressions, prep notes, things to remember…', add: 'Add note', none: 'No notes yet' },
   company: {
     title: 'Company overview',
     subtitle: 'Candidates linked to your company (read-only)',
@@ -981,6 +982,7 @@ const tr: Dict = {
   },
   lang: { en: 'English', tr: 'Türkçe', label: 'Dil' },
   a11y: { skipToContent: 'İçeriğe geç' },
+  relationNotes: { title: 'Özel notlar', hint: 'Bunları yalnızca sen (ve adminler) görebilir — mentee asla göremez.', placeholder: 'İzlenimler, hazırlık notları, hatırlanacaklar…', add: 'Not ekle', none: 'Henüz not yok' },
   company: {
     title: 'Şirket genel görünümü',
     subtitle: 'Şirketinize bağlı adaylar (salt-okunur)',
@@ -1919,6 +1921,7 @@ const de: Dict = {
   },
   lang: { en: 'English', tr: 'Türkçe', label: 'Sprache' },
   a11y: { skipToContent: 'Zum Inhalt springen' },
+  relationNotes: { title: 'Private Notizen', hint: 'Nur du (und Admins) siehst diese — nie der Mentee.', placeholder: 'Eindrücke, Vorbereitungsnotizen, Dinge zum Merken…', add: 'Notiz hinzufügen', none: 'Noch keine Notizen' },
   company: {
     title: 'Unternehmensübersicht',
     subtitle: 'Mit deinem Unternehmen verknüpfte Kandidaten (nur Lesezugriff)',


### PR DESCRIPTION
`PersonalNote` today is mentee-private only (a mentee's own reflections in the portal) — a mentor had nowhere to jot private observations about a mentee (impressions, red flags, prep notes for the next 1:1).

### What's included
- **Schema**: `RelationNote` (`relationId`, `authorId`, `body`) — mentor-private notes scoped to a mentorship relation.
- **`GET`/`POST /api/relation-notes`**, **`DELETE /api/relation-notes/[id]`**: authorized to the relation's mentor or an admin — **never the mentee**, verified with a direct API check, not just a hidden UI panel.
- **`RelationNotesPanel`** on the mentor mentee-detail page: add / list / delete, each note stamped with author + date.
- i18n: `relationNotes.*` (EN/TR/DE).

### Verification
- `npx tsc --noEmit` and `next lint` clean.
- e2e (`e2e/relation-notes.spec.ts`): a mentor adds a note and sees it; an **unrelated mentor** and the **mentee themself** both get 403 hitting the notes API directly for that relation (IDOR check).

Closes #375 · Refs #370
🤖 Generated with [Claude Code](https://claude.com/claude-code)