### PR TITLE
feat(notes): edit private notes + relative timestamps (Betül feedback)

### DIFF
--- a/e2e/relation-note-edit.spec.ts
+++ b/e2e/relation-note-edit.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// #443 (B1): mentor-private notes can now be edited, not just deleted.
+test('a mentor can edit their own private note', async ({ page }) => {
+  const mentorEmail = uniqueEmail('rne-mentor');
+  const menteeEmail = uniqueEmail('rne-mentee');
+  const mentor = await seedUser(mentorEmail, 'Pass1234!', 'MENTOR', 'RNE Mentor');
+  const mentee = await seedUser(menteeEmail, 'Pass1234!', 'MENTEE', 'RNE Mentee');
+  const rel = await prisma.mentorshipRelation.create({
+    data: { mentorId: mentor.id, menteeId: mentee.id, status: 'ACTIVE' },
+  });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', mentorEmail);
+    await page.fill('input[type="password"]', 'Pass1234!');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => !u.pathname.includes('/auth/signin'), { timeout: 20_000 });
+
+    // Create a note, then edit it via PATCH (shares the logged-in session).
+    const created = await page.request.post('/api/relation-notes', {
+      data: { relationId: rel.id, body: 'first draft' },
+    });
+    expect(created.ok()).toBeTruthy();
+    const noteId = (await created.json()).note?.id ?? (await (await page.request.get(`/api/relation-notes?relationId=${rel.id}`)).json()).notes[0].id;
+
+    const edited = await page.request.patch(`/api/relation-notes/${noteId}`, { data: { body: 'revised note' } });
+    expect(edited.ok()).toBeTruthy();
+    expect((await edited.json()).note.body).toBe('revised note');
+
+    // Confirms via the list.
+    const list = await (await page.request.get(`/api/relation-notes?relationId=${rel.id}`)).json();
+    expect(list.notes.find((n: { id: string; body: string }) => n.id === noteId)?.body).toBe('revised note');
+  } finally {
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(menteeEmail);
+  }
+});

--- a/src/app/api/relation-notes/[id]/route.ts
+++ b/src/app/api/relation-notes/[id]/route.ts
@@ -1,7 +1,34 @@
 import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
+import { z } from 'zod';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+
+const patchSchema = z.object({ body: z.string().min(1).max(5000) });
+
+// PATCH — only the note's own author (or an admin) may edit it. `updatedAt`
+// bumps automatically (schema @updatedAt).
+export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { id } = await params;
+  const note = await prisma.relationNote.findUnique({ where: { id }, select: { authorId: true } });
+  if (!note) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  if (note.authorId !== session.user.id && session.user.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const parsed = patchSchema.safeParse(await request.json().catch(() => ({})));
+  if (!parsed.success) return NextResponse.json({ error: 'Invalid body' }, { status: 400 });
+
+  const updated = await prisma.relationNote.update({
+    where: { id },
+    data: { body: parsed.data.body.trim() },
+    select: { id: true, body: true, createdAt: true, updatedAt: true },
+  });
+  return NextResponse.json({ note: updated });
+}
 
 // DELETE — only the note's own author (or an admin) may remove it.
 export async function DELETE(_request: Request, { params }: { params: Promise<{ id: string }> }) {

--- a/src/components/EvaluationPanel.tsx
+++ b/src/components/EvaluationPanel.tsx
@@ -5,7 +5,8 @@ import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { Badge } from '@/components/ui/Badge';
 import { EVAL_CRITERIA, MENTOR_CRITERIA } from '@/lib/evaluation';
-import { useT } from '@/i18n/client';
+import { useT, useLocale } from '@/i18n/client';
+import { relativeTime } from '@/lib/relativeTime';
 
 interface Evaluation {
   id: string;
@@ -29,6 +30,7 @@ export function EvaluationPanel({
   audience?: 'MENTEE' | 'MENTOR';
 }) {
   const t = useT();
+  const locale = useLocale();
   const [items, setItems] = useState<Evaluation[]>([]);
   const [scores, setScores] = useState<Record<string, number>>({});
   const [comment, setComment] = useState('');
@@ -148,7 +150,7 @@ export function EvaluationPanel({
                   ))}
                 </div>
                 {ev.comment && <p className="text-sm text-gray-600 mt-1.5 whitespace-pre-wrap">{ev.comment}</p>}
-                <p className="text-xs text-gray-400 mt-1">{new Date(ev.createdAt).toLocaleString()}</p>
+                <p className="text-xs text-gray-400 mt-1">{relativeTime(ev.createdAt, locale)}</p>
               </div>
             );
           })}

--- a/src/components/RelationNotesPanel.tsx
+++ b/src/components/RelationNotesPanel.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { Trash2, Lock } from 'lucide-react';
+import { Trash2, Lock, Pencil } from 'lucide-react';
 import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
