### PR TITLE
fix(analytics): accurate per-stage aging from real transitions (EPIC G)

### DIFF
--- a/e2e/stage-aging.spec.ts
+++ b/e2e/stage-aging.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+const ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@example.com';
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'ChangeMe123!';
+const DAY = 24 * 60 * 60 * 1000;
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// EPIC G (#420): time-in-stage must be computed from real StatusChange
+// transitions and show meaningful per-stage differences — not one uniform
+// number for every stage.
+test('stage aging reflects real per-stage durations from transitions', async ({ page }) => {
+  const mentorEmail = uniqueEmail('sa-mentor');
+  const menteeEmail = uniqueEmail('sa-mentee');
+  const mentor = await seedUser(mentorEmail, 'Pass1234!', 'MENTOR', 'SA Mentor');
+  const mentee = await seedUser(menteeEmail, 'Pass1234!', 'MENTEE', 'SA Mentee');
+  const now = Date.now();
+  const rel = await prisma.mentorshipRelation.create({
+    data: {
+      mentorId: mentor.id,
+      menteeId: mentee.id,
+      status: 'ACTIVE',
+      pipelineStatus: 'INTERVIEW_PENDING_250',
+      startDate: new Date(now - 10 * DAY),
+    },
+  });
+  // APPLICATION_100 held for ~2 days (start → first change);
+  // APPROVAL_PENDING_220 held for ~5 days (first → second change).
+  await prisma.statusChange.createMany({
+    data: [
+      { relationId: rel.id, fromStatus: 'APPLICATION_100', toStatus: 'APPROVAL_PENDING_220', changedById: mentor.id, createdAt: new Date(now - 8 * DAY) },
+      { relationId: rel.id, fromStatus: 'APPROVAL_PENDING_220', toStatus: 'INTERVIEW_PENDING_250', changedById: mentor.id, createdAt: new Date(now - 3 * DAY) },
+    ],
+  });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', ADMIN_EMAIL);
+    await page.fill('input[type="password"]', ADMIN_PASSWORD);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => !u.pathname.includes('/auth/signin'), { timeout: 20_000 });
+
+    const data = await (await page.request.get('/api/admin/analytics/aging')).json();
+    const byStage: Record<string, { avgDays: number }> = Object.fromEntries(
+      data.stageAging.map((s: { pipelineStatus: string; avgDays: number }) => [s.pipelineStatus, s])
+    );
+
+    // Both completed stages are present with the durations we seeded…
+    expect(byStage['APPLICATION_100']).toBeTruthy();
+    expect(byStage['APPROVAL_PENDING_220']).toBeTruthy();
+    // …and they differ (5 days vs 2 days) — not one uniform value.
+    expect(byStage['APPROVAL_PENDING_220'].avgDays).toBeGreaterThan(byStage['APPLICATION_100'].avgDays);
+  } finally {
+    await prisma.statusChange.deleteMany({ where: { relationId: rel.id } });
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(menteeEmail);
+  }
+});

