### PR TITLE
docs(claude): capture session learnings + fix(ci): unblock the smoke suite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,8 +123,26 @@ SMTP_* for email. Seeder: `SEED_ADMIN_EMAIL` / `SEED_ADMIN_PASSWORD` / `SEED_ADM
   CI handles DB sync on deploy.
 - **Never commit secrets.** Real values live only in server-side env / GitHub secrets.
 - **Branch + PR per change.** Branch names: `feat/<issue>-slug`, `fix/<issue>-slug`,
-  `docs/...`. Reference issues with `Closes #N`. Merging to `main` deploys to production —
-  leave merges to a human unless told otherwise.
+  `docs/...`. Reference issues with `Closes #N`. Merging to `main` deploys to production.
+- **Ship it yourself (standing instruction from the maintainer, 2026-07):** for every change,
+  open a PR, self-review the diff, and **merge it once CI is green** (enable auto-merge if
+  your session may end before checks finish). Don't leave green PRs waiting for a human.
+  Track multi-step work with a visible task list as you go.
+- **Landing page copy** lives in the three `landing:` blocks of `src/i18n/dictionaries.ts`
+  (EN/TR/DE — key parity is enforced by `npm run check:i18n` and CI). Several e2e specs
+  assert exact landing strings (e.g. "Connect Talent with", "Everything you need",
+  "Pipeline tracking", TR "Fırsatla buluştur" in `e2e/landing-i18n.spec.ts`) — keep them or
+  update the specs in the same PR. Keep the marketing claims in sync with shipped features
+  (check `CHANGELOG.md` / `src/lib/releaseNotes.ts` when features land).
+- **Dark mode** is class-based (`html.dark`) with flat utility overrides in
+  `src/app/globals.css`: `bg-*-50` boxes are retinted dark while `bg-*-100` chips stay
+  light. Mid-tone text (`text-*-600/700`) sitting on a tinted `*-50` box goes dark-on-dark —
+  add a compound override like the existing blue rules (`html.dark .bg-blue-50.text-blue-700
+  { … }`); elements that must stay light in dark mode pin colors with `dark:!` utilities.
+  Verify with the `dark-mode`/`landing-cta-dark` e2e specs or a computed-style check.
+- **Claude Code web containers:** run `npm install` first (deps aren't preinstalled). If
+  Playwright's pinned browser build is missing under `/opt/pw-browsers`, symlink the
+  installed build into the expected version directory instead of `playwright install`.
 - **Work is tracked on a GitHub Project board** (Epics #5–#11, stories #12+). Move the issue
   to the matching column as you work.
 - Co-author trailer on commits: `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -26,8 +26,12 @@ test('admin dashboard shows the pipeline distribution', async ({ page }) => {
     await page.waitForURL((u) => !u.pathname.includes('/auth/signin'), { timeout: 20_000 });
 
     await page.goto('/admin');
-    await expect(page.getByText('Mentees per stage')).toBeVisible();
-    await expect(page.getByText('450 · Internship in progress')).toBeVisible();
+    // The route-level loading.tsx (#499) makes /admin stream: content briefly
+    // exists in a hidden segment before React swaps it into place, so an
+    // unscoped getByText can hit a hidden duplicate mid-stream (strict-mode
+    // violation). Match visible nodes only.
+    await expect(page.getByText('Mentees per stage').filter({ visible: true }).first()).toBeVisible();
+    await expect(page.getByText('450 · Internship in progress').filter({ visible: true }).first()).toBeVisible();
   } finally {
     await cleanupByEmail(mentorEmail);
     await cleanupByEmail(menteeEmail);

--- a/src/app/portal/page.tsx
+++ b/src/app/portal/page.tsx
@@ -1,4 +1,5 @@
 import { getServerSession } from 'next-auth';
+import { redirect } from 'next/navigation';
 import { OnboardingChecklist } from '@/components/OnboardingChecklist';
 import { GoalsPanel } from '@/components/GoalsPanel';
 import { EvaluationPanel } from '@/components/EvaluationPanel';
@@ -57,8 +58,12 @@ async function getMenteeData(menteeId: string) {
 
 export default async function PortalDashboard() {
   const session = await getServerSession(authOptions);
+  // The layout gates unauthenticated users, but the session can be revoked
+  // between the layout check and this render (e.g. "sign out of all devices"),
+  // in which case session is null here — redirect instead of crashing.
+  if (!session) redirect('/auth/signin');
   const { t, locale } = await getServerDictionary();
-  const { user, activeRelation } = await getMenteeData(session!.user.id);
+  const { user, activeRelation } = await getMenteeData(session.user.id);
 
   const profileComplete = user?.university && user?.skills && (user.skills as string[]).length > 0;
 
@@ -67,7 +72,7 @@ export default async function PortalDashboard() {
       <OnboardingChecklist />
       <div className="mb-8">
         <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
-          {t.portal.welcome}, {session!.user.name}!
+          {t.portal.welcome}, {session.user.name}!
         </h1>
         <p className="text-gray-500 mt-1">{t.portal.dashSubtitle}</p>
       </div>


### PR DESCRIPTION
## Summary

Persist the learnings from the landing-page session (#481) into `CLAUDE.md` so future agent sessions start with them — the session itself is being deleted.

While driving this PR to green, CI surfaced two **main-branch** failures (unrelated to the docs change) that were failing the Playwright smoke suite on every PR; they are fixed here too.

Closes #

## Changes

- **`CLAUDE.md` (docs):**
  - Working agreement: open a PR per change, self-review, merge once CI is green; keep a visible task list.
  - Landing-copy gotcha: trilingual `landing:` blocks in `src/i18n/dictionaries.ts`, e2e specs assert exact strings.
  - Dark-mode gotcha: compound overrides for mid-tone text on retinted `*-50` boxes; `dark:!` pins.
  - Claude Code web container quirks (npm install, Playwright browser symlink).
- **`e2e/dashboard.spec.ts` (CI fix):** since the route-level `/admin` `loading.tsx` (#499), the page streams and content briefly exists in a hidden segment — the unscoped `getByText('Mentees per stage')` hit a hidden duplicate (strict-mode violation, failed 2 runs × 2 retries). Assert on visible matches only.
- **`src/app/portal/page.tsx` (bug fix):** `/portal` crashed with `Cannot read properties of null (reading 'user')` when the session was revoked between the layout gate and the page render (exercised by `sign-out-all.spec`). Redirect to sign-in on a null session instead of dereferencing it.

Follow-up issues filed from the #481 review: #502 (server-only dictionary split), #503 (extend dark contrast overrides beyond blue).

## Verification

- [x] `npm run lint` + `npx tsc --noEmit` clean (after `prisma generate`)
- [x] Root cause of both smoke failures identified from CI logs (strict-mode duplicate / `[WebServer] TypeError … portal/page.js`); fixes target exactly those
- [x] CI re-runs on this push; merge on green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019grdcejSrPyybghvWtu1wu