### PR TITLE
feat(messages): file/image attachments (Betül B11)

### DIFF
--- a/e2e/message-attachments.spec.ts
+++ b/e2e/message-attachments.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// A 1x1 transparent PNG, inline — no fixture file needed.
+const PNG_BYTES = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
+  'base64'
+);
+
+test('sending a message with an image attachment shows it inline and enforces access control', async ({ page }) => {
+  const mentorEmail = uniqueEmail('att-mentor');
+  const menteeEmail = uniqueEmail('att-mentee');
+  const outsiderEmail = uniqueEmail('att-outsider');
+  const mentor = await seedUser(mentorEmail, 'MentorPass123', 'MENTOR', 'Att Mentor');
+  const mentee = await seedUser(menteeEmail, 'MenteePass123', 'MENTEE', 'Att Mentee');
+  await seedUser(outsiderEmail, 'OutsiderPass123', 'MENTOR', 'Att Outsider');
+  const rel = await prisma.mentorshipRelation.create({ data: { mentorId: mentor.id, menteeId: mentee.id } });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', mentorEmail);
+    await page.fill('input[type="password"]', 'MentorPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/mentor'), { timeout: 20_000 });
+
+    await page.goto(`/messages/${rel.id}`);
+    await page.getByTestId('message-attachment-input').setInputFiles({
+      name: 'screenshot.png',
+      mimeType: 'image/png',
+      buffer: PNG_BYTES,
+    });
+    await expect(page.getByText('screenshot.png')).toBeVisible();
+
+    const done = page.waitForResponse((r) => r.url().includes('/api/messages') && r.request().method() === 'POST');
+    await page.getByRole('button', { name: 'Send' }).click();
+    const res = await done;
+    expect(res.ok()).toBeTruthy();
+
+    // Renders as an inline image in the thread.
+    await expect(page.locator('img[alt="screenshot.png"]')).toBeVisible({ timeout: 10_000 });
+
+    const attachment = await prisma.messageAttachment.findFirst({ where: { message: { relationId: rel.id } } });
+    expect(attachment).not.toBeNull();
+    expect(attachment?.size).toBe(PNG_BYTES.length);
+
+    // An outsider (not a participant) is refused the attachment bytes.
+    await page.context().clearCookies();
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', outsiderEmail);
+    await page.fill('input[type="password"]', 'OutsiderPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/mentor'), { timeout: 20_000 });
+    const forbidden = await page.request.get(`/api/messages/attachments/${attachment!.id}`);
+    expect(forbidden.status()).toBe(403);
+  } finally {
+    await prisma.message.deleteMany({ where: { relationId: rel.id } });
+    await prisma.mentorshipRelation.deleteMany({ where: { id: rel.id } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(outsiderEmail);
+  }
+});

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -192,9 +192,26 @@ model Message {
   readAt     DateTime?
   createdAt  DateTime       @default(now())
 
-  relation MentorshipRelation @relation(fields: [relationId], references: [id], onDelete: Cascade)
+  relation    MentorshipRelation  @relation(fields: [relationId], references: [id], onDelete: Cascade)
+  attachments MessageAttachment[]
 
   @@index([relationId])
+}
+
+// A file/image attached to a message (DB bytes, same approach as CvFile/
+// Document — no external object storage needed).
+model MessageAttachment {
+  id          String   @id @default(cuid())
+  messageId   String
+  filename    String
+  contentType String
+  size        Int
+  data        Bytes
+  createdAt   DateTime @default(now())
+
+  message Message @relation(fields: [messageId], references: [id], onDelete: Cascade)
+
+  @@index([messageId])
 }
 
 // In-app notification for a user.

--- a/src/app/api/messages/attachments/[id]/route.ts
+++ b/src/app/api/messages/attachments/[id]/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { getThreadIfAllowed } from '@/lib/messaging';
+
+// GET — serve a message attachment's bytes. Only the thread's participants
+// (or an admin) may download it, same rule as reading the thread itself.
+export async function GET(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { id } = await params;
+  const attachment = await prisma.messageAttachment.findUnique({
+    where: { id },
+    include: { message: { select: { relationId: true } } },
+  });
+  if (!attachment) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+  const rel = await getThreadIfAllowed(session.user, attachment.message.relationId);
+  if (!rel) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+  return new NextResponse(Buffer.from(attachment.data), {
+    headers: {
+      'Content-Type': attachment.contentType,
+      'Content-Disposition': `inline; filename="${attachment.filename.replace(/"/g, '')}"`,
+      'Content-Length': String(attachment.size),
+    },
+  });
+}

