### PR TITLE
test: stress/load test + XSS test + health probe, nightly cron with email alerts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,12 @@ SMTP_USER="noreply@crm.ersah.in"
 SMTP_PASS="your-smtp-password"
 SMTP_FROM="noreply@crm.ersah.in"
 
+# Automated-test alerts (used by the nightly stress workflow — set as GitHub secrets)
+# ALERT_EMAIL_TO: comma-separated recipient(s) emailed when an automated test fails
+# STRESS_TARGET_URL: env the nightly stress test hits (defaults to production)
+ALERT_EMAIL_TO="team@example.com"
+STRESS_TARGET_URL="https://crm.ersah.in"
+
 # App
 NEXT_PUBLIC_APP_URL="http://localhost:3000"
 

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -1,0 +1,70 @@
+name: Nightly Stress Test
+
+# Runs a load/stress test against the live app on a nightly schedule and emails
+# the team if any latency/error-rate threshold is breached. Can also be run
+# on demand from the Actions tab (with an optional target URL override).
+on:
+  schedule:
+    # 02:30 UTC every night (~03:30/04:30 Europe/Berlin depending on DST).
+    - cron: '30 2 * * *'
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: 'Target URL to stress (defaults to the STRESS_TARGET_URL secret / production)'
+        required: false
+        type: string
+
+concurrency:
+  group: stress-test
+  cancel-in-progress: false
+
+jobs:
+  stress:
+    name: Load & latency
+    runs-on: ubuntu-latest
+    env:
+      # Prefer the manual override, then a dedicated secret, then production.
+      BASE_URL: ${{ github.event.inputs.base_url || secrets.STRESS_TARGET_URL || 'https://crm.ersah.in' }}
+      STRESS_CONCURRENCY: '25'
+      STRESS_DURATION_MS: '30000'
+      STRESS_MAX_ERROR_RATE: '0.02'
+      STRESS_MAX_P95_MS: '2500'
+      STRESS_SUMMARY_FILE: stress-summary.json
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Run stress test
+        id: stress
+        run: node scripts/stress-test.mjs
+
+      - name: Upload stress summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: stress-summary
+          path: stress-summary.json
+          retention-days: 14
+
+      # Email the team only when the stress test failed. Reuses the app's SMTP_*
+      # secrets; ALERT_EMAIL_TO controls the recipient(s).
+      - name: Email alert on failure
+        if: failure()
+        env:
+          SMTP_HOST: ${{ secrets.SMTP_HOST }}
+          SMTP_PORT: ${{ secrets.SMTP_PORT }}
+          SMTP_USER: ${{ secrets.SMTP_USER }}
+          SMTP_PASS: ${{ secrets.SMTP_PASS }}
+          SMTP_FROM: ${{ secrets.SMTP_FROM }}
+          ALERT_EMAIL_TO: ${{ secrets.ALERT_EMAIL_TO }}
+          ALERT_SUBJECT: '⚠️ Internship CRM — nightly stress test FAILED'
+          ALERT_BODY: |
+            The nightly stress test breached its thresholds against ${{ env.BASE_URL }}.
+            Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          ALERT_SUMMARY_FILE: stress-summary.json
+        run: |
+          npm install nodemailer@^7 --no-save --no-audit --no-fund
+          node scripts/send-alert-email.mjs

--- a/README.md
+++ b/README.md
@@ -97,17 +97,25 @@ See [`.env.example`](.env.example) for the full list.
 
 ## Testing
 
-End-to-end smoke tests live in [`e2e/`](e2e/) (Playwright). They cover the home page,
+Several kinds of test guard the app — functional E2E, accessibility, security,
+XSS/injection, and a nightly **stress/load** test. See [`docs/testing.md`](docs/testing.md)
+for the full map and configuration.
+
+End-to-end tests live in [`e2e/`](e2e/) (Playwright). They cover the home page,
 sign-in, admin login, and that the admin pages render without server errors.
 
 ```bash
 npm run test:e2e            # starts the app and runs headless
 npm run test:e2e:headed     # visible browser
 BASE_URL=https://crm-preview.ersah.in npm run test:e2e   # against a deployed env
+
+npm run test:stress         # load test (see docs/testing.md for thresholds/env)
 ```
 
