### PR TITLE
feat(admin): add route-level loading.tsx and error.tsx boundaries

### DIFF
--- a/src/app/admin/error.tsx
+++ b/src/app/admin/error.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useEffect } from 'react';
+import { AlertTriangle } from 'lucide-react';
+import { Card } from '@/components/ui/Card';
+import { Button } from '@/components/ui/Button';
+import { useT } from '@/i18n/client';
+
+// App Router error boundary for everything under /admin. AdminLayout (sidebar,
+// header) stays mounted above this — only the page content is replaced.
+export default function AdminError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  const t = useT();
+
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex items-center justify-center py-20">
+      <Card className="max-w-md w-full text-center">
+        <AlertTriangle className="h-10 w-10 text-red-500 mx-auto mb-4" />
+        <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100">{t.errorBoundary.title}</h1>
+        <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">{t.errorBoundary.description}</p>
+        <div className="mt-6 flex items-center justify-center gap-3">
+          <Button onClick={reset}>{t.errorBoundary.retry}</Button>
+          <Button variant="outline" onClick={() => { window.location.href = '/admin'; }}>
+            {t.errorBoundary.backHome}
+          </Button>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/admin/loading.tsx
+++ b/src/app/admin/loading.tsx
@@ -1,0 +1,18 @@
+import { Card } from '@/components/ui/Card';
+import { Skeleton, SkeletonRows } from '@/components/ui/Skeleton';
+
+// Route-level Suspense fallback for /admin/* — shown during navigation while
+// the next page's server work resolves.
+export default function AdminLoading() {
+  return (
+    <div>
+      <div className="mb-6">
+        <Skeleton className="h-7 w-48 mb-2" />
+        <Skeleton className="h-4 w-72" />
+      </div>
+      <Card>
+        <SkeletonRows rows={6} />
+      </Card>
+    </div>
+  );
+}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -738,6 +738,7 @@ const en = {
   interactionTypes: { Meeting: 'Meeting', Feedback: 'Feedback', Email: 'Email', Call: 'Call', WhatsApp: 'WhatsApp' },
   nextActions: { logFirst: 'Log a first interaction', noContact: 'No contact in {d} days — reach out', lastContact: 'Last contact {d} days ago — follow up', pushHiring: 'Push toward hiring', onTrack: 'On track' },
   notFound: { title: 'Page not found', description: 'This page could not be found.', backHome: 'Back to home' },
+  errorBoundary: { title: 'Something went wrong', description: 'An unexpected error occurred. You can try again or go back to the dashboard.', retry: 'Try again', backHome: 'Back to dashboard' },
   theme: { toggle: 'Toggle theme', light: 'Light', dark: 'Dark', system: 'System' },
   fontSize: { decrease: 'Decrease font size', increase: 'Increase font size', small: 'Small', medium: 'Normal', large: 'Large', extraLarge: 'X-Large' },
   contact: {
@@ -1910,6 +1911,7 @@ const tr: Dict = {
   interactionTypes: { Meeting: 'Toplantı', Feedback: 'Geri bildirim', Email: 'E-posta', Call: 'Arama', WhatsApp: 'WhatsApp' },
   nextActions: { logFirst: 'İlk etkileşimi kaydet', noContact: '{d} gündür iletişim yok — iletişime geç', lastContact: 'Son iletişim {d} gün önce — takip et', pushHiring: 'İşe alıma yönlendir', onTrack: 'Yolunda' },
   notFound: { title: 'Sayfa bulunamadı', description: 'Bu sayfa bulunamadı.', backHome: 'Ana sayfaya dön' },
+  errorBoundary: { title: 'Bir şeyler ters gitti', description: 'Beklenmeyen bir hata oluştu. Tekrar deneyebilir veya panele dönebilirsin.', retry: 'Tekrar dene', backHome: 'Panele dön' },
   theme: { toggle: 'Temayı değiştir', light: 'Açık', dark: 'Koyu', system: 'Sistem' },
   fontSize: { decrease: 'Yazı boyutunu küçült', increase: 'Yazı boyutunu büyüt', small: 'Küçük', medium: 'Normal', large: 'Büyük', extraLarge: 'Çok Büyük' },
   contact: {
@@ -3080,6 +3082,7 @@ const de: Dict = {
   interactionTypes: { Meeting: 'Meeting', Feedback: 'Feedback', Email: 'E-Mail', Call: 'Anruf', WhatsApp: 'WhatsApp' },
   nextActions: { logFirst: 'Erste Interaktion erfassen', noContact: 'Seit {d} Tagen kein Kontakt — melde dich', lastContact: 'Letzter Kontakt vor {d} Tagen — nachfassen', pushHiring: 'Richtung Einstellung drängen', onTrack: 'Auf Kurs' },
   notFound: { title: 'Seite nicht gefunden', description: 'Diese Seite konnte nicht gefunden werden.', backHome: 'Zurück zur Startseite' },
+  errorBoundary: { title: 'Etwas ist schiefgelaufen', description: 'Ein unerwarteter Fehler ist aufgetreten. Du kannst es erneut versuchen oder zum Dashboard zurückkehren.', retry: 'Erneut versuchen', backHome: 'Zurück zum Dashboard' },
   theme: { toggle: 'Theme wechseln', light: 'Hell', dark: 'Dunkel', system: 'System' },
   fontSize: { decrease: 'Schrift verkleinern', increase: 'Schrift vergrößern', small: 'Klein', medium: 'Normal', large: 'Groß', extraLarge: 'Sehr groß' },
   contact: {


### PR DESCRIPTION
## Summary
- \`src/app/admin/loading.tsx\`: a route-level Suspense fallback for \`/admin/*\`, built from the existing \`Skeleton\`/\`SkeletonRows\` components (title-bar skeleton + a card of skeleton rows).
- \`src/app/admin/error.tsx\`: a client-component error boundary (required by the App Router \`error.tsx\` convention — takes \`error\`/\`reset()\` props) styled with the app's \`Card\`/\`Button\` components. Shows a "Try again" button wired to \`reset()\` and a "Back to dashboard" link. \`AdminLayout\`'s sidebar/header stay mounted above the boundary since it's a sibling to \`admin/layout.tsx\`, not inside it — only the page content area is replaced.
- Text sourced from a new \`t.errorBoundary\` i18n block (EN/TR/DE).

Closes #477

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` clean (only pre-existing unrelated warnings)
- [x] \`npm run check:i18n\` — OK, 1163 keys × 3 locales
- [x] \`npm run build\` passes
- [x] Verified locally via a throwaway sandbox route that rendered \`AdminError\`/\`AdminLoading\` directly (screenshotted in dark mode, confirmed the "Try again" button calls \`reset()\` without crashing) — removed before this commit, not part of the diff
- [ ] CI (Lint/Typecheck/Build, Playwright smoke, Preview Deploy)