### PR TITLE
fix(ui): standardize list pages on SkeletonRows instead of plain "Loading..."

### DIFF
--- a/src/app/admin/activity/page.tsx
+++ b/src/app/admin/activity/page.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Badge } from '@/components/ui/Badge';
 import { Button } from '@/components/ui/Button';
+import { SkeletonRows } from '@/components/ui/Skeleton';
 import { useT } from '@/i18n/client';
 
 interface Entry {
@@ -71,7 +72,7 @@ export default function AdminActivityPage() {
       <Card>
         <CardHeader><CardTitle>{t.activity.title} ({total})</CardTitle></CardHeader>
         {loading ? (
-          <p className="text-center py-12 text-gray-400">{t.common.loading}</p>
+          <SkeletonRows rows={8} />
         ) : items.length === 0 ? (
           <p className="text-center py-12 text-gray-400">{t.activity.none}</p>
         ) : (

--- a/src/app/admin/announcements/page.tsx
+++ b/src/app/admin/announcements/page.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Input } from '@/components/ui/Input';
 import { Button } from '@/components/ui/Button';
+import { SkeletonRows } from '@/components/ui/Skeleton';
 import { useT, useLocale } from '@/i18n/client';
 
 interface AnnouncementRecord {
@@ -104,7 +105,7 @@ export default function AdminAnnouncementsPage() {
         <Card>
           <CardHeader><CardTitle>{t.announcements.history}</CardTitle></CardHeader>
           {historyLoading ? (
-            <p className="text-sm text-gray-400">{t.common.loading}</p>
+            <SkeletonRows rows={4} />
           ) : history.length === 0 ? (
             <p className="text-sm text-gray-400">{t.announcements.noHistory}</p>
           ) : (

--- a/src/app/admin/cohorts/page.tsx
+++ b/src/app/admin/cohorts/page.tsx
@@ -5,6 +5,7 @@ import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Input } from '@/components/ui/Input';
 import { Button } from '@/components/ui/Button';
 import { Pencil, Trash2 } from 'lucide-react';
+import { SkeletonRows } from '@/components/ui/Skeleton';
 import { useT } from '@/i18n/client';
 
 interface Cohort {
@@ -94,7 +95,7 @@ export default function AdminCohortsPage() {
       <Card>
         <CardHeader><CardTitle>{t.cohorts.comparison} ({cohorts.length})</CardTitle></CardHeader>
         {loading ? (
-          <p className="text-center py-10 text-gray-400">{t.common.loading}</p>
+          <SkeletonRows rows={5} />
         ) : cohorts.length === 0 ? (
           <p className="text-center py-10 text-gray-400">{t.cohorts.none}</p>
         ) : (

--- a/src/app/admin/mentors/page.tsx
+++ b/src/app/admin/mentors/page.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { Users, Pencil } from 'lucide-react';
 import Link from 'next/link';
+import { SkeletonRows } from '@/components/ui/Skeleton';
 import { useT } from '@/i18n/client';
 
 interface MentorUser {
@@ -95,7 +96,7 @@ export default function MentorsPage() {
         </CardHeader>
 
         {loading ? (
-          <p className="text-center py-12 text-gray-400">{t.common.loading}</p>
+          <SkeletonRows rows={6} />
         ) : shown.length === 0 ? (
           <p className="text-center py-12 text-gray-400">{t.mentors.none}</p>
         ) : (

--- a/src/app/admin/mentorship/page.tsx
+++ b/src/app/admin/mentorship/page.tsx
@@ -8,6 +8,7 @@ import { Badge, StatusBadge } from '@/components/ui/Badge';
 import { Button } from '@/components/ui/Button';
 import { Select } from '@/components/ui/Select';
 import { SavedViews } from '@/components/SavedViews';
+import { SkeletonRows } from '@/components/ui/Skeleton';
 import { BookOpen, Plus } from 'lucide-react';
 
 interface User {
@@ -248,7 +249,7 @@ export default function MentorshipPage() {
 
       {/* Relations */}
       {loading ? (
-        <div className="text-center py-12 text-gray-400">{t.common.loading}</div>
+        <Card><SkeletonRows rows={6} /></Card>
       ) : relations.length === 0 ? (
         <Card className="text-center py-12">
           <BookOpen className="h-12 w-12 text-gray-300 mx-auto mb-4" />

--- a/src/app/admin/sources/page.tsx
+++ b/src/app/admin/sources/page.tsx
@@ -5,6 +5,7 @@ import { Trash2 } from 'lucide-react';
 import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Input } from '@/components/ui/Input';
 import { Button } from '@/components/ui/Button';
+import { SkeletonRows } from '@/components/ui/Skeleton';
 import { useT } from '@/i18n/client';
 
 interface Source {
@@ -122,7 +123,7 @@ export default function AdminSourcesPage() {
       <Card>
         <CardHeader><CardTitle>{t.sources.title} ({sources.length})</CardTitle></CardHeader>
         {loading ? (
-          <p className="text-center py-10 text-gray-400">{t.common.loading}</p>
+          <SkeletonRows rows={5} />
         ) : sources.length === 0 ? (
           <p className="text-center py-10 text-gray-400">{t.sources.none}</p>
         ) : (

--- a/src/app/company/page.tsx
+++ b/src/app/company/page.tsx
@@ -6,6 +6,7 @@ import { ChevronRight } from 'lucide-react';
 import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Badge } from '@/components/ui/Badge';
 import { Select } from '@/components/ui/Select';
+import { SkeletonRows } from '@/components/ui/Skeleton';
 import { pipelineLabel, pipelineOptions } from '@/lib/pipeline';
 import { useT, useLocale } from '@/i18n/client';
 
@@ -67,7 +68,7 @@ export default function CompanyOverviewPage() {
           <CardTitle>{t.company.candidates} ({shown.length})</CardTitle>
         </CardHeader>
         {loading ? (
-          <p className="text-center py-12 text-gray-400">{t.common.loading}</p>
+          <SkeletonRows rows={6} />
         ) : shown.length === 0 ? (
           <p className="text-center py-12 text-gray-400">{t.company.none}</p>
         ) : (

--- a/src/app/mentor/interactions/page.tsx
+++ b/src/app/mentor/interactions/page.tsx
@@ -4,6 +4,7 @@ import { useT } from "@/i18n/client";
 import { useState, useEffect, useCallback } from 'react';
 import { Card } from '@/components/ui/Card';
 import { InteractionTypeBadge } from '@/components/InteractionTypeBadge';
+import { SkeletonRows } from '@/components/ui/Skeleton';
 import { BookOpen } from 'lucide-react';
 
 interface Interaction {
@@ -79,7 +80,7 @@ export default function MentorInteractionsPage() {
       )}
 
       {loading ? (
-        <div className="text-center py-12 text-gray-400">{t.common.loading}</div>
+        <Card><SkeletonRows rows={6} /></Card>
       ) : interactions.length === 0 ? (
         <Card className="text-center py-12">
           <BookOpen className="h-12 w-12 text-gray-300 mx-auto mb-4" />

--- a/src/app/mentor/mentees/page.tsx
+++ b/src/app/mentor/mentees/page.tsx
@@ -9,6 +9,7 @@ import { Users } from 'lucide-react';
 import Link from 'next/link';
 import { ApplyLinkBox } from '@/components/ApplyLinkBox';
 import { EmptyState } from '@/components/EmptyState';
+import { SkeletonRows } from '@/components/ui/Skeleton';
 
 interface MentorshipRelation {
   id: string;
@@ -63,7 +64,7 @@ export default function MenteesPage() {
       <ApplyLinkBox />
 
       {loading ? (
-        <div className="text-center py-12 text-gray-400">{t.common.loading}</div>
+        <Card><SkeletonRows rows={6} /></Card>
       ) : relations.length === 0 ? (
         <Card>
           <EmptyState

--- a/src/app/portal/messages/page.tsx
+++ b/src/app/portal/messages/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
+import { SkeletonRows } from '@/components/ui/Skeleton';
 import { MessageSquare } from 'lucide-react';
 import { useT } from '@/i18n/client';
 
@@ -33,7 +34,7 @@ export default function PortalMessagesPage() {
       <Card>
         <CardHeader><CardTitle>{t.messages.threads}</CardTitle></CardHeader>
         {loading ? (
-          <p className="text-center py-10 text-gray-400">{t.common.loading}</p>
+          <SkeletonRows rows={3} />
         ) : relations.length === 0 ? (
           <p className="text-center py-10 text-gray-400">{t.messages.noThreads}</p>
         ) : (

--- a/src/app/source/page.tsx
+++ b/src/app/source/page.tsx
@@ -5,6 +5,7 @@ import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Input } from '@/components/ui/Input';
 import { Button } from '@/components/ui/Button';
 import { Badge } from '@/components/ui/Badge';
+import { SkeletonRows } from '@/components/ui/Skeleton';
 import { useT } from '@/i18n/client';
 
 interface Mentee {
@@ -80,7 +81,7 @@ export default function SourcePortal() {
       <Card>
         <CardHeader><CardTitle>{t.sourcePortal.myMentees} ({mentees.length})</CardTitle></CardHeader>
         {loading ? (
-          <p className="text-center py-10 text-gray-400">{t.common.loading}</p>
+          <SkeletonRows rows={5} />
         ) : mentees.length === 0 ? (
           <p className="text-center py-10 text-gray-400">{t.sourcePortal.none}</p>
         ) : (


### PR DESCRIPTION
Closes #469

Replaced a bare loading-text placeholder with `<SkeletonRows />` on every genuinely row-shaped list view:
- `mentor/mentees`, `mentor/interactions` (explicitly called out in the issue)
- `portal/messages`, `admin/activity`, `admin/cohorts`, `admin/mentors`, `admin/sources`, `admin/mentorship`, `admin/announcements` (the history panel specifically)
- `company` (candidates list), `source` (assigned mentees list)

### Deliberately left unchanged (scope decisions, listed per the issue's request)
- Detail/form pages (`*/[id]/page.tsx`, `portal/profile`) — out of scope per the issue.
- `admin/candidates/page.tsx:322` — an inline count label (`"X found"`), not a full-page loading placeholder.
- `admin/board`, `mentor/board` — Kanban column layouts; `SkeletonRows` is a stacked-row shape that doesn't represent a multi-column board.
- `admin/analytics` — a stats/chart dashboard, not a row list.
- `admin/companies` — renders as a card **grid**, not a row list. `SkeletonRows`' shape wouldn't match the grid and would look more broken than the plain text it replaced, so I left it as-is rather than force a mismatched skeleton in for the sake of "no plain text left".

### Verification
- `tsc --noEmit` / `next lint` clean.
- Behavior after load is unchanged everywhere — only the loading placeholder itself changed.