### PR TITLE
feat(goals): show goal creator (mentor/mentee) + date (Betül B3)

### DIFF
--- a/e2e/goal-attribution.spec.ts
+++ b/e2e/goal-attribution.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// #443 (B3): goals record which side created them, so the UI can show
+// "Created by mentor/mentee".
+test('a goal records its creator role', async ({ page }) => {
+  const mentorEmail = uniqueEmail('goal-mentor');
+  const menteeEmail = uniqueEmail('goal-mentee');
+  const mentor = await seedUser(mentorEmail, 'Pass1234!', 'MENTOR', 'Goal Mentor');
+  const mentee = await seedUser(menteeEmail, 'Pass1234!', 'MENTEE', 'Goal Mentee');
+  const rel = await prisma.mentorshipRelation.create({
+    data: { mentorId: mentor.id, menteeId: mentee.id, status: 'ACTIVE' },
+  });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', mentorEmail);
+    await page.fill('input[type="password"]', 'Pass1234!');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => !u.pathname.includes('/auth/signin'), { timeout: 20_000 });
+
+    const created = await page.request.post('/api/goals', {
+      data: { relationId: rel.id, title: 'Finish the onboarding doc' },
+    });
+    expect(created.ok()).toBeTruthy();
+
+    const list = await (await page.request.get(`/api/goals?relationId=${rel.id}`)).json();
+    const goal = list.goals.find((g: { title: string }) => g.title === 'Finish the onboarding doc');
+    expect(goal).toBeTruthy();
+    expect(goal.createdByRole).toBe('MENTOR');
+    expect(typeof goal.createdAt).toBe('string');
+  } finally {
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(menteeEmail);
+  }
+});

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -563,13 +563,15 @@ model RelationNote {
 
 // A goal set within a mentorship — supports goal setting + tracking (checklist 7).
 model Goal {
-  id          String     @id @default(cuid())
-  relationId  String
-  title       String
-  description String?    @db.Text
-  status      GoalStatus @default(OPEN)
-  dueDate     DateTime?
-  createdAt   DateTime   @default(now())
+  id            String     @id @default(cuid())
+  relationId    String
+  title         String
+  description   String?    @db.Text
+  status        GoalStatus @default(OPEN)
+  dueDate       DateTime?
+  createdAt     DateTime   @default(now())
+  // Which side created the goal (mentor vs mentee), so it's clear at a glance.
+  createdByRole Role?
 
   relation MentorshipRelation @relation(fields: [relationId], references: [id], onDelete: Cascade)
 
@@ -625,13 +627,13 @@ model StatusChange {
 }
 
 model InvitationToken {
-  id        String   @id @default(cuid())
-  token     String   @unique
-  email     String
-  role      Role
-  used      Boolean  @default(false)
-  createdAt DateTime @default(now())
-  expiresAt DateTime
+  id           String    @id @default(cuid())
+  token        String    @unique
+  email        String
+  role         Role
+  used         Boolean   @default(false)
+  createdAt    DateTime  @default(now())
+  expiresAt    DateTime
   // Lifecycle timestamps (nullable — each set once, the first time it happens):
   // openedAt  → the register link was clicked/opened
   // registeredAt → the account was created from this invitation

--- a/src/app/api/goals/route.ts
+++ b/src/app/api/goals/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import type { Role } from '@prisma/client';
 import { z } from 'zod';
 
 async function relationIfAllowed(userId: string, role: string, relationId: string) {
@@ -48,6 +49,8 @@ export async function POST(request: Request) {
       title: parsed.data.title,
       description: parsed.data.description || null,
       dueDate: parsed.data.dueDate ? new Date(parsed.data.dueDate) : null,
+      // Record which side set the goal so it's clear who owns it.
+      createdByRole: session.user.role as Role,
     },
   });
   return NextResponse.json({ goal }, { status: 201 });

--- a/src/components/GoalsPanel.tsx
+++ b/src/components/GoalsPanel.tsx
@@ -5,7 +5,7 @@ import { Check, Circle, Trash2 } from 'lucide-react';
 import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Input } from '@/components/ui/Input';
 import { Button } from '@/components/ui/Button';
-import { useT } from '@/i18n/client';
+import { useT, useLocale } from '@/i18n/client';
 
 interface Goal {
   id: string;
@@ -13,12 +13,15 @@ interface Goal {
   description: string | null;
   status: 'OPEN' | 'DONE';
   dueDate: string | null;
+  createdAt: string;
+  createdByRole: string | null;
 }
 
 // Goal setting + tracking for a mentorship relation. Read-only viewers (e.g. a
 // company observer) only see progress; participants can add/toggle/remove.
 export function GoalsPanel({ relationId, readOnly = false }: { relationId: string; readOnly?: boolean }) {
   const t = useT();
+  const locale = useLocale();
   const [goals, setGoals] = useState<Goal[]>([]);
   const [title, setTitle] = useState('');
   const [dueDate, setDueDate] = useState('');
@@ -92,9 +95,14 @@ export function GoalsPanel({ relationId, readOnly = false }: { relationId: strin
               >
                 {g.status === 'DONE' ? <Check className="h-4 w-4" /> : <Circle className="h-4 w-4" />}
               </button>
-              <span className={`flex-1 ${g.status === 'DONE' ? 'line-through text-gray-400' : 'text-gray-800'}`}>
-                {g.title}
-                {g.dueDate && <span className="text-xs text-gray-400 ml-2">{new Date(g.dueDate).toLocaleDateString()}</span>}
+              <span className="flex-1 min-w-0">
+                <span className={g.status === 'DONE' ? 'line-through text-gray-400' : 'text-gray-800'}>{g.title}</span>
+                <span className="flex flex-wrap items-center gap-x-2 text-[11px] text-gray-400">
+                  {g.createdByRole === 'MENTOR' && <span>{t.goals.byMentor}</span>}
+                  {g.createdByRole === 'MENTEE' && <span>{t.goals.byMentee}</span>}
+                  <span>· {new Date(g.createdAt).toLocaleDateString(locale)}</span>
+                  {g.dueDate && <span>· {t.goals.dueDate}: {new Date(g.dueDate).toLocaleDateString(locale)}</span>}
+                </span>
               </span>
               {!readOnly && (
                 <button onClick={() => remove(g.id)} aria-label={t.common.delete} className="text-gray-300 hover:text-red-600">

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -582,6 +582,8 @@ const en = {
     completed: 'completed',
     markDone: 'Mark done',
     markOpen: 'Reopen',
+    byMentor: 'Created by mentor',
+    byMentee: 'Created by mentee',
   },
   cohorts: {
     title: 'Cohorts',
@@ -1636,6 +1638,8 @@ const tr: Dict = {
     completed: 'tamamlandı',
     markDone: 'Tamamlandı işaretle',
     markOpen: 'Yeniden aç',
+    byMentor: 'Mentor oluşturdu',
+    byMentee: 'Mentee oluşturdu',
   },
   cohorts: {
     title: 'Kohortlar',
@@ -2688,6 +2692,8 @@ const de: Dict = {
     completed: 'abgeschlossen',
     markDone: 'Als erledigt markieren',
     markOpen: 'Wieder öffnen',
+    byMentor: 'Vom Mentor erstellt',
+    byMentee: 'Vom Mentee erstellt',
   },
   cohorts: {
     title: 'Kohorten',


### PR DESCRIPTION
## Summary

Betül feedback **B3** (#443): it wasn't clear whether a goal was created by the mentor or the mentee.

## Changes

- **schema**: `Goal.createdByRole` (nullable `Role`); stamped from the session on `POST /api/goals`.
- **GoalsPanel**: each goal now shows a **"Created by mentor / by mentee"** label and its **creation date** (locale-aware).
- i18n `goals.byMentor` / `goals.byMentee` (EN/TR/DE).

## Verification

- [x] `npm run lint` / `npm run build` clean
- [x] e2e (`goal-attribution.spec.ts`): a mentor-created goal records `createdByRole=MENTOR`.

CI runs `prisma db push`, so the new nullable column exists in the test DB. Existing goals have `createdByRole = null` (no label shown) — safe.

Remaining Betül items (interaction-log empty state/filters, notes page+categories, meeting preset topics, message attachments) stay tracked on #443.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_