### PR TITLE
feat(ui): toast confirmation on candidate-detail changes

### DIFF
--- a/e2e/candidate-change-toast.spec.ts
+++ b/e2e/candidate-change-toast.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+const ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@example.com';
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'ChangeMe123!';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// #23: changing a field on the candidate detail page (stage/project/…) saved
+// silently. It must now confirm with a toast.
+test('changing a candidate\'s stage shows a confirmation toast', async ({ page }) => {
+  const mentorEmail = uniqueEmail('toast-mentor');
+  const menteeEmail = uniqueEmail('toast-mentee');
+  const mentor = await seedUser(mentorEmail, 'Pass1234!', 'MENTOR', 'Toast Mentor');
+  const mentee = await seedUser(menteeEmail, 'Pass1234!', 'MENTEE', 'Toast Mentee');
+  await prisma.mentorshipRelation.create({
+    data: { mentorId: mentor.id, menteeId: mentee.id, pipelineStatus: 'APPLICATION_100' },
+  });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', ADMIN_EMAIL);
+    await page.fill('input[type="password"]', ADMIN_PASSWORD);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => !u.pathname.includes('/auth/signin'), { timeout: 20_000 });
+
+    await page.goto(`/admin/candidates/${mentee.id}`);
+    // The stage dropdown is the first <select> in the mentorship card.
+    await page.locator('select').first().selectOption('INTERVIEW_PENDING_250');
+
+    // A success toast confirms the save.
+    await expect(page.getByRole('status').filter({ hasText: /saved|kaydedildi|gespeichert/i })).toBeVisible({ timeout: 10_000 });
+  } finally {
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(menteeEmail);
+  }
+});

--- a/src/app/admin/candidates/[id]/page.tsx
+++ b/src/app/admin/candidates/[id]/page.tsx
@@ -18,6 +18,7 @@ import { DocumentsManager } from '@/components/DocumentsManager';
 import { UserActivityPanel } from '@/components/UserActivityPanel';
 import { CandidateEraseDangerZone } from '@/components/CandidateEraseDangerZone';
 import { useT, useLocale } from '@/i18n/client';
+import { useToast } from '@/components/ui/Toast';
 
 interface Interaction { id: string; date: string; notes: string; type: string }
 interface StatusChange { id: string; fromStatus: string; toStatus: string; createdAt: string; changedBy: { fullName: string } }
@@ -67,6 +68,7 @@ export default function AdminMenteeDetailPage() {
   const id = useParams().id as string;
   const t = useT();
   const locale = useLocale();
+  const toast = useToast();
   const [user, setUser] = useState<MenteeDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -90,34 +92,42 @@ export default function AdminMenteeDetailPage() {
     async (relationId: string, pipelineStatus: string) => {
       setSaving(true);
       try {
-        await fetch(`/api/mentorship/${relationId}`, {
+        const res = await fetch(`/api/mentorship/${relationId}`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ pipelineStatus }),
         });
+        if (!res.ok) throw new Error();
         await load();
+        toast(t.candidateDetail.saved);
+      } catch {
+        toast(t.candidateDetail.saveError, 'error');
       } finally {
         setSaving(false);
       }
     },
-    [load]
+    [load, toast, t]
   );
 
   const changeProject = useCallback(
     async (relationId: string, projectId: string) => {
       setSaving(true);
       try {
-        await fetch(`/api/mentorship/${relationId}`, {
+        const res = await fetch(`/api/mentorship/${relationId}`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ projectId: projectId || null }),
         });
+        if (!res.ok) throw new Error();
         await load();
+        toast(t.candidateDetail.saved);
+      } catch {
+        toast(t.candidateDetail.saveError, 'error');
       } finally {
         setSaving(false);
       }
     },
