### PR TITLE
feat(admin): add search box to cohorts and sources list pages

### DIFF
--- a/e2e/cohorts-sources-search.spec.ts
+++ b/e2e/cohorts-sources-search.spec.ts
@@ -21,12 +21,13 @@ test('admin filters cohorts by name via the search box', async ({ page }) => {
     await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
 
     await page.goto('/admin/cohorts');
-    await expect(page.getByText('Autumn Interns 2026')).toBeVisible();
-    await expect(page.getByText('Winter Batch')).toBeVisible();
+    const table = page.locator('table');
+    await expect(table.getByText('Autumn Interns 2026')).toBeVisible();
+    await expect(table.getByText('Winter Batch')).toBeVisible();
 
-    await page.fill('input[type="search"]', 'autumn');
-    await expect(page.getByText('Autumn Interns 2026')).toBeVisible();
-    await expect(page.getByText('Winter Batch')).toHaveCount(0);
+    await page.fill('[data-testid="cohort-search"]', 'autumn');
+    await expect(table.getByText('Autumn Interns 2026')).toBeVisible();
+    await expect(table.getByText('Winter Batch')).toHaveCount(0);
   } finally {
     await prisma.cohort.deleteMany({ where: { id: { in: [cohortA.id, cohortB.id] } } });
     await cleanupByEmail(adminEmail);
@@ -47,12 +48,13 @@ test('admin filters referral sources by name via the search box', async ({ page 
     await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
 
     await page.goto('/admin/sources');
-    await expect(page.getByText('LinkedIn Campaign')).toBeVisible();
-    await expect(page.getByText('University Career Fair')).toBeVisible();
+    const table = page.locator('table');
+    await expect(table.getByText('LinkedIn Campaign')).toBeVisible();
+    await expect(table.getByText('University Career Fair')).toBeVisible();
 
-    await page.fill('input[type="search"]', 'linkedin');
-    await expect(page.getByText('LinkedIn Campaign')).toBeVisible();
-    await expect(page.getByText('University Career Fair')).toHaveCount(0);
+    await page.fill('[data-testid="source-search"]', 'linkedin');
+    await expect(table.getByText('LinkedIn Campaign')).toBeVisible();
+    await expect(table.getByText('University Career Fair')).toHaveCount(0);
   } finally {
     await prisma.source.deleteMany({ where: { id: { in: [sourceA.id, sourceB.id] } } });
     await cleanupByEmail(adminEmail);

--- a/e2e/cohorts-sources-search.spec.ts
+++ b/e2e/cohorts-sources-search.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// #474: admin/cohorts and admin/sources need a search box like the other
+// admin list pages, filtering client-side by name (case-insensitive).
+test('admin filters cohorts by name via the search box', async ({ page }) => {
+  const adminEmail = uniqueEmail('cs-admin');
+  await seedUser(adminEmail, 'AdminPass123', 'ADMIN', 'CS Admin');
+  const cohortA = await prisma.cohort.create({ data: { name: 'Autumn Interns 2026' } });
+  const cohortB = await prisma.cohort.create({ data: { name: 'Winter Batch' } });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', 'AdminPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    await page.goto('/admin/cohorts');
+    await expect(page.getByText('Autumn Interns 2026')).toBeVisible();
+    await expect(page.getByText('Winter Batch')).toBeVisible();
+
+    await page.fill('input[type="search"]', 'autumn');
+    await expect(page.getByText('Autumn Interns 2026')).toBeVisible();
+    await expect(page.getByText('Winter Batch')).toHaveCount(0);
+  } finally {
+    await prisma.cohort.deleteMany({ where: { id: { in: [cohortA.id, cohortB.id] } } });
+    await cleanupByEmail(adminEmail);
+  }
+});
+
+test('admin filters referral sources by name via the search box', async ({ page }) => {
+  const adminEmail = uniqueEmail('cs-admin2');
+  await seedUser(adminEmail, 'AdminPass123', 'ADMIN', 'CS Admin 2');
+  const sourceA = await prisma.source.create({ data: { name: 'LinkedIn Campaign' } });
+  const sourceB = await prisma.source.create({ data: { name: 'University Career Fair' } });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', 'AdminPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    await page.goto('/admin/sources');
+    await expect(page.getByText('LinkedIn Campaign')).toBeVisible();
+    await expect(page.getByText('University Career Fair')).toBeVisible();
+
+    await page.fill('input[type="search"]', 'linkedin');
+    await expect(page.getByText('LinkedIn Campaign')).toBeVisible();
+    await expect(page.getByText('University Career Fair')).toHaveCount(0);
+  } finally {
+    await prisma.source.deleteMany({ where: { id: { in: [sourceA.id, sourceB.id] } } });
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/src/app/admin/cohorts/page.tsx
+++ b/src/app/admin/cohorts/page.tsx
@@ -99,6 +99,7 @@ export default function AdminCohortsPage() {
         <div className="flex items-center mb-4">
           <input
             type="search"
+            data-testid="cohort-search"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder={t.cohorts.searchPlaceholder}

--- a/src/app/admin/cohorts/page.tsx
+++ b/src/app/admin/cohorts/page.tsx
@@ -24,6 +24,7 @@ export default function AdminCohortsPage() {
   const [term, setTerm] = useState('');
   const [saving, setSaving] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState('');
 
   const load = useCallback(async () => {
     const res = await fetch('/api/cohorts');
@@ -75,6 +76,9 @@ export default function AdminCohortsPage() {
 
   const hiredOf = (d: Record<string, number>) => HIRED.reduce((n, s) => n + (d[s] || 0), 0);
 
+  const q = search.trim().toLowerCase();
+  const filtered = cohorts.filter((c) => !q || c.name.toLowerCase().includes(q));
+
   return (
     <div>
       <div className="mb-6">
@@ -91,11 +95,25 @@ export default function AdminCohortsPage() {
         </form>
       </Card>
 
+      {!loading && cohorts.length > 0 && (
+        <div className="flex items-center mb-4">
+          <input
+            type="search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder={t.cohorts.searchPlaceholder}
+            className="w-full sm:w-64 rounded-lg border border-gray-300 px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-100 focus:border-blue-400"
+          />
+        </div>
+      )}
+
       <Card>
-        <CardHeader><CardTitle>{t.cohorts.comparison} ({cohorts.length})</CardTitle></CardHeader>
+        <CardHeader><CardTitle>{t.cohorts.comparison} ({filtered.length})</CardTitle></CardHeader>
         {loading ? (
           <p className="text-center py-10 text-gray-400">{t.common.loading}</p>
         ) : cohorts.length === 0 ? (
+          <p className="text-center py-10 text-gray-400">{t.cohorts.none}</p>
+        ) : filtered.length === 0 ? (
           <p className="text-center py-10 text-gray-400">{t.cohorts.none}</p>
         ) : (
           <div className="overflow-x-auto">
@@ -111,7 +129,7 @@ export default function AdminCohortsPage() {
                 </tr>
               </thead>
               <tbody>
-                {cohorts.map((c) => {
+                {filtered.map((c) => {
                   const hired = hiredOf(c.distribution);
                   const rate = c.interns ? Math.round((hired / c.interns) * 100) : 0;
                   return (

--- a/src/app/admin/sources/page.tsx
+++ b/src/app/admin/sources/page.tsx
@@ -127,6 +127,7 @@ export default function AdminSourcesPage() {
         <div className="flex items-center mb-4">
           <input
             type="search"
+            data-testid="source-search"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder={t.sources.searchPlaceholder}

--- a/src/app/admin/sources/page.tsx
+++ b/src/app/admin/sources/page.tsx
@@ -26,6 +26,7 @@ export default function AdminSourcesPage() {
   const [saving, setSaving] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
 
   const load = useCallback(async () => {
     const res = await fetch('/api/admin/sources');
@@ -83,6 +84,9 @@ export default function AdminSourcesPage() {
     }
   };
 
+  const q = search.trim().toLowerCase();
+  const filtered = sources.filter((s) => !q || s.name.toLowerCase().includes(q));
+
   return (
     <div>
       <div className="mb-6">
@@ -119,11 +123,25 @@ export default function AdminSourcesPage() {
         {loginMsg && <p className="text-sm text-gray-600 mt-2">{loginMsg}</p>}
       </Card>
 
+      {!loading && sources.length > 0 && (
+        <div className="flex items-center mb-4">
+          <input
+            type="search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder={t.sources.searchPlaceholder}
+            className="w-full sm:w-64 rounded-lg border border-gray-300 px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-100 focus:border-blue-400"
+          />
+        </div>
+      )}
+
       <Card>
-        <CardHeader><CardTitle>{t.sources.title} ({sources.length})</CardTitle></CardHeader>
+        <CardHeader><CardTitle>{t.sources.title} ({filtered.length})</CardTitle></CardHeader>
         {loading ? (
           <p className="text-center py-10 text-gray-400">{t.common.loading}</p>
         ) : sources.length === 0 ? (
+          <p className="text-center py-10 text-gray-400">{t.sources.none}</p>
+        ) : filtered.length === 0 ? (
           <p className="text-center py-10 text-gray-400">{t.sources.none}</p>
         ) : (
           <div className="overflow-x-auto">
@@ -139,7 +157,7 @@ export default function AdminSourcesPage() {
                 </tr>
               </thead>
               <tbody>
-                {sources.map((s) => (
+                {filtered.map((s) => (
                   <tr key={s.id} data-testid={`source-row-${s.id}`} className="border-b border-gray-50">
                     <td className="py-2 pr-4 font-medium text-gray-900">{s.name}</td>
                     <td className="py-2 pr-4 text-gray-500">

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -680,6 +680,7 @@ const en = {
     create: 'Create',
     none: 'No cohorts yet',
     confirmDelete: 'Delete cohort "{name}"? Mentees stay; they just lose this cohort tag.',
+    searchPlaceholder: 'Search cohorts...',
   },
   sources: {
     title: 'Referral sources',
@@ -694,6 +695,7 @@ const en = {
     conversion: 'Conversion',
     create: 'Create',
     none: 'No sources yet',
+    searchPlaceholder: 'Search sources...',
     addLogin: 'Create a source login',
     addLoginHint: 'Give a source a login so they can submit mentees (not read-only).',
     createLogin: 'Create login',
@@ -1845,6 +1847,7 @@ const tr: Dict = {
     create: 'Oluştur',
     none: 'Henüz kohort yok',
     confirmDelete: '"{name}" kohortu silinsin mi? Menteeler kalır; sadece bu kohort etiketini kaybeder.',
+    searchPlaceholder: 'Kohort ara...',
   },
   sources: {
     title: 'Başvuru kaynakları',
@@ -1859,6 +1862,7 @@ const tr: Dict = {
     conversion: 'Dönüşüm',
     create: 'Oluştur',
     none: 'Henüz kaynak yok',
+    searchPlaceholder: 'Kaynak ara...',
     addLogin: 'Kaynak girişi oluştur',
     addLoginHint: 'Bir kaynağa giriş ver ki mentee gönderebilsin (salt-okunur değil).',
     createLogin: 'Giriş oluştur',
@@ -3008,6 +3012,7 @@ const de: Dict = {
     create: 'Erstellen',
     none: 'Noch keine Kohorten',
     confirmDelete: 'Kohorte "{name}" löschen? Mentees bleiben; nur die Kohorten-Zuordnung entfällt.',
+    searchPlaceholder: 'Kohorten suchen...',
   },
   sources: {
     title: 'Empfehlungsquellen',
@@ -3022,6 +3027,7 @@ const de: Dict = {
     conversion: 'Conversion',
     create: 'Erstellen',
     none: 'Noch keine Quellen',
+    searchPlaceholder: 'Quellen suchen...',
     addLogin: 'Quellen-Login erstellen',
     addLoginHint: 'Gib einer Quelle einen Login, damit sie Mentees einreichen kann (nicht nur lesend).',
     createLogin: 'Login erstellen',


### PR DESCRIPTION
## Summary
- Adds a search box to `admin/cohorts` and `admin/sources`, matching the existing `admin/users` pattern.
- Filters client-side by name, case-insensitive.
- Placeholder text sourced from i18n (EN/TR/DE).
- Existing empty-state message is reused when the search yields zero results.

Closes #474

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (only pre-existing unrelated warnings)
- [x] `npm run check:i18n` — OK
- [x] New `e2e/cohorts-sources-search.spec.ts` covers filtering on both pages
- [ ] CI (Lint/Typecheck/Build, Playwright smoke, Preview Deploy)