### PR TITLE
test(account-self-service): fix flaky reauth test (wait for PUT response)

### DIFF
--- a/e2e/account-self-service.spec.ts
+++ b/e2e/account-self-service.spec.ts
@@ -61,7 +61,11 @@ test('changing email requires the correct current password', async ({ page }) =>
     const emailForm = page.locator('form', { has: page.getByRole('button', { name: 'Update email' }) });
     await emailForm.getByLabel(/Email address/).fill(newEmail);
     await emailForm.getByLabel(/Current password/).fill('WrongPass999');
+    // Wait for the actual round-trip rather than racing the UI update against
+    // the assertion timeout — under CI load the request can outlast a tight window.
+    const done = page.waitForResponse((r) => r.url().includes('/api/account') && r.request().method() === 'PUT');
     await page.getByRole('button', { name: 'Update email' }).click();
+    await done;
 
     await expect(page.getByText(/Current password is incorrect/i)).toBeVisible({ timeout: 10_000 });
     const after = await prisma.user.findUnique({ where: { id: user.id } });


### PR DESCRIPTION
\`e2e/account-self-service.spec.ts:52\` ("changing email requires the correct current password") has flaked repeatedly this session — reproduced independently across several unrelated PRs (#390, #395, #396), always the same failure: the "Current password is incorrect" text never renders within the 10s window.

Root cause: the test asserted the error text right after clicking, racing the actual \`PUT /api/account\` round-trip against a fixed UI-render timeout — under CI load (many e2e specs running concurrently) the request can outlast that window. The **sibling test in the same file** already avoids this by \`await page.waitForResponse(...)\` before asserting; this applies the same pattern to the second test.

No production code changed — test-only stabilization.
🤖 Generated with [Claude Code](https://claude.com/claude-code)