### PR TITLE
fix(i18n): add shared formatDate/formatDateTime, migrate all call sites

### DIFF
--- a/e2e/date-formatter-locale.spec.ts
+++ b/e2e/date-formatter-locale.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+// #471: dates previously followed the browser's locale (or a hardcoded
+// 'en-US'), ignoring the user's selected TR/DE language. formatDate/
+// formatDateTime (src/lib/relativeTime.ts) now drive every call site.
+test('dates on admin/activity follow the selected app language, not the browser default', async ({ page }) => {
+  const adminEmail = uniqueEmail('datefmt-admin');
+  const admin = await seedUser(adminEmail, 'AdminPass123', 'ADMIN', 'Date Fmt Admin');
+  await prisma.activityLog.create({
+    data: { action: 'test.action', actorId: admin.id, actorEmail: admin.email, level: 'INFO' },
+  });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', 'AdminPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    // Force a non-English OS locale to prove the app ignores the browser default.
+    await page.emulateMedia({ colorScheme: 'light' });
+    await page.evaluate(() => { document.cookie = 'locale=tr;path=/'; });
+    await page.goto('/admin/activity');
+
+    // TR formatting uses dots (gg.aa.yyyy), never the en-US slash format.
+    const firstDate = page.locator('span.text-gray-400').first();
+    await expect(firstDate).toBeVisible();
+    await expect(firstDate).toHaveText(/\d{2}\.\d{2}\.\d{4}/);
+    await expect(firstDate).not.toHaveText(/\d{1,2}\/\d{1,2}\/\d{4}/);
+  } finally {
+    await prisma.activityLog.deleteMany({ where: { actorId: admin.id } });
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/src/app/admin/activity/page.tsx
+++ b/src/app/admin/activity/page.tsx
@@ -5,7 +5,8 @@ import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Badge } from '@/components/ui/Badge';
 import { Button } from '@/components/ui/Button';
 import { SkeletonRows } from '@/components/ui/Skeleton';
-import { useT } from '@/i18n/client';
+import { useT, useLocale } from '@/i18n/client';
+import { formatDateTime } from '@/lib/relativeTime';
 
 interface Entry {
   id: string;
@@ -22,6 +23,7 @@ const LEVEL_VARIANT = { DEBUG: 'default', INFO: 'info', WARNING: 'warning', ERRO
 
 export default function AdminActivityPage() {
   const t = useT();
+  const locale = useLocale();
   const [items, setItems] = useState<Entry[]>([]);
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(1);
@@ -84,7 +86,7 @@ export default function AdminActivityPage() {
                 <span className="text-gray-500 truncate flex-1">
                   {e.actorEmail || '—'}{e.detail ? ` · ${e.detail}` : ''}
                 </span>
-                <span className="text-xs text-gray-400 flex-shrink-0">{new Date(e.createdAt).toLocaleString()}</span>
+                <span className="text-xs text-gray-400 flex-shrink-0">{formatDateTime(e.createdAt, locale)}</span>
               </div>
             ))}
           </div>

--- a/src/app/admin/announcements/page.tsx
+++ b/src/app/admin/announcements/page.tsx
@@ -6,6 +6,7 @@ import { Input } from '@/components/ui/Input';
 import { Button } from '@/components/ui/Button';
 import { SkeletonRows } from '@/components/ui/Skeleton';
 import { useT, useLocale } from '@/i18n/client';
+import { formatDateTime } from '@/lib/relativeTime';
 
 interface AnnouncementRecord {
   id: string;
@@ -119,7 +120,7 @@ export default function AdminAnnouncementsPage() {
                     </a>
                   )}
                   <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 mt-2 text-xs text-gray-500">
-                    <span>{new Date(a.createdAt).toLocaleString(locale)}</span>
+                    <span>{formatDateTime(a.createdAt, locale)}</span>
                     {a.sentByName && <span>{t.announcements.sentBy.replace('{name}', a.sentByName)}</span>}
                     <span>{t.announcements.recipients.replace('{n}', String(a.recipientCount))}</span>
                     {a.emailedCount > 0 && <span>{t.announcements.emailedCount.replace('{n}', String(a.emailedCount))}</span>}

--- a/src/app/admin/candidates/[id]/page.tsx
+++ b/src/app/admin/candidates/[id]/page.tsx
@@ -19,6 +19,7 @@ import { UserActivityPanel } from '@/components/UserActivityPanel';
 import { CandidateEraseDangerZone } from '@/components/CandidateEraseDangerZone';
 import { useT, useLocale } from '@/i18n/client';
 import { useToast } from '@/components/ui/Toast';
+import { formatDate } from '@/lib/relativeTime';
 
 interface Interaction { id: string; date: string; notes: string; type: string }
 interface StatusChange { id: string; fromStatus: string; toStatus: string; createdAt: string; changedBy: { fullName: string } }
@@ -290,7 +291,7 @@ export default function AdminMenteeDetailPage() {
             <Field label={t.candidateDetail.phone} value={user.phone} />
             <Field label={t.candidateDetail.whatsapp} value={user.whatsapp} />
             <Field label={t.candidateDetail.city} value={user.city} />
-            <Field label={t.candidateDetail.birthDate} value={user.birthDate ? new Date(user.birthDate).toLocaleDateString() : null} />
+            <Field label={t.candidateDetail.birthDate} value={user.birthDate ? formatDate(user.birthDate, locale) : null} />
             <Field label={t.candidateDetail.referral} value={user.referralSource} />
             {user.skills.length > 0 && (
               <div>
@@ -402,7 +403,7 @@ export default function AdminMenteeDetailPage() {
                           <span className="text-gray-400">{pipelineLabel(sc.fromStatus, locale)}</span>
                           {' → '}
                           <span className="font-medium">{pipelineLabel(sc.toStatus, locale)}</span>
-                          <span className="text-xs text-gray-400"> · {sc.changedBy.fullName} · {new Date(sc.createdAt).toLocaleDateString()}</span>
+                          <span className="text-xs text-gray-400"> · {sc.changedBy.fullName} · {formatDate(sc.createdAt, locale)}</span>
                         </span>
                         <button
                           onClick={() => deleteHistory(sc.id)}
@@ -451,7 +452,7 @@ export default function AdminMenteeDetailPage() {
                         <InteractionTypeBadge type={i.type} className="text-xs flex-shrink-0" />
                         <div>
                           <p className="text-gray-700">{i.notes}</p>
-                          <p className="text-xs text-gray-400">{new Date(i.date).toLocaleDateString()}</p>
+                          <p className="text-xs text-gray-400">{formatDate(i.date, locale)}</p>
                         </div>
                       </div>
                     ))}

--- a/src/app/admin/integrations/page.tsx
+++ b/src/app/admin/integrations/page.tsx
@@ -6,13 +6,15 @@ import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Input } from '@/components/ui/Input';
 import { Button } from '@/components/ui/Button';
 import { Trash2 } from 'lucide-react';
-import { useT } from '@/i18n/client';
+import { useT, useLocale } from '@/i18n/client';
+import { formatDate } from '@/lib/relativeTime';
 
 interface Hook { id: string; url: string; events: string[]; active: boolean }
 interface Key { id: string; name: string; lastUsedAt: string | null; createdAt: string }
 
 export default function IntegrationsPage() {
   const t = useT();
+  const locale = useLocale();
   const [hooks, setHooks] = useState<Hook[]>([]);
   const [eventTypes, setEventTypes] = useState<string[]>([]);
   const [keys, setKeys] = useState<Key[]>([]);
@@ -109,7 +111,7 @@ export default function IntegrationsPage() {
                 <div key={k.id} className="flex items-center justify-between gap-2 py-2 text-sm">
                   <div>
                     <p className="text-gray-900">{k.name}</p>
-                    <p className="text-xs text-gray-400">{k.lastUsedAt ? `${t.integrations.lastUsed}: ${new Date(k.lastUsedAt).toLocaleDateString()}` : t.integrations.neverUsed}</p>
+                    <p className="text-xs text-gray-400">{k.lastUsedAt ? `${t.integrations.lastUsed}: ${formatDate(k.lastUsedAt, locale)}` : t.integrations.neverUsed}</p>
                   </div>
                   <button onClick={() => delKey(k.id)} aria-label="revoke" className="p-1.5 text-gray-400 hover:text-red-600"><Trash2 className="h-4 w-4" /></button>
                 </div>

--- a/src/app/admin/invite/page.tsx
+++ b/src/app/admin/invite/page.tsx
@@ -11,7 +11,8 @@ import { Button } from '@/components/ui/Button';
 import { Select } from '@/components/ui/Select';
 import { Badge } from '@/components/ui/Badge';
 import { Send, Mail, Copy, Check, CheckCircle2, Circle } from 'lucide-react';
-import { useT } from '@/i18n/client';
+import { useT, useLocale } from '@/i18n/client';
+import { formatDate, formatDateTime } from '@/lib/relativeTime';
 
 const inviteSchema = z.object({
   email: z.string().email('Invalid email'),
@@ -28,6 +29,7 @@ const roleOptions = [
 
 export default function InvitePage() {
   const t = useT();
+  const locale = useLocale();
   const [success, setSuccess] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
@@ -218,7 +220,7 @@ export default function InvitePage() {
                     <div className="min-w-0">
                       <p className="text-sm font-medium text-gray-900 truncate">{invite.email}</p>
                       <p className="text-xs text-gray-400">
-                        {new Date(invite.createdAt).toLocaleDateString()} · {(t.invite.status as Record<string, string>)[status]}
+                        {formatDate(invite.createdAt, locale)} · {(t.invite.status as Record<string, string>)[status]}
                       </p>
                     </div>
                     <div className="flex items-center gap-2 flex-shrink-0">
@@ -239,7 +241,7 @@ export default function InvitePage() {
                           <Circle className="h-3.5 w-3.5 text-gray-300 flex-shrink-0" />
                         )}
                         <span className={s.at ? 'text-gray-700 font-medium' : 'text-gray-400'}>{s.label}</span>
-                        {s.at && <span className="text-gray-400">· {new Date(s.at).toLocaleString()}</span>}
+                        {s.at && <span className="text-gray-400">· {formatDateTime(s.at, locale)}</span>}
                       </li>
                     ))}
                   </ol>

--- a/src/app/admin/mentorship/page.tsx
+++ b/src/app/admin/mentorship/page.tsx
@@ -10,6 +10,7 @@ import { Select } from '@/components/ui/Select';
 import { SavedViews } from '@/components/SavedViews';
 import { SkeletonRows } from '@/components/ui/Skeleton';
 import { BookOpen, Plus } from 'lucide-react';
+import { formatDate } from '@/lib/relativeTime';
 
 interface User {
   id: string;
@@ -273,7 +274,7 @@ export default function MentorshipPage() {
                     {rel.company && (
                       <span>🏢 {rel.company.name}</span>
                     )}
-                    <span>📅 {t.mentorships.started} {new Date(rel.startDate).toLocaleDateString(locale)}</span>
+                    <span>📅 {t.mentorships.started} {formatDate(rel.startDate, locale)}</span>
                     <Badge variant="default">{rel._count.interactions} {t.mentorships.interactions}</Badge>
                   </div>
                 </div>

--- a/src/app/admin/retention/page.tsx
+++ b/src/app/admin/retention/page.tsx
@@ -1,13 +1,14 @@
 import Link from 'next/link';
 import { getRetentionReview, getRetentionMonths, RETENTION_GRACE_DAYS } from '@/lib/retention';
 import { getServerDictionary } from '@/i18n/server';
+import { formatDate } from '@/lib/relativeTime';
 
 // Admin retention review (GDPR Art. 5(1)(e)): candidates whose consent has
 // passed the retention limit. "overdue" ones (past the grace period without
 // renewal) should be reviewed for erasure — deletion stays a manual admin
 // action (via the candidate's danger zone), never automatic.
 export default async function AdminRetentionPage() {
-  const { t } = await getServerDictionary();
+  const { t, locale } = await getServerDictionary();
   const r = t.retentionAdmin;
   const [items, months] = await Promise.all([getRetentionReview(), getRetentionMonths()]);
 
@@ -42,7 +43,7 @@ export default async function AdminRetentionPage() {
                     <div className="text-xs text-gray-400">{it.email}</div>
                   </td>
                   <td className="px-4 py-3 text-gray-600 dark:text-gray-300">
-                    {it.consentAt ? new Date(it.consentAt).toLocaleDateString() : '—'}
+                    {it.consentAt ? formatDate(it.consentAt, locale) : '—'}
                   </td>
                   <td className="px-4 py-3 text-gray-600 dark:text-gray-300">{it.monthsSinceConsent ?? '—'}</td>
                   <td className="px-4 py-3">

--- a/src/app/mentor/interactions/page.tsx
+++ b/src/app/mentor/interactions/page.tsx
@@ -1,11 +1,12 @@
 'use client';
-import { useT } from "@/i18n/client";
+import { useT, useLocale } from "@/i18n/client";
 
 import { useState, useEffect, useCallback } from 'react';
 import { Card } from '@/components/ui/Card';
 import { InteractionTypeBadge } from '@/components/InteractionTypeBadge';
 import { SkeletonRows } from '@/components/ui/Skeleton';
 import { BookOpen } from 'lucide-react';
+import { formatDate } from '@/lib/relativeTime';
 
 interface Interaction {
   id: string;
@@ -23,6 +24,7 @@ const TYPES = ['ALL', 'Meeting', 'Feedback', 'Email', 'Call', 'WhatsApp'] as con
 
 export default function MentorInteractionsPage() {
   const t = useT();
+  const locale = useLocale();
   const [interactions, setInteractions] = useState<Interaction[]>([]);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
@@ -94,7 +96,7 @@ export default function MentorInteractionsPage() {
                 <p className="text-sm font-medium text-gray-700 mb-1">{t.mentor.exampleLogWith}</p>
                 <p className="text-sm text-gray-600">{t.mentor.exampleLogNote}</p>
               </div>
-              <span className="text-xs text-gray-400 flex-shrink-0">{new Date().toLocaleDateString()}</span>
+              <span className="text-xs text-gray-400 flex-shrink-0">{formatDate(new Date(), locale)}</span>
             </div>
           </div>
         </Card>
@@ -120,7 +122,7 @@ export default function MentorInteractionsPage() {
                   <p className="text-sm text-gray-600">{interaction.notes}</p>
                 </div>
                 <span className="text-xs text-gray-400 flex-shrink-0">
-                  {new Date(interaction.date).toLocaleDateString()}
+                  {formatDate(interaction.date, locale)}
                 </span>
               </div>
             ))}

--- a/src/app/mentor/meetings/page.tsx
+++ b/src/app/mentor/meetings/page.tsx
@@ -5,7 +5,8 @@ import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Input } from '@/components/ui/Input';
 import { Button } from '@/components/ui/Button';
 import { Badge } from '@/components/ui/Badge';
-import { useT } from '@/i18n/client';
+import { useT, useLocale } from '@/i18n/client';
+import { formatDateTime } from '@/lib/relativeTime';
 
 interface Relation {
   id: string;
@@ -24,6 +25,7 @@ const RSVP_VARIANT = { PENDING: 'warning', ACCEPTED: 'success', DECLINED: 'dange
 
 export default function MentorMeetingsPage() {
   const t = useT();
+  const locale = useLocale();
   const [relations, setRelations] = useState<Relation[]>([]);
   const [meetings, setMeetings] = useState<Meeting[]>([]);
   const [selected, setSelected] = useState<Record<string, boolean>>({});
@@ -162,7 +164,7 @@ export default function MentorMeetingsPage() {
                   <div className="min-w-0">
                     <p className="text-sm font-medium text-gray-900 truncate">{m.title}</p>
                     <p className="text-xs text-gray-500 truncate">
-                      {m.relation.mentee.fullName} · {new Date(m.scheduledAt).toLocaleString()}
+                      {m.relation.mentee.fullName} · {formatDateTime(m.scheduledAt, locale)}
                     </p>
                   </div>
                   <Badge variant={RSVP_VARIANT[m.rsvp]}>{t.meetings[m.rsvp.toLowerCase() as 'pending' | 'accepted' | 'declined']}</Badge>

--- a/src/app/mentor/mentees/[id]/page.tsx
+++ b/src/app/mentor/mentees/[id]/page.tsx
@@ -21,6 +21,7 @@ import { ContactActions } from '@/components/ContactActions';
 import { UserActivityPanel } from '@/components/UserActivityPanel';
 import { DocumentsManager } from '@/components/DocumentsManager';
 import { useToast } from '@/components/ui/Toast';
+import { formatDate, formatDateTime } from '@/lib/relativeTime';
 
 interface InteractionLog {
   id: string;
@@ -237,7 +238,7 @@ export default function MenteeDetailPage() {
               <div>
                 <p className="text-xs text-gray-500">{t.candidateDetail.birthDate}</p>
                 <p className="text-sm text-gray-900">
-                  {new Date(relation.mentee.birthDate).toLocaleDateString()}
+                  {formatDate(relation.mentee.birthDate, locale)}
                 </p>
               </div>
             )}
@@ -307,7 +308,7 @@ export default function MenteeDetailPage() {
                     <span className="font-medium text-gray-900">{pipelineLabel(sc.toStatus, locale)}</span>
                   </p>
                   <p className="text-xs text-gray-400 mt-0.5">
-                    {sc.changedBy.fullName} · {new Date(sc.createdAt).toLocaleString()}
+                    {sc.changedBy.fullName} · {formatDateTime(sc.createdAt, locale)}
                   </p>
                 </li>
               ))}
@@ -382,7 +383,7 @@ export default function MenteeDetailPage() {
                     <InteractionTypeBadge type="Meeting" className="text-xs flex-shrink-0 mt-0.5" />
                     <div className="flex-1 min-w-0">
                       <p className="text-sm text-gray-700">{t.mentor.exampleLogNote}</p>
-                      <p className="text-xs text-gray-400 mt-1">{new Date().toLocaleDateString()}</p>
+                      <p className="text-xs text-gray-400 mt-1">{formatDate(new Date(), locale)}</p>
                     </div>
                   </div>
                 </div>
@@ -397,7 +398,7 @@ export default function MenteeDetailPage() {
                   )}
                   <p className="text-sm text-gray-700">{interaction.notes}</p>
                   <p className="text-xs text-gray-400 mt-1">
-                    {new Date(interaction.date).toLocaleDateString()}
+                    {formatDate(interaction.date, locale)}
                   </p>
                 </div>
                 <button

--- a/src/app/mentor/page.tsx
+++ b/src/app/mentor/page.tsx
@@ -10,6 +10,7 @@ import { Badge, StatusBadge } from '@/components/ui/Badge';
 import { InteractionTypeBadge } from '@/components/InteractionTypeBadge';
 import { Users, BookOpen, MessageSquare, Calendar } from 'lucide-react';
 import Link from 'next/link';
+import { formatDate } from '@/lib/relativeTime';
 
 async function getMentorData(mentorId: string) {
   const relations = await prisma.mentorshipRelation.findMany({
@@ -56,7 +57,7 @@ async function getMentorData(mentorId: string) {
 
 export default async function MentorDashboard() {
   const session = await getServerSession(authOptions);
-  const { t } = await getServerDictionary();
+  const { t, locale } = await getServerDictionary();
   const { relations, recentInteractions } = await getMentorData(session!.user.id);
   const attentionItems = await getAttentionItems(session!.user.id);
 
@@ -205,7 +206,7 @@ export default async function MentorDashboard() {
                   </div>
                   <p className="text-sm text-gray-700 truncate">{interaction.notes}</p>
                   <p className="text-xs text-gray-400 mt-1">
-                    {new Date(interaction.date).toLocaleDateString()}
+                    {formatDate(interaction.date, locale)}
                   </p>
                 </div>
               </div>

--- a/src/app/messages/[relationId]/page.tsx
+++ b/src/app/messages/[relationId]/page.tsx
@@ -5,7 +5,8 @@ import { useSession } from 'next-auth/react';
 import { Paperclip, X, FileText, Download } from 'lucide-react';
 import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
-import { useT } from '@/i18n/client';
+import { useT, useLocale } from '@/i18n/client';
+import { formatDateTime } from '@/lib/relativeTime';
 
 interface Attachment {
   id: string;
@@ -27,6 +28,7 @@ interface Party { id: string; fullName: string }
 export default function ThreadPage({ params }: { params: Promise<{ relationId: string }> }) {
   const { relationId } = use(params);
   const t = useT();
+  const locale = useLocale();
   const { data: session } = useSession();
   const myId = session?.user?.id;
   const [messages, setMessages] = useState<Msg[]>([]);
@@ -134,7 +136,7 @@ export default function ThreadPage({ params }: { params: Promise<{ relationId: s
                       )
                     )}
                     <p className={`text-[10px] mt-1 ${mine ? 'text-blue-100' : 'text-gray-400'}`}>
-                      {m.channel === 'EMAIL' ? '✉ ' : ''}{new Date(m.createdAt).toLocaleString()}
+                      {m.channel === 'EMAIL' ? '✉ ' : ''}{formatDateTime(m.createdAt, locale)}
                       {isMyLast && <span className="ml-1">· {m.readAt ? t.messages.read : t.messages.sent}</span>}
                     </p>
                   </div>

--- a/src/app/portal/interactions/page.tsx
+++ b/src/app/portal/interactions/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { Card } from '@/components/ui/Card';
 import { InteractionTypeBadge } from '@/components/InteractionTypeBadge';
 import { BookOpen } from 'lucide-react';
+import { useLocale } from '@/i18n/client';
 
 interface Interaction {
   id: string;
@@ -17,6 +18,7 @@ interface Interaction {
 }
 
 export default function PortalInteractionsPage() {
+  const locale = useLocale();
   const [interactions, setInteractions] = useState<Interaction[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -57,7 +59,7 @@ export default function PortalInteractionsPage() {
                 <div className="flex-1">
                   <p className="text-sm text-gray-700">{interaction.notes}</p>
                   <p className="text-xs text-gray-400 mt-2">
-                    {new Date(interaction.date).toLocaleDateString('en-US', {
+                    {new Date(interaction.date).toLocaleDateString(locale, {
                       weekday: 'long',
                       year: 'numeric',
                       month: 'long',

--- a/src/app/portal/page.tsx
+++ b/src/app/portal/page.tsx
@@ -14,6 +14,7 @@ import { Badge, StatusBadge } from '@/components/ui/Badge';
 import { InteractionTypeBadge } from '@/components/InteractionTypeBadge';
 import { User, Building2, BookOpen, ExternalLink, MessageCircle, Mail, Github, Linkedin } from 'lucide-react';
 import Link from 'next/link';
+import { formatDate } from '@/lib/relativeTime';
 
 async function getMenteeData(menteeId: string) {
   const [user, activeRelation] = await Promise.all([
@@ -202,7 +203,7 @@ export default async function PortalDashboard() {
               <div className="flex items-center justify-between">
                 <StatusBadge status={activeRelation.status} />
                 <span className="text-xs text-gray-400">
-                  {t.portal.since} {new Date(activeRelation.startDate).toLocaleDateString(locale)}
+                  {t.portal.since} {formatDate(activeRelation.startDate, locale)}
                 </span>
               </div>
 
@@ -267,7 +268,7 @@ export default async function PortalDashboard() {
                         <div className="min-w-0">
                           <p className="text-sm text-gray-700 truncate">{interaction.notes}</p>
                           <p className="text-xs text-gray-400">
-                            {new Date(interaction.date).toLocaleDateString(locale)}
+                            {formatDate(interaction.date, locale)}
                           </p>
                         </div>
                       </div>

--- a/src/components/GoalsPanel.tsx
+++ b/src/components/GoalsPanel.tsx
@@ -6,6 +6,7 @@ import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Input } from '@/components/ui/Input';
 import { Button } from '@/components/ui/Button';
 import { useT, useLocale } from '@/i18n/client';
+import { formatDate } from '@/lib/relativeTime';
 
 interface Goal {
   id: string;
@@ -101,8 +102,8 @@ export function GoalsPanel({ relationId, readOnly = false }: { relationId: strin
                 <span className="flex flex-wrap items-center gap-x-2 text-[11px] text-gray-400">
                   {g.createdByRole === 'MENTOR' && <span>{t.goals.byMentor}</span>}
                   {g.createdByRole === 'MENTEE' && <span>{t.goals.byMentee}</span>}
-                  <span>· {new Date(g.createdAt).toLocaleDateString(locale)}</span>
-                  {g.dueDate && <span>· {t.goals.dueDate}: {new Date(g.dueDate).toLocaleDateString(locale)}</span>}
+                  <span>· {formatDate(g.createdAt, locale)}</span>
+                  {g.dueDate && <span>· {t.goals.dueDate}: {formatDate(g.dueDate, locale)}</span>}
                 </span>
               </span>
               {!readOnly && (

--- a/src/components/MeetingRequestsPanel.tsx
+++ b/src/components/MeetingRequestsPanel.tsx
@@ -6,6 +6,7 @@ import { Input } from '@/components/ui/Input';
 import { Button } from '@/components/ui/Button';
 import { Badge } from '@/components/ui/Badge';
 import { useT, useLocale } from '@/i18n/client';
+import { formatDateTime } from '@/lib/relativeTime';
 
 interface MReq {
   id: string;
@@ -82,7 +83,7 @@ export function MeetingRequestsPanel({ relationId, mode }: { relationId: string;
             <div key={r.id} data-testid={`mreq-${r.id}`} className="flex items-center justify-between gap-2 rounded-lg border border-gray-100 p-2.5">
               <div className="min-w-0">
                 <p className="text-sm font-medium text-gray-900 truncate">{r.topic}</p>
-                <p className="text-xs text-gray-400">{new Date(r.proposedAt).toLocaleString(locale)}</p>
+                <p className="text-xs text-gray-400">{formatDateTime(r.proposedAt, locale)}</p>
               </div>
               {mode === 'manage' ? (
                 <div className="flex gap-2 flex-shrink-0">

--- a/src/components/NotificationBell.tsx
+++ b/src/components/NotificationBell.tsx
@@ -4,7 +4,8 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSession } from 'next-auth/react';
 import Link from 'next/link';
 import { Bell } from 'lucide-react';
-import { useT } from '@/i18n/client';
+import { useT, useLocale } from '@/i18n/client';
+import { formatDateTime } from '@/lib/relativeTime';
 
 interface Note {
   id: string;
@@ -16,6 +17,7 @@ interface Note {
 
 export function NotificationBell() {
   const t = useT();
+  const locale = useLocale();
   const { status } = useSession();
   const [items, setItems] = useState<Note[]>([]);
   const [unread, setUnread] = useState(0);
@@ -81,7 +83,7 @@ export function NotificationBell() {
               const inner = (
                 <div className={`px-4 py-3 border-b border-gray-50 text-sm ${n.read ? 'text-gray-500' : 'text-gray-900 bg-blue-50/40'}`}>
                   <p>{n.text}</p>
-                  <p className="text-xs text-gray-400 mt-0.5">{new Date(n.createdAt).toLocaleString()}</p>
+                  <p className="text-xs text-gray-400 mt-0.5">{formatDateTime(n.createdAt, locale)}</p>
                 </div>
               );
               return n.link ? (

--- a/src/components/ProjectsManager.tsx
+++ b/src/components/ProjectsManager.tsx
@@ -7,7 +7,8 @@ import { Button } from '@/components/ui/Button';
 import { Select } from '@/components/ui/Select';
 import { Badge } from '@/components/ui/Badge';
 import { Github, ExternalLink, Trash2, Pencil, Trello } from 'lucide-react';
-import { useT } from '@/i18n/client';
+import { useT, useLocale } from '@/i18n/client';
+import { formatDate } from '@/lib/relativeTime';
 
 interface Task {
   id: string;
@@ -42,6 +43,7 @@ const blank = { name: '', description: '', technologies: '', repoUrl: '', demoUr
 
 export function ProjectsManager({ isAdmin }: { isAdmin: boolean }) {
   const t = useT();
+  const locale = useLocale();
   const [projects, setProjects] = useState<Project[]>([]);
   const [loading, setLoading] = useState(true);
   const [form, setForm] = useState({ ...blank });
@@ -264,7 +266,7 @@ export function ProjectsManager({ isAdmin }: { isAdmin: boolean }) {
                       {p.boardUrl && <a href={p.boardUrl} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 text-gray-600 hover:text-blue-600"><Trello className="h-3.5 w-3.5" />{t.projects.board}</a>}
                       {(p.startDate || p.endDate) && (
                         <span className="text-gray-400">
-                          {p.startDate ? new Date(p.startDate).toLocaleDateString() : '…'} – {p.endDate ? new Date(p.endDate).toLocaleDateString() : '…'}
+                          {p.startDate ? formatDate(p.startDate, locale) : '…'} – {p.endDate ? formatDate(p.endDate, locale) : '…'}
                         </span>
                       )}
                     </div>

--- a/src/components/UserActivityPanel.tsx
+++ b/src/components/UserActivityPanel.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Badge } from '@/components/ui/Badge';
 import { useT, useLocale } from '@/i18n/client';
+import { formatDate } from '@/lib/relativeTime';
 
 interface Item {
   id: string;
@@ -57,7 +58,7 @@ export function UserActivityPanel({ userId, flagInactive = false }: { userId: st
               <Badge variant={i.level === 'WARNING' ? 'warning' : i.level === 'ERROR' ? 'danger' : 'info'} className="text-[10px]">{i.level}</Badge>
               <span className="font-mono text-xs text-gray-700">{i.action}</span>
               {i.detail && <span className="text-xs text-gray-400 truncate">· {i.detail}</span>}
-              <span className="ml-auto text-[11px] text-gray-400 flex-shrink-0">{new Date(i.createdAt).toLocaleDateString(locale)}</span>
+              <span className="ml-auto text-[11px] text-gray-400 flex-shrink-0">{formatDate(i.createdAt, locale)}</span>
             </div>
           ))}
         </div>

--- a/src/lib/relativeTime.ts
+++ b/src/lib/relativeTime.ts
@@ -19,3 +19,17 @@ export function relativeTime(date: Date | string, locale: string): string {
   }
   return rtf.format(-sec, 'second'); // < 1 minute → "just now"
 }
+
+// Locale-aware absolute date/date-time formatting, so displayed dates follow
+// the app's selected language (TR/DE) instead of the browser's default.
+export function formatDate(date: Date | string, locale: string): string {
+  const d = typeof date === 'string' ? new Date(date) : date;
+  return new Intl.DateTimeFormat(locale, { year: 'numeric', month: '2-digit', day: '2-digit' }).format(d);
+}
+
+export function formatDateTime(date: Date | string, locale: string): string {
+  const d = typeof date === 'string' ? new Date(date) : date;
+  return new Intl.DateTimeFormat(locale, {
+    year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit',
+  }).format(d);
+}


### PR DESCRIPTION
## Summary
- Added \`formatDate(date, locale)\` and \`formatDateTime(date, locale)\` to \`src/lib/relativeTime.ts\` (next to the existing \`relativeTime()\`), using \`Intl.DateTimeFormat\`.
- Migrated every absolute-date call site found via \`grep -rn "toLocaleDate\|toLocaleString" src/\` to the shared util — both the buggy ones (missing locale, or \`portal/interactions/page.tsx\`'s hardcoded \`'en-US'\`) and the ones that already passed \`locale\` correctly, so there's a single consistent formatting path:
  \`admin/invite\`, \`admin/candidates/[id]\`, \`admin/activity\`, \`admin/retention\`, \`admin/integrations\`, \`admin/announcements\`, \`admin/mentorship\`, \`mentor/page\`, \`mentor/interactions\`, \`mentor/meetings\`, \`mentor/mentees/[id]\`, \`portal/page\`, \`portal/interactions\`, \`messages/[relationId]\`, \`GoalsPanel\`, \`MeetingRequestsPanel\`, \`NotificationBell\`, \`ProjectsManager\`, \`UserActivityPanel\`.
- **Intentionally left alone** (with a comment in the commit message):
  - \`rsvp/[token]/page.tsx\` — public/unauthenticated, no established app-locale context.
  - \`services/emailService.ts\` — transactional email templates fix \`'en-GB'\` independent of any session; no recipient locale available in that cron/mailer context.
  - \`portal/interactions/page.tsx\`'s long weekday-format date keeps its own \`Intl.DateTimeFormat\` options (that visual style — "Friday, July 3, 2026" — is distinct from the shared short-date format); only the hardcoded \`'en-US'\` locale argument was replaced with the dynamic \`locale\`.

Closes #471

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` clean (only pre-existing unrelated warnings)
- [x] \`npm run build\` passes
- [x] New \`e2e/date-formatter-locale.spec.ts\`: sets the TR locale cookie, asserts the activity log date renders as \`gg.aa.yyyy\` (dots) and never the en-US slash format