--- a/src/app/api/messages/route.ts
+++ b/src/app/api/messages/route.ts
@@ -9,6 +9,9 @@ import { replyAddress } from '@/lib/replyToken';
 import { sendEmail } from '@/services/emailService';
 import { logger } from '@/lib/logger';
 import { emailAllowed } from '@/lib/notificationPrefs';
+import { ALLOWED_DOC_MIME, MAX_DOC_BYTES } from '@/lib/documentAccess';
+
+const ATTACHMENT_SELECT = { id: true, filename: true, contentType: true, size: true } as const;
 
 // GET ?relationId= — messages in a thread (participants/admin only).
 export async function GET(request: Request) {
@@ -22,6 +25,7 @@ export async function GET(request: Request) {
   const messages = await prisma.message.findMany({
     where: { relationId },
     orderBy: { createdAt: 'asc' },
+    include: { attachments: { select: ATTACHMENT_SELECT } },
   });
 
   // Mark the viewer's incoming unread messages as read.
@@ -40,19 +44,65 @@ export async function GET(request: Request) {
 
 const schema = z.object({ relationId: z.string().min(1), body: z.string().min(1).max(5000) });
 
-// POST — post a message to a thread (participants/admin). Notifies the other party.
+// POST — post a message to a thread (participants/admin). Notifies the other
+// party. Accepts either JSON (text-only, the original shape) or multipart
+// form-data (text + an optional file attachment).
 export async function POST(request: Request) {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
-  const parsed = schema.safeParse(await request.json());
-  if (!parsed.success) return NextResponse.json({ error: 'Validation failed' }, { status: 400 });
+  const contentType = request.headers.get('content-type') || '';
+  let relationId: string;
+  let body: string;
+  let file: File | null = null;
 
-  const rel = await getThreadIfAllowed(session.user, parsed.data.relationId);
+  if (contentType.includes('multipart/form-data')) {
+    const form = await request.formData();
+    relationId = String(form.get('relationId') || '');
+    body = String(form.get('body') || '');
+    const f = form.get('file');
+    if (f instanceof File && f.size > 0) file = f;
+    if (!relationId || (!body.trim() && !file) || body.length > 5000) {
+      return NextResponse.json({ error: 'Validation failed' }, { status: 400 });
+    }
+    if (file) {
+      if (!ALLOWED_DOC_MIME.has(file.type)) {
+        return NextResponse.json({ error: 'File type not allowed' }, { status: 400 });
+      }
+      if (file.size > MAX_DOC_BYTES) {
+        return NextResponse.json({ error: 'File too large (max 10 MB)' }, { status: 400 });
+      }
+    }
+  } else {
+    const parsed = schema.safeParse(await request.json().catch(() => null));
+    if (!parsed.success) return NextResponse.json({ error: 'Validation failed' }, { status: 400 });
+    relationId = parsed.data.relationId;
+    body = parsed.data.body;
+  }
+
+  const rel = await getThreadIfAllowed(session.user, relationId);
   if (!rel) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
 
   const message = await prisma.message.create({
-    data: { relationId: rel.id, senderId: session.user.id, body: parsed.data.body, channel: 'IN_APP' },
+    data: {
+      relationId: rel.id,
+      senderId: session.user.id,
+      body,
+      channel: 'IN_APP',
+      ...(file
+        ? {
+            attachments: {
+              create: {
+                filename: file.name,
+                contentType: file.type,
+                size: file.size,
+                data: Buffer.from(await file.arrayBuffer()),
+              },
+            },
+          }
+        : {}),
+    },
+    include: { attachments: { select: ATTACHMENT_SELECT } },
   });
 
   // Notify the other participant (unless an admin is posting to someone else's thread).
@@ -68,7 +118,7 @@ export async function POST(request: Request) {
     });
     if (rcpt?.email && emailAllowed(rcpt, 'messages')) {
       const sender = session.user.name ?? 'Your mentor';
-      const safe = parsed.data.body.replace(/[<>&]/g, (c) => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;' }[c] as string));
+      const safe = body.replace(/[<>&]/g, (c) => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;' }[c] as string));
       sendEmail({
         to: rcpt.email,
         subject: `New message from ${sender}`,

--- a/src/app/messages/[relationId]/page.tsx
+++ b/src/app/messages/[relationId]/page.tsx
@@ -2,10 +2,17 @@
 
 import { use, useCallback, useEffect, useRef, useState } from 'react';
 import { useSession } from 'next-auth/react';
+import { Paperclip, X, FileText, Download } from 'lucide-react';
 import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { useT } from '@/i18n/client';
 
+interface Attachment {
+  id: string;
+  filename: string;
+  contentType: string;
+  size: number;
+}
 interface Msg {
   id: string;
   senderId: string;
@@ -13,6 +20,7 @@ interface Msg {
   channel: 'IN_APP' | 'EMAIL';
   readAt: string | null;
   createdAt: string;
+  attachments: Attachment[];
 }
 interface Party { id: string; fullName: string }
 
@@ -25,10 +33,13 @@ export default function ThreadPage({ params }: { params: Promise<{ relationId: s
   const [mentor, setMentor] = useState<Party | null>(null);
   const [mentee, setMentee] = useState<Party | null>(null);
   const [body, setBody] = useState('');
+  const [file, setFile] = useState<File | null>(null);
+  const [attachError, setAttachError] = useState('');
   const [loading, setLoading] = useState(true);
   const [sending, setSending] = useState(false);
   const [forbidden, setForbidden] = useState(false);
   const endRef = useRef<HTMLDivElement>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
 
   const load = useCallback(async () => {
     const res = await fetch(`/api/messages?relationId=${relationId}`);
@@ -45,15 +56,33 @@ export default function ThreadPage({ params }: { params: Promise<{ relationId: s
 
   const send = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!body.trim()) return;
+    if (!body.trim() && !file) return;
     setSending(true);
+    setAttachError('');
     try {
-      const res = await fetch('/api/messages', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ relationId, body }),
-      });
-      if (res.ok) { setBody(''); await load(); }
+      let res: Response;
+      if (file) {
+        const fd = new FormData();
+        fd.append('relationId', relationId);
+        fd.append('body', body);
+        fd.append('file', file);
+        res = await fetch('/api/messages', { method: 'POST', body: fd });
+      } else {
+        res = await fetch('/api/messages', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ relationId, body }),
+        });
+      }
+      if (res.ok) {
+        setBody('');
+        setFile(null);
+        if (fileRef.current) fileRef.current.value = '';
+        await load();
+      } else {
+        const data = await res.json().catch(() => ({}));
+        setAttachError(data.error || t.messages.sendFailed);
+      }
     } finally {
       setSending(false);
     }
@@ -84,7 +113,26 @@ export default function ThreadPage({ params }: { params: Promise<{ relationId: s
                 <div key={m.id} className={`flex ${mine ? 'justify-end' : 'justify-start'}`}>
                   <div className={`max-w-[80%] rounded-2xl px-4 py-2 text-sm ${mine ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-900'}`}>
                     {!mine && <p className="text-xs font-medium mb-0.5 opacity-70">{nameFor(m.senderId)}</p>}
-                    <p className="whitespace-pre-wrap break-words">{m.body}</p>
+                    {m.body && <p className="whitespace-pre-wrap break-words">{m.body}</p>}
+                    {m.attachments.map((a) =>
+                      a.contentType.startsWith('image/') ? (
+                        <a key={a.id} href={`/api/messages/attachments/${a.id}`} target="_blank" rel="noopener noreferrer" className="block mt-1.5">
+                          <img src={`/api/messages/attachments/${a.id}`} alt={a.filename} className="max-h-48 rounded-lg" />
+                        </a>
+                      ) : (
+                        <a
+                          key={a.id}
+                          href={`/api/messages/attachments/${a.id}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className={`flex items-center gap-1.5 mt-1.5 text-xs rounded-lg px-2 py-1.5 ${mine ? 'bg-blue-700 hover:bg-blue-800' : 'bg-white hover:bg-gray-50 border border-gray-200'}`}
+                        >
+                          <FileText className="h-3.5 w-3.5 flex-shrink-0" />
+                          <span className="truncate">{a.filename}</span>
+                          <Download className="h-3 w-3 flex-shrink-0 ml-auto" />
+                        </a>
+                      )
+                    )}
                     <p className={`text-[10px] mt-1 ${mine ? 'text-blue-100' : 'text-gray-400'}`}>
                       {m.channel === 'EMAIL' ? '✉ ' : ''}{new Date(m.createdAt).toLocaleString()}
                       {isMyLast && <span className="ml-1">· {m.readAt ? t.messages.read : t.messages.sent}</span>}
@@ -98,7 +146,28 @@ export default function ThreadPage({ params }: { params: Promise<{ relationId: s
         )}
       </Card>
 
+      {attachError && <p className="text-xs text-red-600 mb-2">{attachError}</p>}
+      {file && (
+        <div className="flex items-center gap-2 mb-2 text-xs bg-gray-100 rounded-lg px-2.5 py-1.5 w-fit">
+          <FileText className="h-3.5 w-3.5 text-gray-500" />
+          <span className="text-gray-700">{file.name}</span>
+          <button type="button" onClick={() => { setFile(null); if (fileRef.current) fileRef.current.value = ''; }} aria-label={t.common.delete} className="text-gray-400 hover:text-red-600">
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      )}
       <form onSubmit={send} className="flex gap-2">
+        <input
+          ref={fileRef}
+          type="file"
+          data-testid="message-attachment-input"
+          accept=".pdf,.doc,.docx,.png,.jpg,.jpeg,application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,image/png,image/jpeg"
+          className="hidden"
+          onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+        />
+        <Button type="button" variant="outline" onClick={() => fileRef.current?.click()} aria-label={t.messages.attach} title={t.messages.attach}>
+          <Paperclip className="h-4 w-4" />
+        </Button>
         <textarea
           value={body}
           onChange={(e) => setBody(e.target.value)}
@@ -106,7 +175,7 @@ export default function ThreadPage({ params }: { params: Promise<{ relationId: s
           placeholder={t.messages.replyPlaceholder}
           className="flex-1 rounded-lg border border-gray-300 px-3.5 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-100 focus:border-blue-400 resize-none"
         />
-        <Button type="submit" loading={sending} disabled={!body.trim()}>{t.messages.send}</Button>
+        <Button type="submit" loading={sending} disabled={!body.trim() && !file}>{t.messages.send}</Button>
       </form>
     </div>
   );

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -767,6 +767,8 @@ const en = {
     send: 'Send',
     read: 'Read',
     sent: 'Sent',
+    attach: 'Attach a file',
+    sendFailed: 'Could not send. Please try again.',
   },
   announcements: {
     title: 'Announcements',
@@ -1898,6 +1900,8 @@ const tr: Dict = {
     send: 'Gönder',
     read: 'Okundu',
     sent: 'İletildi',
+    attach: 'Dosya ekle',
+    sendFailed: 'Gönderilemedi. Lütfen tekrar deneyin.',
   },
   announcements: {
     title: 'Duyurular',
@@ -3027,6 +3031,8 @@ const de: Dict = {
     send: 'Senden',
     read: 'Gelesen',
     sent: 'Gesendet',
+    attach: 'Datei anhängen',
+    sendFailed: 'Konnte nicht gesendet werden. Bitte versuche es erneut.',
   },
   announcements: {
     title: 'Ankündigungen',


### PR DESCRIPTION
Refs #443 (B11) — last of the mentee-feedback (Betül) items.

### What's included
- New `MessageAttachment` model — DB-stored bytes (same approach as `CvFile`/`Document`, no object storage needed, survives container redeploys). Reuses the existing `ALLOWED_DOC_MIME` (pdf/doc/docx/png/jpeg) and `MAX_DOC_BYTES` (10 MB) conventions from `lib/documentAccess.ts` rather than inventing new ones.
- `POST /api/messages` now branches on `Content-Type`: JSON keeps working exactly as before (both `comms.spec.ts` and `idor-hardening.spec.ts` post JSON directly against this endpoint and are untouched), `multipart/form-data` carries text + an optional file. A message needs text or an attachment, not strictly both.
- New `GET /api/messages/attachments/[id]` serves the bytes, gated by the same `getThreadIfAllowed()` participant/admin check the thread itself uses.
- Compose box: paperclip button → file picker → a removable chip preview before sending. The thread renders image attachments inline (`<img>`, same pattern as `AvatarManager`/`SidebarAvatar`) and other file types as a download-link chip.

### Verification
- `tsc --noEmit` / `next lint` clean; `prisma format && validate && generate` run for the schema change.
- e2e (`e2e/message-attachments.spec.ts`): sends a message with an inline-buffer PNG through the real UI (`setInputFiles`, no fixture file needed), confirms it renders as an `<img>` in the thread, confirms the DB row's size matches, and confirms a non-participant gets a 403 fetching the attachment URL directly.
- Checked existing messaging e2e coverage (`messaging.spec.ts`, `comms.spec.ts`, `idor-hardening.spec.ts`) — none assert on request Content-Type or the exact message JSON shape, so the additive `attachments` field and dual JSON/multipart handling don't break them.