### PR TITLE
fix(dark-mode): add explicit dark: variant to page-title headers

### DIFF
--- a/e2e/dark-mode-admin-headers.spec.ts
+++ b/e2e/dark-mode-admin-headers.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test';
+import { seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+// #476: page-title <h1> elements used a plain text-gray-900 with no dark:
+// variant. Verify the fix renders a light color (not near-black) once dark
+// mode is on, on both an admin page and a non-admin one.
+test('page titles are readable in dark mode', async ({ page }) => {
+  const email = uniqueEmail('darkhead-admin');
+  await seedUser(email, 'AdminPass123', 'ADMIN', 'Dark Head Admin');
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', email);
+    await page.fill('input[type="password"]', 'AdminPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    for (const path of ['/admin/companies', '/admin/users']) {
+      await page.goto(path);
+      await page.evaluate(() => document.documentElement.classList.add('dark'));
+      const [r, g, b] = (await page.locator('h1').first().evaluate((el) => getComputedStyle(el).color))
+        .match(/\d+(\.\d+)?/g)!
+        .map(Number);
+      // Retinted h1 should be a light gray (~#f3f4f6), not the original near-black.
+      expect(r).toBeGreaterThan(150);
+      expect(g).toBeGreaterThan(150);
+      expect(b).toBeGreaterThan(150);
+    }
+  } finally {
+    await cleanupByEmail(email);
+  }
+});

