### PR TITLE
feat(mentorship): ASCII-transliterate generated mentee emails + guard tests (#419)

### DIFF
--- a/e2e/dup-guard-transliteration.spec.ts
+++ b/e2e/dup-guard-transliteration.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// EPIC F (#419) — a mentee added without an email gets a generated placeholder.
+// The name may contain Turkish letters (ı, ş, ğ, ü, ö, ç); the placeholder must
+// be transliterated to plain ASCII so it stays a valid, sane-looking email.
+test('a Turkish-named mentee without email gets an ASCII placeholder email', async ({ page }) => {
+  const mentorEmail = uniqueEmail('translit-mentor');
+  const password = 'MentorPass123!';
+  await seedUser(mentorEmail, password, 'MENTOR', 'Translit Mentor');
+  const menteeName = `Şükrü Çağdaş Öğütürk ${Date.now()}`;
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', mentorEmail);
+    await page.fill('input[type="password"]', password);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/mentor'), { timeout: 20_000 });
+
+    await page.goto('/mentor/mentees/new');
+    await page.getByLabel(/Full Name/).fill(menteeName);
+    // Deliberately leave the email empty → placeholder path.
+    const created = page.waitForResponse(
+      (r) => r.url().includes('/api/mentor/mentees') && r.request().method() === 'POST'
+    );
+    await page.getByRole('button', { name: 'Create' }).click();
+    await created;
+
+    const mentee = await prisma.user.findFirst({ where: { fullName: menteeName, role: 'MENTEE' } });
+    expect(mentee).not.toBeNull();
+    // Pure ASCII, no Turkish diacritics leaked into the address.
+    expect(mentee!.email).toMatch(/^mentee\.[a-z0-9.]+\.[0-9a-f]+@import\.local$/);
+    expect(mentee!.email).toContain('sukru.cagdas.oguturk');
+    // eslint-disable-next-line no-control-regex
+    expect(mentee!.email).toMatch(/^[\x00-\x7F]+$/);
+
+    await prisma.mentorshipRelation.deleteMany({ where: { menteeId: mentee!.id } });
+    await prisma.user.delete({ where: { id: mentee!.id } }).catch(() => {});
+  } finally {
+    await cleanupByEmail(mentorEmail);
+  }
+});
+
+// EPIC F (#419) — a mentee can only have one ACTIVE mentorship relation at a time.
+// Assigning a second mentor while one is active must be rejected with 409.
+test('assigning a mentee who already has an active relation returns 409', async ({ page }) => {
+  const adminEmail = uniqueEmail('dup-admin');
+  const mentorAEmail = uniqueEmail('dup-mentor-a');
+  const mentorBEmail = uniqueEmail('dup-mentor-b');
+  const menteeEmail = uniqueEmail('dup-mentee');
+  const password = 'AdminPass123!';
+
+  await seedUser(adminEmail, password, 'ADMIN', 'Dup Admin');
+  const mentorA = await seedUser(mentorAEmail, 'MentorPass123!', 'MENTOR', 'Dup Mentor A');
+  const mentorB = await seedUser(mentorBEmail, 'MentorPass123!', 'MENTOR', 'Dup Mentor B');
+  const mentee = await seedUser(menteeEmail, 'MenteePass123!', 'MENTEE', 'Dup Mentee');
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', password);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    // First assignment succeeds (creates an ACTIVE relation).
+    const first = await page.request.post('/api/mentorship', {
+      data: { mentorId: mentorA.id, menteeId: mentee.id },
+    });
+    expect(first.status()).toBe(201);
+
+    // Second assignment for the same mentee is rejected — already active.
+    const second = await page.request.post('/api/mentorship', {
+      data: { mentorId: mentorB.id, menteeId: mentee.id },
+    });
+    expect(second.status()).toBe(409);
+    const body = await second.json();
+    expect(body.error).toMatch(/active mentorship/i);
+
+    // Only one relation was ever persisted for this mentee.
+    const relCount = await prisma.mentorshipRelation.count({ where: { menteeId: mentee.id } });
+    expect(relCount).toBe(1);
+  } finally {
+    await prisma.mentorshipRelation.deleteMany({ where: { menteeId: mentee.id } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorAEmail);
+    await cleanupByEmail(mentorBEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/src/app/api/cohorts/route.ts
+++ b/src/app/api/cohorts/route.ts
@@ -31,6 +31,8 @@ export async function POST(request: Request) {
   if (!session || session.user.role !== 'ADMIN') return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   const parsed = schema.safeParse(await request.json());
   if (!parsed.success) return NextResponse.json({ error: 'Validation failed' }, { status: 400 });
-  const cohort = await prisma.cohort.create({ data: { name: parsed.data.name, term: parsed.data.term || null } });
+  // Trim so a whitespace-only term is stored as null (shows as "—") rather than
+  // a blank string. Term is free-text (e.g. "Fall 2026"), so no format check.
+  const cohort = await prisma.cohort.create({ data: { name: parsed.data.name.trim(), term: parsed.data.term?.trim() || null } });
   return NextResponse.json({ cohort }, { status: 201 });
 }

--- a/src/app/api/mentor/mentees/route.ts
+++ b/src/app/api/mentor/mentees/route.ts
@@ -6,6 +6,7 @@ import crypto from 'crypto';
 import { z } from 'zod';
 import { createPasswordResetToken } from '@/lib/passwordReset';
 import { sendPasswordResetEmail } from '@/services/emailService';
+import { slugify } from '@/lib/transliterate';
 
 const schema = z.object({
   fullName: z.string().min(1),
@@ -17,9 +18,6 @@ const schema = z.object({
   department: z.string().optional(),
   referralSource: z.string().optional(),
 });
-
-const slug = (s: string) =>
-  s.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '').replace(/[^a-z0-9]+/g, '.').replace(/^\.|\.$/g, '');
 
 // A mentor (or admin) creates a mentee and assigns it to themselves in one step.
 export async function POST(request: Request) {
@@ -39,7 +37,7 @@ export async function POST(request: Request) {
     const hasRealEmail = !!(email && email.length > 0);
     const finalEmail = hasRealEmail
       ? email!
-      : `mentee.${slug(fullName)}.${crypto.randomBytes(2).toString('hex')}@import.local`;
+      : `mentee.${slugify(fullName)}.${crypto.randomBytes(2).toString('hex')}@import.local`;
 
     const existing = await prisma.user.findUnique({ where: { email: finalEmail } });
     if (existing) {

--- a/src/lib/transliterate.ts
+++ b/src/lib/transliterate.ts
@@ -1,0 +1,23 @@
+// Transliterate Turkish (and common accented) letters to ASCII so generated
+// emails/usernames/slugs stay valid. NFD-stripping alone drops the dotless ı
+// (it has no combining mark), so map the Turkish letters explicitly first.
+const MAP: Record<string, string> = {
+  ı: 'i', İ: 'I', ş: 's', Ş: 'S', ğ: 'g', Ğ: 'G',
+  ü: 'u', Ü: 'U', ö: 'o', Ö: 'O', ç: 'c', Ç: 'C',
+};
+
+export function transliterate(input: string): string {
+  return input
+    .replace(/[ıİşŞğĞüÜöÖçÇ]/g, (ch) => MAP[ch] ?? ch)
+    // Decompose remaining accents (é → e, etc.) and strip combining marks.
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '');
+}
+
+// A dotted email/username slug: transliterate, lowercase, non-alphanumerics → '.'.
+export function slugify(input: string): string {
+  return transliterate(input)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '.')
+    .replace(/^\.|\.$/g, '');
+}


### PR DESCRIPTION
## EPIC F — Duplicate mentorship & email transliteration (#419)

When a mentee is added without an email address, the app generates a placeholder
address so the record is valid. For Turkish names (`ı ş ğ ü ö ç`) the old inline
slug leaked non-ASCII characters into the address.

### Changes
- **`src/lib/transliterate.ts`** (new): `transliterate()` maps Turkish letters to
  ASCII (NFD-strip alone drops the dotless `ı`), plus `slugify()` for dotted
  email/username slugs.
- **`src/app/api/mentor/mentees/route.ts`**: placeholder email now uses
  `slugify(fullName)` → `mentee.<ascii-slug>.<hex>@import.local`.
- **`src/app/api/cohorts/route.ts`**: trim cohort `name`/`term` so a
  whitespace-only term is stored as `null`.
- **e2e** (`e2e/dup-guard-transliteration.spec.ts`): a Turkish-named mentee
  without an email gets a pure-ASCII placeholder; assigning a mentee who already
  has an ACTIVE relation is rejected with `409` (covers the existing guard in
  `/api/mentorship`).

Closes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_