### PR TITLE
docs: document missing env vars in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,19 @@ SMTP_FROM="noreply@crm.ersah.in"
 ALERT_EMAIL_TO="team@example.com"
 STRESS_TARGET_URL="https://crm.ersah.in"
 
+# Inbound email (mentee/mentor replies routed back into a message thread)
+# INBOUND_EMAIL_DOMAIN: domain used in the generated reply-to address
+# (reply+<token>@<domain>); defaults to "crm.ersah.in" if unset.
+INBOUND_EMAIL_DOMAIN="crm.ersah.in"
+# INBOUND_SECRET: shared secret the inbound-email webhook checks via the
+# x-inbound-secret header. Optional — if unset, the route relies solely on
+# the per-thread HMAC reply token for auth (fine for dev/CI, not prod).
+INBOUND_SECRET=
+
+# LOG_LEVEL: minimum level the structured logger emits — debug | info |
+# warning | error. Defaults to "info" if unset.
+LOG_LEVEL="info"
+
 # App
 NEXT_PUBLIC_APP_URL="http://localhost:3000"
 


### PR DESCRIPTION
Closes #467

Documented the three env vars that were read in code but missing from `.env.example`:
- `INBOUND_EMAIL_DOMAIN` (`src/lib/replyToken.ts:33`) — domain used in generated reply-to addresses, defaults to `crm.ersah.in`.
- `INBOUND_SECRET` (`src/app/api/inbound-email/route.ts:24`) — optional shared secret for the inbound-email webhook; falls back to the per-thread HMAC token when unset.
- `LOG_LEVEL` (`src/lib/logger.ts:6`) — structured logger threshold, defaults to `info`.

`GIT_SHA` intentionally excluded per the issue's note — it's a build-time Dockerfile arg, not a runtime env var.

No real/secret values committed — placeholders and documented defaults only.