### PR TITLE
fix(admin): impersonation error feedback + destructive-action hardening (EPIC C)

### DIFF
--- a/e2e/impersonation-governance.spec.ts
+++ b/e2e/impersonation-governance.spec.ts
@@ -34,3 +34,61 @@ test('impersonation records a reason and notifies the impersonated user', async 
     await cleanupByEmail(adminEmail);
   }
 });
+
+test('impersonating another admin is rejected by the API', async ({ page }) => {
+  const adminEmail = uniqueEmail('ig-admin2');
+  const otherAdminEmail = uniqueEmail('ig-other-admin');
+  await seedUser(adminEmail, 'AdminPass123', 'ADMIN', 'IG Admin Two');
+  const otherAdmin = await seedUser(otherAdminEmail, 'x', 'ADMIN', 'IG Other Admin');
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', 'AdminPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    const res = await page.request.post('/api/admin/impersonate', {
+      data: { targetUserId: otherAdmin.id },
+    });
+    expect(res.status()).toBe(400);
+    expect((await res.json()).error).toContain('admin');
+    const started = await prisma.auditLog.findFirst({
+      where: { action: 'IMPERSONATE_START', targetId: otherAdmin.id },
+    });
+    expect(started).toBeNull();
+  } finally {
+    await cleanupByEmail(otherAdminEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});
+
+test('a failed impersonation attempt shows an inline error and re-enables the button', async ({ page }) => {
+  const adminEmail = uniqueEmail('ig-admin3');
+  const otherAdminEmail = uniqueEmail('ig-other-admin2');
+  await seedUser(adminEmail, 'AdminPass123', 'ADMIN', 'IG Admin Three');
+  const otherAdmin = await seedUser(otherAdminEmail, 'x', 'ADMIN', 'IG Other Admin Two');
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', 'AdminPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    await page.goto('/admin/users');
+    page.once('dialog', (d) => d.dismiss());
+    const row = page.getByTestId(`user-row-${otherAdmin.id}`);
+    await expect(row).toBeVisible({ timeout: 10_000 });
+    await row.getByRole('button', { name: 'Login as' }).click();
+
+    await expect(row.getByText(/cannot impersonate an admin/i)).toBeVisible({ timeout: 10_000 });
+    // The button resets to clickable rather than staying stuck disabled.
+    await expect(row.getByRole('button', { name: 'Login as' })).toBeEnabled();
+    // No session/route change happened.
+    expect(page.url()).toContain('/admin/users');
+  } finally {
+    await cleanupByEmail(otherAdminEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -40,11 +40,14 @@ export default function AdminUsersPage() {
   const [search, setSearch] = useState('');
   const [page, setPage] = useState(1);
   const [busyId, setBusyId] = useState<string | null>(null);
+  const [impersonateError, setImpersonateError] = useState<{ userId: string; message: string } | null>(null);
   const PAGE_SIZE = 20;
 
   const loginAs = async (u: AdminUser) => {
+    if (busyId) return; // guard against a double-click firing two grants at once
     const reason = window.prompt(t.usersAdmin.impersonateReason) ?? undefined;
     setBusyId(u.id);
+    setImpersonateError(null);
     try {
       const res = await fetch('/api/admin/impersonate', {
         method: 'POST',
@@ -52,15 +55,16 @@ export default function AdminUsersPage() {
         body: JSON.stringify({ targetUserId: u.id, reason }),
       });
       const data = await res.json();
-      if (!res.ok) throw new Error(data.error);
+      if (!res.ok) throw new Error(data.error || t.usersAdmin.impersonateFailed);
       const signed = await signIn('impersonate', { grant: data.grant, redirect: false });
       if (signed?.ok) {
         router.push(roleHome(u.role));
         router.refresh();
         return;
       }
-    } catch {
-      // fall through to reset busy state
+      throw new Error(t.usersAdmin.impersonateFailed);
+    } catch (err) {
+      setImpersonateError({ userId: u.id, message: err instanceof Error ? err.message : t.usersAdmin.impersonateFailed });
     }
     setBusyId(null);
   };
@@ -151,6 +155,9 @@ export default function AdminUsersPage() {
                     <p className="text-sm font-medium text-gray-900 truncate">{u.fullName}</p>
                   )}
                   <p className="text-xs text-gray-500 truncate">{u.email}</p>
+                  {impersonateError?.userId === u.id && (
+                    <p className="text-xs text-red-600 mt-1">{impersonateError.message}</p>
+                  )}
                 </div>
                 <div className="flex flex-wrap items-center gap-2">
                   <Badge variant={ROLE_VARIANT[u.role]}>{t.usersAdmin[u.role.toLowerCase() as RoleLabel]}</Badge>
@@ -158,7 +165,7 @@ export default function AdminUsersPage() {
                     {u.isActive ? t.usersAdmin.active : t.usersAdmin.inactive}
                   </Badge>
                   {u.id !== session?.user?.id && (
-                    <Button variant="ghost" size="sm" disabled={busyId === u.id} onClick={() => loginAs(u)}>
+                    <Button variant="ghost" size="sm" loading={busyId === u.id} disabled={!!busyId} onClick={() => loginAs(u)}>
                       {t.usersAdmin.loginAs}
                     </Button>
                   )}

--- a/src/app/api/account/route.ts
+++ b/src/app/api/account/route.ts
@@ -20,6 +20,10 @@ export async function PUT(request: Request) {
     if (!session) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
+    // Don't allow rotating the impersonated user's email/password while impersonating it.
+    if (session.user.impersonatorId) {
+      return NextResponse.json({ error: 'Cannot change account credentials while impersonating' }, { status: 400 });
+    }
     const parsed = schema.safeParse(await request.json());
     if (!parsed.success) {
       return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 });

--- a/src/app/api/admin/impersonate/route.ts
+++ b/src/app/api/admin/impersonate/route.ts
@@ -30,6 +30,11 @@ export async function POST(request: Request) {
   if (!target) {
     return NextResponse.json({ error: 'Target user not found' }, { status: 404 });
   }
+  // Impersonating another admin would grant elevated destructive access while
+  // masked as a different session — never allowed, regardless of reason.
+  if (target.role === 'ADMIN') {
+    return NextResponse.json({ error: 'Cannot impersonate an admin account' }, { status: 400 });
+  }
 
   const reason = parsed.data.reason?.trim() || null;
   const grant = await createImpersonationGrant(session.user.id, target.id, 'START');

--- a/src/components/ImpersonationBanner.tsx
+++ b/src/components/ImpersonationBanner.tsx
@@ -13,22 +13,27 @@ export function ImpersonationBanner() {
   const router = useRouter();
   const { data: session } = useSession();
   const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   if (!session?.user?.impersonatorName) return null;
 
   const stop = async () => {
     setBusy(true);
+    setError(null);
     try {
       const res = await fetch('/api/impersonate/stop', { method: 'POST' });
       const data = await res.json();
       if (res.ok) {
-        await signIn('impersonate', { grant: data.grant, redirect: false });
-        router.push('/admin/users');
-        router.refresh();
-        return;
+        const signed = await signIn('impersonate', { grant: data.grant, redirect: false });
+        if (signed?.ok) {
+          router.push('/admin/users');
+          router.refresh();
+          return;
+        }
       }
+      setError(t.impersonation.stopFailed);
     } catch {
-      /* ignore */
+      setError(t.impersonation.stopFailed);
     }
     setBusy(false);
   };
@@ -39,6 +44,7 @@ export function ImpersonationBanner() {
       <span className="flex-1 min-w-0">
         {t.impersonation.viewingAs.replace('{name}', session.user.name ?? '')}
       </span>
+      {error && <span className="text-red-700 dark:text-red-300">{error}</span>}
       <button onClick={stop} disabled={busy} className="font-semibold underline hover:no-underline disabled:opacity-50">
         {t.impersonation.return}
       </button>

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -416,12 +416,14 @@ const en = {
     deactivate: 'Deactivate',
     loginAs: 'Login as',
     impersonateReason: 'Reason for accessing this account (optional):',
+    impersonateFailed: 'Could not start impersonation. Please try again.',
     none: 'No users',
     searchPlaceholder: 'Search by name or email...',
   },
   impersonation: {
     viewingAs: 'You are viewing the app as {name}.',
     return: 'Return to your account',
+    stopFailed: 'Could not return to your account. Please try again.',
   },
   adminBoard: {
     subtitle: 'All mentees across every mentor — drag a card to change its stage',
@@ -1436,12 +1438,14 @@ const tr: Dict = {
     deactivate: 'Pasifleştir',
     loginAs: 'Bu kullanıcı gibi gir',
     impersonateReason: 'Bu hesaba erişme nedeni (opsiyonel):',
+    impersonateFailed: 'Taklit oturumu başlatılamadı. Lütfen tekrar deneyin.',
     none: 'Kullanıcı yok',
     searchPlaceholder: 'Ad veya e-posta ile ara...',
   },
   impersonation: {
     viewingAs: 'Uygulamayı {name} olarak görüntülüyorsun.',
     return: 'Kendi hesabına dön',
+    stopFailed: 'Kendi hesabına dönülemedi. Lütfen tekrar deneyin.',
   },
   adminBoard: {
     subtitle: 'Tüm mentorların tüm mentee’leri — aşamayı değiştirmek için kartı sürükle',
@@ -2454,12 +2458,14 @@ const de: Dict = {
     deactivate: 'Deaktivieren',
     loginAs: 'Anmelden als',
     impersonateReason: 'Grund für den Zugriff auf dieses Konto (optional):',
+    impersonateFailed: 'Der Identitätswechsel konnte nicht gestartet werden. Bitte versuche es erneut.',
     none: 'Keine Benutzer',
     searchPlaceholder: 'Nach Name oder E-Mail suchen...',
   },
   impersonation: {
     viewingAs: 'Du siehst die App als {name}.',
     return: 'Zu deinem Konto zurückkehren',
+    stopFailed: 'Rückkehr zu deinem Konto fehlgeschlagen. Bitte versuche es erneut.',
   },
   adminBoard: {
     subtitle: 'Alle Mentees aller Mentoren — ziehe eine Karte, um die Phase zu ändern',


### PR DESCRIPTION
Closes #416

### Investigation
The issue's own note flagged the start→banner→stop chain as likely broken client-side (session not refreshing after `signIn(..., {redirect:false})`). Before patching that blind, I verified it directly:
- Read `next-auth`'s client `signIn()` source (`node_modules/next-auth/react/index.js`): on a successful credentials-provider sign-in with `redirect:false`, it already calls `__NEXTAUTH._getSession({event:'storage'})`, which refetches `/api/auth/session` and updates every `useSession()` subscriber via the shared `SessionProvider` state — no manual `update()`/reload needed.
- Confirmed against the latest green CI run (`gh run view 28542118659 --log`): all three impersonation tests pass today on `main`, including the one that asserts the "viewing the app as" banner appears and disappears across start/stop.

So the specific "session doesn't switch, banner never shows" symptom is **not reproducible against current `main`** — I didn't want to ship an unverifiable fix for a bug I can't observe. What I did find and fix are the acceptance criteria that ARE genuinely unmet:

### What's included
- **Silent failure → visible error.** If the impersonate-start (or stop) call actually fails (expired/consumed grant, race, network blip), the UI previously just re-enabled the button with zero feedback — exactly matching the reported symptom for that one failure path. Now shows an inline message and the same for the "return to your account" banner.
- **Double-click guard** on "Login as" so two grants can't be requested concurrently.
- **Can no longer impersonate another ADMIN** (`/api/admin/impersonate` now rejects `target.role === 'ADMIN'` with 400) — removes the single biggest "destructive action while masked" risk outright, rather than trying to guard every admin-only destructive route individually.
- **Email/password changes blocked while impersonating** (`PUT /api/account`), mirroring the existing self-delete-while-impersonating guard.
- i18n: `usersAdmin.impersonateFailed` / `impersonation.stopFailed` added in EN/TR/DE.

### Verification
- `tsc --noEmit` / `next lint` clean (also regenerated the Prisma client — schema had drifted from a since-merged PR).
- e2e (`e2e/impersonation-governance.spec.ts`): impersonating an admin is rejected at the API (400, no audit-log entry created) and via the UI (inline error shown on the exact row, button re-enables, no navigation away from `/admin/users`).
- Existing `impersonation.spec.ts` / `impersonation-governance.spec.ts` untouched assertions still pass — this doesn't change the working start/banner/stop path, only the failure path and the admin-impersonating-admin case.

### Deferred
Auto-expiry (30 min cap), reason capture, and audit logging already exist and work (`src/lib/auth.ts` JWT callback, `createImpersonationGrant`) — not touched here. If the original symptom recurs, it's most likely production-environment-specific (cookie/proxy config) rather than app-code, since the exact same code path is what CI just exercised successfully.