### PR TITLE
i18n: translate hardcoded English strings on admin/companies

### DIFF
--- a/src/app/admin/companies/page.tsx
+++ b/src/app/admin/companies/page.tsx
@@ -44,7 +44,7 @@ export default function CompaniesPage() {
         body: JSON.stringify({ companyId: clCompanyId, email: clEmail, fullName: clName }),
       });
       const data = await res.json();
-      setClMsg(res.ok ? t.companiesPage.loginCreated : data.error || 'Failed');
+      setClMsg(res.ok ? t.companiesPage.loginCreated : data.error || t.common.error);
       if (res.ok) {
         setClEmail('');
         setClName('');
@@ -60,7 +60,7 @@ export default function CompaniesPage() {
       const data = await res.json();
       setCompanies(data.companies || []);
     } catch {
-      setError('Failed to load companies');
+      setError(t.companiesPage.loadFailed);
     } finally {
       setLoading(false);
     }
@@ -90,7 +90,7 @@ export default function CompaniesPage() {
     });
     if (!res.ok) {
       const body = await res.json();
-      throw new Error(body.error || 'Failed to create company');
+      throw new Error(body.error || t.companiesPage.createFailed);
     }
     await fetchCompanies();
     setShowForm(false);
@@ -111,14 +111,14 @@ export default function CompaniesPage() {
     });
     if (!res.ok) {
       const body = await res.json();
-      throw new Error(body.error || 'Failed to update company');
+      throw new Error(body.error || t.companiesPage.updateFailed);
     }
     await fetchCompanies();
     setEditingCompany(null);
   };
 
-  const handleDelete = async (id: string) => {
-    if (!confirm('Are you sure you want to delete this company?')) return;
+  const handleDelete = async (id: string, name: string) => {
+    if (!confirm(t.companiesPage.confirmDelete.replace('{name}', name))) return;
     await fetch(`/api/companies/${id}`, { method: 'DELETE' });
     await fetchCompanies();
   };
@@ -255,7 +255,7 @@ export default function CompaniesPage() {
                       <Pencil className="h-4 w-4" />
                     </button>
                     <button
-                      onClick={() => handleDelete(company.id)}
+                      onClick={() => handleDelete(company.id, company.name)}
                       className="p-1.5 rounded-lg hover:bg-red-50 text-gray-400 hover:text-red-600 transition-colors"
                     >
                       <Trash2 className="h-4 w-4" />

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -243,6 +243,10 @@ const en = {
     positions: 'positions',
     openPositions: 'Open positions',
     loginCreated: 'Login created — we emailed a set-password link.',
+    loadFailed: 'Failed to load companies',
+    createFailed: 'Failed to create company',
+    updateFailed: 'Failed to update company',
+    confirmDelete: 'Are you sure you want to delete "{name}"?',
   },
   companyForm: {
     name: 'Company Name',
@@ -1403,6 +1407,10 @@ const tr: Dict = {
     positions: 'pozisyon',
     openPositions: 'Açık pozisyonlar',
     loginCreated: 'Giriş oluşturuldu — parola belirleme bağlantısı e-postalandı.',
+    loadFailed: 'Şirketler yüklenemedi',
+    createFailed: 'Şirket oluşturulamadı',
+    updateFailed: 'Şirket güncellenemedi',
+    confirmDelete: '"{name}" şirketini silmek istediğine emin misin?',
   },
   companyForm: {
     name: 'Şirket Adı',
@@ -2561,6 +2569,10 @@ const de: Dict = {
     positions: 'Positionen',
     openPositions: 'Offene Positionen',
     loginCreated: 'Zugang erstellt — wir haben einen Link zum Setzen des Passworts per E-Mail gesendet.',
+    loadFailed: 'Unternehmen konnten nicht geladen werden',
+    createFailed: 'Unternehmen konnte nicht erstellt werden',
+    updateFailed: 'Unternehmen konnte nicht aktualisiert werden',
+    confirmDelete: 'Möchtest du "{name}" wirklich löschen?',
   },
   companyForm: {
     name: 'Firmenname',


### PR DESCRIPTION
Closes #464

Five spots on `admin/companies` bypassed the dictionary and stayed English regardless of the selected language:
- `src/app/admin/companies/page.tsx:121` — delete confirmation (`confirm(...)`) — now uses `t.companiesPage.confirmDelete.replace('{name}', name)`, matching the `admin/cohorts` pattern (names the company being deleted).
- Line 63 — load-failure fallback.
- Line 93 — create-failure fallback.
- Line 114 — update-failure fallback.
- Line 47 — company-login-creation generic failure message — reuses the existing `t.common.error` instead of a bespoke `'Failed'`.

Added `loadFailed` / `createFailed` / `updateFailed` / `confirmDelete` to `companiesPage` in EN/TR/DE.

### Verification
- `npm run check:i18n` passes (1151 keys × 3 locales).
- `tsc --noEmit` / `next lint` clean.
- No hardcoded English user-facing text remains on the page.