### PR TITLE
feat(candidates): server-side pagination for the candidates list (EPIC H)

### DIFF
--- a/e2e/candidates-pagination.spec.ts
+++ b/e2e/candidates-pagination.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+const ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@example.com';
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'ChangeMe123!';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// EPIC H (#421): the candidates API paginates server-side and reports a total,
+// with all=1 as the escape hatch used by CSV/Excel export.
+test('candidates API paginates and supports all=1 for export', async ({ page }) => {
+  const emails = [uniqueEmail('pg1'), uniqueEmail('pg2'), uniqueEmail('pg3')];
+  for (const [i, e] of emails.entries()) await seedUser(e, 'Pass1234!', 'MENTEE', `Pager ${i}`);
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', ADMIN_EMAIL);
+    await page.fill('input[type="password"]', ADMIN_PASSWORD);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => !u.pathname.includes('/auth/signin'), { timeout: 20_000 });
+
+    // Page 1 with pageSize=2 returns exactly 2, and total counts everything.
+    const p1 = await (await page.request.get('/api/candidates?pageSize=2&page=1')).json();
+    expect(p1.candidates.length).toBe(2);
+    expect(typeof p1.total).toBe('number');
+    expect(p1.total).toBeGreaterThanOrEqual(3);
+
+    // Page 2 returns different rows (no overlap with page 1).
+    const p2 = await (await page.request.get('/api/candidates?pageSize=2&page=2')).json();
+    expect(p2.candidates.length).toBeGreaterThanOrEqual(1);
+    const p1ids = new Set(p1.candidates.map((c: { id: string }) => c.id));
+    expect(p2.candidates.every((c: { id: string }) => !p1ids.has(c.id))).toBe(true);
+
+    // all=1 ignores pagination (used by export) → returns at least our 3 seeds.
+    const all = await (await page.request.get('/api/candidates?all=1')).json();
+    expect(all.candidates.length).toBeGreaterThanOrEqual(3);
+  } finally {
+    for (const e of emails) await cleanupByEmail(e);
+  }
+});