-CI runs these on every PR ([`.github/workflows/e2e.yml`](.github/workflows/e2e.yml)) against
-an isolated MySQL service, so a regression fails the check before merge.
+CI runs the E2E suite on every PR ([`.github/workflows/e2e.yml`](.github/workflows/e2e.yml))
+against an isolated MySQL service, so a regression fails the check before merge. A
+scheduled workflow ([`.github/workflows/stress.yml`](.github/workflows/stress.yml)) runs
+the stress test nightly and **emails the team on failure**.
 
 ## Deployment
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,86 @@
+# Testing
+
+This project is validated by several **kinds** of automated test, each catching a
+different class of regression. This document is the map: what exists today, and how
+the newer non-functional tests (stress + nightly automation) are wired.
+
+## Test types in this repo
+
+| Type | What it checks | Where | When it runs |
+|------|----------------|-------|--------------|
+| **Static analysis** | Lint + strict TypeScript typecheck | `npm run lint`, `npx tsc --noEmit` | CI (`ci.yml`) on every PR |
+| **Build test** | Production build compiles | `npm run build` | CI (`ci.yml`) |
+| **i18n parity** | EN/TR/DE translation keys stay in sync | `npm run check:i18n` | CI (`ci.yml`) |
+| **Smoke / functional (E2E)** | App boots, auth works, core pages render without errors | `e2e/*.spec.ts` (Playwright) | CI (`e2e.yml`) on every PR |
+| **Accessibility (a11y)** | Landmarks, roles, keyboard/contrast basics | `e2e/a11y.spec.ts`, `e2e/board-a11y.spec.ts` | with E2E |
+| **Security** | Headers, IDOR/RBAC, rate limiting, 2FA, login hardening | `e2e/security-headers.spec.ts`, `e2e/authz-idor.spec.ts`, `e2e/idor-hardening.spec.ts`, `e2e/rate-limit.spec.ts`, `e2e/login-security.spec.ts`, `e2e/two-factor-*.spec.ts` | with E2E |
+| **XSS / injection** | User input is escaped, never executed as HTML/JS | `e2e/xss-injection.spec.ts` | with E2E |
+| **Responsive / mobile** | Layout at small viewports | `e2e/mobile.spec.ts`, `e2e/users-responsive.spec.ts` | with E2E |
+| **PWA / offline** | Manifest, service worker, offline page | `e2e/pwa.spec.ts`, `e2e/offline-page.spec.ts` | with E2E |
+| **Health probe** | `/api/health` liveness + optional DB readiness | `e2e/health.spec.ts` | with E2E |
+| **Stress / load** | Latency percentiles, throughput, error rate under sustained concurrency | `scripts/stress-test.mjs` | **nightly cron** (`stress.yml`) + on demand |
+
+The first ten are **functional / correctness** tests: given an input, is the output
+right? The stress test is a **non-functional** test: the app may be correct yet too
+slow or fragile under load — this catches that.
+
+## Stress / load test
+
+`scripts/stress-test.mjs` is a dependency-free (native `fetch`) load generator. It
+fires sustained concurrent GET requests at a set of public, read-only routes for a
+fixed duration, then reports throughput and latency percentiles (p50/p95/p99) and the
+error rate. It **exits non-zero** when any threshold is breached, so it can gate CI and
+trigger the failure-email alert. It only issues side-effect-free GETs, so it is safe to
+point at a live preview/production environment.
+
+```bash
+# Against local dev (start the app first with `npm run dev`)
+npm run test:stress
+
+# Against a deployed environment
+BASE_URL=https://crm-preview.ersah.in npm run test:stress
+```
+
+### Configuration (env vars)
+
+| Var | Default | Meaning |
+|-----|---------|---------|
+| `BASE_URL` | `http://localhost:3000` | Target origin |
+| `STRESS_PATHS` | `/,/auth/signin,/api/health` | Comma-separated paths to hammer |
+| `STRESS_CONCURRENCY` | `20` | Parallel workers |
+| `STRESS_DURATION_MS` | `20000` | Test duration |
+| `STRESS_WARMUP_MS` | `1000` | Ignore samples before this (skips cold-start) |
+| `STRESS_TIMEOUT_MS` | `10000` | Per-request timeout |
+| `STRESS_MAX_ERROR_RATE` | `0.02` | Fail above 2% errors |
+| `STRESS_MAX_P95_MS` | `2000` | Fail if p95 latency exceeds this |
+| `STRESS_MIN_RPS` | `0` (off) | Fail if throughput drops below this |
+| `STRESS_SUMMARY_FILE` | — | If set, writes a JSON summary (used by the alert email) |
+
+## Nightly automation (the cron)
+
+[`.github/workflows/stress.yml`](../.github/workflows/stress.yml) runs the stress test
+on a schedule — **02:30 UTC nightly** — and can also be triggered manually from the
+Actions tab (with an optional target-URL override). It targets the URL in the
+`STRESS_TARGET_URL` secret, falling back to production.
+
+If any threshold is breached, the job fails and the **"Email alert on failure"** step
+sends a notification via [`scripts/send-alert-email.mjs`](../scripts/send-alert-email.mjs),
+reusing the app's existing `SMTP_*` secrets. The recipient is the `ALERT_EMAIL_TO`
+secret. When SMTP is not configured the script logs and skips (exit 0) so it never masks
+the underlying failure.
+
+### Required GitHub secrets for the alert
+
+- `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, `SMTP_FROM` — already used by deploy.
+- `ALERT_EMAIL_TO` — comma-separated recipient(s) for failure alerts. **(new)**
+- `STRESS_TARGET_URL` — optional; the env to stress. Defaults to `https://crm.ersah.in`. **(new)**
+
+The same alert script can be reused by any other CI job that wants to email on failure
+(e.g. adding an `if: failure()` step to `e2e.yml`).
+
+## Ideas for further test types
+
+- **Contract / API tests** for `/api/v1/*` against the published OpenAPI spec.
+- **Visual regression** (Playwright screenshots) to catch unintended UI drift.
+- **Dependency/SCA scanning** (`npm audit`, Dependabot) on a schedule.
+- **Load-with-auth** scenarios (currently the stress test only hits public routes).

