### PR TITLE
fix(ui): make RoleBadge i18n-aware and cover all 5 roles

### DIFF
--- a/e2e/role-badge.spec.ts
+++ b/e2e/role-badge.spec.ts
@@ -17,13 +17,13 @@ test('admin/users shows translated role badges for every role', async ({ page })
     await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
 
     await page.goto('/admin/users');
-    await expect(page.getByTestId(`user-row-${company.id}`).getByText('Company')).toBeVisible();
-    await expect(page.getByTestId(`user-row-${source.id}`).getByText('Source')).toBeVisible();
+    await expect(page.getByTestId(`user-row-${company.id}`).getByText('Company', { exact: true })).toBeVisible();
+    await expect(page.getByTestId(`user-row-${source.id}`).getByText('Source', { exact: true })).toBeVisible();
 
     // Turkish label for the same COMPANY role, no other page-specific translation work needed.
     await page.evaluate(() => { document.cookie = 'locale=tr;path=/'; });
     await page.reload();
-    await expect(page.getByTestId(`user-row-${company.id}`).getByText('Şirket')).toBeVisible();
+    await expect(page.getByTestId(`user-row-${company.id}`).getByText('Şirket', { exact: true })).toBeVisible();
   } finally {
     await cleanupByEmail(company.email);
     await cleanupByEmail(source.email);

--- a/e2e/role-badge.spec.ts
+++ b/e2e/role-badge.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test';
+import { seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+// #472: RoleBadge now covers all 5 roles with i18n labels, and admin/users
+// renders through it instead of a locally duplicated variant map.
+test('admin/users shows translated role badges for every role', async ({ page }) => {
+  const adminEmail = uniqueEmail('rb-admin');
+  await seedUser(adminEmail, 'AdminPass123', 'ADMIN', 'RB Admin');
+  const company = await seedUser(uniqueEmail('rb-company'), 'x', 'COMPANY', 'RB Company');
+  const source = await seedUser(uniqueEmail('rb-source'), 'x', 'SOURCE', 'RB Source');
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', 'AdminPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    await page.goto('/admin/users');
+    await expect(page.getByTestId(`user-row-${company.id}`).getByText('Company')).toBeVisible();
+    await expect(page.getByTestId(`user-row-${source.id}`).getByText('Source')).toBeVisible();
+
+    // Turkish label for the same COMPANY role, no other page-specific translation work needed.
+    await page.evaluate(() => { document.cookie = 'locale=tr;path=/'; });
+    await page.reload();
+    await expect(page.getByTestId(`user-row-${company.id}`).getByText('Şirket')).toBeVisible();
+  } finally {
+    await cleanupByEmail(company.email);
+    await cleanupByEmail(source.email);
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/src/app/admin/invite/page.tsx
+++ b/src/app/admin/invite/page.tsx
@@ -9,7 +9,7 @@ import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Input } from '@/components/ui/Input';
 import { Button } from '@/components/ui/Button';
 import { Select } from '@/components/ui/Select';
-import { Badge } from '@/components/ui/Badge';
+import { Badge, RoleBadge } from '@/components/ui/Badge';
 import { Send, Mail, Copy, Check, CheckCircle2, Circle } from 'lucide-react';
 import { useT } from '@/i18n/client';
 
@@ -222,9 +222,7 @@ export default function InvitePage() {
                       </p>
                     </div>
                     <div className="flex items-center gap-2 flex-shrink-0">
-                      <Badge variant={invite.role === 'ADMIN' ? 'danger' : invite.role === 'MENTOR' ? 'info' : 'success'}>
-                        {invite.role}
-                      </Badge>
+                      <RoleBadge role={invite.role} />
                       <Badge variant={status === 'accepted' ? 'success' : status === 'expired' ? 'warning' : 'default'}>
                         {(t.invite.status as Record<string, string>)[status]}
                       </Badge>

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { signIn, useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
-import { Badge } from '@/components/ui/Badge';
+import { Badge, RoleBadge } from '@/components/ui/Badge';
 import { Button } from '@/components/ui/Button';
 import { roleHome } from '@/lib/roleHome';
 import { SkeletonRows } from '@/components/ui/Skeleton';
@@ -19,14 +19,6 @@ interface AdminUser {
   isActive: boolean;
   emailVerified: boolean;
 }
-
-const ROLE_VARIANT: Record<string, 'info' | 'success' | 'warning' | 'purple' | 'default'> = {
-  ADMIN: 'warning',
-  MENTOR: 'success',
-  MENTEE: 'info',
-  COMPANY: 'purple',
-  SOURCE: 'default',
-};
 
 type RoleLabel = 'admin' | 'mentor' | 'mentee' | 'company' | 'source';
 
@@ -160,7 +152,7 @@ export default function AdminUsersPage() {
                   )}
                 </div>
                 <div className="flex flex-wrap items-center gap-2">
-                  <Badge variant={ROLE_VARIANT[u.role]}>{t.usersAdmin[u.role.toLowerCase() as RoleLabel]}</Badge>
+                  <RoleBadge role={u.role} />
                   <Badge variant={u.isActive ? 'success' : 'warning'}>
                     {u.isActive ? t.usersAdmin.active : t.usersAdmin.inactive}
                   </Badge>

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -37,16 +37,19 @@ export function Badge({ className, variant = 'default', children, ...props }: Ba
   );
 }
 
+const ROLE_VARIANT: Record<string, BadgeProps['variant']> = {
+  ADMIN: 'warning',
+  MENTOR: 'success',
+  MENTEE: 'info',
+  COMPANY: 'purple',
+  SOURCE: 'default',
+};
+
 export function RoleBadge({ role }: { role: string }) {
-  const config = {
-    ADMIN: { variant: 'danger' as const, label: 'Admin' },
-    MENTOR: { variant: 'info' as const, label: 'Mentor' },
-    MENTEE: { variant: 'success' as const, label: 'Mentee' },
-  };
+  const t = useT();
+  const label = (t.usersAdmin as Record<string, string>)[role.toLowerCase()] ?? role;
 
-  const { variant, label } = config[role as keyof typeof config] || { variant: 'default' as const, label: role };
-
-  return <Badge variant={variant}>{label}</Badge>;
+  return <Badge variant={ROLE_VARIANT[role] ?? 'default'}>{label}</Badge>;
 }
 
 export function StatusBadge({ status }: { status: string }) {


### PR DESCRIPTION
## Summary
- `RoleBadge` (`src/components/ui/Badge.tsx`) was dead code: unused, hardcoded English labels, and only knew 3 of 5 roles.
- Rewrote it to source labels from `t.usersAdmin.{admin,mentor,mentee,company,source}` (the same keys `admin/users` already used) and cover all 5 roles with the color scheme already live on `admin/users`.
- `admin/users/page.tsx`: deleted the local `ROLE_VARIANT` map, now renders `<RoleBadge role={u.role} />`.
- `admin/invite/page.tsx`: found via `grep -rn "role ===" src/app --include=*.tsx | grep -i badge` — its invite-role badge was rendering the raw untranslated enum value (`ADMIN`/`MENTOR`/`MENTEE`) with its own inline ternary. Now uses `RoleBadge` too.

Closes #472

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (only pre-existing unrelated warnings)
- [x] `npm run check:i18n` — OK (no new keys, reused existing `usersAdmin.*`)
- [x] New `e2e/role-badge.spec.ts`: seeds a COMPANY and SOURCE user, asserts their translated badge label on `admin/users` in EN, then confirms the Turkish label after switching locale
- [ ] CI (Lint/Typecheck/Build, Playwright smoke, Preview Deploy)