-    [load]
+    [load, toast, t]
   );
 
   const resetPassword = useCallback(async () => {
@@ -195,30 +205,38 @@ export default function AdminMenteeDetailPage() {
     async (sourceId: string) => {
       setSaving(true);
       try {
-        await fetch(`/api/users/${id}`, {
+        const res = await fetch(`/api/users/${id}`, {
           method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ sourceId: sourceId || null }),
         });
+        if (!res.ok) throw new Error();
         await load();
+        toast(t.candidateDetail.saved);
+      } catch {
+        toast(t.candidateDetail.saveError, 'error');
       } finally {
         setSaving(false);
       }
     },
-    [id, load]
+    [id, load, toast, t]
   );
 
   const changeRelField = useCallback(
     async (relationId: string, body: Record<string, unknown>) => {
       setSaving(true);
       try {
-        await fetch(`/api/mentorship/${relationId}`, {
+        const res = await fetch(`/api/mentorship/${relationId}`, {
           method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body),
         });
+        if (!res.ok) throw new Error();
         await load();
+        toast(t.candidateDetail.saved);
+      } catch {
+        toast(t.candidateDetail.saveError, 'error');
       } finally {
         setSaving(false);
       }
     },
-    [load]
+    [load, toast, t]
   );
 
   if (loading) return <div className="text-center py-12 text-gray-400">{t.common.loading}</div>;

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -2,6 +2,7 @@
 
 import { SessionProvider } from 'next-auth/react';
 import { LocaleProvider } from '@/i18n/client';
+import { ToastProvider } from '@/components/ui/Toast';
 import { CookieConsent } from '@/components/CookieConsent';
 import type { Locale } from '@/i18n/config';
 import type { Dictionary } from '@/i18n/dictionaries';
@@ -18,8 +19,10 @@ export function Providers({
   return (
     <SessionProvider>
       <LocaleProvider locale={locale} dict={dict}>
-        {children}
-        <CookieConsent />
+        <ToastProvider>
+          {children}
+          <CookieConsent />
+        </ToastProvider>
       </LocaleProvider>
     </SessionProvider>
   );

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { createContext, useCallback, useContext, useRef, useState } from 'react';
+import { CheckCircle2, XCircle } from 'lucide-react';
+
+type ToastType = 'success' | 'error';
+interface ToastItem { id: number; message: string; type: ToastType }
+
+// Minimal, dependency-free toast system. `useToast()` returns a `toast(message,
+// type?)` function; toasts auto-dismiss after a few seconds. Rendered in a fixed
+// bottom-right stack, dark-mode aware, and announced via role="status".
+const ToastContext = createContext<((message: string, type?: ToastType) => void) | null>(null);
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [items, setItems] = useState<ToastItem[]>([]);
+  const idRef = useRef(0);
+
+  const toast = useCallback((message: string, type: ToastType = 'success') => {
+    const id = ++idRef.current;
+    setItems((prev) => [...prev, { id, message, type }]);
+    setTimeout(() => setItems((prev) => prev.filter((it) => it.id !== id)), 3200);
+  }, []);
+
+  return (
+    <ToastContext.Provider value={toast}>
+      {children}
+      <div className="fixed bottom-4 right-4 z-[200] flex flex-col gap-2 pointer-events-none">
+        {items.map((it) => (
+          <div
+            key={it.id}
+            role="status"
+            className={`pointer-events-auto flex items-center gap-2 rounded-lg border px-4 py-2.5 text-sm shadow-lg bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-100 ${
+              it.type === 'success' ? 'border-green-200 dark:border-green-900' : 'border-red-200 dark:border-red-900'
+            }`}
+          >
+            {it.type === 'success' ? (
+              <CheckCircle2 className="h-4 w-4 text-green-600 flex-shrink-0" />
+            ) : (
+              <XCircle className="h-4 w-4 text-red-600 flex-shrink-0" />
+            )}
+            <span>{it.message}</span>
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error('useToast must be used within ToastProvider');
+  return ctx;
+}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -134,6 +134,8 @@ const en = {
   },
   candidateDetail: {
     companyInterest: { interested: 'Company is interested', shortlisted: 'Shortlisted by company', pass: 'Company passed' },
+    saved: 'Changes saved',
+    saveError: 'Could not save — please try again',
     back: 'Back to candidates',
     profile: 'Profile',
     university: 'University',
@@ -1163,6 +1165,8 @@ const tr: Dict = {
   },
   candidateDetail: {
     companyInterest: { interested: 'Şirket ilgileniyor', shortlisted: 'Şirket kısa listeye aldı', pass: 'Şirket geçti' },
+    saved: 'Değişiklikler kaydedildi',
+    saveError: 'Kaydedilemedi — lütfen tekrar deneyin',
     back: 'Adaylara dön',
     profile: 'Profil',
     university: 'Üniversite',
@@ -2190,6 +2194,8 @@ const de: Dict = {
   },
   candidateDetail: {
     companyInterest: { interested: 'Unternehmen interessiert', shortlisted: 'Vom Unternehmen auf die Shortlist gesetzt', pass: 'Unternehmen hat abgesagt' },
+    saved: 'Änderungen gespeichert',
+    saveError: 'Speichern fehlgeschlagen — bitte erneut versuchen',
     back: 'Zurück zu den Kandidaten',
     profile: 'Profil',
     university: 'Universität',


### PR DESCRIPTION
## Summary

Per user feedback: on the admin candidate detail page, changing the **stage / project / cohort / source / stage-deadline** saved silently with no feedback. Each save now shows a toast confirmation (and an error toast on failure).

## Changes

- **New toast system** (`src/components/ui/Toast.tsx`) — a minimal, **dependency-free** `ToastProvider` + `useToast()`; auto-dismissing, dark-mode aware, `role="status"` for a11y. Wired into `Providers` (inside the locale provider).
- **Candidate detail handlers** (`changeStage`, `changeProject`, `changeSource`, `changeRelField`) now check the response and toast `saved` / `saveError`.
- **i18n**: `candidateDetail.saved` / `candidateDetail.saveError` (EN/TR/DE).

## Verification

- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] e2e (`candidate-change-toast.spec.ts`): changing a candidate's stage shows the confirmation toast.

The toast provider is app-wide, so it can be reused for other actions later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_