--- a/e2e/health.spec.ts
+++ b/e2e/health.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+
+// The /api/health probe backs uptime monitoring and the nightly stress test.
+// It must stay public, cheap, and side-effect free.
+test('health endpoint reports ok without a DB check', async ({ request }) => {
+  const res = await request.get('/api/health');
+  expect(res.status()).toBe(200);
+  const body = await res.json();
+  expect(body.status).toBe('ok');
+  expect(typeof body.version).toBe('string');
+  expect(body.db).toBe('skipped');
+  expect(typeof body.responseMs).toBe('number');
+});
+
+test('health endpoint verifies DB connectivity when asked', async ({ request }) => {
+  const res = await request.get('/api/health?db=1');
+  // 200 when the DB is reachable (CI/preview), 503 if it is degraded.
+  expect([200, 503]).toContain(res.status());
+  const body = await res.json();
+  expect(['ok', 'error']).toContain(body.db);
+});

--- a/e2e/xss-injection.spec.ts
+++ b/e2e/xss-injection.spec.ts
@@ -1,0 +1,106 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+/**
+ * XSS / stored-injection tests.
+ *
+ * User-supplied text (personal notes, profile fields) must be rendered as inert
+ * text, never as live HTML/JS. React escapes by default, but a regression that
+ * introduces `dangerouslySetInnerHTML` or an unescaped sink would be silent —
+ * these tests fail loudly if an injected <script>/onerror payload ever executes.
+ */
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// A payload that would pop a dialog if the string were ever evaluated as HTML/JS.
+const XSS_PAYLOAD = '<img src=x onerror="window.__xss=1"><script>window.__xss=1</script>hello-xss';
+
+test('stored note with an XSS payload is rendered as inert text, not executed', async ({ page }) => {
+  const email = uniqueEmail('xss-mentee');
+  await seedUser(email, 'XssPass123', 'MENTEE', 'XSS Mentee');
+  let noteId = '';
+
+  // If any injected script actually runs, this flips the page flag / opens a dialog.
+  let dialogFired = false;
+  page.on('dialog', async (d) => {
+    dialogFired = true;
+    await d.dismiss().catch(() => {});
+  });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', email);
+    await page.fill('input[type="password"]', 'XssPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/portal'), { timeout: 20_000 });
+
+    const created = await page.request.post('/api/notes', { data: { body: XSS_PAYLOAD } });
+    expect(created.status()).toBe(201);
+    noteId = (await created.json()).note.id;
+
+    // Render the notes page and let any (mis)injected script attempt to run.
+    await page.goto('/portal/notes');
+    await page.waitForTimeout(500);
+
+    // 1. The payload must appear verbatim as text content.
+    await expect(page.getByText('hello-xss')).toBeVisible();
+
+    // 2. No <script> or <img> element was actually parsed from the note body —
+    //    it must live as a text node only.
+    const injectedNodes = await page.evaluate(() => {
+      const marker = 'window.__xss';
+      const scripts = Array.from(document.querySelectorAll('script')).filter((s) =>
+        s.textContent?.includes(marker)
+      ).length;
+      const imgs = Array.from(document.querySelectorAll('img')).filter((i) =>
+        (i.getAttribute('onerror') || '').includes(marker)
+      ).length;
+      // @ts-expect-error - runtime flag set only if the payload executed
+      const executed = window.__xss === 1;
+      return { scripts, imgs, executed };
+    });
+
+    expect(injectedNodes.scripts, 'no injected <script> node should be parsed').toBe(0);
+    expect(injectedNodes.imgs, 'no injected <img onerror> node should be parsed').toBe(0);
+    expect(injectedNodes.executed, 'injected script must not execute').toBe(false);
+    expect(dialogFired, 'no dialog should be triggered by the payload').toBe(false);
+  } finally {
+    if (noteId) await prisma.personalNote.deleteMany({ where: { id: noteId } }).catch(() => {});
+    await cleanupByEmail(email);
+  }
+});
+
+test('XSS payload in a profile display name is escaped in the admin users list', async ({ page }) => {
+  const adminEmail = process.env.ADMIN_EMAIL || 'admin@example.com';
+  const adminPassword = process.env.ADMIN_PASSWORD || 'ChangeMe123!';
+  const victimEmail = uniqueEmail('xss-name');
+  await seedUser(victimEmail, 'x', 'MENTEE', XSS_PAYLOAD);
+
+  let dialogFired = false;
+  page.on('dialog', async (d) => {
+    dialogFired = true;
+    await d.dismiss().catch(() => {});
+  });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', adminPassword);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => !u.pathname.includes('/auth/signin'), { timeout: 20_000 });
+
+    await page.goto('/admin/users');
+    await page.waitForTimeout(500);
+
+    const executed = await page.evaluate(() => {
+      // @ts-expect-error - runtime flag
+      return window.__xss === 1;
+    });
+    expect(executed, 'name payload must not execute').toBe(false);
+    expect(dialogFired, 'no dialog should be triggered by the name payload').toBe(false);
+  } finally {
+    await cleanupByEmail(victimEmail);
+  }
+});

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "check:i18n": "node --experimental-strip-types scripts/check-i18n.ts",
     "test:e2e": "playwright test",
     "test:e2e:headed": "playwright test --headed",
