### PR TITLE
fix(i18n): localize status badges, next-action, interaction types, 404 (EPIC E)

### DIFF
--- a/e2e/not-found.spec.ts
+++ b/e2e/not-found.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+// EPIC E (#418): the 404 page must be localized (was hardcoded English) and
+// render our own styled page rather than Next's default.
+test('unknown routes render the localized 404 page with a home link', async ({ page }) => {
+  const res = await page.goto('/this-route-truly-does-not-exist-xyz');
+  expect(res?.status()).toBe(404);
+
+  // Our custom page shows the big 404 and a link back home (locale-independent
+  // structure; text comes from the active dictionary).
+  await expect(page.getByText('404')).toBeVisible();
+  await expect(page.getByRole('link', { name: /home|start|ana sayfa|startseite/i })).toBeVisible();
+});

--- a/src/app/admin/candidates/[id]/page.tsx
+++ b/src/app/admin/candidates/[id]/page.tsx
@@ -5,6 +5,7 @@ import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Badge } from '@/components/ui/Badge';
+import { InteractionTypeBadge } from '@/components/InteractionTypeBadge';
 import { Select } from '@/components/ui/Select';
 import { Button } from '@/components/ui/Button';
 import { ArrowLeft, KeyRound, Trash2, Plus } from 'lucide-react';
