### PR TITLE
feat(board): group kanban stages into collapsible phases + WIP & overdue (#422)

### DIFF
--- a/e2e/board-grouping.spec.ts
+++ b/e2e/board-grouping.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// EPIC I (#422) — the admin board groups the 13 stages into collapsible phases
+// and flags overdue cards.
+test('admin board groups stages into collapsible phases and flags overdue cards', async ({ page }) => {
+  const adminEmail = uniqueEmail('bg-admin');
+  const mentorEmail = uniqueEmail('bg-mentor');
+  const menteeEmail = uniqueEmail('bg-mentee');
+  const password = 'AdminPass123!';
+  await seedUser(adminEmail, password, 'ADMIN', 'BG Admin');
+  const mentor = await seedUser(mentorEmail, 'MentorPass123!', 'MENTOR', 'BG Mentor');
+  const mentee = await seedUser(menteeEmail, 'MenteePass123!', 'MENTEE', 'BG Zeynep Overdue');
+
+  // A pre-internship stage with a deadline in the past → overdue badge.
+  const rel = await prisma.mentorshipRelation.create({
+    data: {
+      mentorId: mentor.id,
+      menteeId: mentee.id,
+      pipelineStatus: 'APPLICATION_100',
+      stageDeadline: new Date('2020-01-01T00:00:00Z'),
+    },
+  });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', password);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    await page.goto('/admin/board');
+
+    // The three phase headers are present (labels are exact span text).
+    await expect(page.getByText('Pre-internship', { exact: true })).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('Internship', { exact: true })).toBeVisible();
+    await expect(page.getByText('Outcome', { exact: true })).toBeVisible();
+    const preHeader = page.getByRole('button', { name: /Pre-internship/i });
+
+    // The overdue candidate card is shown with its badge.
+    await expect(page.getByText('BG Zeynep Overdue')).toBeVisible();
+    await expect(page.getByText(/overdue/i).first()).toBeVisible();
+
+    // Collapsing the pre-internship phase hides its cards.
+    await preHeader.click();
+    await expect(page.getByText('BG Zeynep Overdue')).toBeHidden({ timeout: 10_000 });
+  } finally {
+    await prisma.mentorshipRelation.deleteMany({ where: { id: rel.id } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/src/app/admin/board/page.tsx
+++ b/src/app/admin/board/page.tsx
@@ -2,20 +2,25 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
-import { GraduationCap, User } from 'lucide-react';
-import { PIPELINE_STATUSES, pipelineLabel } from '@/lib/pipeline';
+import { GraduationCap, User, ChevronDown, ChevronRight, AlertTriangle } from 'lucide-react';
+import { PIPELINE_STATUSES, PIPELINE_GROUPS, pipelineLabel, type PipelineGroupKey } from '@/lib/pipeline';
 import { useT, useLocale } from '@/i18n/client';
 
 interface Relation {
   id: string;
   pipelineStatus: string;
+  stageDeadline?: string | null;
   mentee: { id: string; fullName: string; university?: string };
   mentor: { fullName: string };
   _count: { interactions: number };
 }
 
+// Soft work-in-progress limit: a column holding more than this many candidates
+// gets an amber count so bottlenecks stand out. Advisory only — never blocks.
+const WIP_LIMIT = 8;
+
 // Admin kanban across ALL mentorship relations (every mentor's mentees).
-// Reuses the mentor-board mechanics: drag a card to change its pipeline stage.
+// Stages are grouped into three collapsible phases so 13 columns don't sprawl.
 export default function AdminBoardPage() {
   const t = useT();
   const locale = useLocale();
@@ -25,6 +30,11 @@ export default function AdminBoardPage() {
   const [dragOver, setDragOver] = useState<string | null>(null);
   const [search, setSearch] = useState('');
   const [hideEmpty, setHideEmpty] = useState(false);
+  const [collapsed, setCollapsed] = useState<Record<PipelineGroupKey, boolean>>({
+    pre: false,
+    internship: false,
+    result: false,
+  });
 
   const fetchRelations = useCallback(async () => {
     const res = await fetch('/api/mentorship');
@@ -54,6 +64,102 @@ export default function AdminBoardPage() {
 
   if (loading) return <div className="text-center py-12 text-gray-400">{t.common.loading}</div>;
 
+  const q = search.trim().toLowerCase();
+  const now = Date.now();
+  const itemsFor = (status: string) =>
+    relations.filter(
+      (r) => r.pipelineStatus === status &&
+        (!q || r.mentee.fullName.toLowerCase().includes(q) || r.mentor.fullName.toLowerCase().includes(q))
+    );
+
+  const toggleGroup = (key: PipelineGroupKey) =>
+    setCollapsed((c) => ({ ...c, [key]: !c[key] }));
+
+  const renderColumn = (status: string) => {
+    const items = itemsFor(status);
+    const overLimit = items.length > WIP_LIMIT;
+    return (
+      <div
+        key={status}
+        onDragOver={(e) => { e.preventDefault(); setDragOver(status); }}
+        onDragLeave={() => setDragOver((s) => (s === status ? null : s))}
+        onDrop={(e) => {
+          e.preventDefault();
+          setDragOver(null);
+          const id = e.dataTransfer.getData('relationId');
+          if (id) moveTo(id, status);
+        }}
+        className={`flex-shrink-0 w-64 rounded-xl border p-3 transition-colors ${
+          dragOver === status ? 'border-blue-400 bg-blue-50' : 'border-gray-200 bg-gray-50'
+        }`}
+      >
+        <div className="flex items-center justify-between mb-3 px-1">
+          <span className="text-xs font-semibold text-gray-700">{pipelineLabel(status, locale)}</span>
+          <span
+            title={overLimit ? t.adminBoard.wipWarning : undefined}
+            className={`text-xs rounded-full px-2 py-0.5 border ${
+              overLimit
+                ? 'text-amber-700 bg-amber-50 border-amber-300 font-semibold'
+                : 'text-gray-400 bg-white border-gray-200'
+            }`}
+          >
+            {items.length}{overLimit ? ` / ${WIP_LIMIT}` : ''}
+          </span>
+        </div>
+
+        <div className="space-y-2 min-h-[40px]">
+          {items.map((r) => {
+            const overdue = !!r.stageDeadline && new Date(r.stageDeadline).getTime() < now;
+            return (
+              <div
+                key={r.id}
+                draggable
+                onDragStart={(e) => e.dataTransfer.setData('relationId', r.id)}
+                onClick={() => router.push(`/admin/candidates/${r.mentee.id}`)}
+                className="bg-white border border-gray-200 rounded-lg p-3 cursor-grab active:cursor-grabbing hover:border-blue-300 hover:shadow-sm transition"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <p className="text-sm font-medium text-gray-900 truncate">{r.mentee.fullName}</p>
+                  {overdue && (
+                    <span className="flex-shrink-0 flex items-center gap-1 text-[10px] font-medium text-red-600 bg-red-50 border border-red-200 rounded-full px-1.5 py-0.5">
+                      <AlertTriangle className="h-3 w-3" />
+                      {t.adminBoard.overdue}
+                    </span>
+                  )}
+                </div>
+                {r.mentee.university && (
+                  <p className="text-xs text-gray-500 truncate mt-0.5">{r.mentee.university}</p>
+                )}
+                <div className="flex items-center gap-3 text-xs text-gray-400 mt-2">
+                  <span className="flex items-center gap-1 truncate">
+                    <User className="h-3 w-3 flex-shrink-0" />
+                    {r.mentor.fullName}
+                  </span>
+                  <span className="flex items-center gap-1 flex-shrink-0">
+                    <GraduationCap className="h-3 w-3" />
+                    {r._count.interactions}
+                  </span>
+                </div>
+                {/* Keyboard/touch-accessible alternative to drag-and-drop. */}
+                <select
+                  aria-label={t.adminBoard.moveTo}
+                  value={status}
+                  onClick={(e) => e.stopPropagation()}
+                  onChange={(e) => { e.stopPropagation(); moveTo(r.id, e.target.value); }}
+                  className="mt-2 w-full rounded border border-gray-200 px-1.5 py-1 text-xs text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-100"
+                >
+                  {PIPELINE_STATUSES.map((sv) => (
+                    <option key={sv} value={sv}>{pipelineLabel(sv, locale)}</option>
+                  ))}
+                </select>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  };
+
   return (
     <div>
       <div className="mb-6">
@@ -75,78 +181,34 @@ export default function AdminBoardPage() {
         </label>
       </div>
 
-      <div className="flex gap-4 overflow-x-auto pb-4">
-        {PIPELINE_STATUSES.map((status) => {
-          const q = search.trim().toLowerCase();
-          const items = relations.filter(
-            (r) => r.pipelineStatus === status &&
-              (!q || r.mentee.fullName.toLowerCase().includes(q) || r.mentor.fullName.toLowerCase().includes(q))
-          );
-          if (hideEmpty && items.length === 0) return null;
+      <div className="space-y-5">
+        {PIPELINE_GROUPS.map((group) => {
+          const statuses = hideEmpty
+            ? group.statuses.filter((s) => itemsFor(s).length > 0)
+            : group.statuses;
+          const groupTotal = group.statuses.reduce((n, s) => n + itemsFor(s).length, 0);
+          if (hideEmpty && groupTotal === 0) return null;
+          const isCollapsed = collapsed[group.key];
           return (
-            <div
-              key={status}
-              onDragOver={(e) => {
-                e.preventDefault();
-                setDragOver(status);
-              }}
-              onDragLeave={() => setDragOver((s) => (s === status ? null : s))}
-              onDrop={(e) => {
-                e.preventDefault();
-                setDragOver(null);
-                const id = e.dataTransfer.getData('relationId');
-                if (id) moveTo(id, status);
-              }}
-              className={`flex-shrink-0 w-64 rounded-xl border p-3 transition-colors ${
-                dragOver === status ? 'border-blue-400 bg-blue-50' : 'border-gray-200 bg-gray-50'
-              }`}
-            >
-              <div className="flex items-center justify-between mb-3 px-1">
-                <span className="text-xs font-semibold text-gray-700">{pipelineLabel(status, locale)}</span>
-                <span className="text-xs text-gray-400 bg-white border border-gray-200 rounded-full px-2 py-0.5">
-                  {items.length}
+            <section key={group.key} className="rounded-xl border border-gray-100 bg-white/40">
+              <button
+                type="button"
+                onClick={() => toggleGroup(group.key)}
+                aria-expanded={!isCollapsed}
+                className="w-full flex items-center gap-2 px-3 py-2 text-left"
+              >
+                {isCollapsed ? <ChevronRight className="h-4 w-4 text-gray-400" /> : <ChevronDown className="h-4 w-4 text-gray-400" />}
+                <span className="text-sm font-semibold text-gray-800">
+                  {(t.adminBoard.groups as Record<string, string>)[group.key]}
                 </span>
-              </div>
-
-              <div className="space-y-2 min-h-[40px]">
-                {items.map((r) => (
-                  <div
-                    key={r.id}
-                    draggable
-                    onDragStart={(e) => e.dataTransfer.setData('relationId', r.id)}
-                    onClick={() => router.push(`/admin/candidates/${r.mentee.id}`)}
-                    className="bg-white border border-gray-200 rounded-lg p-3 cursor-grab active:cursor-grabbing hover:border-blue-300 hover:shadow-sm transition"
-                  >
-                    <p className="text-sm font-medium text-gray-900 truncate">{r.mentee.fullName}</p>
-                    {r.mentee.university && (
-                      <p className="text-xs text-gray-500 truncate mt-0.5">{r.mentee.university}</p>
-                    )}
-                    <div className="flex items-center gap-3 text-xs text-gray-400 mt-2">
-                      <span className="flex items-center gap-1 truncate">
-                        <User className="h-3 w-3 flex-shrink-0" />
-                        {r.mentor.fullName}
-                      </span>
-                      <span className="flex items-center gap-1 flex-shrink-0">
-                        <GraduationCap className="h-3 w-3" />
-                        {r._count.interactions}
-                      </span>
-                    </div>
-                    {/* Keyboard-accessible alternative to drag-and-drop. */}
-                    <select
-                      aria-label={t.adminBoard.moveTo}
-                      value={status}
-                      onClick={(e) => e.stopPropagation()}
-                      onChange={(e) => { e.stopPropagation(); moveTo(r.id, e.target.value); }}
-                      className="mt-2 w-full rounded border border-gray-200 px-1.5 py-1 text-xs text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-100"
-                    >
-                      {PIPELINE_STATUSES.map((sv) => (
-                        <option key={sv} value={sv}>{pipelineLabel(sv, locale)}</option>
-                      ))}
-                    </select>
-                  </div>
-                ))}
-              </div>
-            </div>
+                <span className="text-xs text-gray-400 bg-gray-100 rounded-full px-2 py-0.5">{groupTotal}</span>
+              </button>
+              {!isCollapsed && (
+                <div className="flex gap-4 overflow-x-auto px-3 pb-4">
+                  {statuses.map(renderColumn)}
+                </div>
+              )}
+            </section>
           );
         })}
       </div>

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -479,6 +479,9 @@ const en = {
     searchPlaceholder: 'Find a mentee or mentor...',
     hideEmpty: 'Hide empty stages',
     moveTo: 'Move to stage',
+    overdue: 'overdue',
+    wipWarning: 'Over the recommended limit',
+    groups: { pre: 'Pre-internship', internship: 'Internship', result: 'Outcome' },
   },
   mentorEmail: {
     title: 'Email mentees',
@@ -1594,6 +1597,9 @@ const tr: Dict = {
     searchPlaceholder: 'Mentee veya mentor bul...',
     hideEmpty: 'Boş aşamaları gizle',
     moveTo: 'Aşamaya taşı',
+    overdue: 'gecikmiş',
+    wipWarning: 'Önerilen limitin üzerinde',
+    groups: { pre: 'Staj öncesi', internship: 'Staj', result: 'Sonuç' },
   },
   mentorEmail: {
     title: 'Mentee’lere e-posta',
@@ -2707,6 +2713,9 @@ const de: Dict = {
     searchPlaceholder: 'Mentee oder Mentor finden...',
     hideEmpty: 'Leere Phasen ausblenden',
     moveTo: 'In Phase verschieben',
+    overdue: 'überfällig',
+    wipWarning: 'Über dem empfohlenen Limit',
+    groups: { pre: 'Vor dem Praktikum', internship: 'Praktikum', result: 'Ergebnis' },
   },
   mentorEmail: {
     title: 'Mentees per E-Mail erreichen',

--- a/src/lib/pipeline.ts
+++ b/src/lib/pipeline.ts
@@ -77,6 +77,26 @@ export function pipelineOptions(locale: Locale = 'en') {
   return PIPELINE_STATUSES.map((value) => ({ value, label: pipelineLabel(value, locale) }));
 }
 
+// Logical groupings of the 13 stages, so the kanban board can collapse the
+// horizontal sprawl into three phases: before the internship, during it, and
+// the outcome. Every PipelineStatus belongs to exactly one group.
+export type PipelineGroupKey = 'pre' | 'internship' | 'result';
+
+export const PIPELINE_GROUPS: { key: PipelineGroupKey; statuses: PipelineStatus[] }[] = [
+  {
+    key: 'pre',
+    statuses: ['APPLICATION_100', 'APPROVAL_PENDING_220', 'INTERVIEW_PENDING_250', 'INTRODUCTION_PENDING_270'],
+  },
+  {
+    key: 'internship',
+    statuses: ['INTERNSHIP_STARTING_300', 'INTERNSHIP_IN_PROGRESS_450', 'INTERNSHIP_DROPPED_460', 'INTERNSHIP_COMPLETED_490'],
+  },
+  {
+    key: 'result',
+    statuses: ['JOB_SEEKING_500', 'HIREABLE_600', 'HIRED_660', 'EMPLOYED_700', 'INTERNSHIP_FOUND_ELSEWHERE_800'],
+  },
+];
+
 // Mentee-facing "what to do now" guidance per stage — turns the journey from a
 // passive status display into actionable direction. Off-path statuses
 // (dropped / found elsewhere) aren't included; the tracker shows a note instead.


### PR DESCRIPTION
## EPIC I — Kanban scale & focus (#422)

Tames the admin board's 13-column horizontal sprawl.

### Changes
- **Stage grouping**: `PIPELINE_GROUPS` in `src/lib/pipeline.ts` splits the 13
  stages into three phases — **Pre-internship** (100–270), **Internship**
  (300–490), **Outcome** (500–800). The admin board renders each phase as a
  **collapsible** section with its own running total, so a whole phase can be
  folded away and each row scrolls at most ~5 columns.
- **WIP warning**: a column holding more than 8 candidates shows an amber
  `count / 8` badge (advisory — never blocks a move).
- **Overdue badges**: cards whose `stageDeadline` has passed get a red "overdue"
  pill (the deadline already ships in the `/api/mentorship` payload).
- **Mobile/keyboard moves**: unchanged — the existing per-card stage `<select>`
  remains the touch/keyboard-friendly alternative to drag-and-drop.
- EN/TR/DE labels for the phase names, overdue and WIP warning.
- **e2e** (`e2e/board-grouping.spec.ts`): asserts the three phase headers, the
  overdue badge, and that collapsing a phase hides its cards.

Closes #422

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_