### PR TITLE
fix(api): add zod validation to documents and notifications routes

### DIFF
--- a/e2e/api-validation-documents-notifications.spec.ts
+++ b/e2e/api-validation-documents-notifications.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test';
+import { seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+// #473: documents/route.ts and notifications/route.ts previously accepted
+// malformed bodies with no validation, risking a 500 instead of a 400.
+test('POST /api/notifications returns 400 (not 500) for a malformed id', async ({ page }) => {
+  const email = uniqueEmail('zod-notif');
+  await seedUser(email, 'MenteePass123', 'MENTEE', 'Zod Notif Mentee');
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', email);
+    await page.fill('input[type="password"]', 'MenteePass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/portal'), { timeout: 20_000 });
+
+    // id should be a string; an array/object must be rejected with 400.
+    const bad = await page.request.post('/api/notifications', { data: { id: ['not', 'a', 'string'] } });
+    expect(bad.status()).toBe(400);
+
+    // Valid, id-less body (mark-all-read) still works.
+    const ok = await page.request.post('/api/notifications', { data: {} });
+    expect(ok.ok()).toBeTruthy();
+  } finally {
+    await cleanupByEmail(email);
+  }
+});
+
+test('POST /api/documents returns 400 (not 500) for an invalid document type', async ({ page }) => {
+  const email = uniqueEmail('zod-doc');
+  await seedUser(email, 'MenteePass123', 'MENTEE', 'Zod Doc Mentee');
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', email);
+    await page.fill('input[type="password"]', 'MenteePass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/portal'), { timeout: 20_000 });
+
+    const res = await page.request.post('/api/documents', {
+      multipart: { file: { name: 'r.pdf', mimeType: 'application/pdf', buffer: Buffer.from('hello') }, type: 'NOT_A_REAL_TYPE' },
+    });
+    expect(res.status()).toBe(400);
+
+    // A non-multipart body against the same endpoint must not 500 either.
+    const malformed = await page.request.post('/api/documents', {
+      headers: { 'Content-Type': 'multipart/form-data; boundary=x' },
+      data: 'not actually multipart',
+    });
+    expect(malformed.status()).toBe(400);
+  } finally {
+    await cleanupByEmail(email);
+  }
+});

--- a/src/app/api/documents/route.ts
+++ b/src/app/api/documents/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
+import { z } from 'zod';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { canAccessUserDocs, DOCUMENT_TYPES, ALLOWED_DOC_MIME, MAX_DOC_BYTES } from '@/lib/documentAccess';
@@ -10,6 +11,13 @@ const META_SELECT = {
   id: true, ownerId: true, uploaderId: true, type: true, title: true,
   filename: true, contentType: true, size: true, version: true, isTemplate: true, createdAt: true,
 } as const;
+
+const uploadSchema = z.object({
+  type: z.enum(DOCUMENT_TYPES).default('OTHER'),
+  title: z.string().trim().max(200).optional(),
+  targetUserId: z.string().min(1).optional(),
+  isTemplate: z.boolean().optional(),
+});
 
 // GET ?userId= — a user's documents (access-controlled).
 // GET ?templates=1 — admin-managed template documents (any signed-in user).
@@ -44,25 +52,35 @@ export async function POST(request: Request) {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
-  const form = await request.formData();
+  let form: FormData;
+  try {
+    form = await request.formData();
+  } catch {
+    return NextResponse.json({ error: 'Expected multipart/form-data' }, { status: 400 });
+  }
   const file = form.get('file');
-  const type = ((form.get('type') as string) || 'OTHER').toUpperCase();
-  const title = ((form.get('title') as string) || '').trim();
-  const isTemplate = form.get('isTemplate') === 'true';
+
+  const parsed = uploadSchema.safeParse({
+    type: ((form.get('type') as string) || 'OTHER').toUpperCase(),
+    title: ((form.get('title') as string) || '').trim() || undefined,
+    targetUserId: (form.get('targetUserId') as string) || undefined,
+    isTemplate: form.get('isTemplate') === 'true',
+  });
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 });
+  }
+  const { type, title, isTemplate } = parsed.data;
 
   if (!(file instanceof File)) return NextResponse.json({ error: 'No file provided' }, { status: 400 });
   if (!ALLOWED_DOC_MIME.has(file.type)) return NextResponse.json({ error: 'Unsupported file type' }, { status: 400 });
   if (file.size > MAX_DOC_BYTES) return NextResponse.json({ error: 'File too large (max 10 MB)' }, { status: 400 });
-  if (!DOCUMENT_TYPES.includes(type as (typeof DOCUMENT_TYPES)[number])) {
-    return NextResponse.json({ error: 'Invalid type' }, { status: 400 });
-  }
 
   // Templates are admin-only and have no owner.
   if (isTemplate) {
     if (session.user.role !== 'ADMIN') return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
 
-  const ownerId = isTemplate ? null : (form.get('targetUserId') as string) || session.user.id;
+  const ownerId = isTemplate ? null : parsed.data.targetUserId || session.user.id;
   if (ownerId && !(await canAccessUserDocs(session.user, ownerId))) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,7 +1,12 @@
 import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
+import { z } from 'zod';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+
+const markReadSchema = z.object({
+  id: z.string().min(1).optional(),
+});
 
 // GET — the current user's recent notifications + unread count.
 export async function GET() {
@@ -25,8 +30,13 @@ export async function POST(request: Request) {
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
   const body = await request.json().catch(() => ({}));
+  const parsed = markReadSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 });
+  }
+
   await prisma.notification.updateMany({
-    where: { userId: session.user.id, ...(body.id ? { id: body.id } : {}) },
+    where: { userId: session.user.id, ...(parsed.data.id ? { id: parsed.data.id } : {}) },
     data: { read: true },
   });
   return NextResponse.json({ ok: true });


### PR DESCRIPTION
## Summary
- `POST /api/notifications`: `{ id? }` now runs through a zod schema (`z.object({ id: z.string().min(1).optional() })`) before hitting Prisma. Previously an array/object `id` would be passed straight into `updateMany({ where: { id } })`, which Prisma rejects with an unhandled validation error → 500.
- `POST /api/documents`: the multipart fields (`type`, `title`, `targetUserId`, `isTemplate`) now validate through a zod schema (`type: z.enum(DOCUMENT_TYPES)`, etc.), matching the `safeParse` + `{ error: 'Validation failed', details: ... }` + 400 pattern used in `src/app/api/interactions/route.ts`. Also wrapped `request.formData()` itself in try/catch — a non-multipart body previously threw uncaught (500), now returns 400.
- `documents/[id]/route.ts` (also named in the issue): GET/DELETE only, no request body — `id` comes from the URL and a miss already resolves to a clean 404. Nothing to validate; left unchanged.

Closes #473

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (only pre-existing unrelated warnings)
- [x] New `e2e/api-validation-documents-notifications.spec.ts`: asserts `POST /api/notifications` with a non-string `id` returns 400 (and a valid mark-all-read body still works), and `POST /api/documents` returns 400 for both an invalid `type` and a non-multipart body
- [ ] CI (Lint/Typecheck/Build, Playwright smoke, Preview Deploy)