-import { useT } from '@/i18n/client';
+import { useT, useLocale } from '@/i18n/client';
+import { relativeTime } from '@/lib/relativeTime';
 
 interface Note {
   id: string;
@@ -18,10 +19,13 @@ interface Note {
 // never sees this panel or its data (EPIC: mentor private notes).
 export function RelationNotesPanel({ relationId }: { relationId: string }) {
   const t = useT();
+  const locale = useLocale();
   const c = t.relationNotes;
   const [notes, setNotes] = useState<Note[]>([]);
   const [body, setBody] = useState('');
   const [saving, setSaving] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editBody, setEditBody] = useState('');
 
   const load = useCallback(async () => {
     const res = await fetch(`/api/relation-notes?relationId=${relationId}`);
@@ -50,6 +54,23 @@ export function RelationNotesPanel({ relationId }: { relationId: string }) {
     await load();
   };
 
+  const startEdit = (n: Note) => { setEditingId(n.id); setEditBody(n.body); };
+  const cancelEdit = () => { setEditingId(null); setEditBody(''); };
+  const saveEdit = async (id: string) => {
+    if (!editBody.trim()) return;
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/relation-notes/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ body: editBody }),
+      });
+      if (res.ok) { cancelEdit(); await load(); }
+    } finally {
+      setSaving(false);
+    }
+  };
+
   return (
     <Card data-testid="relation-notes-panel">
       <CardHeader>
@@ -76,15 +97,37 @@ export function RelationNotesPanel({ relationId }: { relationId: string }) {
         <div className="space-y-3">
           {notes.map((n) => (
             <div key={n.id} className="rounded-lg border border-gray-100 dark:border-gray-800 p-3">
-              <p className="text-sm text-gray-800 dark:text-gray-200 whitespace-pre-line">{n.body}</p>
-              <div className="flex items-center justify-between mt-2">
-                <p className="text-xs text-gray-400">
-                  {n.author.fullName} · {new Date(n.createdAt).toLocaleDateString()}
-                </p>
-                <button onClick={() => remove(n.id)} aria-label={t.common.delete} className="text-gray-300 hover:text-red-600 dark:text-gray-600 dark:hover:text-red-400">
-                  <Trash2 className="h-4 w-4" />
-                </button>
-              </div>
+              {editingId === n.id ? (
+                <div>
+                  <textarea
+                    value={editBody}
+                    onChange={(e) => setEditBody(e.target.value)}
+                    rows={3}
+                    className="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2 text-sm mb-2"
+                  />
+                  <div className="flex gap-2">
+                    <Button size="sm" loading={saving} disabled={!editBody.trim()} onClick={() => saveEdit(n.id)}>{t.common.save}</Button>
+                    <Button size="sm" variant="outline" onClick={cancelEdit}>{t.common.cancel}</Button>
+                  </div>
+                </div>
+              ) : (
+                <>
+                  <p className="text-sm text-gray-800 dark:text-gray-200 whitespace-pre-line">{n.body}</p>
+                  <div className="flex items-center justify-between mt-2">
+                    <p className="text-xs text-gray-400">
+                      {n.author.fullName} · {relativeTime(n.createdAt, locale)}
+                    </p>
+                    <div className="flex items-center gap-2">
+                      <button onClick={() => startEdit(n)} aria-label={t.common.edit} className="text-gray-300 hover:text-blue-600 dark:text-gray-600 dark:hover:text-blue-400">
+                        <Pencil className="h-4 w-4" />
+                      </button>
+                      <button onClick={() => remove(n.id)} aria-label={t.common.delete} className="text-gray-300 hover:text-red-600 dark:text-gray-600 dark:hover:text-red-400">
+                        <Trash2 className="h-4 w-4" />
+                      </button>
+                    </div>
+                  </div>
+                </>
+              )}
             </div>
           ))}
         </div>

--- a/src/lib/relativeTime.ts
+++ b/src/lib/relativeTime.ts
@@ -1,0 +1,21 @@
+// Locale-aware relative time ("just now", "5 hours ago", "4 days ago"). Uses
+// Intl.RelativeTimeFormat so it localizes for free. Past dates read as "… ago".
+const UNITS: [Intl.RelativeTimeFormatUnit, number][] = [
+  ['year', 31536000],
+  ['month', 2592000],
+  ['week', 604800],
+  ['day', 86400],
+  ['hour', 3600],
+  ['minute', 60],
+];
+
+export function relativeTime(date: Date | string, locale: string): string {
+  const d = typeof date === 'string' ? new Date(date) : date;
+  const sec = Math.round((Date.now() - d.getTime()) / 1000);
+  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' });
+  const abs = Math.abs(sec);
+  for (const [unit, s] of UNITS) {
+    if (abs >= s) return rtf.format(-Math.round(sec / s), unit);
+  }
+  return rtf.format(-sec, 'second'); // < 1 minute → "just now"
+}


### PR DESCRIPTION
## Summary

First batch of mentee feedback from **Betül Buldu** (#443):

- **B1 — edit private notes.** Mentor-private notes were delete-only; you can now **edit** them inline. New `PATCH /api/relation-notes/[id]` (author or admin only; the existing `updatedAt` bumps automatically).
- **B2 — relative timestamps.** Note and mentor-evaluation times now show as **locale-aware relative time** ("just now", "5 hours ago", "4 days ago") via a small `relativeTime` util (`Intl.RelativeTimeFormat`, so EN/TR/DE for free).

## Verification

- [x] `npm run lint` / `npm run build` clean
- [x] e2e (`relation-note-edit.spec.ts`): a mentor edits their own note and the change persists.

Remaining Betül items (goals attribution, interaction-log empty state/filters, notes page + categories, meeting preset topics, message attachments) are tracked on #443 and will land in follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_