### PR TITLE
chore(release): 0.3.0-beta — A–L backlog + feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,34 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-03
+
+Backlog epics A–L plus user-reported feedback, shipped as individual PRs.
+
+### Added
+- **Meetings, RSVP & calendar** (EPIC D) — meetings surface on the admin/mentor
+  calendar, RSVP flows feed analytics, auto Meet link + reminders (#417/#432).
+- **Mentor management & capacity** (EPIC A/B) — skill-overlap matching, mentor
+  expertise + capacity, at-capacity flags, mentor detail page (#414/#415).
+- **Analytics accuracy** (EPIC G) — time-in-stage computed from real
+  `StatusChange` history + a date-range selector (#420).
+- **Kanban grouping** (EPIC I) — 13 stages grouped into collapsible phases
+  (pre/internship/outcome), WIP warnings, overdue badges (#422).
+- **Auth hardening** (EPIC J) — role-based 2FA enforcement gate, 12h session
+  timeout, and "sign out of all devices" session revocation (#423).
+- **Category cookie consent** (EPIC K) (#424) and full EN/TR/DE localization
+  (EPIC E) (#418).
+- **CI/CD gates** (EPIC L) — production deploy gated on E2E success
+  (`workflow_run`) + i18n EN/TR/DE parity check (#425).
+- **List UX** (EPIC H) — candidates + mentorships pagination and search (#421).
+- Invitation lifecycle with timestamped history (#433/#434); change toasts on
+  candidate detail (#436); editable notes; a dedicated My Notes page; interaction
+  log subject/filter; message attachments; adjustable font size (Betül feedback).
+
 ### Fixed
+- P0: never-activated users were shown a "deactivated" dead-end at sign-in with
+  no way to resend verification (#447).
+- Generated mentee placeholder emails are ASCII-transliterated (EPIC F) (#419).
 - Onboarding checklist card on the dashboard was nearly unreadable in dark mode (#389).
 
 ## [0.2.0] - 2026-07-01

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.2.0-beta",
+  "version": "0.3.0-beta",
   "private": true,
   "prisma": {
     "seed": "node prisma/seed.mjs"

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,39 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.3.0-beta',
+    date: '2026-07-03',
+    highlights: {
+      en: [
+        'Meetings & calendar — schedule a meeting, mentees RSVP with one click, and everything shows on the calendar with reminder emails.',
+        'Smarter mentor matching — suggestions now rank by real skill overlap, and mentors can set their expertise and how many mentees they can take on.',
+        'Analytics you can trust — "time in stage" is now computed from real pipeline history, plus a date-range filter (last 30/90 days, 6/12 months).',
+        'Cleaner pipeline board — the 13 stages are grouped into collapsible phases (pre-internship / internship / outcome), with overdue flags and a workload hint.',
+        'Account security — your organization can require two-factor authentication, sessions time out automatically, and you can now "sign out of all devices".',
+        'Privacy — cookie consent is now by category (necessary / analytics / …), and the whole app is fully translated in English, Turkish and German.',
+        'Everyday polish — invitation status with timestamps, confirmation toasts on changes, editable notes, a dedicated My Notes page, message attachments, and an adjustable font size.',
+      ],
+      tr: [
+        'Toplantılar & takvim — toplantı planla, mentee’ler tek tıkla katılım (RSVP) versin; her şey hatırlatma e-postalarıyla takvimde görünsün.',
+        'Daha akıllı mentor eşleştirme — öneriler artık gerçek yetenek örtüşmesine göre sıralanıyor; mentörler uzmanlıklarını ve kaç mentee alabileceklerini belirleyebiliyor.',
+        'Güvenilir analitik — "aşamada geçen süre" artık gerçek süreç geçmişinden hesaplanıyor; ayrıca tarih aralığı filtresi (son 30/90 gün, 6/12 ay).',
+        'Daha derli toplu pano — 13 aşama katlanabilir fazlara gruplandı (staj öncesi / staj / sonuç); gecikme işaretleri ve iş yükü uyarısıyla.',
+        'Hesap güvenliği — kuruluşunuz iki adımlı doğrulamayı zorunlu kılabilir, oturumlar otomatik zaman aşımına uğrar ve artık "tüm cihazlardan çıkış" yapabilirsiniz.',
+        'Gizlilik — çerez rızası artık kategori bazlı (gerekli / analitik / …) ve tüm uygulama İngilizce, Türkçe ve Almanca olarak eksiksiz çevrildi.',
+        'Günlük iyileştirmeler — zaman damgalı davet durumu, değişikliklerde onay bildirimleri, düzenlenebilir notlar, ayrı bir Notlarım sayfası, mesaj ekleri ve ayarlanabilir yazı boyutu.',
+      ],
+      de: [
+        'Meetings & Kalender — plane ein Meeting, Mentees sagen mit einem Klick zu (RSVP), und alles erscheint im Kalender samt Erinnerungs-E-Mails.',
+        'Intelligenteres Mentoren-Matching — Vorschläge werden nach echter Fähigkeiten-Überschneidung sortiert, und Mentoren können ihre Expertise und Kapazität festlegen.',
+        'Verlässliche Analysen — die „Zeit in Phase" wird jetzt aus dem echten Pipeline-Verlauf berechnet, plus ein Zeitraumfilter (letzte 30/90 Tage, 6/12 Monate).',
+        'Übersichtlicheres Board — die 13 Phasen sind in einklappbare Abschnitte gruppiert (vor dem Praktikum / Praktikum / Ergebnis), mit Überfällig-Markierungen und Auslastungshinweis.',
+        'Kontosicherheit — deine Organisation kann Zwei-Faktor-Authentifizierung verlangen, Sitzungen laufen automatisch ab, und du kannst dich jetzt „von allen Geräten abmelden".',
+        'Datenschutz — die Cookie-Einwilligung erfolgt jetzt kategorienweise (notwendig / Analyse / …), und die gesamte App ist vollständig auf Englisch, Türkisch und Deutsch übersetzt.',
+        'Feinschliff im Alltag — Einladungsstatus mit Zeitstempeln, Bestätigungs-Toasts bei Änderungen, bearbeitbare Notizen, eine eigene „Meine Notizen"-Seite, Nachrichtenanhänge und eine anpassbare Schriftgröße.',
+      ],
+    },
+  },
+  {
     version: '0.2.0-beta',
     date: '2026-07-01',
     highlights: {


### PR DESCRIPTION
## Release 0.3.0-beta

Housekeeping per the project's versioning convention: a notable batch (EPICs
A–L + P0 auth fix + all user-reported feedback) has shipped, so this bumps the
version and records it.

- `package.json`: `0.2.0-beta` → `0.3.0-beta`
- `CHANGELOG.md`: new `## [0.3.0]` section summarizing the shipped epics
- `src/lib/releaseNotes.ts`: user-facing `/release-notes` entry (EN/TR/DE)

No runtime logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_