--- a/src/app/admin/activity/page.tsx
+++ b/src/app/admin/activity/page.tsx
@@ -52,7 +52,7 @@ export default function AdminActivityPage() {
   return (
     <div>
       <div className="mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">{t.activity.title}</h1>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.activity.title}</h1>
         <p className="text-gray-500 mt-1">{t.activity.subtitle}</p>
       </div>
 

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -96,7 +96,7 @@ export default function AdminAnalyticsPage() {
     <div>
       <div className="mb-6 flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">{t.analytics.title}</h1>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.analytics.title}</h1>
           <p className="text-gray-500 mt-1">{t.analytics.subtitle}</p>
         </div>
         <div className="flex items-center gap-2 no-print">

--- a/src/app/admin/announcements/page.tsx
+++ b/src/app/admin/announcements/page.tsx
@@ -70,7 +70,7 @@ export default function AdminAnnouncementsPage() {
   return (
     <div>
       <div className="mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">{t.announcements.title}</h1>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.announcements.title}</h1>
         <p className="text-gray-500 mt-1">{t.announcements.subtitle}</p>
       </div>
 

--- a/src/app/admin/api-docs/page.tsx
+++ b/src/app/admin/api-docs/page.tsx
@@ -23,7 +23,7 @@ export default function ApiDocsPage() {
   return (
     <div>
       <div className="mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">{t.apiDocs.title}</h1>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.apiDocs.title}</h1>
         <p className="text-gray-500 mt-1">{t.apiDocs.subtitle}</p>
       </div>
 

--- a/src/app/admin/board/page.tsx
+++ b/src/app/admin/board/page.tsx
@@ -163,7 +163,7 @@ export default function AdminBoardPage() {
   return (
     <div>
       <div className="mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">{t.nav.board}</h1>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.nav.board}</h1>
         <p className="text-gray-500 mt-1">{t.adminBoard.subtitle}</p>
       </div>
 

--- a/src/app/admin/calendar/page.tsx
+++ b/src/app/admin/calendar/page.tsx
@@ -8,7 +8,7 @@ export default function AdminCalendarPage() {
   return (
     <div>
       <div className="mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">{t.calendar.title}</h1>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.calendar.title}</h1>
         <p className="text-gray-500 mt-1">{t.calendar.subtitle}</p>
       </div>
       <CalendarView />

--- a/src/app/admin/candidates/[id]/page.tsx
+++ b/src/app/admin/candidates/[id]/page.tsx
@@ -253,7 +253,7 @@ export default function AdminMenteeDetailPage() {
         </Link>
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-2xl font-bold text-gray-900">{user.fullName}</h1>
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{user.fullName}</h1>
             <p className="text-gray-500">{user.email}</p>
           </div>
           <div className="flex items-center gap-3">

--- a/src/app/admin/candidates/page.tsx
+++ b/src/app/admin/candidates/page.tsx
@@ -195,7 +195,7 @@ export default function CandidatesPage() {
     <div>
       <div className="mb-8 flex items-start justify-between gap-4">
         <div>
-        <h1 className="text-2xl font-bold text-gray-900">{t.candidates.title}</h1>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.candidates.title}</h1>
         <p className="text-gray-500 mt-1">{t.candidates.subtitle}</p>
         {statusFilter && (
           <div className="mt-3 inline-flex items-center gap-2 bg-blue-50 border border-blue-200 rounded-full px-3 py-1 text-sm text-blue-700">

--- a/src/app/admin/cohorts/page.tsx
+++ b/src/app/admin/cohorts/page.tsx
@@ -78,7 +78,7 @@ export default function AdminCohortsPage() {
   return (
     <div>
       <div className="mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">{t.cohorts.title}</h1>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.cohorts.title}</h1>
         <p className="text-gray-500 mt-1">{t.cohorts.subtitle}</p>
       </div>
 

--- a/src/app/admin/companies/page.tsx
+++ b/src/app/admin/companies/page.tsx
@@ -127,7 +127,7 @@ export default function CompaniesPage() {
     <div>
       <div className="flex items-center justify-between mb-8">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">{t.companiesPage.title}</h1>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.companiesPage.title}</h1>
           <p className="text-gray-500 mt-1">{t.companiesPage.subtitle}</p>
         </div>
         <Button onClick={() => setShowForm(true)}>

--- a/src/app/admin/documents/page.tsx
+++ b/src/app/admin/documents/page.tsx
@@ -9,7 +9,7 @@ export default function AdminDocumentsPage() {
   return (
     <div>
       <div className="mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">{t.documents.templates}</h1>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.documents.templates}</h1>
         <p className="text-gray-500 mt-1">{t.documents.templatesSubtitle}</p>
       </div>
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 max-w-4xl">

--- a/src/app/admin/integrations/page.tsx
+++ b/src/app/admin/integrations/page.tsx
@@ -54,7 +54,7 @@ export default function IntegrationsPage() {
   return (
     <div>
       <div className="mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">{t.integrations.title}</h1>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.integrations.title}</h1>
         <p className="text-gray-500 mt-1">{t.integrations.subtitle}</p>
       </div>
 

--- a/src/app/admin/invite/page.tsx
+++ b/src/app/admin/invite/page.tsx
@@ -128,7 +128,7 @@ export default function InvitePage() {
   return (
     <div>
       <div className="mb-8">
-        <h1 className="text-2xl font-bold text-gray-900">{t.invite.title}</h1>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.invite.title}</h1>
         <p className="text-gray-500 mt-1">{t.invite.subtitle}</p>
       </div>
 

--- a/src/app/admin/mentorship/page.tsx
+++ b/src/app/admin/mentorship/page.tsx
@@ -161,7 +161,7 @@ export default function MentorshipPage() {
     <div>
       <div className="flex items-center justify-between mb-8">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">{t.mentorships.title}</h1>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.mentorships.title}</h1>
           <p className="text-gray-500 mt-1">{t.mentorships.subtitle}</p>
         </div>
         <Button onClick={() => setShowForm(true)}>

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -69,7 +69,7 @@ export default async function AdminDashboard() {
     <div>
       <OnboardingChecklist />
       <div className="mb-8">
-        <h1 className="text-2xl font-bold text-gray-900">{t.dashboard.title}</h1>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.dashboard.title}</h1>
         <p className="text-gray-500 mt-1">{t.dashboard.subtitle}</p>
       </div>
 

--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -76,7 +76,7 @@ export default function AdminSettingsPage() {
   return (
     <div>
       <div className="mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">{t.settings.title}</h1>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.settings.title}</h1>
         <p className="text-gray-500 mt-1">{t.settings.subtitle}</p>
       </div>
 

--- a/src/app/admin/sources/page.tsx
+++ b/src/app/admin/sources/page.tsx
@@ -86,7 +86,7 @@ export default function AdminSourcesPage() {
   return (
     <div>
       <div className="mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">{t.sources.title}</h1>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.sources.title}</h1>
         <p className="text-gray-500 mt-1">{t.sources.subtitle}</p>
       </div>
 

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -109,7 +109,7 @@ export default function AdminUsersPage() {
   return (
     <div>
       <div className="mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">{t.usersAdmin.title}</h1>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.usersAdmin.title}</h1>
         <p className="text-gray-500 mt-1">{t.usersAdmin.subtitle}</p>
       </div>
 

--- a/src/app/company/page.tsx
+++ b/src/app/company/page.tsx
@@ -42,7 +42,7 @@ export default function CompanyOverviewPage() {
   return (
     <div>
       <div className="mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">{t.company.title}</h1>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.company.title}</h1>
         <p className="text-gray-500 mt-1">{t.company.subtitle}</p>
       </div>
 

--- a/src/app/mentor/availability/page.tsx
+++ b/src/app/mentor/availability/page.tsx
@@ -51,7 +51,7 @@ export default function AvailabilityPage() {
   return (
     <div>
       <div className="mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">{t.availability.title}</h1>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.availability.title}</h1>
         <p className="text-gray-500 mt-1">{t.availability.subtitle}</p>
       </div>
 

--- a/src/app/mentor/board/page.tsx
+++ b/src/app/mentor/board/page.tsx
@@ -59,7 +59,7 @@ export default function MentorBoardPage() {
   return (
     <div>
       <div className="mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">{t.nav.board}</h1>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.nav.board}</h1>
         <p className="text-gray-500 mt-1">
           {t.mentor.boardSubtitle}
         </p>

--- a/src/app/mentor/calendar/page.tsx
+++ b/src/app/mentor/calendar/page.tsx
@@ -8,7 +8,7 @@ export default function MentorCalendarPage() {
   return (
     <div>
       <div className="mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">{t.calendar.title}</h1>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.calendar.title}</h1>
         <p className="text-gray-500 mt-1">{t.calendar.subtitle}</p>
       </div>
       <CalendarView />

--- a/src/app/mentor/email/page.tsx
+++ b/src/app/mentor/email/page.tsx
@@ -59,7 +59,7 @@ export default function MentorEmailPage() {
   return (
     <div>
       <div className="mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">{t.mentorEmail.title}</h1>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.mentorEmail.title}</h1>
         <p className="text-gray-500 mt-1">{t.mentorEmail.subtitle}</p>
       </div>
 

--- a/src/app/mentor/interactions/page.tsx
+++ b/src/app/mentor/interactions/page.tsx
@@ -51,7 +51,7 @@ export default function MentorInteractionsPage() {
   return (
     <div>
       <div className="mb-8">
-        <h1 className="text-2xl font-bold text-gray-900">{t.nav.interactionLogs}</h1>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.nav.interactionLogs}</h1>
         <p className="text-gray-500 mt-1">{t.mentor.interactionLogsSubtitle}</p>
       </div>
 

--- a/src/app/mentor/meetings/page.tsx
+++ b/src/app/mentor/meetings/page.tsx
@@ -77,7 +77,7 @@ export default function MentorMeetingsPage() {
   return (
     <div>
       <div className="mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">{t.meetings.title}</h1>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.meetings.title}</h1>
         <p className="text-gray-500 mt-1">{t.meetings.subtitle}</p>
       </div>
 

--- a/src/app/mentor/mentees/[id]/page.tsx
+++ b/src/app/mentor/mentees/[id]/page.tsx
@@ -163,7 +163,7 @@ export default function MenteeDetailPage() {
         </Link>
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-2xl font-bold text-gray-900">{relation.mentee.fullName}</h1>
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{relation.mentee.fullName}</h1>
             <p className="text-gray-500">{relation.mentee.email}</p>
           </div>
           <div className="flex flex-col items-end gap-2 min-w-[240px]">

--- a/src/app/mentor/mentees/new/page.tsx
+++ b/src/app/mentor/mentees/new/page.tsx
@@ -94,7 +94,7 @@ export default function NewMenteePage() {
         {t.mentor.backToMentees}
       </Link>
       <div className="mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">{t.mentor.newMentee}</h1>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.mentor.newMentee}</h1>
       </div>
 
       <Card className="max-w-2xl">

--- a/src/app/mentor/mentees/page.tsx
+++ b/src/app/mentor/mentees/page.tsx
@@ -49,7 +49,7 @@ export default function MenteesPage() {
     <div>
       <div className="mb-8 flex items-start justify-between gap-4">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">{t.mentor.myMentees}</h1>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.mentor.myMentees}</h1>
           <p className="text-gray-500 mt-1">{t.mentor.menteesSubtitle}</p>
         </div>
         <Link href="/mentor/mentees/new">

--- a/src/app/mentor/page.tsx
+++ b/src/app/mentor/page.tsx
@@ -66,7 +66,7 @@ export default async function MentorDashboard() {
     <div>
       <OnboardingChecklist />
       <div className="mb-8">
-        <h1 className="text-2xl font-bold text-gray-900">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
           {t.mentor.welcomeBack}, {session!.user.name}
         </h1>
         <p className="text-gray-500 mt-1">{t.mentor.dashSubtitle}</p>

--- a/src/app/portal/interactions/page.tsx
+++ b/src/app/portal/interactions/page.tsx
@@ -34,7 +34,7 @@ export default function PortalInteractionsPage() {
   return (
     <div>
       <div className="mb-8">
-        <h1 className="text-2xl font-bold text-gray-900">Interaction Logs</h1>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Interaction Logs</h1>
         <p className="text-gray-500 mt-1">Your interaction history with your mentor</p>
       </div>
 

--- a/src/app/portal/messages/page.tsx
+++ b/src/app/portal/messages/page.tsx
@@ -27,7 +27,7 @@ export default function PortalMessagesPage() {
   return (
     <div>
       <div className="mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">{t.messages.title}</h1>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.messages.title}</h1>
         <p className="text-gray-500 mt-1">{t.messages.listSubtitle}</p>
       </div>
       <Card>

--- a/src/app/portal/notes/page.tsx
+++ b/src/app/portal/notes/page.tsx
@@ -8,7 +8,7 @@ export default function PortalNotesPage() {
   return (
     <div>
       <div className="mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">{t.portal.notes.title}</h1>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.portal.notes.title}</h1>
         <p className="text-gray-500 mt-1">{t.portal.notes.privateHint}</p>
       </div>
       <div className="max-w-2xl">

--- a/src/app/portal/page.tsx
+++ b/src/app/portal/page.tsx
@@ -65,7 +65,7 @@ export default async function PortalDashboard() {
     <div>
       <OnboardingChecklist />
       <div className="mb-8">
-        <h1 className="text-2xl font-bold text-gray-900">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
           {t.portal.welcome}, {session!.user.name}!
         </h1>
         <p className="text-gray-500 mt-1">{t.portal.dashSubtitle}</p>

--- a/src/app/portal/profile/page.tsx
+++ b/src/app/portal/profile/page.tsx
@@ -231,7 +231,7 @@ export default function ProfilePage() {
   return (
     <div>
       <div className="mb-8">
-        <h1 className="text-2xl font-bold text-gray-900">{t.profileForm.title}</h1>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.profileForm.title}</h1>
         <p className="text-gray-500 mt-1">{t.profileForm.subtitle}</p>
       </div>
 

--- a/src/app/source/page.tsx
+++ b/src/app/source/page.tsx
@@ -57,7 +57,7 @@ export default function SourcePortal() {
   return (
     <div>
       <div className="mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">{t.sourcePortal.title}</h1>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.sourcePortal.title}</h1>
         <p className="text-gray-500 mt-1">{t.sourcePortal.subtitle}</p>
       </div>
 


### PR DESCRIPTION
## Summary
- The three locations named in #476 (`admin/companies`, `admin/users`, `mentor/mentees`) plus every other page using the identical `<h1 className="text-2xl font-bold text-gray-900">` pattern (35 files total, scanned via `grep -rn "text-2xl font-bold text-gray-900" src/app --include="*.tsx" | grep -v "dark:"`) now get `dark:text-gray-100` — matching the existing `admin/retention` and `admin/mentors` convention.
- Investigated first: `globals.css` already has a global dark-mode retint (`html.dark .text-gray-900 { color: #f3f4f6; }` and the same for `.text-gray-500`), landed in an earlier PR. I verified via computed-style injection that the named h1/subtitle pairs were, in practice, already passing ~8:1 contrast against the actual page background even before this change. This PR adds the *explicit* `dark:` variant anyway for consistency with the codebase's stated "good examples" and defense-in-depth (doesn't rely solely on the global class-selector remap). Subtitle `<p className="text-gray-500 mt-1">` text is intentionally left alone — the good examples (retention/mentors) don't annotate it either, and the global retint already covers it.
- Light theme is visually unchanged (no `dark:` class active → same as before).

Closes #476

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (only pre-existing unrelated warnings)
- [x] `npm run check:i18n` — OK (no i18n changes, pure CSS)
- [x] New `e2e/dark-mode-admin-headers.spec.ts`: logs in as admin, enables dark mode, asserts the `<h1>` on `/admin/companies` and `/admin/users` renders a light color (not near-black)
- [ ] CI (Lint/Typecheck/Build, Playwright smoke incl. existing `dark-mode.spec.ts`, Preview Deploy)