--- a/src/app/admin/candidates/page.tsx
+++ b/src/app/admin/candidates/page.tsx
@@ -46,6 +46,9 @@ export default function CandidatesPage() {
   const t = useT();
   const locale = useLocale();
   const [candidates, setCandidates] = useState<Candidate[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const PAGE_SIZE = 24;
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
   const [skillFilter, setSkillFilter] = useState('');
@@ -70,9 +73,20 @@ export default function CandidatesPage() {
     ];
   };
 
-  const exportCsv = () => {
+  // Exports cover ALL matching candidates (every page), not just the page in
+  // view — fetch the full filtered set with all=1 before building the file.
+  const fetchAllForExport = async (): Promise<Candidate[]> => {
+    const params = buildFilterParams();
+    params.set('all', '1');
+    const res = await fetch(`/api/candidates?${params}`);
+    const data = await res.json();
+    return (data.candidates || []) as Candidate[];
+  };
+
+  const exportCsv = async () => {
+    const rows0 = await fetchAllForExport();
     const esc = (v: unknown) => `"${String(v ?? '').replace(/"/g, '""')}"`;
-    const rows = candidates.map((c) => toRow(c).map(esc).join(','));
+    const rows = rows0.map((c) => toRow(c).map(esc).join(','));
     const csv = [COLS.join(','), ...rows].join('\n');
     const url = URL.createObjectURL(new Blob(['﻿' + csv], { type: 'text/csv;charset=utf-8' }));
     const a = document.createElement('a');
@@ -83,8 +97,9 @@ export default function CandidatesPage() {
   };
 
   const exportExcel = async () => {
+    const rows0 = await fetchAllForExport();
     const { exportXlsx } = await import('@/lib/excel');
-    await exportXlsx(`candidates-${new Date().toISOString().slice(0, 10)}`, COLS, candidates.map(toRow), 'Candidates');
+    await exportXlsx(`candidates-${new Date().toISOString().slice(0, 10)}`, COLS, rows0.map(toRow), 'Candidates');
   };
 
   // Read an optional ?status= filter from the URL (e.g. from dashboard pipeline bars)
@@ -92,27 +107,35 @@ export default function CandidatesPage() {
     setStatusFilter(new URLSearchParams(window.location.search).get('status') || '');
   }, []);
 
+  // Build the shared filter query string (without pagination params).
+  const buildFilterParams = useCallback(() => {
+    const params = new URLSearchParams();
+    if (skillFilter) params.set('skills', skillFilter);
+    if (yearFilter) params.set('graduationYear', yearFilter);
+    if (search) params.set('search', search);
+    if (statusFilter) params.set('status', statusFilter);
+    if (cityFilter) params.set('city', cityFilter);
+    if (projectFilter) params.set('project', projectFilter);
+    if (sourceFilter) params.set('source', sourceFilter);
+    return params;
+  }, [skillFilter, yearFilter, search, statusFilter, cityFilter, projectFilter, sourceFilter]);
+
   const fetchCandidates = useCallback(async () => {
     setLoading(true);
     try {
-      const params = new URLSearchParams();
-      if (skillFilter) params.set('skills', skillFilter);
-      if (yearFilter) params.set('graduationYear', yearFilter);
-      if (search) params.set('search', search);
-      if (statusFilter) params.set('status', statusFilter);
-      if (cityFilter) params.set('city', cityFilter);
-      if (projectFilter) params.set('project', projectFilter);
-      if (sourceFilter) params.set('source', sourceFilter);
-
+      const params = buildFilterParams();
+      params.set('page', String(page));
+      params.set('pageSize', String(PAGE_SIZE));
       const res = await fetch(`/api/candidates?${params}`);
       const data = await res.json();
       setCandidates(data.candidates || []);
+      setTotal(typeof data.total === 'number' ? data.total : (data.candidates?.length ?? 0));
     } catch {
       setError('Failed to load candidates');
     } finally {
       setLoading(false);
     }
-  }, [skillFilter, yearFilter, search, statusFilter, cityFilter, projectFilter, sourceFilter]);
+  }, [buildFilterParams, page]);
 
   useEffect(() => {
     fetch('/api/admin/sources')
@@ -125,6 +148,13 @@ export default function CandidatesPage() {
     const timeout = setTimeout(fetchCandidates, 300);
     return () => clearTimeout(timeout);
   }, [fetchCandidates]);
+
+  // Any filter change returns to the first page.
+  useEffect(() => {
+    setPage(1);
+  }, [search, skillFilter, yearFilter, statusFilter, cityFilter, projectFilter, sourceFilter]);
+
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
   const toggleSelect = (id: string) => {
     setSelected((prev) => {
@@ -289,7 +319,7 @@ export default function CandidatesPage() {
             </label>
           )}
           <p className="text-sm text-gray-500">
-            {loading ? t.common.loading : `${candidates.length} ${t.candidates.found}`}
+            {loading ? t.common.loading : `${total} ${t.candidates.found}`}
           </p>
         </div>
         {selected.size > 0 && (
@@ -402,6 +432,18 @@ export default function CandidatesPage() {
               </Card>
             );
           })}
+        </div>
+      )}
+
+      {!loading && totalPages > 1 && (
+        <div className="flex items-center justify-center gap-3 mt-8">
+          <Button variant="outline" size="sm" disabled={page <= 1} onClick={() => setPage((p) => Math.max(1, p - 1))}>
+            {t.common.prev}
+          </Button>
+          <span className="text-sm text-gray-500">{page} / {totalPages}</span>
+          <Button variant="outline" size="sm" disabled={page >= totalPages} onClick={() => setPage((p) => Math.min(totalPages, p + 1))}>
+            {t.common.next}
+          </Button>
         </div>
       )}
     </div>

