### PR TITLE
fix(mentorship): stack admin mentorship rows on mobile

### DIFF
--- a/e2e/mentorship-mobile.spec.ts
+++ b/e2e/mentorship-mobile.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// Regression: on a phone viewport the mentorship row must stack, so the company
+// picker and "Mark complete" control stay within the screen instead of bleeding
+// off the right edge.
+test('mentorship rows do not overflow the viewport on mobile', async ({ page }) => {
+  const W = 390;
+  const adminEmail = uniqueEmail('mm-admin');
+  const mentorEmail = uniqueEmail('mm-mentor');
+  const menteeEmail = uniqueEmail('mm-mentee');
+  await seedUser(adminEmail, 'AdminPass123!', 'ADMIN', 'MM Admin');
+  const mentor = await seedUser(mentorEmail, 'MentorPass123!', 'MENTOR', 'MM Mentor');
+  const mentee = await seedUser(menteeEmail, 'MenteePass123!', 'MENTEE', 'MM Mentee');
+  const rel = await prisma.mentorshipRelation.create({
+    data: { mentorId: mentor.id, menteeId: mentee.id, status: 'ACTIVE' },
+  });
+
+  try {
+    await page.setViewportSize({ width: W, height: 820 });
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', 'AdminPass123!');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    await page.goto('/admin/mentorship');
+    const row = page.getByTestId(`mentorship-row-${rel.id}`);
+    await expect(row).toBeVisible({ timeout: 10_000 });
+
+    // The "Mark complete" button sits fully within the viewport width (would be
+    // clipped off the right edge with the old non-wrapping row layout).
+    const btn = row.getByRole('button', { name: /Mark complete|Tamamland|Abgeschlossen/i });
+    const box = await btn.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.x).toBeGreaterThanOrEqual(0);
+    expect(box!.x + box!.width).toBeLessThanOrEqual(W + 1);
+  } finally {
+    await prisma.mentorshipRelation.deleteMany({ where: { id: rel.id } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/src/app/admin/mentorship/page.tsx
+++ b/src/app/admin/mentorship/page.tsx
@@ -262,15 +262,15 @@ export default function MentorshipPage() {
         <div className="space-y-4">
           {relations.map((rel) => (
             <Card key={rel.id} data-testid={`mentorship-row-${rel.id}`}>
-              <div className="flex items-center justify-between">
-                <div className="flex-1">
-                  <div className="flex items-center gap-3 mb-2">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex-1 min-w-0">
+                  <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mb-2">
                     <Link href={`/admin/candidates/${rel.mentee.id}`} className="font-semibold text-gray-900 hover:text-blue-700 hover:underline">{rel.mentee.fullName}</Link>
                     <span className="text-gray-400">→</span>
                     <span className="font-semibold text-gray-900">{rel.mentor.fullName}</span>
                     <StatusBadge status={rel.status} />
                   </div>
-                  <div className="flex items-center gap-4 text-sm text-gray-500">
+                  <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-gray-500">
                     {rel.company && (
                       <span>🏢 {rel.company.name}</span>
                     )}
@@ -278,18 +278,19 @@ export default function MentorshipPage() {
                     <Badge variant="default">{rel._count.interactions} {t.mentorships.interactions}</Badge>
                   </div>
                 </div>
-                <div className="flex flex-col items-end gap-2 shrink-0">
+                <div className="flex flex-col gap-2 w-full sm:w-auto sm:items-end sm:shrink-0">
                   <Select
                     aria-label={t.mentorships.changeCompany}
                     options={companyOptions}
                     value={rel.company?.id ?? ''}
                     onChange={(e) => handleChangeCompany(rel.id, e.target.value)}
-                    className="w-44"
+                    className="w-full sm:w-44"
                   />
                   {rel.status === 'ACTIVE' && (
                     <Button
                       variant="outline"
                       size="sm"
+                      className="w-full sm:w-auto"
                       onClick={() => handleComplete(rel.id)}
                     >
                       {t.mentorships.markComplete}


### PR DESCRIPTION
## Mobile overflow on the admin Mentorships page

Reported: on a phone the mentorship row's company picker and **Mark complete**
button bleed off the right edge (screenshot).

### Cause
The row was a single `flex items-center justify-between` that never stacked, so
the fixed-width `Select` (`w-44`) + button overflowed narrow viewports.

### Fix
- Outer row: `flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between`
  — stacks on mobile, horizontal from `sm` up.
- Name and metadata rows now `flex-wrap` so long names/badges reflow.
- Controls: full-width on mobile (`w-full`), right-aligned `w-44` from `sm` up.

### Test
`e2e/mentorship-mobile.spec.ts` — at a 390px viewport, asserts the row's
control's bounding box stays within the screen width (would fail with the old
layout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_