@@ -347,7 +348,7 @@ export default function AdminMenteeDetailPage() {
               </div>
 
               {(() => {
-                const na = nextAction({ pipelineStatus: rel.pipelineStatus, lastInteractionAt: rel.interactions[0]?.date });
+                const na = nextAction({ pipelineStatus: rel.pipelineStatus, lastInteractionAt: rel.interactions[0]?.date }, t.nextActions);
                 const color = na.level === 'urgent' ? 'text-red-700 bg-red-50 border-red-200' : na.level === 'warn' ? 'text-amber-700 bg-amber-50 border-amber-200' : 'text-green-700 bg-green-50 border-green-200';
                 return (
                   <div className={`inline-flex items-center gap-2 text-sm rounded-lg border px-3 py-1.5 ${color}`}>
@@ -429,7 +430,7 @@ export default function AdminMenteeDetailPage() {
                   <div className="space-y-2">
                     {rel.interactions.map((i) => (
                       <div key={i.id} className="flex items-start gap-2 text-sm">
-                        <Badge variant={i.type === 'Meeting' ? 'info' : i.type === 'Feedback' ? 'success' : 'warning'} className="text-xs flex-shrink-0">{i.type}</Badge>
+                        <InteractionTypeBadge type={i.type} className="text-xs flex-shrink-0" />
                         <div>
                           <p className="text-gray-700">{i.notes}</p>
                           <p className="text-xs text-gray-400">{new Date(i.date).toLocaleDateString()}</p>

--- a/src/app/mentor/interactions/page.tsx
+++ b/src/app/mentor/interactions/page.tsx
@@ -3,7 +3,7 @@ import { useT } from "@/i18n/client";
 
 import { useState, useEffect, useCallback } from 'react';
 import { Card } from '@/components/ui/Card';
-import { Badge } from '@/components/ui/Badge';
+import { InteractionTypeBadge } from '@/components/InteractionTypeBadge';
 import { BookOpen } from 'lucide-react';
 
 interface Interaction {
@@ -53,14 +53,7 @@ export default function MentorInteractionsPage() {
           <div className="space-y-3">
             {interactions.map((interaction) => (
               <div key={interaction.id} className="flex items-start gap-4 py-4 border-b border-gray-50 last:border-0">
-                <Badge
-                  variant={
-                    interaction.type === 'Meeting' ? 'info' : interaction.type === 'Feedback' ? 'success' : 'warning'
-                  }
-                  className="text-xs flex-shrink-0 mt-0.5"
-                >
-                  {interaction.type}
-                </Badge>
+                <InteractionTypeBadge type={interaction.type} className="text-xs flex-shrink-0 mt-0.5" />
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2 mb-1">
                     <span className="text-sm font-medium text-gray-700">

--- a/src/app/mentor/mentees/[id]/page.tsx
+++ b/src/app/mentor/mentees/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useParams } from 'next/navigation';
 import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Badge, StatusBadge } from '@/components/ui/Badge';
+import { InteractionTypeBadge } from '@/components/InteractionTypeBadge';
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { Select } from '@/components/ui/Select';
@@ -361,12 +362,7 @@ export default function MenteeDetailPage() {
             )}
             {relation.interactions.map((interaction) => (
               <div key={interaction.id} className="flex items-start gap-3 py-3 border-b border-gray-50 last:border-0">
-                <Badge
-                  variant={interaction.type === 'Meeting' ? 'info' : interaction.type === 'Feedback' ? 'success' : 'warning'}
-                  className="text-xs flex-shrink-0 mt-0.5"
-                >
-                  {interaction.type}
-                </Badge>
+                <InteractionTypeBadge type={interaction.type} className="text-xs flex-shrink-0 mt-0.5" />
                 <div className="flex-1 min-w-0">
                   <p className="text-sm text-gray-700">{interaction.notes}</p>
                   <p className="text-xs text-gray-400 mt-1">

--- a/src/app/mentor/page.tsx
+++ b/src/app/mentor/page.tsx
@@ -7,6 +7,7 @@ import { prisma } from '@/lib/prisma';
 import { getAttentionItems } from '@/lib/mentorAttention';
 import { Card, CardHeader, CardTitle, CardDescription } from '@/components/ui/Card';
 import { Badge, StatusBadge } from '@/components/ui/Badge';
+import { InteractionTypeBadge } from '@/components/InteractionTypeBadge';
 import { Users, BookOpen, MessageSquare, Calendar } from 'lucide-react';
 import Link from 'next/link';
 
@@ -197,18 +198,7 @@ export default async function MentorDashboard() {
                 />
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2 mb-1">
-                    <Badge
-                      variant={
-                        interaction.type === 'Meeting'
-                          ? 'info'
-                          : interaction.type === 'Feedback'
-                          ? 'success'
-                          : 'warning'
-                      }
-                      className="text-xs"
-                    >
-                      {interaction.type}
-                    </Badge>
+                    <InteractionTypeBadge type={interaction.type} className="text-xs" />
                     <span className="text-xs text-gray-500">
                       with {interaction.relation.mentee.fullName}
                     </span>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link';
+import { getServerDictionary } from '@/i18n/server';
+
+// Localized 404. Rendered inside the root layout (which sets <html lang>), so
+// it inherits the active locale like every other page.
+export default async function NotFound() {
+  const { t } = await getServerDictionary();
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4 bg-gradient-to-br from-blue-50 to-indigo-50 dark:from-gray-900 dark:to-gray-950">
+      <div className="text-center">
+        <p className="text-6xl font-bold text-blue-600">404</p>
+        <h1 className="mt-4 text-2xl font-bold text-gray-900 dark:text-gray-100">{t.notFound.title}</h1>
+        <p className="mt-2 text-gray-500 dark:text-gray-400">{t.notFound.description}</p>
+        <Link
+          href="/"
+          className="mt-6 inline-block rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-blue-700 transition-colors"
+        >
+          {t.notFound.backHome}
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/portal/interactions/page.tsx
+++ b/src/app/portal/interactions/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { Card } from '@/components/ui/Card';
-import { Badge } from '@/components/ui/Badge';
+import { InteractionTypeBadge } from '@/components/InteractionTypeBadge';
 import { BookOpen } from 'lucide-react';
 
 interface Interaction {
@@ -53,18 +53,7 @@ export default function PortalInteractionsPage() {
           {interactions.map((interaction) => (
             <Card key={interaction.id}>
               <div className="flex items-start gap-4">
-                <Badge
-                  variant={
-                    interaction.type === 'Meeting'
-                      ? 'info'
-                      : interaction.type === 'Feedback'
-                      ? 'success'
-                      : 'warning'
-                  }
-                  className="flex-shrink-0 mt-0.5"
-                >
-                  {interaction.type}
-                </Badge>
+                <InteractionTypeBadge type={interaction.type} className="flex-shrink-0 mt-0.5" />
                 <div className="flex-1">
                   <p className="text-sm text-gray-700">{interaction.notes}</p>
                   <p className="text-xs text-gray-400 mt-2">

--- a/src/app/portal/page.tsx
+++ b/src/app/portal/page.tsx
@@ -11,6 +11,7 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Badge, StatusBadge } from '@/components/ui/Badge';
+import { InteractionTypeBadge } from '@/components/InteractionTypeBadge';
 import { User, Building2, BookOpen, ExternalLink, MessageCircle, Mail, Github, Linkedin } from 'lucide-react';
 import Link from 'next/link';
 
@@ -262,18 +263,7 @@ export default async function PortalDashboard() {
                         key={interaction.id}
                         className="flex items-start gap-3 py-2 border-b border-gray-50 last:border-0"
                       >
-                        <Badge
-                          variant={
-                            interaction.type === 'Meeting'
-                              ? 'info'
-                              : interaction.type === 'Feedback'
-                              ? 'success'
-                              : 'warning'
-                          }
-                          className="text-xs flex-shrink-0"
-                        >
-                          {interaction.type}
-                        </Badge>
+                        <InteractionTypeBadge type={interaction.type} className="text-xs flex-shrink-0" />
                         <div className="min-w-0">
                           <p className="text-sm text-gray-700 truncate">{interaction.notes}</p>
                           <p className="text-xs text-gray-400">

--- a/src/components/InteractionTypeBadge.tsx
+++ b/src/components/InteractionTypeBadge.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { Badge } from '@/components/ui/Badge';
+import { useT } from '@/i18n/client';
+
+// A localized badge for an interaction's type (Meeting / Feedback / Email /
+// Call / WhatsApp). Self-contained (brings its own useT) so it works even in
+// pages that aren't otherwise wired for i18n.
+export function InteractionTypeBadge({ type, className }: { type: string; className?: string }) {
+  const t = useT();
+  const variant = type === 'Meeting' ? 'info' : type === 'Feedback' ? 'success' : 'warning';
+  const label = t.interactionTypes[type as keyof typeof t.interactionTypes] ?? type;
+  return <Badge variant={variant} className={className}>{label}</Badge>;
+}

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -1,6 +1,9 @@
+'use client';
+
 import { HTMLAttributes } from 'react';
 import { clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
+import { useT } from '@/i18n/client';
 
 function cn(...inputs: Parameters<typeof clsx>) {
   return twMerge(clsx(inputs));
@@ -47,15 +50,13 @@ export function RoleBadge({ role }: { role: string }) {
 }
 
 export function StatusBadge({ status }: { status: string }) {
-  const config = {
-    ACTIVE: { variant: 'success' as const, label: 'Active' },
-    COMPLETED: { variant: 'default' as const, label: 'Completed' },
+  const t = useT();
+  const variantByStatus: Record<string, 'success' | 'default'> = {
+    ACTIVE: 'success',
+    COMPLETED: 'default',
   };
-
-  const { variant, label } = config[status as keyof typeof config] || {
-    variant: 'default' as const,
-    label: status,
-  };
+  const variant = variantByStatus[status] ?? 'default';
+  const label = t.relationStatus[status as keyof typeof t.relationStatus] ?? status;
 
   return <Badge variant={variant}>{label}</Badge>;
 }

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -632,6 +632,10 @@ const en = {
     weekdays: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
   },
   activityFeed: { title: 'Activity', none: 'No activity yet', neverActive: 'No recorded activity yet.', inactiveDays: 'Inactive for {d} days — consider reaching out.' },
+  relationStatus: { ACTIVE: 'Active', COMPLETED: 'Completed' },
+  interactionTypes: { Meeting: 'Meeting', Feedback: 'Feedback', Email: 'Email', Call: 'Call', WhatsApp: 'WhatsApp' },
+  nextActions: { logFirst: 'Log a first interaction', noContact: 'No contact in {d} days — reach out', lastContact: 'Last contact {d} days ago — follow up', pushHiring: 'Push toward hiring', onTrack: 'On track' },
+  notFound: { title: 'Page not found', description: 'This page could not be found.', backHome: 'Back to home' },
   theme: { toggle: 'Toggle theme', light: 'Light', dark: 'Dark', system: 'System' },
   contact: {
     call: 'Call',
@@ -1657,6 +1661,10 @@ const tr: Dict = {
     weekdays: ['Pzt', 'Sal', 'Çar', 'Per', 'Cum', 'Cmt', 'Paz'],
   },
   activityFeed: { title: 'Aktivite', none: 'Henüz aktivite yok', neverActive: 'Henüz kayıtlı aktivite yok.', inactiveDays: '{d} gündür pasif — iletişime geçmeyi düşün.' },
+  relationStatus: { ACTIVE: 'Aktif', COMPLETED: 'Tamamlandı' },
+  interactionTypes: { Meeting: 'Toplantı', Feedback: 'Geri bildirim', Email: 'E-posta', Call: 'Arama', WhatsApp: 'WhatsApp' },
+  nextActions: { logFirst: 'İlk etkileşimi kaydet', noContact: '{d} gündür iletişim yok — iletişime geç', lastContact: 'Son iletişim {d} gün önce — takip et', pushHiring: 'İşe alıma yönlendir', onTrack: 'Yolunda' },
+  notFound: { title: 'Sayfa bulunamadı', description: 'Bu sayfa bulunamadı.', backHome: 'Ana sayfaya dön' },
   theme: { toggle: 'Temayı değiştir', light: 'Açık', dark: 'Koyu', system: 'Sistem' },
   contact: {
     call: 'Ara',
@@ -2680,6 +2688,10 @@ const de: Dict = {
     weekdays: ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So'],
   },
   activityFeed: { title: 'Aktivität', none: 'Noch keine Aktivität', neverActive: 'Noch keine Aktivität erfasst.', inactiveDays: 'Seit {d} Tagen inaktiv — kontaktiere sie.' },
+  relationStatus: { ACTIVE: 'Aktiv', COMPLETED: 'Abgeschlossen' },
+  interactionTypes: { Meeting: 'Meeting', Feedback: 'Feedback', Email: 'E-Mail', Call: 'Anruf', WhatsApp: 'WhatsApp' },
+  nextActions: { logFirst: 'Erste Interaktion erfassen', noContact: 'Seit {d} Tagen kein Kontakt — melde dich', lastContact: 'Letzter Kontakt vor {d} Tagen — nachfassen', pushHiring: 'Richtung Einstellung drängen', onTrack: 'Auf Kurs' },
+  notFound: { title: 'Seite nicht gefunden', description: 'Diese Seite konnte nicht gefunden werden.', backHome: 'Zurück zur Startseite' },
   theme: { toggle: 'Theme wechseln', light: 'Hell', dark: 'Dunkel', system: 'System' },
   contact: {
     call: 'Anrufen',

--- a/src/lib/matching.ts
+++ b/src/lib/matching.ts
@@ -31,19 +31,39 @@ export interface NextActionInput {
   lastInteractionAt?: Date | string | null;
 }
 
-// Returns a short suggested next action + a severity level.
-export function nextAction({ pipelineStatus, lastInteractionAt }: NextActionInput): {
-  text: string;
-  level: 'ok' | 'warn' | 'urgent';
-} {
+// Localized labels for the next-action hint. `{d}` is replaced with the day
+// count. Optional so server/tests can call without a dictionary (English default).
+export interface NextActionLabels {
+  logFirst: string;
+  noContact: string;
+  lastContact: string;
+  pushHiring: string;
+  onTrack: string;
+}
+
+const DEFAULT_LABELS: NextActionLabels = {
+  logFirst: 'Log a first interaction',
+  noContact: 'No contact in {d} days — reach out',
+  lastContact: 'Last contact {d} days ago — follow up',
+  pushHiring: 'Push toward hiring',
+  onTrack: 'On track',
+};
+
+// Returns a short suggested next action + a severity level. Pass `labels`
+// (e.g. `t.nextActions`) to localize; falls back to English.
+export function nextAction(
+  { pipelineStatus, lastInteractionAt }: NextActionInput,
+  labels: NextActionLabels = DEFAULT_LABELS
+): { text: string; level: 'ok' | 'warn' | 'urgent' } {
   const last = lastInteractionAt ? new Date(lastInteractionAt) : null;
   const days = last ? Math.floor((Date.now() - last.getTime()) / 86_400_000) : null;
+  const withDays = (s: string) => s.replace('{d}', String(days));
 
-  if (days === null) return { text: 'Log a first interaction', level: 'warn' };
-  if (days >= 21) return { text: `No contact in ${days} days — reach out`, level: 'urgent' };
-  if (days >= 14) return { text: `Last contact ${days} days ago — follow up`, level: 'warn' };
+  if (days === null) return { text: labels.logFirst, level: 'warn' };
+  if (days >= 21) return { text: withDays(labels.noContact), level: 'urgent' };
+  if (days >= 14) return { text: withDays(labels.lastContact), level: 'warn' };
 
   const ending = ['INTERNSHIP_COMPLETED_490', 'JOB_SEEKING_500', 'HIREABLE_600'];
-  if (ending.includes(pipelineStatus)) return { text: 'Push toward hiring', level: 'warn' };
-  return { text: 'On track', level: 'ok' };
+  if (ending.includes(pipelineStatus)) return { text: labels.pushHiring, level: 'warn' };
+  return { text: labels.onTrack, level: 'ok' };
 }


### PR DESCRIPTION
## Summary

**EPIC E (#418).** Closes the remaining English/mixed-language strings so everything follows the active locale.

## Changes

- **Mentorship status badges** — `StatusBadge` (ACTIVE/COMPLETED) now reads `t.relationStatus` (EN/TR/DE). `Badge.tsx` becomes a client component so the badge can access the dictionary.
- **Next-action hint** — `nextAction()` takes an optional `labels` object (`t.nextActions`) and localizes "No contact in N days — reach out", "follow up", "push toward hiring", etc. Keeps an English default so server/test callers work unchanged.
- **Interaction type badges** — new self-contained `<InteractionTypeBadge>` (carries its own `useT`) localizes Meeting/Feedback/Email/Call/WhatsApp, used across the admin, mentor and portal views (also dedupes the repeated variant logic).
- **404 page** — added `src/app/not-found.tsx` (localized, styled) replacing Next's English default.

## Verification

- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] e2e (`not-found.spec.ts`): an unknown route returns 404 and renders the localized page with a home link.

## Scope notes

- `<html lang>` already reflects the locale, so date inputs inherit it — the native date **placeholder** ("tt.mm.jjjj") is controlled by the browser's own locale, not the page, so it can't be fully forced without a custom date picker (out of scope).
- The company need **"period"** ("now", "in July") is a free-text field the admin types, not an app string — localizing it isn't applicable (could become a select with fixed options as a separate enhancement).
- The **missing-translation-key CI check** is tracked together with EPIC L (#425).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_