### PR TITLE
fix(ux): confirm before destructive deletes (goals, docs, notes, projects, availability, interactions)

### DIFF
--- a/e2e/delete-confirm.spec.ts
+++ b/e2e/delete-confirm.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// #470: unconfirmed delete actions must ask for confirmation first, and
+// cancelling must not send the delete request at all.
+test('deleting a personal note asks for confirmation; cancelling keeps the note', async ({ page }) => {
+  const email = uniqueEmail('delconfirm-mentee');
+  const mentee = await seedUser(email, 'MenteePass123', 'MENTEE', 'Del Confirm Mentee');
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', email);
+    await page.fill('input[type="password"]', 'MenteePass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/portal'), { timeout: 20_000 });
+
+    await page.goto('/portal/notes');
+    await page.fill('textarea', 'Note that should survive a cancelled delete');
+    await page.click('button[type="submit"]');
+    await expect(page.getByText('Note that should survive a cancelled delete')).toBeVisible();
+
+    let dialogMessage = '';
+    page.once('dialog', async (d) => {
+      dialogMessage = d.message();
+      await d.dismiss();
+    });
+    const deleteRequest = page.waitForRequest((r) => r.method() === 'DELETE' && r.url().includes('/api/notes/'), { timeout: 2_000 }).catch(() => null);
+    await page.getByLabel('Delete').click();
+    expect(await deleteRequest).toBeNull();
+    expect(dialogMessage.length).toBeGreaterThan(0);
+    await expect(page.getByText('Note that should survive a cancelled delete')).toBeVisible();
+
+    page.once('dialog', (d) => d.accept());
+    await page.getByLabel('Delete').click();
+    await expect(page.getByText('Note that should survive a cancelled delete')).toHaveCount(0);
+  } finally {
+    await prisma.personalNote.deleteMany({ where: { userId: mentee.id } });
+    await cleanupByEmail(email);
+  }
+});

--- a/src/app/mentor/availability/page.tsx
+++ b/src/app/mentor/availability/page.tsx
@@ -44,6 +44,7 @@ export default function AvailabilityPage() {
   };
 
   const remove = async (id: string) => {
+    if (!window.confirm(t.common.confirmDelete)) return;
     await fetch(`/api/availability?id=${id}`, { method: 'DELETE' });
     await load();
   };