--- a/src/app/api/admin/analytics/aging/route.ts
+++ b/src/app/api/admin/analytics/aging/route.ts
@@ -3,9 +3,15 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 
-// GET — hiring-funnel aging & SLA (EPIC: HR funnel-aging). Reuses the
-// StatusChange audit trail to compute time-in-current-stage per active
-// relation, without a separate "stage entered at" column.
+const DAY = 24 * 60 * 60 * 1000;
+
+// GET — hiring-funnel aging & SLA.
+// - stageAging: average/median time actually SPENT in each stage, computed from
+//   completed transitions in the StatusChange audit trail (entering a stage →
+//   leaving it). This gives meaningful per-stage differences instead of every
+//   stage showing the same current-dwell number.
+// - oldestStuck / overdue: current dwell in the present stage for ACTIVE
+//   relations (how long they've been sitting where they are now).
 export async function GET() {
   const session = await getServerSession(authOptions);
   if (!session || session.user.role !== 'ADMIN') {
@@ -14,42 +20,68 @@ export async function GET() {
 
   const now = Date.now();
   const relations = await prisma.mentorshipRelation.findMany({
-    where: { status: 'ACTIVE' },
     select: {
       id: true,
+      status: true,
       pipelineStatus: true,
       startDate: true,
       stageDeadline: true,
       mentee: { select: { id: true, fullName: true } },
-      statusChanges: { orderBy: { createdAt: 'desc' }, take: 1, select: { createdAt: true } },
+      statusChanges: {
+        orderBy: { createdAt: 'asc' },
+        select: { fromStatus: true, toStatus: true, createdAt: true },
+      },
     },
   });
 
-  const items = relations.map((r) => {
-    const enteredStageAt = r.statusChanges[0]?.createdAt ?? r.startDate;
-    const daysInStage = Math.floor((now - enteredStageAt.getTime()) / (24 * 60 * 60 * 1000));
+  // Completed durations per stage, from consecutive transitions.
+  const byStage = new Map<string, number[]>();
+  const pushDuration = (stage: string, ms: number) => {
+    if (ms <= 0) return;
+    if (!byStage.has(stage)) byStage.set(stage, []);
+    byStage.get(stage)!.push(ms / DAY);
+  };
+
+  for (const r of relations) {
+    const changes = r.statusChanges;
+    if (changes.length > 0) {
+      // Initial stage: from relation start until the first recorded transition.
+      pushDuration(changes[0].fromStatus, changes[0].createdAt.getTime() - r.startDate.getTime());
+      // Each subsequent stage: entered at changes[i], left at changes[i+1].
+      for (let i = 0; i < changes.length - 1; i++) {
+        pushDuration(changes[i].toStatus, changes[i + 1].createdAt.getTime() - changes[i].createdAt.getTime());
+      }
+    }
+  }
+
+  const median = (nums: number[]) => {
+    const s = [...nums].sort((a, b) => a - b);
+    const mid = Math.floor(s.length / 2);
+    return s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2;
+  };
+  const stageAging = Array.from(byStage.entries())
+    .map(([pipelineStatus, days]) => ({
+      pipelineStatus,
+      count: days.length,
+      avgDays: Math.round(days.reduce((s, d) => s + d, 0) / days.length),
+      medianDays: Math.round(median(days)),
+    }))
+    .sort((a, b) => b.avgDays - a.avgDays);
+
+  // Current dwell in the present stage, for active relations only.
+  const active = relations.filter((r) => r.status === 'ACTIVE');
+  const items = active.map((r) => {
+    const last = r.statusChanges[r.statusChanges.length - 1];
+    const enteredStageAt = last ? last.createdAt : r.startDate;
     return {
       relationId: r.id,
       menteeId: r.mentee.id,
       menteeName: r.mentee.fullName,
       pipelineStatus: r.pipelineStatus,
-      daysInStage,
+      daysInStage: Math.floor((now - enteredStageAt.getTime()) / DAY),
       overdue: !!r.stageDeadline && r.stageDeadline.getTime() < now,
     };
   });
-
-  // Average + median days-in-stage per pipeline status.
-  const byStage = new Map<string, number[]>();
-  for (const it of items) {
-    if (!byStage.has(it.pipelineStatus)) byStage.set(it.pipelineStatus, []);
-    byStage.get(it.pipelineStatus)!.push(it.daysInStage);
-  }
-  const stageAging = Array.from(byStage.entries()).map(([pipelineStatus, days]) => {
-    const sorted = [...days].sort((a, b) => a - b);
-    const avg = Math.round(days.reduce((s, d) => s + d, 0) / days.length);
-    const median = sorted[Math.floor(sorted.length / 2)];
-    return { pipelineStatus, count: days.length, avgDays: avg, medianDays: median };
-  }).sort((a, b) => b.avgDays - a.avgDays);
 
   const oldestStuck = [...items].sort((a, b) => b.daysInStage - a.daysInStage).slice(0, 10);
   const overdue = items.filter((it) => it.overdue).sort((a, b) => b.daysInStage - a.daysInStage);


### PR DESCRIPTION
## Summary

**EPIC G (#420)** + HR finding (#439). The "time in stage" panel showed nearly the **same value for every stage** because it only measured the *current dwell* of active relations (all seeded around the same time) — not the time actually spent in each stage.

## Changes

- **`/api/admin/analytics/aging`** — `stageAging` now aggregates **completed stage segments** (entered a stage → left it) from the `StatusChange` audit trail across all relations, so stages show meaningfully different averages + medians. The initial stage counts from the relation's start to its first transition; median uses the proper even-length midpoint.
- **`oldestStuck` / `overdue`** keep measuring current dwell in the present stage for active relations (unchanged behaviour, that part was correct).

## Verification

- [x] `npm run lint` / `npm run build` clean
- [x] e2e (`stage-aging.spec.ts`): a relation with a 2-day and a 5-day segment produces different per-stage averages — guards against the uniform-value regression.

## Notes

RSVP/interaction metrics were already corrected in **EPIC D (#432)**. The **date-range selector** criterion remains open on #420 (UI follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_