+    "test:stress": "node scripts/stress-test.mjs",
     "import:csv": "node scripts/import-csv.mjs",
     "postinstall": "prisma generate",
     "seed:templates": "node prisma/seed-templates.mjs",

--- a/scripts/send-alert-email.mjs
+++ b/scripts/send-alert-email.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * Sends a failure-alert email using the same SMTP_* env vars as the app's
+ * emailService. Intended to be invoked by CI / the nightly cron when a test
+ * job (stress test, e2e, …) fails, so the team is notified without watching
+ * the pipeline.
+ *
+ * Env:
+ *   SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS, SMTP_FROM   (SMTP transport)
+ *   ALERT_EMAIL_TO      recipient(s), comma-separated       (required)
+ *   ALERT_SUBJECT       subject line                        (optional)
+ *   ALERT_BODY          plain-text body / details           (optional)
+ *   ALERT_SUMMARY_FILE  path to a JSON summary to attach     (optional)
+ *
+ * Exits 0 even when SMTP is unconfigured (logs and skips) so it never masks
+ * the original test failure in CI; exits non-zero only if sending was
+ * attempted and failed.
+ */
+import nodemailer from 'nodemailer';
+import { readFileSync } from 'node:fs';
+
+const to = process.env.ALERT_EMAIL_TO;
+if (!to) {
+  console.error('ALERT_EMAIL_TO is not set — cannot send alert. Skipping.');
+  process.exit(0);
+}
+
+if (!process.env.SMTP_HOST || !process.env.SMTP_USER) {
+  console.log(`[alert email skipped — no SMTP config] would notify: ${to}`);
+  process.exit(0);
+}
+
+const subject = process.env.ALERT_SUBJECT || '⚠️ Internship CRM — automated test failure';
+
+let detail = process.env.ALERT_BODY || 'An automated test run failed. See CI logs for details.';
+if (process.env.ALERT_SUMMARY_FILE) {
+  try {
+    detail += `\n\n--- summary ---\n${readFileSync(process.env.ALERT_SUMMARY_FILE, 'utf8')}`;
+  } catch {
+    /* summary is best-effort */
+  }
+}
+
+const html = `<div style="font-family:system-ui,Arial,sans-serif;line-height:1.5">
+  <h2 style="color:#b91c1c;margin:0 0 8px">Automated test failure</h2>
+  <p>An automated test run for <strong>Internship CRM</strong> did not pass.</p>
+  <pre style="background:#f3f4f6;padding:12px;border-radius:8px;white-space:pre-wrap;font-size:13px">${escapeHtml(detail)}</pre>
+  <p style="color:#6b7280;font-size:12px">Sent by the CI/nightly automation. Reply-to is unmonitored.</p>
+</div>`;
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, (c) =>
+    ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c])
+  );
+}
+
+const port = Number(process.env.SMTP_PORT) || 587;
+const transporter = nodemailer.createTransport({
+  host: process.env.SMTP_HOST,
+  port,
+  secure: port === 465,
+  auth: { user: process.env.SMTP_USER, pass: process.env.SMTP_PASS },
+});
+
+try {
+  const info = await transporter.sendMail({
+    from: process.env.SMTP_FROM || process.env.SMTP_USER,
+    to,
+    subject,
+    text: detail,
+    html,
+  });
+  console.log(`Alert email sent to ${to} (messageId=${info.messageId})`);
+} catch (err) {
+  console.error('Failed to send alert email:', err);
+  process.exit(1);
+}

