### PR TITLE
chore(release): mark the app as beta (0.2.0-beta)

### DIFF
--- a/e2e/beta-badge.spec.ts
+++ b/e2e/beta-badge.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from '@playwright/test';
+
+// The app is pre-1.0, so a "beta" badge sits next to the brand wordmark and the
+// version (package.json) carries a -beta suffix surfaced by the version footer.
+test('landing page shows the beta badge', async ({ page }) => {
+  await page.goto('/');
+  // The badge renders its label as exact text "beta" (the version footer shows
+  // "v0.2.0-beta", which is excluded by the exact match).
+  await expect(page.getByText('beta', { exact: true }).first()).toBeVisible();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "internship-crm",
-  "version": "0.1.0",
+  "version": "0.2.0-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "internship-crm",
-      "version": "0.1.0",
+      "version": "0.2.0-beta",
       "hasInstallScript": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.109.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.2.0",
+  "version": "0.2.0-beta",
   "private": true,
   "prisma": {
     "seed": "node prisma/seed.mjs"

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -2,6 +2,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
+import { BetaBadge } from '@/components/BetaBadge';
 import { GraduationCap, LogOut } from 'lucide-react';
 import { getServerDictionary } from '@/i18n/server';
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
@@ -37,6 +38,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
           <div className="flex items-center gap-2">
             <GraduationCap className="h-7 w-7 text-blue-600" />
             <span className="font-bold text-gray-900">InternshipCRM</span>
+            <BetaBadge />
           </div>
           <p className="text-xs text-gray-500 mt-1">{t.panel.admin}</p>
         </div>

--- a/src/app/company/layout.tsx
+++ b/src/app/company/layout.tsx
@@ -2,6 +2,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
+import { BetaBadge } from '@/components/BetaBadge';
 import { GraduationCap, LayoutDashboard, LogOut } from 'lucide-react';
 import { getServerDictionary } from '@/i18n/server';
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
@@ -30,6 +31,7 @@ export default async function CompanyLayout({ children }: { children: React.Reac
             <div className="flex items-center gap-2">
               <GraduationCap className="h-7 w-7 text-blue-600" />
               <span className="font-bold text-gray-900">InternshipCRM</span>
+              <BetaBadge />
             </div>
             <p className="text-xs text-gray-500 mt-1">{t.panel.company}</p>
           </div>

--- a/src/app/mentor/layout.tsx
+++ b/src/app/mentor/layout.tsx
@@ -2,6 +2,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
+import { BetaBadge } from '@/components/BetaBadge';
 import { GraduationCap, LayoutDashboard, Columns3, Users, BookOpen, Mail, CalendarClock, CalendarRange, CalendarDays, FolderGit2, LogOut } from 'lucide-react';
 import { getServerDictionary } from '@/i18n/server';
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
@@ -35,6 +36,7 @@ export default async function MentorLayout({ children }: { children: React.React
           <div className="flex items-center gap-2">
             <GraduationCap className="h-7 w-7 text-blue-600" />
             <span className="font-bold text-gray-900">InternshipCRM</span>
+            <BetaBadge />
           </div>
           <p className="text-xs text-gray-500 mt-1">{t.panel.mentor}</p>
         </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,7 @@ import { getServerDictionary } from '@/i18n/server';
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
 import { ThemeToggle } from '@/components/ThemeToggle';
 import { VersionFooter } from '@/components/VersionFooter';
+import { BetaBadge } from '@/components/BetaBadge';
 import { APP_VERSION } from '@/lib/version';
 
 export default async function HomePage() {
@@ -52,6 +53,7 @@ export default async function HomePage() {
             <div className="flex items-center gap-2 min-w-0">
               <GraduationCap className="h-7 w-7 sm:h-8 sm:w-8 text-blue-600 flex-shrink-0" />
               <span className="text-lg sm:text-xl font-bold text-gray-900 truncate">InternshipCRM</span>
+              <BetaBadge className="flex-shrink-0" />
             </div>
             <div className="flex items-center gap-2 sm:gap-4 flex-shrink-0">
               <LanguageSwitcher current={locale} />

--- a/src/app/portal/layout.tsx
+++ b/src/app/portal/layout.tsx
@@ -2,6 +2,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
+import { BetaBadge } from '@/components/BetaBadge';
 import { GraduationCap, LogOut } from 'lucide-react';
 import { getServerDictionary } from '@/i18n/server';
 import { PortalNav } from '@/components/PortalNav';
@@ -44,6 +45,7 @@ export default async function PortalLayout({ children }: { children: React.React
           <div className="flex items-center gap-2">
             <GraduationCap className="h-7 w-7 text-blue-600" />
             <span className="font-bold text-gray-900">InternshipCRM</span>
+            <BetaBadge />
           </div>
           <p className="text-xs text-gray-500 mt-1">{t.panel.mentee}</p>
         </div>

--- a/src/app/source/layout.tsx
+++ b/src/app/source/layout.tsx
@@ -2,6 +2,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
+import { BetaBadge } from '@/components/BetaBadge';
 import { GraduationCap, LayoutDashboard, LogOut } from 'lucide-react';
 import { getServerDictionary } from '@/i18n/server';
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
@@ -30,6 +31,7 @@ export default async function SourceLayout({ children }: { children: React.React
             <div className="flex items-center gap-2">
               <GraduationCap className="h-7 w-7 text-blue-600" />
               <span className="font-bold text-gray-900">InternshipCRM</span>
+              <BetaBadge />
             </div>
             <p className="text-xs text-gray-500 mt-1">{t.panel.source}</p>
           </div>

--- a/src/components/BetaBadge.tsx
+++ b/src/components/BetaBadge.tsx
@@ -1,0 +1,14 @@
+// Small "beta" badge shown next to the brand wordmark while the app is
+// pre-1.0. Kept as a tiny presentational component so every placement stays
+// consistent and the label can be changed in one place.
+export function BetaBadge({ className = '' }: { className?: string }) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-full bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase leading-none tracking-wide text-amber-700 dark:bg-amber-900/40 dark:text-amber-300 ${className}`}
+      title="Beta"
+      aria-label="Beta"
+    >
+      beta
+    </span>
+  );
+}

--- a/src/components/ResponsiveShell.tsx
+++ b/src/components/ResponsiveShell.tsx
@@ -5,6 +5,7 @@ import { Menu, X } from 'lucide-react';
 import { EmailVerificationBanner } from '@/components/EmailVerificationBanner';
 import { ImpersonationBanner } from '@/components/ImpersonationBanner';
 import { NotificationBell } from '@/components/NotificationBell';
+import { BetaBadge } from '@/components/BetaBadge';
 
 // App shell: sidebar is a static column on desktop and an off-canvas drawer
 // (with a hamburger top bar) on mobile.
@@ -24,6 +25,7 @@ export function ResponsiveShell({
       {/* Mobile top bar */}
       <div className="lg:hidden sticky top-0 z-30 flex items-center justify-between bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-800 h-14 px-4">
         <span className="font-bold text-gray-900 dark:text-gray-100">InternshipCRM</span>
+        <BetaBadge className="ml-2" />
         <div className="flex items-center gap-1">
           <NotificationBell />
           <button onClick={() => setOpen(true)} aria-label="Open menu" className="p-2 -mr-2 text-gray-600 hover:text-gray-900">

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,7 +13,7 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
-    version: '0.2.0',
+    version: '0.2.0-beta',
     date: '2026-07-01',
     highlights: {
       en: [
@@ -48,15 +48,15 @@ export const RELEASE_NOTES: ReleaseNote[] = [
     highlights: {
       en: [
         'The original platform: mentor–mentee pipeline tracking, role-based dashboards for admins, mentors, mentees and companies, interaction logging, analytics, document uploads, two-factor authentication, and multi-language support (EN/TR/DE).',
-        'This is a retroactive summary — detailed release notes start with 0.2.0.',
+        'This is a retroactive summary — detailed release notes start with 0.2.0-beta.',
       ],
       tr: [
         'Orijinal platform: mentor–mentee süreç takibi, admin/mentör/mentee/şirket için rol bazlı panolar, etkileşim kaydı, analitik, doküman yükleme, iki faktörlü kimlik doğrulama ve çok dilli destek (EN/TR/DE).',
-        'Bu geriye dönük bir özettir — detaylı sürüm notları 0.2.0 ile başlar.',
+        'Bu geriye dönük bir özettir — detaylı sürüm notları 0.2.0-beta ile başlar.',
       ],
       de: [
         'Die ursprüngliche Plattform: Mentor-Mentee-Pipeline-Tracking, rollenbasierte Dashboards für Admins, Mentoren, Mentees und Unternehmen, Interaktionsprotokolle, Analysen, Dokument-Uploads, Zwei-Faktor-Authentifizierung und mehrsprachige Unterstützung (EN/TR/DE).',
-        'Dies ist eine rückwirkende Zusammenfassung — detaillierte Versionshinweise beginnen mit 0.2.0.',
+        'Dies ist eine rückwirkende Zusammenfassung — detaillierte Versionshinweise beginnen mit 0.2.0-beta.',
       ],
     },
   },


### PR DESCRIPTION
## Summary

Makes the app's pre-1.0 status visible: a small `BetaBadge` next to the brand wordmark and a `-beta` version suffix.

Closes #404

## Changes

- New reusable `BetaBadge` component (small amber "beta" pill).
- Placed next to the brand wordmark in all role layouts (admin/mentor/portal/source/company), the mobile top bar (`ResponsiveShell`) and the landing header.
- `package.json` version `0.2.0` → `0.2.0-beta`, so the existing version footer renders `v0.2.0-beta` everywhere. Synced `package-lock.json` (its root version was stale at `0.1.0`).
- Added an e2e test asserting the badge shows on the landing page.

## Verification

- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] Added an e2e test (`beta-badge.spec.ts`); runs in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_