### PR TITLE
fix(invite): dark-mode contrast on the How it works panel

### DIFF
--- a/src/app/admin/invite/page.tsx
+++ b/src/app/admin/invite/page.tsx
@@ -181,9 +181,9 @@ export default function InvitePage() {
             </Link>
           </p>
 
-          <div className="mt-6 p-4 bg-blue-50 rounded-xl">
-            <p className="text-sm font-medium text-blue-800 mb-2">{t.invite.howItWorks}</p>
-            <ol className="text-sm text-blue-700 space-y-1 list-decimal list-inside">
+          <div className="mt-6 p-4 bg-blue-50 dark:bg-blue-950/40 border border-blue-200 dark:border-blue-800 rounded-xl">
+            <p className="text-sm font-medium text-blue-800 dark:text-blue-200 mb-2">{t.invite.howItWorks}</p>
+            <ol className="text-sm text-blue-700 dark:text-blue-300 space-y-1 list-decimal list-inside">
               <li>{t.invite.step1}</li>
               <li>{t.invite.step2}</li>
               <li>{t.invite.step3}</li>


### PR DESCRIPTION
Screenshot from the user showed the invite page's "How it works" box (light-blue-tinted card with numbered steps) rendering with unreadable text in dark mode.

### Cause
`bg-blue-50`, `text-blue-800`, and `text-blue-700` had no `dark:` variants, so dark mode kept the light-mode colors.

### Fix
Added `dark:bg-blue-950/40`, `dark:border-blue-800`, `dark:text-blue-200` (heading), `dark:text-blue-300` (list) — the same pattern already used in `admin/candidates` and `mentor/mentees/[id]`.

### Verification
- `tsc --noEmit` / `next lint` clean.
- Computed WCAG contrast for the new dark-mode colors against the composited `blue-950/40` background: heading ≈ 11.7:1, list text ≈ 9.2:1 — both pass AAA (≥7:1). Didn't sign into the shared preview DB to screenshot live since I don't have those admin credentials in this session; the classes are copy-identical to the already-working pattern elsewhere in the app.