### PR TITLE
feat(ui): consolidate the crowded sidebar footer into an account menu

### DIFF
--- a/e2e/account-menu.spec.ts
+++ b/e2e/account-menu.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+
+const ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@example.com';
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'ChangeMe123!';
+
+// #410: the sidebar footer collapses into a single account menu. Sign-out,
+// language and theme live inside a popover, not stacked in the footer.
+test('sidebar account menu holds sign-out, language and theme behind one trigger', async ({ page }) => {
+  await page.goto('/auth/signin');
+  await page.fill('input[type="email"], input[name="email"]', ADMIN_EMAIL);
+  await page.fill('input[type="password"]', ADMIN_PASSWORD);
+  await page.click('button[type="submit"]');
+  await page.waitForURL((u) => !u.pathname.includes('/auth/signin'), { timeout: 20_000 });
+
+  await page.goto('/admin');
+
+  const trigger = page.locator('button[aria-haspopup="menu"]');
+  await expect(trigger).toBeVisible();
+
+  // Collapsed: the sign-out action is not shown until the menu opens.
+  await expect(page.getByRole('menuitem', { name: /sign out|çıkış/i })).toHaveCount(0);
+
+  await trigger.click();
+
+  const menu = page.getByRole('menu');
+  await expect(menu).toBeVisible();
+  await expect(menu.getByRole('menuitem', { name: /sign out|çıkış/i })).toBeVisible();
+  // Language + theme controls moved inside the menu.
+  await expect(menu.getByRole('button', { name: 'DE' })).toBeVisible();
+});

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -25,7 +25,9 @@ test('authenticated admin sees a Sign Out control', async ({ page }) => {
   await page.click('button[type="submit"]');
   await page.waitForURL((u) => !u.pathname.includes('/auth/signin'), { timeout: 20_000 });
   await page.goto('/admin');
-  await expect(page.getByRole('link', { name: /sign out/i })).toBeVisible();
+  // Sign Out now lives inside the account menu (open it first).
+  await page.locator('button[aria-haspopup="menu"]').click();
+  await expect(page.getByRole('menuitem', { name: /sign out/i })).toBeVisible();
 });
 
 test('admin sidebar links to the invite page', async ({ page }) => {

--- a/e2e/i18n-de.spec.ts
+++ b/e2e/i18n-de.spec.ts
@@ -24,7 +24,8 @@ test('German is available in the switcher and a saved preference is applied at s
     await expect(page.getByRole('link', { name: 'Kandidaten', exact: true })).toBeVisible({ timeout: 10_000 });
     await expect(page.getByRole('link', { name: 'Unternehmen', exact: true })).toBeVisible();
 
-    // A DE option is offered by the language switcher.
+    // A DE option is offered by the language switcher (inside the account menu).
+    await page.locator('button[aria-haspopup="menu"]').click();
     await expect(page.getByRole('button', { name: 'de', exact: true })).toBeVisible();
   } finally {
     await cleanupByEmail(email);

--- a/e2e/i18n.spec.ts
+++ b/e2e/i18n.spec.ts
@@ -14,7 +14,9 @@ test('language switcher toggles the admin nav between EN and TR', async ({ page 
   // Default locale is English (exact avoids matching the "Send Invitations" card)
   await expect(page.getByRole('link', { name: 'Send Invitation', exact: true })).toBeVisible();
 
-  // Switch to Turkish — the switcher sets a cookie and reloads
+  // Switch to Turkish — the switcher lives in the account menu; open it, then
+  // clicking TR sets a cookie and reloads.
+  await page.locator('button[aria-haspopup="menu"]').click();
   await page.getByRole('button', { name: 'tr' }).click();
   await page.waitForLoadState('load');
   await expect(page.getByRole('link', { name: 'Davet Gönder', exact: true })).toBeVisible();

--- a/e2e/layout.spec.ts
+++ b/e2e/layout.spec.ts
@@ -10,8 +10,9 @@ test('sidebar footer (Sign Out) stays in the viewport on long pages', async ({ p
   await page.click('button[type="submit"]');
   await page.waitForURL((u) => !u.pathname.includes('/auth/signin'), { timeout: 20_000 });
 
-  // Mentorships is a long list; the sticky sidebar should keep Sign Out on screen.
+  // Mentorships is a long list; the sticky sidebar should keep the account menu
+  // (which holds Sign Out) on screen.
   await page.goto('/admin/mentorship');
   await page.waitForTimeout(1000);
-  await expect(page.getByRole('link', { name: 'Sign Out', exact: true })).toBeInViewport();
+  await expect(page.locator('button[aria-haspopup="menu"]')).toBeInViewport();
 });

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,17 +1,13 @@
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { redirect } from 'next/navigation';
-import Link from 'next/link';
 import { BetaBadge } from '@/components/BetaBadge';
-import { GraduationCap, LogOut } from 'lucide-react';
+import { AccountMenu } from '@/components/AccountMenu';
+import { GraduationCap } from 'lucide-react';
 import { getServerDictionary } from '@/i18n/server';
-import { LanguageSwitcher } from '@/components/LanguageSwitcher';
-import { ThemeToggle } from '@/components/ThemeToggle';
-import { VersionFooter } from '@/components/VersionFooter';
 import { APP_VERSION } from '@/lib/version';
 import { ResponsiveShell } from '@/components/ResponsiveShell';
 import { AdminNav } from '@/components/AdminNav';
-import { SidebarAvatar } from '@/components/SidebarAvatar';
 import { GlobalSearch } from '@/components/GlobalSearch';
 import { prisma } from '@/lib/prisma';
 
@@ -45,31 +41,16 @@ export default async function AdminLayout({ children }: { children: React.ReactN
 
         <AdminNav />
 
-        <div className="p-4 border-t border-gray-200">
-          <Link
-            href="/admin/account"
-            title={t.account.title}
-            className="flex items-center gap-3 mb-3 px-3 py-1.5 rounded-lg hover:bg-gray-50 transition-colors"
-          >
-            <SidebarAvatar avatarUrl={me?.avatarUrl} name={session.user.name} fallback="A" className="bg-blue-100 text-blue-700" />
-            <div className="min-w-0">
-              <p className="text-sm font-medium text-gray-900 truncate">{session.user.name}</p>
-              <p className="text-xs text-gray-500 truncate">{session.user.email}</p>
-            </div>
-          </Link>
-          <Link
-            href="/api/auth/signout"
-            className="flex items-center gap-2 w-full px-3 py-2 text-sm text-red-600 hover:bg-red-50 rounded-lg transition-colors"
-          >
-            <LogOut className="h-4 w-4" />
-            {t.nav.signOut}
-          </Link>
-          <div className="mt-3 px-3 flex flex-col gap-2 items-start">
-            <LanguageSwitcher current={locale} />
-            <ThemeToggle />
-            <VersionFooter version={APP_VERSION} />
-          </div>
-        </div>
+        <AccountMenu
+          name={session.user.name}
+          email={session.user.email}
+          avatarUrl={me?.avatarUrl}
+          fallback="A"
+          avatarClassName="bg-blue-100 text-blue-700"
+          accountHref="/admin/account"
+          locale={locale}
+          version={APP_VERSION}
+        />
         </aside>
       }
     >

--- a/src/app/company/layout.tsx
+++ b/src/app/company/layout.tsx
@@ -3,15 +3,12 @@ import { authOptions } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import { BetaBadge } from '@/components/BetaBadge';
-import { GraduationCap, LayoutDashboard, LogOut } from 'lucide-react';
+import { AccountMenu } from '@/components/AccountMenu';
+import { GraduationCap, LayoutDashboard } from 'lucide-react';
 import { getServerDictionary } from '@/i18n/server';
-import { LanguageSwitcher } from '@/components/LanguageSwitcher';
-import { ThemeToggle } from '@/components/ThemeToggle';
-import { VersionFooter } from '@/components/VersionFooter';
 import { APP_VERSION } from '@/lib/version';
 import { ResponsiveShell } from '@/components/ResponsiveShell';
 import { InstallAppButton } from '@/components/InstallAppButton';
-import { SidebarAvatar } from '@/components/SidebarAvatar';
 import { prisma } from '@/lib/prisma';
 
 export default async function CompanyLayout({ children }: { children: React.ReactNode }) {
@@ -47,27 +44,16 @@ export default async function CompanyLayout({ children }: { children: React.Reac
             <InstallAppButton />
         </nav>
 
-          <div className="p-4 border-t border-gray-200">
-            <Link href="/account" title={t.account.nav} className="flex items-center gap-3 mb-3 px-3 py-1.5 rounded-lg hover:bg-gray-50 transition-colors">
-              <SidebarAvatar avatarUrl={me?.avatarUrl} name={session.user.name} fallback="C" className="bg-indigo-100 text-indigo-700" />
-              <div className="min-w-0">
-                <p className="text-sm font-medium text-gray-900 truncate">{session.user.name}</p>
-                <p className="text-xs text-gray-500 truncate">{session.user.email}</p>
-              </div>
-            </Link>
-            <Link
-              href="/api/auth/signout"
-              className="flex items-center gap-2 w-full px-3 py-2 text-sm text-red-600 hover:bg-red-50 rounded-lg transition-colors"
-            >
-              <LogOut className="h-4 w-4" />
-              {t.nav.signOut}
-            </Link>
-            <div className="mt-3 px-3 flex flex-col gap-2 items-start">
-              <LanguageSwitcher current={locale} />
-              <ThemeToggle />
-            <VersionFooter version={APP_VERSION} />
-            </div>
-          </div>
+          <AccountMenu
+            name={session.user.name}
+            email={session.user.email}
+            avatarUrl={me?.avatarUrl}
+            fallback="C"
+            avatarClassName="bg-indigo-100 text-indigo-700"
+            accountHref="/account"
+            locale={locale}
+            version={APP_VERSION}
+          />
         </aside>
       }
     >

--- a/src/app/mentor/layout.tsx
+++ b/src/app/mentor/layout.tsx
@@ -3,15 +3,12 @@ import { authOptions } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import { BetaBadge } from '@/components/BetaBadge';
-import { GraduationCap, LayoutDashboard, Columns3, Users, BookOpen, Mail, CalendarClock, CalendarRange, CalendarDays, FolderGit2, LogOut } from 'lucide-react';
+import { AccountMenu } from '@/components/AccountMenu';
+import { GraduationCap, LayoutDashboard, Columns3, Users, BookOpen, Mail, CalendarClock, CalendarRange, CalendarDays, FolderGit2 } from 'lucide-react';
 import { getServerDictionary } from '@/i18n/server';
-import { LanguageSwitcher } from '@/components/LanguageSwitcher';
-import { ThemeToggle } from '@/components/ThemeToggle';
-import { VersionFooter } from '@/components/VersionFooter';
 import { APP_VERSION } from '@/lib/version';
 import { ResponsiveShell } from '@/components/ResponsiveShell';
 import { InstallAppButton } from '@/components/InstallAppButton';
-import { SidebarAvatar } from '@/components/SidebarAvatar';
 import { prisma } from '@/lib/prisma';
 
 export default async function MentorLayout({ children }: { children: React.ReactNode }) {
@@ -108,27 +105,16 @@ export default async function MentorLayout({ children }: { children: React.React
           <InstallAppButton />
         </nav>
 
-        <div className="p-4 border-t border-gray-200">
-          <Link href="/account" title={t.account.nav} className="flex items-center gap-3 mb-3 px-3 py-1.5 rounded-lg hover:bg-gray-50 transition-colors">
-            <SidebarAvatar avatarUrl={me?.avatarUrl} name={session.user.name} fallback="M" className="bg-green-100 text-green-700" />
-            <div className="min-w-0">
-              <p className="text-sm font-medium text-gray-900 truncate">{session.user.name}</p>
-              <p className="text-xs text-gray-500 truncate">{session.user.email}</p>
-            </div>
-          </Link>
-          <Link
-            href="/api/auth/signout"
-            className="flex items-center gap-2 w-full px-3 py-2 text-sm text-red-600 hover:bg-red-50 rounded-lg transition-colors"
-          >
-            <LogOut className="h-4 w-4" />
-            {t.nav.signOut}
-          </Link>
-          <div className="mt-3 px-3 flex flex-col gap-2 items-start">
-            <LanguageSwitcher current={locale} />
-            <ThemeToggle />
-            <VersionFooter version={APP_VERSION} />
-          </div>
-        </div>
+        <AccountMenu
+          name={session.user.name}
+          email={session.user.email}
+          avatarUrl={me?.avatarUrl}
+          fallback="M"
+          avatarClassName="bg-green-100 text-green-700"
+          accountHref="/account"
+          locale={locale}
+          version={APP_VERSION}
+        />
         </aside>
       }
     >

--- a/src/app/portal/layout.tsx
+++ b/src/app/portal/layout.tsx
@@ -1,18 +1,14 @@
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { redirect } from 'next/navigation';
-import Link from 'next/link';
 import { BetaBadge } from '@/components/BetaBadge';
-import { GraduationCap, LogOut } from 'lucide-react';
+import { AccountMenu } from '@/components/AccountMenu';
+import { GraduationCap } from 'lucide-react';
 import { getServerDictionary } from '@/i18n/server';
 import { PortalNav } from '@/components/PortalNav';
-import { LanguageSwitcher } from '@/components/LanguageSwitcher';
-import { ThemeToggle } from '@/components/ThemeToggle';
-import { VersionFooter } from '@/components/VersionFooter';
 import { APP_VERSION } from '@/lib/version';
 import { ResponsiveShell } from '@/components/ResponsiveShell';
 import { InstallAppButton } from '@/components/InstallAppButton';
-import { SidebarAvatar } from '@/components/SidebarAvatar';
 import { prisma } from '@/lib/prisma';
 
 export default async function PortalLayout({ children }: { children: React.ReactNode }) {
@@ -55,27 +51,16 @@ export default async function PortalLayout({ children }: { children: React.React
           <InstallAppButton />
         </nav>
 
-        <div className="p-4 border-t border-gray-200">
-          <Link href="/account" title={t.account.nav} className="flex items-center gap-3 mb-3 px-3 py-1.5 rounded-lg hover:bg-gray-50 transition-colors">
-            <SidebarAvatar avatarUrl={me?.avatarUrl} name={session.user.name} fallback="M" className="bg-purple-100 text-purple-700" />
-            <div className="min-w-0">
-              <p className="text-sm font-medium text-gray-900 truncate">{session.user.name}</p>
-              <p className="text-xs text-gray-500 truncate">{session.user.email}</p>
-            </div>
-          </Link>
-          <Link
-            href="/api/auth/signout"
-            className="flex items-center gap-2 w-full px-3 py-2 text-sm text-red-600 hover:bg-red-50 rounded-lg transition-colors"
-          >
-            <LogOut className="h-4 w-4" />
-            {t.nav.signOut}
-          </Link>
-          <div className="mt-3 px-3 flex flex-col gap-2 items-start">
-            <LanguageSwitcher current={locale} />
-            <ThemeToggle />
-            <VersionFooter version={APP_VERSION} />
-          </div>
-        </div>
+        <AccountMenu
+          name={session.user.name}
+          email={session.user.email}
+          avatarUrl={me?.avatarUrl}
+          fallback="M"
+          avatarClassName="bg-purple-100 text-purple-700"
+          accountHref="/account"
+          locale={locale}
+          version={APP_VERSION}
+        />
         </aside>
       }
     >

--- a/src/app/source/layout.tsx
+++ b/src/app/source/layout.tsx
@@ -3,15 +3,12 @@ import { authOptions } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import { BetaBadge } from '@/components/BetaBadge';
-import { GraduationCap, LayoutDashboard, LogOut } from 'lucide-react';
+import { AccountMenu } from '@/components/AccountMenu';
+import { GraduationCap, LayoutDashboard } from 'lucide-react';
 import { getServerDictionary } from '@/i18n/server';
-import { LanguageSwitcher } from '@/components/LanguageSwitcher';
-import { ThemeToggle } from '@/components/ThemeToggle';
-import { VersionFooter } from '@/components/VersionFooter';
 import { APP_VERSION } from '@/lib/version';
 import { ResponsiveShell } from '@/components/ResponsiveShell';
 import { InstallAppButton } from '@/components/InstallAppButton';
-import { SidebarAvatar } from '@/components/SidebarAvatar';
 import { prisma } from '@/lib/prisma';
 
 export default async function SourceLayout({ children }: { children: React.ReactNode }) {
@@ -47,27 +44,16 @@ export default async function SourceLayout({ children }: { children: React.React
             <InstallAppButton />
           </nav>
 
-          <div className="p-4 border-t border-gray-200">
-            <Link href="/account" title={t.account.nav} className="flex items-center gap-3 mb-3 px-3 py-1.5 rounded-lg hover:bg-gray-50 transition-colors">
-              <SidebarAvatar avatarUrl={me?.avatarUrl} name={session.user.name} fallback="S" className="bg-green-100 text-green-700" />
-              <div className="min-w-0">
-                <p className="text-sm font-medium text-gray-900 truncate">{session.user.name}</p>
-                <p className="text-xs text-gray-500 truncate">{session.user.email}</p>
-              </div>
-            </Link>
-            <Link
-              href="/api/auth/signout"
-              className="flex items-center gap-2 w-full px-3 py-2 text-sm text-red-600 hover:bg-red-50 rounded-lg transition-colors"
-            >
-              <LogOut className="h-4 w-4" />
-              {t.nav.signOut}
-            </Link>
-            <div className="mt-3 px-3 flex flex-col gap-2 items-start">
-              <LanguageSwitcher current={locale} />
-              <ThemeToggle />
-            <VersionFooter version={APP_VERSION} />
-            </div>
-          </div>
+          <AccountMenu
+            name={session.user.name}
+            email={session.user.email}
+            avatarUrl={me?.avatarUrl}
+            fallback="S"
+            avatarClassName="bg-green-100 text-green-700"
+            accountHref="/account"
+            locale={locale}
+            version={APP_VERSION}
+          />
         </aside>
       }
     >

--- a/src/components/AccountMenu.tsx
+++ b/src/components/AccountMenu.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+import Link from 'next/link';
+import { LogOut, Settings, ChevronUp } from 'lucide-react';
+import { SidebarAvatar } from '@/components/SidebarAvatar';
+import { LanguageSwitcher } from '@/components/LanguageSwitcher';
+import { ThemeToggle } from '@/components/ThemeToggle';
+import { VersionFooter } from '@/components/VersionFooter';
+import { useT } from '@/i18n/client';
+import type { Locale } from '@/i18n/config';
+
+// Consolidated sidebar footer: the collapsed row shows just the user's identity
+// (avatar + name + email) and a chevron; clicking opens an upward popover with
+// the account link, sign-out, language + theme controls and the version. Keeps
+// the footer from becoming a crowded stack of controls.
+export function AccountMenu({
+  name,
+  email,
+  avatarUrl,
+  fallback,
+  avatarClassName,
+  accountHref,
+  locale,
+  version,
+}: {
+  name?: string | null;
+  email?: string | null;
+  avatarUrl?: string | null;
+  fallback: string;
+  avatarClassName: string;
+  accountHref: string;
+  locale: Locale;
+  version: string;
+}) {
+  const t = useT();
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', onClick);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onClick);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  return (
+    <div ref={ref} className="relative p-4 border-t border-gray-200 dark:border-gray-800">
+      {open && (
+        <div
+          role="menu"
+          className="absolute bottom-full left-4 right-4 mb-2 rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 shadow-lg p-2 z-50"
+        >
+          <Link
+            href={accountHref}
+            role="menuitem"
+            onClick={() => setOpen(false)}
+            className="flex items-center gap-2 px-3 py-2 rounded-lg text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+          >
+            <Settings className="h-4 w-4" />
+            {t.account.nav}
+          </Link>
+          <Link
+            href="/api/auth/signout"
+            role="menuitem"
+            className="flex items-center gap-2 px-3 py-2 rounded-lg text-sm text-red-600 hover:bg-red-50 dark:hover:bg-red-900/30 transition-colors"
+          >
+            <LogOut className="h-4 w-4" />
+            {t.nav.signOut}
+          </Link>
+          <div className="my-1 border-t border-gray-100 dark:border-gray-800" />
+          <div className="flex items-center justify-between gap-2 px-3 py-1.5">
+            <LanguageSwitcher current={locale} />
+            <ThemeToggle />
+          </div>
+          <div className="px-3 pt-1">
+            <VersionFooter version={version} />
+          </div>
+        </div>
+      )}
+
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={t.account.nav}
+        className="flex items-center gap-3 w-full px-3 py-1.5 rounded-lg text-left hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+      >
+        <SidebarAvatar avatarUrl={avatarUrl} name={name} fallback={fallback} className={avatarClassName} />
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">{name}</p>
+          <p className="text-xs text-gray-500 truncate">{email}</p>
+        </div>
+        <ChevronUp className={`h-4 w-4 shrink-0 text-gray-400 transition-transform ${open ? 'rotate-180' : ''}`} />
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

The sidebar footer was a crowded vertical stack — avatar + name + email, **Sign out**, the **EN/TR/DE** switcher, the **theme** toggle and the **version**. This replaces it, across all five role layouts, with a shared **`AccountMenu`** popover.

Closes #410

## Before → After

- **Collapsed footer:** just the identity row (avatar + name + email) with a chevron — one clean line.
- **On click:** an upward popover with **Account settings**, **Sign out**, the **language** switcher, the **theme** toggle, and the **version** at the bottom.
- Closes on outside-click / Escape; `aria-haspopup`/`aria-expanded` on the trigger, `role="menu"`/`menuitem` inside.

## Changes

- New shared `src/components/AccountMenu.tsx` (client).
- All 5 layouts (`admin`, `mentor`, `portal`, `source`, `company`) now render `<AccountMenu … />` instead of the inline footer block; removed the now-unused imports.
- e2e (`account-menu.spec.ts`): the trigger is present, sign-out is hidden until opened, and language/theme live inside the menu.

## Verification

- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] e2e added; runs in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_