### PR TITLE
ci: gate production deploy on E2E success + i18n parity check (#425)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,4 +27,6 @@ jobs:
       - run: npx prisma validate
       - run: npm run lint
       - run: npx tsc --noEmit
+      - name: i18n parity (EN/TR/DE)
+        run: npm run check:i18n
       - run: npm run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,15 +1,23 @@
 name: Deploy to Plesk Server
 
 on:
-  push:
-    branches: [main]
+  # Previews deploy on every PR (tests run alongside — a broken preview is fine).
   pull_request:
+    branches: [main]
+  # Production deploys ONLY after the E2E suite finishes on main. The job below
+  # additionally requires conclusion == success, so a red build never ships.
+  # This is a code-level complement to branch protection (issue #425).
+  workflow_run:
+    workflows: ["E2E Tests"]
+    types: [completed]
     branches: [main]
 
 jobs:
   build-and-deploy:
     name: ${{ github.event_name == 'pull_request' && 'Preview Deploy' || 'Production Deploy' }}
     runs-on: ubuntu-latest
+    # Preview: always (on PR). Production: only when the E2E run it followed passed.
+    if: ${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}
     permissions:
       contents: read
       packages: write       # push images to ghcr.io
@@ -18,6 +26,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # For workflow_run, build the exact commit the E2E suite validated
+          # (github.sha would be the branch tip, which may have moved).
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -47,7 +59,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tag }}
           build-args: |
-            GIT_SHA=${{ github.sha }}
+            GIT_SHA=${{ github.event.workflow_run.head_sha || github.sha }}
           # No build-time secrets — all real values are injected at `docker run`
 
       # ── SSH key setup (shared by both deploy steps) ──────────────────────────
@@ -69,9 +81,9 @@ jobs:
           ssh-keyscan -H "$SSH_HOST" \
             >> ~/.ssh/known_hosts 2>/dev/null || true
 
-      # ── Production deploy (push to main) ────────────────────────────────────
+      # ── Production deploy (after E2E succeeds on main) ───────────────────────
       - name: Deploy to production via SSH
-        if: github.event_name == 'push'
+        if: github.event_name == 'workflow_run'
         env:
           SSH_HOST: ${{ secrets.SSH_HOST }}
           SSH_USER: ${{ secrets.SSH_USER }}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "check:i18n": "node --experimental-strip-types scripts/check-i18n.ts",
     "test:e2e": "playwright test",
     "test:e2e:headed": "playwright test --headed",
     "import:csv": "node scripts/import-csv.mjs",

--- a/scripts/check-i18n.ts
+++ b/scripts/check-i18n.ts
@@ -1,0 +1,46 @@
+// CI guard for i18n dictionary integrity (EN/TR/DE). TypeScript already enforces
+// key parity via the `Dict` type, so this is defense-in-depth that ALSO catches
+// what the type can't: empty / whitespace-only translations, and reports any
+// drift with a clear, actionable message. Run with Node's TS stripping:
+//   node --experimental-strip-types scripts/check-i18n.ts
+import { dictionaries } from '../src/i18n/dictionaries.ts';
+
+type AnyRec = Record<string, unknown>;
+
+function flatten(obj: AnyRec, prefix = ''): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    const key = prefix ? `${prefix}.${k}` : k;
+    if (v && typeof v === 'object' && !Array.isArray(v)) {
+      Object.assign(out, flatten(v as AnyRec, key));
+    } else {
+      out[key] = String(v);
+    }
+  }
+  return out;
+}
+
+const locales = Object.keys(dictionaries);
+const BASE = 'en';
+const baseFlat = flatten(dictionaries[BASE as keyof typeof dictionaries] as AnyRec);
+const baseKeys = Object.keys(baseFlat);
+const baseKeySet = new Set(baseKeys);
+const errors: string[] = [];
+
+for (const loc of locales) {
+  const flat = flatten(dictionaries[loc as keyof typeof dictionaries] as AnyRec);
+  const keySet = new Set(Object.keys(flat));
+  for (const k of baseKeys) if (!keySet.has(k)) errors.push(`[${loc}] missing key: ${k}`);
+  for (const k of keySet) if (!baseKeySet.has(k)) errors.push(`[${loc}] extra key: ${k}`);
+  for (const [k, v] of Object.entries(flat)) {
+    if (v.trim() === '') errors.push(`[${loc}] empty value: ${k}`);
+  }
+}
+
+if (errors.length > 0) {
+  console.error(`i18n check FAILED — ${errors.length} issue(s):`);
+  for (const e of errors) console.error('  ' + e);
+  process.exit(1);
+}
+
+console.log(`i18n OK — ${baseKeys.length} keys × ${locales.length} locales (${locales.join(', ')})`);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,6 +35,7 @@
     ".next/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "scripts"
   ]
 }


### PR DESCRIPTION
## EPIC L — CI/CD & quality gates (#425)

Code-level complement to branch protection.

### Changes
- **Production deploy gated on tests**: `deploy.yml` no longer runs production in
  parallel with the test suite. It now triggers via `workflow_run` after the
  **E2E Tests** workflow completes on `main`, and the job only runs when
  `conclusion == success` — so a red build can never ship. It checks out and
  builds the exact `head_sha` the suite validated (not the branch tip). PR
  previews are unchanged (still deploy on `pull_request`).
- **i18n integrity check**: new `scripts/check-i18n.ts` (`npm run check:i18n`),
  wired into the CI **Lint · Typecheck · Build** job. It verifies EN/TR/DE key
  parity (defense-in-depth over the `Dict` type) and flags empty/whitespace-only
  translations, with a clear failure message. Uses Node's runtime type stripping;
  `scripts/` is excluded from `tsc` (the `.ts` import extension it needs isn't
  valid under the app's `tsc` config).

### Required checks after this merge
`Lint · Typecheck · Build` (now includes i18n) and `Playwright smoke` remain the
quality gates; production deploy is downstream of E2E success.

### Note on the first deploy
Because this removes the `push`-triggered production deploy, the first production
deploy after merge happens via the new `workflow_run` path once E2E goes green on
`main`. Worth a human eye on that first run.

Closes #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_