### PR TITLE
feat(a11y): global font-size control (small/normal/large/x-large)

### DIFF
--- a/e2e/account-menu.spec.ts
+++ b/e2e/account-menu.spec.ts
@@ -25,6 +25,8 @@ test('sidebar account menu holds sign-out, language and theme behind one trigger
   const menu = page.getByRole('menu');
   await expect(menu).toBeVisible();
   await expect(menu.getByRole('menuitem', { name: /sign out|çıkış/i })).toBeVisible();
-  // Language + theme controls moved inside the menu.
-  await expect(menu.getByRole('button', { name: 'DE' })).toBeVisible();
+  // Language + theme controls moved inside the menu. Exact match — a
+  // substring match on 'DE' also picks up other controls in the menu whose
+  // accessible name happens to contain "de" (e.g. "Decrease font size").
+  await expect(menu.getByRole('button', { name: 'DE', exact: true })).toBeVisible();
 });

--- a/e2e/account-menu.spec.ts
+++ b/e2e/account-menu.spec.ts
@@ -25,8 +25,9 @@ test('sidebar account menu holds sign-out, language and theme behind one trigger
   const menu = page.getByRole('menu');
   await expect(menu).toBeVisible();
   await expect(menu.getByRole('menuitem', { name: /sign out|çıkış/i })).toBeVisible();
-  // Language + theme controls moved inside the menu. Exact match — a
-  // substring match on 'DE' also picks up other controls in the menu whose
-  // accessible name happens to contain "de" (e.g. "Decrease font size").
-  await expect(menu.getByRole('button', { name: 'DE', exact: true })).toBeVisible();
+  // Language + theme controls moved inside the menu. Exact match on the
+  // actual (lowercase) locale code — a loose substring match on 'DE' also
+  // picks up other controls whose accessible name happens to contain "de"
+  // (e.g. "Decrease font size").
+  await expect(menu.getByRole('button', { name: 'de', exact: true })).toBeVisible();
 });

--- a/e2e/font-size.spec.ts
+++ b/e2e/font-size.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test';
+import { seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+// Global font-size preference: a stepper in the account menu scales the whole
+// app (via a class on <html>, same approach as the dark-mode toggle) and
+// persists across reload.
+test('font-size stepper scales the app and persists across reload', async ({ page }) => {
+  const email = uniqueEmail('fontsize');
+  await seedUser(email, 'Pass1234!', 'MENTEE', 'FontSize Tester');
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', email);
+    await page.fill('input[type="password"]', 'Pass1234!');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => !u.pathname.includes('/auth/signin'), { timeout: 20_000 });
+
+    const html = page.locator('html');
+    await expect(html).not.toHaveClass(/font-(sm|lg|xl)/);
+
+    await page.locator('button[aria-haspopup="menu"]').click();
+    const increase = page.getByRole('button', { name: /increase font size/i });
+    const decrease = page.getByRole('button', { name: /decrease font size/i });
+
+    // md -> lg -> xl.
+    await increase.click();
+    await expect(html).toHaveClass(/\bfont-lg\b/);
+    await increase.click();
+    await expect(html).toHaveClass(/\bfont-xl\b/);
+
+    const cookies = await page.context().cookies();
+    expect(cookies.find((c) => c.name === 'fontSize')?.value).toBe('xl');
+
+    // Actually scales the root font-size, not just a cosmetic class.
+    const size = await html.evaluate((el) => getComputedStyle(el).fontSize);
+    expect(parseFloat(size)).toBeGreaterThan(16);
+
+    // Survives a full reload (no flash back to the default size).
+    await page.reload();
+    await expect(html).toHaveClass(/\bfont-xl\b/);
+
+    // xl -> lg -> md (back to no font-* class).
+    await page.locator('button[aria-haspopup="menu"]').click();
+    await decrease.click();
+    await expect(html).toHaveClass(/\bfont-lg\b/);
+    await decrease.click();
+    await expect(html).not.toHaveClass(/font-(sm|lg|xl)/);
+  } finally {
+    await cleanupByEmail(email);
+  }
+});

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -110,6 +110,8 @@ model User {
   preferredLanguage       String?
   // UI theme preference ('light' | 'dark' | 'system'); applied at sign-in.
   theme                   String?
+  // UI font-size preference ('sm' | 'md' | 'lg' | 'xl'); applied at sign-in.
+  fontSize                String?
   createdAt               DateTime  @default(now())
   updatedAt               DateTime  @updatedAt
 

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -61,6 +61,7 @@ const updateProfileSchema = z.object({
   notificationPrefs: z.record(z.string(), z.boolean()).optional(),
   preferredLanguage: z.enum(['en', 'tr', 'de']).optional(),
   theme: z.enum(['light', 'dark', 'system']).optional(),
+  fontSize: z.enum(['sm', 'md', 'lg', 'xl']).optional(),
 });
 
 // Profile fields surfaced by both GET and PUT responses.
@@ -97,6 +98,7 @@ const PROFILE_SELECT = {
   notificationPrefs: true,
   preferredLanguage: true,
   theme: true,
+  fontSize: true,
   createdAt: true,
 } as const;
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13,6 +13,16 @@
   }
 }
 
