### PR TITLE
ci: build-only fallback for fork PRs instead of a hard-failing Preview Deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,20 @@ jobs:
             echo "tag=ghcr.io/${REPO}:latest" >> $GITHUB_OUTPUT
           fi
 
+      # PRs from forks (typical for outside/first-time contributors) don't get
+      # write access to ghcr.io or repo secrets — that's a GitHub security
+      # guardrail, not something to work around. Detect it so the rest of this
+      # job can degrade to a build-only check instead of failing outright.
+      - name: Detect fork PR
+        id: fork
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ] && \
+             [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+            echo "is_fork=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_fork=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -56,14 +70,19 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: true
+          # Fork PRs: build-only, so this check still verifies the image builds
+          # without needing ghcr.io write access.
+          push: ${{ steps.fork.outputs.is_fork != 'true' }}
           tags: ${{ steps.meta.outputs.tag }}
           build-args: |
             GIT_SHA=${{ github.event.workflow_run.head_sha || github.sha }}
           # No build-time secrets — all real values are injected at `docker run`
 
       # ── SSH key setup (shared by both deploy steps) ──────────────────────────
+      # Skipped for fork PRs — no deploy follows, and repo secrets aren't
+      # exposed to fork-triggered runs anyway.
       - name: Setup SSH key
+        if: steps.fork.outputs.is_fork != 'true'
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
           SSH_HOST: ${{ secrets.SSH_HOST }}
@@ -172,8 +191,10 @@ jobs:
           EOF
 
       # ── Preview deploy (pull_request) ───────────────────────────────────────
+      # Skipped for fork PRs — no pushed image to pull, and the SSH/DB secrets
+      # aren't available to fork-triggered runs.
       - name: Deploy preview via SSH
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.fork.outputs.is_fork != 'true'
         env:
           SSH_HOST: ${{ secrets.SSH_HOST }}
           SSH_USER: ${{ secrets.SSH_USER }}
@@ -263,7 +284,7 @@ jobs:
           EOF
 
       - name: Post preview URL comment
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.fork.outputs.is_fork != 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -298,5 +319,50 @@ jobs:
                 issue_number: context.issue.number,
                 body,
               });
+            }
+
+      # Fork PRs don't get a live preview (no secrets access to deploy with),
+      # so explain that instead of leaving contributors guessing why there's
+      # no preview-URL comment like other PRs get.
+      # Note: GitHub also forces the GITHUB_TOKEN to read-only for `pull_request`
+      # runs triggered from a fork, regardless of the `permissions:` block above
+      # — so this comment may not be postable either. That's fine; it's a nice-
+      # to-have, not something that should turn this step red.
+      - name: Post fork-PR notice comment
+        if: github.event_name == 'pull_request' && steps.fork.outputs.is_fork == 'true'
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = `### 🔍 Preview deployment skipped\n\n` +
+              `This PR is from a fork, so it doesn't have access to the deploy secrets ` +
+              `(a GitHub security default for outside contributions). The Docker image ` +
+              `still gets built here to verify it compiles — a maintainer can merge once ` +
+              `the other checks pass.`;
+
+            try {
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+              });
+
+              const existing = comments.find(c =>
+                c.user.login === 'github-actions[bot]' &&
+                c.body.includes('Preview deployment skipped')
+              );
+
+              if (!existing) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body,
+                });
+              }
+            } catch (e) {
+              // Expected for forks without a write-scoped token — the build-only
+              // check still ran and reported its own pass/fail.
+              core.info(`Could not post fork-PR comment (likely read-only token for fork PRs): ${e.message}`);
             }
 


### PR DESCRIPTION
Found while reviewing PR #479: every fork PR is guaranteed to fail the required "Preview Deploy" check with `denied: installation not allowed to Write organization package`. GitHub restricts `ghcr.io` write access (and custom repo secrets) for fork-triggered `pull_request` runs regardless of the workflow's own `permissions:` block — a security default, not something wrong with the contributor's code. Since this is a required status check, no external contribution — including the new intern "good first issues" (#463–478) — could ever go fully green.

### Fix
Detects fork PRs (`head.repo.full_name != github.repository`) and:
- Builds the Docker image without pushing (`push: false`) — still proves it compiles.
- Skips SSH key setup and the SSH preview-deploy step entirely (no secrets to use anyway).
- Posts an explanatory comment instead of the preview-URL one, wrapped in try/catch + `continue-on-error` — the comment-write token is *also* forced read-only for forks, so if posting fails too it shouldn't turn the step red over something cosmetic.

Same-repo PRs and the production `workflow_run` deploy are untouched — `is_fork` only evaluates true for `pull_request` + cross-repo head, so this PR's own "Preview Deploy" run (same-repo branch) exercises the unchanged path as a sanity check.

### Verification
- YAML validated (`js-yaml` parse).
- Traced every new/changed `if:` condition by hand against the existing `Log in to GitHub Container Registry` step (confirmed `GITHUB_TOKEN` is present but permission-scoped down for forks — matches the actual failure log from #479, which got past login and failed only at push).
- Can't fully integration-test the fork branch of this logic without a real fork PR event; the non-fork path is exercised by this PR's own CI run.