--- a/src/app/api/candidates/route.ts
+++ b/src/app/api/candidates/route.ts
@@ -21,6 +21,11 @@ export async function GET(request: Request) {
     const project = searchParams.get('project');
     const cohortId = searchParams.get('cohort');
     const sourceId = searchParams.get('source');
+    // Pagination. `all=1` returns everything (used by CSV/Excel export so the
+    // download isn't limited to the current page).
+    const all = searchParams.get('all') === '1';
+    const page = Math.max(1, parseInt(searchParams.get('page') || '1', 10) || 1);
+    const pageSize = Math.min(100, Math.max(1, parseInt(searchParams.get('pageSize') || '24', 10) || 24));
 
     const where: Record<string, unknown> = {
       role: 'MENTEE',
@@ -56,47 +61,61 @@ export async function GET(request: Request) {
       ];
     }
 
-    const rawCandidates = await prisma.user.findMany({
-      where,
-      select: {
-        id: true,
-        fullName: true,
-        email: true,
-        university: true,
-        department: true,
-        graduationYear: true,
-        skills: true,
-        cvUrl: true,
-        phone: true,
-        whatsapp: true,
-        city: true,
-        createdAt: true,
-        isActive: true,
-        source: { select: { id: true, name: true } },
-        menteeRelations: {
-          where: { status: 'ACTIVE' },
-          include: {
-            mentor: { select: { id: true, fullName: true } },
-            company: { select: { id: true, name: true } },
-            project: { select: { id: true, name: true } },
-          },
+    const select = {
+      id: true,
+      fullName: true,
+      email: true,
+      university: true,
+      department: true,
+      graduationYear: true,
+      skills: true,
+      cvUrl: true,
+      phone: true,
+      whatsapp: true,
+      city: true,
+      createdAt: true,
+      isActive: true,
+      source: { select: { id: true, name: true } },
+      menteeRelations: {
+        where: { status: 'ACTIVE' as const },
+        include: {
+          mentor: { select: { id: true, fullName: true } },
+          company: { select: { id: true, name: true } },
+          project: { select: { id: true, name: true } },
         },
       },
-      orderBy: { createdAt: 'desc' },
-    });
+    };
+    const normalize = (c: { skills: unknown }) => ({ ...c, skills: (c.skills ?? []) as string[] });
+    const matchesSkills = (c: { skills: string[] }) => {
+      if (skillList.length === 0) return true;
+      const owned = c.skills.map((k) => k.toLowerCase());
+      // Every typed term must be a substring of at least one skill (so "docke"
+      // matches "Docker"), case-insensitive.
+      return skillList.every((term) => owned.some((k) => k.includes(term)));
+    };
 
-    // Normalise skills (stored as JSON array) and apply optional skill filter
-    const candidates = rawCandidates
-      .map((c) => ({ ...c, skills: (c.skills ?? []) as string[] }))
-      .filter((c) => {
-        if (skillList.length === 0) return true;
-        const owned = c.skills.map((k) => k.toLowerCase());
-        // Every typed term must be a substring of at least one of the candidate's
-        // skills (so "docke" matches "Docker"), case-insensitive.
-        return skillList.every((term) => owned.some((k) => k.includes(term)));
+    let candidates;
+    let total: number;
+    if (skillList.length === 0) {
+      // No JSON-skill filter → paginate at the database level.
+      total = await prisma.user.count({ where });
+      const raw = await prisma.user.findMany({
+        where,
+        select,
+        orderBy: { createdAt: 'desc' },
+        ...(all ? {} : { skip: (page - 1) * pageSize, take: pageSize }),
       });
+      candidates = raw.map(normalize);
+    } else {
+      // Skill filter is applied in-memory (MySQL JSON arrays don't support
+      // hasSome), so fetch, filter, then slice the page from the filtered set.
+      const raw = await prisma.user.findMany({ where, select, orderBy: { createdAt: 'desc' } });
+      const filtered = raw.map(normalize).filter(matchesSkills);
+      total = filtered.length;
+      candidates = all ? filtered : filtered.slice((page - 1) * pageSize, page * pageSize);
+    }
 
-    return NextResponse.json({ candidates });
+    return NextResponse.json({ candidates, total, page, pageSize });
   } catch (error) {
     console.error('Get candidates error:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });


### PR DESCRIPTION
## Summary

**EPIC H (#421), part 1.** The candidates list fetched and rendered **every** matching mentee at once (50+ cards on a single page). This adds server-side pagination.

## Changes

- **`/api/candidates`** accepts `page` & `pageSize` and returns `{ candidates, total, page, pageSize }`.
  - DB-level `skip`/`take` when there's no skill filter.
  - When a skill filter is active (applied in-memory because MySQL JSON arrays don't support `hasSome`), it filters the set then slices the page.
  - `all=1` returns everything (used by export).
- **Candidates page** renders one page at a time with prev/next controls, shows the true `total`, and resets to page 1 on any filter change.
- **CSV/Excel export** now fetches the full filtered set (`all=1`) so downloads aren't limited to the visible page.

## Verification

- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] e2e (`candidates-pagination.spec.ts`): API returns a page + total, page 2 doesn't overlap page 1, and `all=1` returns the full set.

## Remaining in #421 (kept open)

- Server-side pagination for the **Mentorships** list.
- **Mentors** search/filter — overlaps **EPIC B (#415)**, so I'll do it there.
- Spreading "save view" to more lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_