+/*
+ * Global font-size scale (accessibility preference, independent of theme).
+ * Tailwind's text-* utilities are rem-based, so scaling the root font-size
+ * scales the whole app proportionally — no per-component changes needed.
+ * Default (no class) is 100% (browser default, ~16px).
+ */
+html.font-sm { font-size: 87.5%; }
+html.font-lg { font-size: 112.5%; }
+html.font-xl { font-size: 125%; }
+
 /* Dark mode base surfaces (class strategy); primitives add their own dark: */
 html.dark body { background-color: #030712; color: #f3f4f6; }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,26 +21,34 @@ export const viewport: Viewport = {
 
 // Runs before paint to set the dark class from the saved preference or the OS,
 // so there's no light flash. Mirrors the server-side cookie read below.
-const NO_FLASH = `(function(){try{var m=document.cookie.match(/(?:^|; )theme=([^;]+)/);var e=m?decodeURIComponent(m[1]):localStorage.getItem('theme');var h=document.documentElement;if(e==='dark')h.classList.add('dark');else if(e==='light')h.classList.remove('dark');else if(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches)h.classList.add('dark');}catch(e){}})();`;
+const NO_FLASH = `(function(){try{var m=document.cookie.match(/(?:^|; )theme=([^;]+)/);var e=m?decodeURIComponent(m[1]):localStorage.getItem('theme');var h=document.documentElement;if(e==='dark')h.classList.add('dark');else if(e==='light')h.classList.remove('dark');else if(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches)h.classList.add('dark');var fm=document.cookie.match(/(?:^|; )fontSize=([^;]+)/);var fe=fm?decodeURIComponent(fm[1]):localStorage.getItem('fontSize');if(fe==='sm'||fe==='lg'||fe==='xl')h.classList.add('font-'+fe);}catch(e){}})();`;
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const locale = await getLocale();
   const dict = getDictionary(locale);
-  let theme = (await cookies()).get('theme')?.value;
-  // No device cookie yet? Fall back to the signed-in user's saved theme so it
-  // follows them across devices (the no-flash script still handles OS default).
-  if (!theme) {
+  const cookieStore = await cookies();
+  let theme = cookieStore.get('theme')?.value;
+  let fontSize = cookieStore.get('fontSize')?.value;
+  // No device cookie yet? Fall back to the signed-in user's saved preferences
+  // so they follow them across devices (the no-flash script still handles OS default).
+  if (!theme || !fontSize) {
     try {
       const session = await getServerSession(authOptions);
       if (session?.user?.id) {
-        const u = await prisma.user.findUnique({ where: { id: session.user.id }, select: { theme: true } });
-        if (u?.theme) theme = u.theme;
+        const u = await prisma.user.findUnique({ where: { id: session.user.id }, select: { theme: true, fontSize: true } });
+        if (!theme && u?.theme) theme = u.theme;
+        if (!fontSize && u?.fontSize) fontSize = u.fontSize;
       }
     } catch { /* ignore */ }
   }
+  const fontSizeClass = fontSize === 'sm' || fontSize === 'lg' || fontSize === 'xl' ? `font-${fontSize}` : undefined;
 
   return (
-    <html lang={locale} className={theme === 'dark' ? 'dark' : undefined} suppressHydrationWarning>
+    <html
+      lang={locale}
+      className={[theme === 'dark' ? 'dark' : undefined, fontSizeClass].filter(Boolean).join(' ') || undefined}
+      suppressHydrationWarning
+    >
       <head>
         <script dangerouslySetInnerHTML={{ __html: NO_FLASH }} />
       </head>

--- a/src/components/AccountMenu.tsx
+++ b/src/components/AccountMenu.tsx
@@ -6,6 +6,7 @@ import { LogOut, Settings, ChevronUp } from 'lucide-react';
 import { SidebarAvatar } from '@/components/SidebarAvatar';
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
 import { ThemeToggle } from '@/components/ThemeToggle';
+import { FontSizeControl } from '@/components/FontSizeControl';
 import { VersionFooter } from '@/components/VersionFooter';
 import { useT } from '@/i18n/client';
 import type { Locale } from '@/i18n/config';
@@ -81,6 +82,9 @@ export function AccountMenu({
           <div className="flex items-center justify-between gap-2 px-3 py-1.5">
             <LanguageSwitcher current={locale} />
             <ThemeToggle />
+          </div>
+          <div className="flex items-center justify-center px-3 py-1">
+            <FontSizeControl />
           </div>
           <div className="px-3 pt-1">
             <VersionFooter version={version} />

--- a/src/components/FontSizeControl.tsx
+++ b/src/components/FontSizeControl.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Minus, Plus } from 'lucide-react';
+import { useT } from '@/i18n/client';
+
+type FontSize = 'sm' | 'md' | 'lg' | 'xl';
+const SIZES: FontSize[] = ['sm', 'md', 'lg', 'xl'];
+
+// Global font-size stepper (small/normal/large/extra-large). Persists to
+// localStorage + a cookie (SSR + no-flash script agree) and, when signed in,
+// to the account — same pattern as ThemeToggle.
+export function FontSizeControl() {
+  const t = useT();
+  const [size, setSize] = useState<FontSize>('md');
+
+  useEffect(() => {
+    const h = document.documentElement;
+    const current = SIZES.find((s) => s !== 'md' && h.classList.contains(`font-${s}`));
+    setSize(current ?? 'md');
+  }, []);
+
+  const apply = (next: FontSize) => {
+    setSize(next);
+    const h = document.documentElement;
+    SIZES.forEach((s) => h.classList.remove(`font-${s}`));
+    if (next !== 'md') h.classList.add(`font-${next}`);
+    try { localStorage.setItem('fontSize', next); } catch { /* ignore */ }
+    document.cookie = `fontSize=${next}; path=/; max-age=${60 * 60 * 24 * 365}; samesite=lax`;
+    // Best-effort persist to the account (ignored / 401 when signed out).
+    fetch('/api/profile', {
+      method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ fontSize: next }),
+    }).catch(() => {});
+  };
+
+  const index = SIZES.indexOf(size);
+  const label = { sm: t.fontSize.small, md: t.fontSize.medium, lg: t.fontSize.large, xl: t.fontSize.extraLarge }[size];
+
+  return (
+    <div className="inline-flex items-center gap-1 rounded-lg px-1 py-1 text-xs text-gray-500 dark:text-gray-400">
+      <button
+        type="button"
+        onClick={() => apply(SIZES[Math.max(0, index - 1)])}
+        disabled={index === 0}
+        aria-label={t.fontSize.decrease}
+        title={t.fontSize.decrease}
+        className="p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-800 dark:hover:text-gray-100 disabled:opacity-30 disabled:hover:bg-transparent transition-colors"
+      >
+        <Minus className="h-3.5 w-3.5" />
+      </button>
+      <span className="min-w-[3.5rem] text-center select-none">{label}</span>
+      <button
+        type="button"
+        onClick={() => apply(SIZES[Math.min(SIZES.length - 1, index + 1)])}
+        disabled={index === SIZES.length - 1}
+        aria-label={t.fontSize.increase}
+        title={t.fontSize.increase}
+        className="p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-800 dark:hover:text-gray-100 disabled:opacity-30 disabled:hover:bg-transparent transition-colors"
+      >
+        <Plus className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -693,6 +693,7 @@ const en = {
   nextActions: { logFirst: 'Log a first interaction', noContact: 'No contact in {d} days — reach out', lastContact: 'Last contact {d} days ago — follow up', pushHiring: 'Push toward hiring', onTrack: 'On track' },
   notFound: { title: 'Page not found', description: 'This page could not be found.', backHome: 'Back to home' },
   theme: { toggle: 'Toggle theme', light: 'Light', dark: 'Dark', system: 'System' },
+  fontSize: { decrease: 'Decrease font size', increase: 'Increase font size', small: 'Small', medium: 'Normal', large: 'Large', extraLarge: 'X-Large' },
   contact: {
     call: 'Call',
     reachedQ: 'Did you reach them?',
@@ -1811,6 +1812,7 @@ const tr: Dict = {
   nextActions: { logFirst: 'İlk etkileşimi kaydet', noContact: '{d} gündür iletişim yok — iletişime geç', lastContact: 'Son iletişim {d} gün önce — takip et', pushHiring: 'İşe alıma yönlendir', onTrack: 'Yolunda' },
   notFound: { title: 'Sayfa bulunamadı', description: 'Bu sayfa bulunamadı.', backHome: 'Ana sayfaya dön' },
   theme: { toggle: 'Temayı değiştir', light: 'Açık', dark: 'Koyu', system: 'Sistem' },
+  fontSize: { decrease: 'Yazı boyutunu küçült', increase: 'Yazı boyutunu büyüt', small: 'Küçük', medium: 'Normal', large: 'Büyük', extraLarge: 'Çok Büyük' },
   contact: {
     call: 'Ara',
     reachedQ: 'Görüşebildin mi?',
@@ -2927,6 +2929,7 @@ const de: Dict = {
   nextActions: { logFirst: 'Erste Interaktion erfassen', noContact: 'Seit {d} Tagen kein Kontakt — melde dich', lastContact: 'Letzter Kontakt vor {d} Tagen — nachfassen', pushHiring: 'Richtung Einstellung drängen', onTrack: 'Auf Kurs' },
   notFound: { title: 'Seite nicht gefunden', description: 'Diese Seite konnte nicht gefunden werden.', backHome: 'Zurück zur Startseite' },
   theme: { toggle: 'Theme wechseln', light: 'Hell', dark: 'Dunkel', system: 'System' },
+  fontSize: { decrease: 'Schrift verkleinern', increase: 'Schrift vergrößern', small: 'Klein', medium: 'Normal', large: 'Groß', extraLarge: 'Sehr groß' },
   contact: {
     call: 'Anrufen',
     reachedQ: 'Hast du sie erreicht?',


### PR DESCRIPTION
Closes #457

Kullanıcı isteği: tema nasıl değiştirilebiliyorsa, yazı boyutu da genel olarak büyütülüp küçültülebilmeli.

### Yaklaşım
Mevcut dark-mode toggle'ının aynısı: `<html>` üzerinde bir class (`font-sm`/`font-lg`/`font-xl`, class yoksa varsayılan %100) kök font-size'ı ölçekliyor. Tailwind'in `text-*` utility'leri rem tabanlı olduğu için tüm uygulama component başına değişiklik gerekmeden orantılı ölçekleniyor.

- Kalıcılık tema ile birebir aynı desen: localStorage + 1 yıllık cookie (no-flash script + server-side layout tarafından okunuyor) + oturum açıksa hesaba senkron (yeni `User.fontSize` alanı) — cihazlar arası taşınıyor.
- Yeni `FontSizeControl` (-/etiket/+ stepper), `AccountMenu` içinde `ThemeToggle`'ın yanında.
- `/api/profile`: mevcut `theme` alanının yanına `fontSize` eklendi.
- `layout.tsx`: no-flash script + server-side cookie/hesap okuma, font-size class'ını da paint öncesi çözecek şekilde genişletildi.

### Doğrulama
- `tsc --noEmit` / `next lint` temiz; şema değişikliği için `prisma format && validate && generate` çalıştırıldı.
- Preview tarayıcısında görsel olarak doğrulandı: class'ı elle değiştirince başlıklar/gövde/butonlar orantılı büyüyor, layout bozulmuyor, konsol hatası yok (16px → 20px, `font-xl`).
- e2e (`e2e/font-size.spec.ts`): stepper'ın tam aralığını (normal→büyük→çok büyük→büyük→normal) dolaşıyor, cookie + gerçek hesaplanan kök font-size'ın değiştiğini ve seçimin sayfa yenilemede kalıcı olduğunu doğruluyor.