### PR TITLE
feat(admin): hiring-funnel aging & SLA — time-in-stage, oldest stuck (#377)

### DIFF
--- a/e2e/analytics-aging.spec.ts
+++ b/e2e/analytics-aging.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('hiring funnel aging: overdue and stuck candidates are surfaced', async ({ page }) => {
+  const adminEmail = uniqueEmail('aging-admin');
+  const mentorEmail = uniqueEmail('aging-mentor');
+  const menteeEmail = uniqueEmail('aging-mentee');
+  await seedUser(adminEmail, 'AdminPass123', 'ADMIN', 'Aging Admin');
+  const mentor = await seedUser(mentorEmail, 'x', 'MENTOR', 'Aging Mentor');
+  const mentee = await seedUser(menteeEmail, 'x', 'MENTEE', 'Stuck Candidate');
+
+  // Active, overdue stage deadline, backdated startDate → clearly "stuck".
+  const rel = await prisma.mentorshipRelation.create({
+    data: {
+      mentorId: mentor.id,
+      menteeId: mentee.id,
+      status: 'ACTIVE',
+      pipelineStatus: 'INTERVIEW_PENDING_250',
+      startDate: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
+      stageDeadline: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000),
+    },
+  });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', 'AdminPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    const data = await (await page.request.get('/api/admin/analytics/aging')).json();
+    expect(data.overdueCount).toBeGreaterThanOrEqual(1);
+    const stuck = data.oldestStuck.find((it: { relationId: string }) => it.relationId === rel.id);
+    expect(stuck).toBeTruthy();
+    expect(stuck.daysInStage).toBeGreaterThanOrEqual(29);
+    expect(stuck.overdue).toBe(true);
+
+    await page.goto('/admin/analytics');
+    await expect(page.getByText(/Time in stage|Aşamada geçen süre/i)).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByRole('link', { name: /Stuck Candidate/ })).toBeVisible();
+  } finally {
+    await prisma.mentorshipRelation.deleteMany({ where: { id: rel.id } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -1,8 +1,11 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { AlertTriangle } from 'lucide-react';
 import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
+import { Badge } from '@/components/ui/Badge';
 import { PIPELINE_STATUSES, pipelineLabel } from '@/lib/pipeline';
 import { useT, useLocale } from '@/i18n/client';
 
@@ -15,6 +18,21 @@ interface Analytics {
   engagement: { interactions: number; meetings: number };
   rsvp: { ACCEPTED?: number; DECLINED?: number; PENDING?: number; acceptanceRate: number };
   trends?: { months: string[]; newRelations: number[]; interactions: number[] };
+}
+
+interface AgingItem {
+  relationId: string;
+  menteeId: string;
+  menteeName: string;
+  pipelineStatus: string;
+  daysInStage: number;
+  overdue: boolean;
+}
+interface Aging {
+  stageAging: { pipelineStatus: string; count: number; avgDays: number; medianDays: number }[];
+  oldestStuck: AgingItem[];
+  overdue: AgingItem[];
+  overdueCount: number;
 }
 
 function Stat({ label, value }: { label: string; value: string | number }) {
@@ -30,6 +48,7 @@ export default function AdminAnalyticsPage() {
   const t = useT();
   const locale = useLocale();
   const [data, setData] = useState<Analytics | null>(null);
+  const [aging, setAging] = useState<Aging | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -37,6 +56,10 @@ export default function AdminAnalyticsPage() {
       .then((r) => r.json())
       .then((d) => setData(d))
       .finally(() => setLoading(false));
+    fetch('/api/admin/analytics/aging')
+      .then((r) => r.json())
+      .then((d) => setAging(d))
+      .catch(() => {});
   }, []);
 
   if (loading) return <div className="text-center py-12 text-gray-400">{t.common.loading}</div>;
@@ -153,6 +176,63 @@ export default function AdminAnalyticsPage() {
           </Card>
         );
       })()}
+
+      {aging && (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mt-6">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                {t.analytics.aging.stageAging}
+                {aging.overdueCount > 0 && (
+                  <Badge variant="danger" className="flex items-center gap-1">
+                    <AlertTriangle className="h-3 w-3" /> {aging.overdueCount} {t.analytics.aging.overdue}
+                  </Badge>
+                )}
+              </CardTitle>
+            </CardHeader>
+            {aging.stageAging.length === 0 ? (
+              <p className="text-sm text-gray-400">—</p>
+            ) : (
+              <div className="divide-y divide-gray-50 dark:divide-gray-800">
+                {aging.stageAging.map((s) => (
+                  <div key={s.pipelineStatus} className="flex items-center justify-between py-2 text-sm">
+                    <span className="truncate">{pipelineLabel(s.pipelineStatus, locale)}</span>
+                    <span className="text-gray-500 flex-shrink-0">
+                      {t.analytics.aging.avg} {s.avgDays}{t.analytics.aging.days} · {t.analytics.aging.median} {s.medianDays}{t.analytics.aging.days} · {s.count} {t.analytics.aging.candidates}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </Card>
+
+          <Card>
+            <CardHeader><CardTitle>{t.analytics.aging.oldestStuck}</CardTitle></CardHeader>
+            {aging.oldestStuck.length === 0 ? (
+              <p className="text-sm text-gray-400">—</p>
+            ) : (
+              <div className="divide-y divide-gray-50 dark:divide-gray-800">
+                {aging.oldestStuck.map((it) => (
+                  <Link
+                    key={it.relationId}
+                    href={`/admin/candidates/${it.menteeId}`}
+                    className="flex items-center justify-between gap-2 py-2 text-sm hover:bg-gray-50 dark:hover:bg-gray-800/60 -mx-2 px-2 rounded-lg transition-colors"
+                  >
+                    <div className="min-w-0">
+                      <p className="truncate">{it.menteeName}</p>
+                      <p className="text-xs text-gray-400 truncate">{pipelineLabel(it.pipelineStatus, locale)}</p>
+                    </div>
+                    <span className="flex items-center gap-1.5 flex-shrink-0">
+                      {it.overdue && <AlertTriangle className="h-3.5 w-3.5 text-red-500" />}
+                      <span className="text-gray-500">{it.daysInStage}{t.analytics.aging.days}</span>
+                    </span>
+                  </Link>
+                ))}
+              </div>
+            )}
+          </Card>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/api/admin/analytics/aging/route.ts
+++ b/src/app/api/admin/analytics/aging/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+// GET — hiring-funnel aging & SLA (EPIC: HR funnel-aging). Reuses the
+// StatusChange audit trail to compute time-in-current-stage per active
+// relation, without a separate "stage entered at" column.
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const now = Date.now();
+  const relations = await prisma.mentorshipRelation.findMany({
+    where: { status: 'ACTIVE' },
+    select: {
+      id: true,
+      pipelineStatus: true,
+      startDate: true,
+      stageDeadline: true,
+      mentee: { select: { id: true, fullName: true } },
+      statusChanges: { orderBy: { createdAt: 'desc' }, take: 1, select: { createdAt: true } },
+    },
+  });
+
+  const items = relations.map((r) => {
+    const enteredStageAt = r.statusChanges[0]?.createdAt ?? r.startDate;
+    const daysInStage = Math.floor((now - enteredStageAt.getTime()) / (24 * 60 * 60 * 1000));
+    return {
+      relationId: r.id,
+      menteeId: r.mentee.id,
+      menteeName: r.mentee.fullName,
+      pipelineStatus: r.pipelineStatus,
+      daysInStage,
+      overdue: !!r.stageDeadline && r.stageDeadline.getTime() < now,
+    };
+  });
+
+  // Average + median days-in-stage per pipeline status.
+  const byStage = new Map<string, number[]>();
+  for (const it of items) {
+    if (!byStage.has(it.pipelineStatus)) byStage.set(it.pipelineStatus, []);
+    byStage.get(it.pipelineStatus)!.push(it.daysInStage);
+  }
+  const stageAging = Array.from(byStage.entries()).map(([pipelineStatus, days]) => {
+    const sorted = [...days].sort((a, b) => a - b);
+    const avg = Math.round(days.reduce((s, d) => s + d, 0) / days.length);
+    const median = sorted[Math.floor(sorted.length / 2)];
+    return { pipelineStatus, count: days.length, avgDays: avg, medianDays: median };
+  }).sort((a, b) => b.avgDays - a.avgDays);
+
+  const oldestStuck = [...items].sort((a, b) => b.daysInStage - a.daysInStage).slice(0, 10);
+  const overdue = items.filter((it) => it.overdue).sort((a, b) => b.daysInStage - a.daysInStage);
+
+  return NextResponse.json({ stageAging, oldestStuck, overdue, overdueCount: overdue.length });
+}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -738,6 +738,15 @@ const en = {
     none: 'No activity',
   },
   analytics: {
+    aging: {
+      stageAging: 'Time in stage',
+      oldestStuck: 'Oldest stuck candidates',
+      overdue: 'overdue',
+      avg: 'avg',
+      median: 'median',
+      days: 'd',
+      candidates: 'candidates',
+    },
     title: 'Analytics',
     subtitle: 'Pipeline, mentor workload and engagement insights',
     totalRelations: 'Relations',
@@ -1678,6 +1687,15 @@ const tr: Dict = {
     none: 'Aktivite yok',
   },
   analytics: {
+    aging: {
+      stageAging: 'Aşamada geçen süre',
+      oldestStuck: 'En uzun bekleyen adaylar',
+      overdue: 'süresi geçmiş',
+      avg: 'ort.',
+      median: 'medyan',
+      days: 'g',
+      candidates: 'aday',
+    },
     title: 'Analitik',
     subtitle: 'Pipeline, mentor yükü ve etkileşim içgörüleri',
     totalRelations: 'İlişkiler',
@@ -2616,6 +2634,15 @@ const de: Dict = {
     none: 'Keine Aktivität',
   },
   analytics: {
+    aging: {
+      stageAging: 'Zeit in Phase',
+      oldestStuck: 'Am längsten wartende Kandidaten',
+      overdue: 'überfällig',
+      avg: 'Ø',
+      median: 'Median',
+      days: 'T',
+      candidates: 'Kandidaten',
+    },
     title: 'Analysen',
     subtitle: 'Pipeline, Mentorenauslastung und Engagement-Erkenntnisse',
     totalRelations: 'Beziehungen',


### PR DESCRIPTION
The analytics dashboard showed a static funnel snapshot and a 6-month trend, but nothing about **where candidates get stuck or for how long**. The underlying data (`StatusChange` timestamps, `stageDeadline`) already existed for other features but was never aggregated into an aging view.

### What's included
- **`GET /api/admin/analytics/aging`**: for each active relation, time-in-current-stage is computed from the **latest `StatusChange` into that stage** (falls back to `startDate` when no transition has happened yet — no new column needed). Returns:
  - avg/median days-in-stage per pipeline status
  - the 10 **oldest-stuck** relations
  - the **overdue** set (`stageDeadline` in the past)
- **Admin analytics page**: two new cards — "Time in stage" (avg/median/count per stage, with an overdue-count badge) and "Oldest stuck candidates" (linking to the candidate detail page).
- i18n: `analytics.aging.*` (EN/TR/DE).

### Verification
- `npx tsc --noEmit` and `next lint` clean.
- e2e (`e2e/analytics-aging.spec.ts`): a backdated, overdue relation appears in `oldestStuck` with the correct day count and `overdue: true`, both via the API and rendered on the page.

Closes #377 · Refs #370
🤖 Generated with [Claude Code](https://claude.com/claude-code)