### PR TITLE
fix(mentor): move mentee activity feed below private notes

### DIFF
--- a/src/app/mentor/mentees/[id]/page.tsx
+++ b/src/app/mentor/mentees/[id]/page.tsx
@@ -405,11 +405,13 @@ export default function MenteeDetailPage() {
         </div>
 
         <div className="lg:col-span-2">
-          <UserActivityPanel userId={relation.mentee.id} flagInactive />
+          <RelationNotesPanel relationId={id} />
         </div>
 
+        {/* Activity feed sits last — it's the least frequently acted-on panel,
+            so private notes and the working panels stay above the fold. */}
         <div className="lg:col-span-2">
-          <RelationNotesPanel relationId={id} />
+          <UserActivityPanel userId={relation.mentee.id} flagInactive />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

On the mentor's mentee-detail screen (`/mentor/mentees/[id]`), the **activity feed ("Aktivite")** sat above the **private notes ("Özel notlar")** panel, pushing the panels a mentor actually works in further down the page.

Per user feedback ("bu ekranda aktiviteler altta olsa daha iyi olur"), the activity feed is the least frequently acted-on panel, so it now sits **last** — private notes and the working panels stay higher up.

## Changes

- `src/app/mentor/mentees/[id]/page.tsx`: swap the order of `RelationNotesPanel` and `UserActivityPanel` so the activity feed renders at the bottom.

Pure JSX reorder — no logic, imports, or data changes.

## Verification

- [x] `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_