--- a/src/app/mentor/mentees/[id]/page.tsx
+++ b/src/app/mentor/mentees/[id]/page.tsx
@@ -124,6 +124,7 @@ export default function MenteeDetailPage() {
   };
 
   const handleDeleteInteraction = async (interactionId: string) => {
+    if (!window.confirm(t.common.confirmDelete)) return;
     await fetch(`/api/interactions/${interactionId}`, { method: 'DELETE' });
     await fetchRelation();
     toast(t.mentor.interactionDeleted);

--- a/src/components/DocumentsManager.tsx
+++ b/src/components/DocumentsManager.tsx
@@ -70,8 +70,9 @@ export function DocumentsManager({
     }
   };
 
-  const remove = async (id: string) => {
-    await fetch(`/api/documents/${id}`, { method: 'DELETE' });
+  const remove = async (d: Doc) => {
+    if (!window.confirm(t.documents.confirmDelete.replace('{title}', d.title))) return;
+    await fetch(`/api/documents/${d.id}`, { method: 'DELETE' });
     await load();
   };
 
@@ -98,7 +99,7 @@ export function DocumentsManager({
               {!templates && <Badge variant="info">{typeLabel(d.type)}</Badge>}
               <a href={`/api/documents/${d.id}`} target="_blank" rel="noopener noreferrer" aria-label={t.documents.download} className="text-gray-400 hover:text-blue-600"><Download className="h-4 w-4" /></a>
               {canDelete && (
-                <button onClick={() => remove(d.id)} aria-label={t.common.delete} className="text-gray-300 hover:text-red-600"><Trash2 className="h-4 w-4" /></button>
+                <button onClick={() => remove(d)} aria-label={t.common.delete} className="text-gray-300 hover:text-red-600"><Trash2 className="h-4 w-4" /></button>
               )}
             </div>
           ))}

--- a/src/components/GoalsPanel.tsx
+++ b/src/components/GoalsPanel.tsx
@@ -57,8 +57,9 @@ export function GoalsPanel({ relationId, readOnly = false }: { relationId: strin
     await load();
   };
 
-  const remove = async (id: string) => {
-    await fetch(`/api/goals/${id}`, { method: 'DELETE' });
+  const remove = async (g: Goal) => {
+    if (!window.confirm(t.goals.confirmDelete.replace('{title}', g.title))) return;
+    await fetch(`/api/goals/${g.id}`, { method: 'DELETE' });
     await load();
   };
 
@@ -105,7 +106,7 @@ export function GoalsPanel({ relationId, readOnly = false }: { relationId: strin
                 </span>
               </span>
               {!readOnly && (
-                <button onClick={() => remove(g.id)} aria-label={t.common.delete} className="text-gray-300 hover:text-red-600">
+                <button onClick={() => remove(g)} aria-label={t.common.delete} className="text-gray-300 hover:text-red-600">
                   <Trash2 className="h-4 w-4" />
                 </button>
               )}

--- a/src/components/NotesPanel.tsx
+++ b/src/components/NotesPanel.tsx
@@ -49,6 +49,7 @@ export function NotesPanel() {
   };
 
   const remove = async (id: string) => {
+    if (!window.confirm(t.common.confirmDelete)) return;
     await fetch(`/api/notes/${id}`, { method: 'DELETE' });
     await load();
     toast(t.portal.notes.deleted);

--- a/src/components/ProjectsManager.tsx
+++ b/src/components/ProjectsManager.tsx
@@ -131,8 +131,9 @@ export function ProjectsManager({ isAdmin }: { isAdmin: boolean }) {
     window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
-  const remove = async (id: string) => {
-    await fetch(`/api/projects/${id}`, { method: 'DELETE' });
+  const remove = async (p: Project) => {
+    if (!window.confirm(t.projects.confirmDelete.replace('{name}', p.name))) return;
+    await fetch(`/api/projects/${p.id}`, { method: 'DELETE' });
     await load();
   };
 
@@ -152,8 +153,9 @@ export function ProjectsManager({ isAdmin }: { isAdmin: boolean }) {
     });
     await load();
   };
-  const deleteTask = async (taskId: string) => {
-    await fetch(`/api/project-tasks/${taskId}`, { method: 'DELETE' });
+  const deleteTask = async (task: Task) => {
+    if (!window.confirm(t.projects.confirmDeleteTask.replace('{title}', task.title))) return;
+    await fetch(`/api/project-tasks/${task.id}`, { method: 'DELETE' });
     await load();
   };
 
@@ -288,7 +290,7 @@ export function ProjectsManager({ isAdmin }: { isAdmin: boolean }) {
                                   <div key={tk.id} data-testid={`task-${tk.id}`} className="flex items-center gap-2 text-sm">
                                     <input type="checkbox" checked={tk.done} onChange={() => toggleTask(tk)} />
                                     <span className={`flex-1 ${tk.done ? 'line-through text-gray-400' : 'text-gray-700'}`}>{tk.title}</span>
-                                    <button onClick={() => deleteTask(tk.id)} aria-label={t.common.delete} className="text-gray-300 hover:text-red-600"><Trash2 className="h-3.5 w-3.5" /></button>
+                                    <button onClick={() => deleteTask(tk)} aria-label={t.common.delete} className="text-gray-300 hover:text-red-600"><Trash2 className="h-3.5 w-3.5" /></button>
                                   </div>
                                 ))}
                               </div>
@@ -310,7 +312,7 @@ export function ProjectsManager({ isAdmin }: { isAdmin: boolean }) {
                   </div>
                   <div className="flex gap-1 flex-shrink-0">
                     <button onClick={() => edit(p)} aria-label={t.projects.editProject} className="p-2 text-gray-400 hover:text-blue-600"><Pencil className="h-4 w-4" /></button>
-                    <button onClick={() => remove(p.id)} aria-label={t.projects.deleteProject} className="p-2 text-gray-400 hover:text-red-600"><Trash2 className="h-4 w-4" /></button>
+                    <button onClick={() => remove(p)} aria-label={t.projects.deleteProject} className="p-2 text-gray-400 hover:text-red-600"><Trash2 className="h-4 w-4" /></button>
                   </div>
                 </div>
               </div>

--- a/src/components/RelationNotesPanel.tsx
+++ b/src/components/RelationNotesPanel.tsx
@@ -50,6 +50,7 @@ export function RelationNotesPanel({ relationId }: { relationId: string }) {
   };
 
   const remove = async (id: string) => {
+    if (!window.confirm(t.common.confirmDelete)) return;
     await fetch(`/api/relation-notes/${id}`, { method: 'DELETE' });
     await load();
   };

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -85,6 +85,7 @@ const en = {
     save: 'Save',
     prev: 'Previous',
     next: 'Next',
+    confirmDelete: 'Are you sure you want to delete this?',
   },
   dashboard: {
     title: 'Admin Dashboard',
@@ -638,6 +639,8 @@ const en = {
     showcaseSubtitle: 'Community and company internship projects.',
     noPublic: 'No public projects yet.',
     by: 'by',
+    confirmDelete: 'Delete project "{name}"? This cannot be undone.',
+    confirmDeleteTask: 'Delete task "{title}"?',
   },
   evaluation: {
     title: 'Evaluation',
@@ -666,6 +669,7 @@ const en = {
     markOpen: 'Reopen',
     byMentor: 'Created by mentor',
     byMentee: 'Created by mentee',
+    confirmDelete: 'Delete goal "{title}"?',
   },
   cohorts: {
     title: 'Cohorts',
@@ -829,6 +833,7 @@ const en = {
     download: 'Download',
     titlePlaceholder: 'Title (optional)',
     types: { CV: 'CV', CONTRACT: 'Contract', CERTIFICATE: 'Certificate', OTHER: 'Other' },
+    confirmDelete: 'Delete document "{title}"?',
   },
   securitySetup: {
     title: 'Set up two-factor authentication',
@@ -1250,6 +1255,7 @@ const tr: Dict = {
     save: 'Kaydet',
     prev: 'Önceki',
     next: 'Sonraki',
+    confirmDelete: 'Bunu silmek istediğinize emin misiniz?',
   },
   dashboard: {
     title: 'Yönetim Paneli',
@@ -1803,6 +1809,8 @@ const tr: Dict = {
     showcaseSubtitle: 'Topluluk ve şirket staj projeleri.',
     noPublic: 'Henüz herkese açık proje yok.',
     by: '·',
+    confirmDelete: '"{name}" projesini silmek istiyor musun? Bu işlem geri alınamaz.',
+    confirmDeleteTask: '"{title}" görevini silmek istiyor musun?',
   },
   evaluation: {
     title: 'Değerlendirme',
@@ -1831,6 +1839,7 @@ const tr: Dict = {
     markOpen: 'Yeniden aç',
     byMentor: 'Mentor oluşturdu',
     byMentee: 'Mentee oluşturdu',
+    confirmDelete: '"{title}" hedefini silmek istiyor musun?',
   },
   cohorts: {
     title: 'Kohortlar',
@@ -1994,6 +2003,7 @@ const tr: Dict = {
     download: 'İndir',
     titlePlaceholder: 'Başlık (opsiyonel)',
     types: { CV: 'CV', CONTRACT: 'Sözleşme', CERTIFICATE: 'Sertifika', OTHER: 'Diğer' },
+    confirmDelete: '"{title}" belgesini silmek istiyor musun?',
   },
   securitySetup: {
     title: 'İki adımlı doğrulamayı kur',
@@ -2413,6 +2423,7 @@ const de: Dict = {
     save: 'Speichern',
     prev: 'Zurück',
     next: 'Weiter',
+    confirmDelete: 'Möchtest du das wirklich löschen?',
   },
   dashboard: {
     title: 'Admin-Dashboard',
@@ -2966,6 +2977,8 @@ const de: Dict = {
     showcaseSubtitle: 'Gemeinschafts- und Unternehmens-Praktikumsprojekte.',
     noPublic: 'Noch keine öffentlichen Projekte.',
     by: 'von',
+    confirmDelete: 'Projekt "{name}" löschen? Dies kann nicht rückgängig gemacht werden.',
+    confirmDeleteTask: 'Aufgabe "{title}" löschen?',
   },
   evaluation: {
     title: 'Bewertung',
@@ -2994,6 +3007,7 @@ const de: Dict = {
     markOpen: 'Wieder öffnen',
     byMentor: 'Vom Mentor erstellt',
     byMentee: 'Vom Mentee erstellt',
+    confirmDelete: 'Ziel "{title}" löschen?',
   },
   cohorts: {
     title: 'Kohorten',
@@ -3157,6 +3171,7 @@ const de: Dict = {
     download: 'Herunterladen',
     titlePlaceholder: 'Titel (optional)',
     types: { CV: 'Lebenslauf', CONTRACT: 'Vertrag', CERTIFICATE: 'Zertifikat', OTHER: 'Sonstiges' },
+    confirmDelete: 'Dokument "{title}" löschen?',
   },
   securitySetup: {
     title: 'Zwei-Faktor-Authentifizierung einrichten',


### PR DESCRIPTION
## Summary
- Adds `window.confirm()` guards before every unconfirmed DELETE action across 7 locations: goals, documents, relation notes, personal notes, projects, project tasks, availability slots, and mentee interaction logs.
- Confirmation copy is sourced from the i18n dictionary (EN/TR/DE) — specific messages include the item's name/title where available (goal, document, project, task), a generic `common.confirmDelete` elsewhere.
- Cancelling the dialog sends no request at all.

Closes #470

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (only pre-existing unrelated warnings)
- [x] `npm run check:i18n` — 1157 keys × 3 locales, OK
- [x] New `e2e/delete-confirm.spec.ts`: creates a note via UI, clicks delete, dismisses the confirm dialog and asserts no DELETE request was sent and the note survives, then accepts the dialog and asserts the note is removed
- [ ] CI (Lint/Typecheck/Build, Playwright smoke, Preview Deploy)