--- a/scripts/stress-test.mjs
+++ b/scripts/stress-test.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+/**
+ * Stress / load test harness (dependency-free, Node 18+ native fetch).
+ *
+ * Hammers a set of public, read-only GET endpoints with sustained concurrency
+ * for a fixed duration, then reports throughput, latency percentiles and the
+ * error rate. Exits non-zero when any configured threshold is breached, so it
+ * can gate CI / the nightly cron and trigger the failure-email alert.
+ *
+ * It only issues GET requests to unauthenticated, side-effect-free routes —
+ * it never mutates data — so it is safe to run against a live preview/prod env.
+ *
+ * Configuration (all via env, with sane defaults):
+ *   BASE_URL         target origin              (default http://localhost:3000)
+ *   STRESS_PATHS     comma-separated paths      (default "/,/auth/signin,/api/health")
+ *   STRESS_CONCURRENCY  parallel workers        (default 20)
+ *   STRESS_DURATION_MS  test duration in ms     (default 20000)
+ *   STRESS_TIMEOUT_MS   per-request timeout     (default 10000)
+ *   STRESS_MAX_ERROR_RATE  fail above this      (default 0.02  => 2%)
+ *   STRESS_MAX_P95_MS   fail if p95 above this  (default 2000)
+ *   STRESS_MIN_RPS      fail if throughput below (default 0 => disabled)
+ *   STRESS_WARMUP_MS    ignore results before   (default 1000)
+ *
+ * Usage:
+ *   BASE_URL=https://crm-preview.ersah.in node scripts/stress-test.mjs
+ */
+
+const BASE_URL = (process.env.BASE_URL || 'http://localhost:3000').replace(/\/$/, '');
+const PATHS = (process.env.STRESS_PATHS || '/,/auth/signin,/api/health')
+  .split(',')
+  .map((p) => p.trim())
+  .filter(Boolean);
+const CONCURRENCY = Number(process.env.STRESS_CONCURRENCY) || 20;
+const DURATION_MS = Number(process.env.STRESS_DURATION_MS) || 20_000;
+const TIMEOUT_MS = Number(process.env.STRESS_TIMEOUT_MS) || 10_000;
+const WARMUP_MS = Number(process.env.STRESS_WARMUP_MS) || 1_000;
+const MAX_ERROR_RATE = Number(process.env.STRESS_MAX_ERROR_RATE) || 0.02;
+const MAX_P95_MS = Number(process.env.STRESS_MAX_P95_MS) || 2_000;
+const MIN_RPS = Number(process.env.STRESS_MIN_RPS) || 0;
+
+/** @type {{ ok: boolean; status: number; ms: number; path: string; error?: string }[]} */
+const samples = [];
+let warmupUntil = 0;
+
+function percentile(sortedMs, p) {
+  if (sortedMs.length === 0) return 0;
+  const idx = Math.min(sortedMs.length - 1, Math.ceil((p / 100) * sortedMs.length) - 1);
+  return sortedMs[Math.max(0, idx)];
+}
+
+async function hit(path) {
+  const url = BASE_URL + path;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  const start = performance.now();
+  try {
+    const res = await fetch(url, {
+      signal: controller.signal,
+      redirect: 'manual',
+      headers: { 'user-agent': 'internship-crm-stress-test' },
+    });
+    // Drain the body so the connection can be reused and timing reflects a full response.
+    await res.arrayBuffer().catch(() => {});
+    const ms = performance.now() - start;
+    // 2xx and 3xx are healthy for these public routes (signin may redirect).
+    const ok = res.status >= 200 && res.status < 400;
+    if (performance.now() >= warmupUntil) {
+      samples.push({ ok, status: res.status, ms, path });
+    }
+  } catch (err) {
+    const ms = performance.now() - start;
+    if (performance.now() >= warmupUntil) {
+      samples.push({ ok: false, status: 0, ms, path, error: err?.name || String(err) });
+    }
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function worker(deadline, counter) {
+  while (performance.now() < deadline) {
+    const path = PATHS[counter.i++ % PATHS.length];
+    await hit(path);
+  }
+}
+
+async function main() {
+  console.log(`\n▶ Stress test: ${BASE_URL}`);
+  console.log(`  paths=${PATHS.join(' ')}`);
+  console.log(
+    `  concurrency=${CONCURRENCY} duration=${DURATION_MS}ms warmup=${WARMUP_MS}ms timeout=${TIMEOUT_MS}ms`
+  );
+  console.log(
+    `  thresholds: errorRate<=${(MAX_ERROR_RATE * 100).toFixed(1)}% p95<=${MAX_P95_MS}ms` +
+      (MIN_RPS ? ` rps>=${MIN_RPS}` : '')
+  );
+
+  const testStart = performance.now();
+  warmupUntil = testStart + WARMUP_MS;
+  const deadline = testStart + DURATION_MS;
+  const counter = { i: 0 };
+
+  await Promise.all(
+    Array.from({ length: CONCURRENCY }, () => worker(deadline, counter))
+  );
+
+  const measuredMs = DURATION_MS - WARMUP_MS;
+  const total = samples.length;
+  const failures = samples.filter((s) => !s.ok);
+  const errorRate = total === 0 ? 1 : failures.length / total;
+  const latencies = samples.map((s) => s.ms).sort((a, b) => a - b);
+  const rps = total / (measuredMs / 1000);
+
+  const p50 = percentile(latencies, 50);
+  const p95 = percentile(latencies, 95);
+  const p99 = percentile(latencies, 99);
+  const avg = latencies.reduce((a, b) => a + b, 0) / (latencies.length || 1);
+  const max = latencies[latencies.length - 1] || 0;
+
+  // Per-path status-code breakdown for quick diagnosis.
+  const byPath = {};
+  for (const s of samples) {
+    byPath[s.path] ??= { total: 0, failures: 0 };
+    byPath[s.path].total++;
+    if (!s.ok) byPath[s.path].failures++;
+  }
+
+  console.log(`\n── Results (${(measuredMs / 1000).toFixed(1)}s measured window) ──`);
+  console.log(`  requests:   ${total}`);
+  console.log(`  throughput: ${rps.toFixed(1)} req/s`);
+  console.log(`  errors:     ${failures.length} (${(errorRate * 100).toFixed(2)}%)`);
+  console.log(
+    `  latency ms: avg=${avg.toFixed(0)} p50=${p50.toFixed(0)} p95=${p95.toFixed(0)} p99=${p99.toFixed(0)} max=${max.toFixed(0)}`
+  );
+  for (const [path, agg] of Object.entries(byPath)) {
+    console.log(`    ${path}: ${agg.total} reqs, ${agg.failures} errors`);
+  }
+
+  const breaches = [];
+  if (errorRate > MAX_ERROR_RATE) {
+    breaches.push(`error rate ${(errorRate * 100).toFixed(2)}% > ${(MAX_ERROR_RATE * 100).toFixed(1)}%`);
+  }
+  if (p95 > MAX_P95_MS) {
+    breaches.push(`p95 ${p95.toFixed(0)}ms > ${MAX_P95_MS}ms`);
+  }
+  if (MIN_RPS && rps < MIN_RPS) {
+    breaches.push(`throughput ${rps.toFixed(1)} req/s < ${MIN_RPS} req/s`);
+  }
+  if (total === 0) {
+    breaches.push('no requests completed (target unreachable?)');
+  }
+
+  // Emit a machine-readable summary for the CI/cron job and email alert.
+  const summary = {
+    baseUrl: BASE_URL,
+    startedAt: new Date().toISOString(),
+    total,
+    errors: failures.length,
+    errorRate: Number(errorRate.toFixed(4)),
+    rps: Number(rps.toFixed(1)),
+    latencyMs: { avg: Math.round(avg), p50: Math.round(p50), p95: Math.round(p95), p99: Math.round(p99), max: Math.round(max) },
+    thresholds: { maxErrorRate: MAX_ERROR_RATE, maxP95Ms: MAX_P95_MS, minRps: MIN_RPS },
+    breaches,
+    passed: breaches.length === 0,
+  };
+
+  if (process.env.STRESS_SUMMARY_FILE) {
+    const { writeFileSync } = await import('node:fs');
+    writeFileSync(process.env.STRESS_SUMMARY_FILE, JSON.stringify(summary, null, 2));
+    console.log(`\n  summary written to ${process.env.STRESS_SUMMARY_FILE}`);
+  }
+
+  if (breaches.length > 0) {
+    console.error(`\n✖ STRESS TEST FAILED:\n  - ${breaches.join('\n  - ')}\n`);
+    process.exit(1);
+  }
+  console.log(`\n✔ Stress test passed — all thresholds within limits.\n`);
+}
+
+main().catch((err) => {
+  console.error('Stress test crashed:', err);
+  process.exit(2);
+});

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { APP_VERSION, GIT_SHA } from '@/lib/version';
+
+// Public, unauthenticated liveness/readiness probe used by uptime monitors and
+// the nightly stress test. Always cheap by default; pass ?db=1 to additionally
+// verify database connectivity. Never touches or mutates domain data.
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: Request) {
+  const started = Date.now();
+  const wantsDb = new URL(request.url).searchParams.get('db') === '1';
+
+  let db: 'ok' | 'error' | 'skipped' = 'skipped';
+  if (wantsDb) {
+    try {
+      await prisma.$queryRaw`SELECT 1`;
+      db = 'ok';
+    } catch {
+      db = 'error';
+    }
+  }
+
+  const healthy = db !== 'error';
+  return NextResponse.json(
+    {
+      status: healthy ? 'ok' : 'degraded',
+      version: APP_VERSION,
+      sha: GIT_SHA,
+      db,
+      uptimeMs: Math.round(process.uptime() * 1000),
+      responseMs: Date.now() - started,
+      timestamp: new Date().toISOString(),
+    },
+    { status: healthy ? 200 : 503 }
+  );
+}


### PR DESCRIPTION
## Summary

Adds the missing **non-functional** test coverage on top of the existing functional/E2E suite: a stress/load test that runs nightly on a cron schedule against the live app and **emails the team when thresholds are breached**, plus a stored-XSS security test and a public health probe.

Closes #

## Changes

- `scripts/stress-test.mjs` — dependency-free load generator (native `fetch`): sustained concurrency against public read-only routes, reports throughput + latency p50/p95/p99 + error rate, exits non-zero on threshold breach; configurable via `STRESS_*` env vars; writes a JSON summary for the alert email
- `.github/workflows/stress.yml` — nightly schedule (02:30 UTC) + manual dispatch; targets `STRESS_TARGET_URL` secret (falls back to production); on failure sends an alert email
- `scripts/send-alert-email.mjs` — failure-alert mailer reusing the app's `SMTP_*` secrets; recipient from `ALERT_EMAIL_TO`; skips safely (exit 0) when SMTP is unconfigured so it never masks the original failure
- `e2e/xss-injection.spec.ts` — stored XSS payloads in personal notes and profile display name must render as inert text, never execute
- `src/app/api/health/route.ts` — public liveness probe (`?db=1` adds a DB connectivity check), used by the stress test and uptime monitoring
- `e2e/health.spec.ts` — covers the health probe in the E2E gate
- `docs/testing.md` — maps every test type in the repo and documents the nightly automation + required secrets
- `package.json` (`test:stress`), README testing section, `.env.example` alert vars

New GitHub secrets to set for the alert to fire: `ALERT_EMAIL_TO` (recipient), optional `STRESS_TARGET_URL`.

## Verification

- [x] `npm run lint` + `npx tsc --noEmit` clean
- [x] `npm run test:e2e` passing (or CI green)
- [x] Tested the change manually / added an e2e test — ran the stress harness against a local dev server (measures, writes summary, fails correctly on breach), curled `/api/health` and `/api/health?db=1`, and verified both safe-skip paths of the alert mailer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZ7JgdBocHYjWfCgyqb9fH

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZ7JgdBocHYjWfCgyqb9fH)_