### PR TITLE
feat(theme): green accent for the preview environment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,6 +76,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tag }}
           build-args: |
             GIT_SHA=${{ github.event.workflow_run.head_sha || github.sha }}
+            NEXT_PUBLIC_APP_ENV=${{ github.event_name == 'pull_request' && 'preview' || 'production' }}
           # No build-time secrets — all real values are injected at `docker run`
 
       # ── SSH key setup (shared by both deploy steps) ──────────────────────────

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,15 @@ COPY . .
 # Generate Prisma client (no DB connection needed at this stage)
 RUN npx prisma generate
 
+# Deployment flavour ('preview' | 'production'). NEXT_PUBLIC_* is inlined at
+# build time, so it must be present here (not just at runtime). Preview builds
+# pass 'preview' to get the green accent; production defaults to 'production'.
+ARG NEXT_PUBLIC_APP_ENV=production
+
 # Provide dummy env vars so Next.js can analyse routes without a live DB.
 # Real secrets are injected at runtime via `docker run -e`.
 ENV NEXT_TELEMETRY_DISABLED=1 \
+    NEXT_PUBLIC_APP_ENV=$NEXT_PUBLIC_APP_ENV \
     DATABASE_URL="mysql://build:build@127.0.0.1:3306/build" \
     NEXTAUTH_SECRET="build-placeholder" \
     NEXTAUTH_URL="http://localhost:3000"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -100,6 +100,37 @@ html.dark .hover\:text-blue-700:hover,
 html.dark .group:hover .group-hover\:text-blue-600 { color: #93c5fd; } /* blue-300 */
 
 /*
+ * Preview environment accent — the preview deployment is themed GREEN so it is
+ * never mistaken for production (which stays blue). Retints the primary blue
+ * utilities to green with the same flat-selector approach as dark mode, so no
+ * component markup changes are needed. `data-env="preview"` is set on <html>
+ * when NEXT_PUBLIC_APP_ENV=preview (see src/lib/appEnv.ts).
+ */
+html[data-env="preview"] .bg-blue-600 { background-color: #16a34a; }   /* green-600 */
+html[data-env="preview"] .bg-blue-500 { background-color: #22c55e; }   /* green-500 */
+html[data-env="preview"] .hover\:bg-blue-700:hover { background-color: #15803d; } /* green-700 */
+html[data-env="preview"] .focus\:bg-blue-600:focus { background-color: #16a34a; }
+html[data-env="preview"] .text-blue-600 { color: #16a34a; }
+html[data-env="preview"] .text-blue-700 { color: #15803d; }
+html[data-env="preview"] .hover\:text-blue-700:hover { color: #15803d; }
+html[data-env="preview"] .border-blue-400 { border-color: #4ade80; }   /* green-400 */
+html[data-env="preview"] .bg-blue-50 { background-color: #f0fdf4; }     /* green-50 */
+/* Dark + preview: lighter greens so text/boxes stay legible on dark surfaces. */
+html.dark[data-env="preview"] .text-blue-600,
+html.dark[data-env="preview"] .text-blue-700 { color: #4ade80; }        /* green-400 */
+html.dark[data-env="preview"] .bg-blue-50 { background-color: rgba(20,83,45,0.25); }
+html.dark[data-env="preview"] .bg-blue-50.text-blue-700,
+html.dark[data-env="preview"] .bg-blue-50 .text-blue-700,
+html.dark[data-env="preview"] .bg-blue-50 .text-blue-600 { color: #86efac; } /* green-300 */
+/* Keyboard focus ring in preview → green. */
+html[data-env="preview"] a:focus-visible,
+html[data-env="preview"] button:focus-visible,
+html[data-env="preview"] [role='button']:focus-visible,
+html[data-env="preview"] input:focus-visible,
+html[data-env="preview"] select:focus-visible,
+html[data-env="preview"] textarea:focus-visible { outline-color: #16a34a; }
+
+/*
  * Native form controls. Inline <input>/<select>/<textarea> scattered through
  * pages don't all use the themed UI primitives, so default them to dark here.
  * The UI primitives carry their own dark: classes in the same palette, so the

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { getLocale } from '@/i18n/server';
 import { getDictionary } from '@/i18n/dictionaries';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { IS_PREVIEW } from '@/lib/appEnv';
 
 export const metadata: Metadata = {
   title: 'Internship CRM - Mentor-Mentee Management',
@@ -54,6 +55,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
     <html
       lang={locale}
       className={[theme === 'dark' ? 'dark' : undefined, fontSizeClass].filter(Boolean).join(' ') || undefined}
+      data-env={IS_PREVIEW ? 'preview' : undefined}
       suppressHydrationWarning
     >
       <head>

--- a/src/components/BetaBadge.tsx
+++ b/src/components/BetaBadge.tsx
@@ -1,14 +1,22 @@
-// Small "beta" badge shown next to the brand wordmark while the app is
-// pre-1.0. Kept as a tiny presentational component so every placement stays
-// consistent and the label can be changed in one place.
+import { IS_PREVIEW } from '@/lib/appEnv';
+
+// Small badge shown next to the brand wordmark while the app is pre-1.0. Kept as
+// a tiny presentational component so every placement stays consistent and the
+// label lives in one place. On the preview deployment it turns green and reads
+// "preview" so the environment is unmistakable; production keeps the amber
+// "beta".
 export function BetaBadge({ className = '' }: { className?: string }) {
+  const styles = IS_PREVIEW
+    ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300'
+    : 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300';
+  const label = IS_PREVIEW ? 'preview' : 'beta';
   return (
     <span
-      className={`inline-flex items-center rounded-full bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase leading-none tracking-wide text-amber-700 dark:bg-amber-900/40 dark:text-amber-300 ${className}`}
-      title="Beta"
-      aria-label="Beta"
+      className={`inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-semibold uppercase leading-none tracking-wide ${styles} ${className}`}
+      title={label}
+      aria-label={label}
     >
-      beta
+      {label}
     </span>
   );
 }

--- a/src/lib/appEnv.ts
+++ b/src/lib/appEnv.ts
@@ -1,0 +1,11 @@
+// Which deployment this build is running as. Baked in at build time via the
+// NEXT_PUBLIC_APP_ENV build-arg (see Dockerfile + deploy.yml), so it is safe to
+// read in both server and client components. Defaults to 'production' locally.
+export type AppEnv = 'production' | 'preview';
+
+export const APP_ENV: AppEnv =
+  process.env.NEXT_PUBLIC_APP_ENV === 'preview' ? 'preview' : 'production';
+
+// The preview deployment gets a distinct green accent + a "preview" badge so it
+// is impossible to confuse with production (which stays blue).
+export const IS_PREVIEW = APP_ENV === 'preview';


### PR DESCRIPTION
## Preview = green, production = blue

Makes the preview deployment (`crm-preview.ersah.in`) visually unmistakable so
it's never confused with production.

### How
- **`NEXT_PUBLIC_APP_ENV`** build-arg (inlined at build; preview and production
  already build separate images). `deploy.yml` passes `preview` on PRs,
  `production` otherwise; `Dockerfile` declares the ARG/ENV before `next build`.
- **`src/lib/appEnv.ts`** — `APP_ENV` / `IS_PREVIEW` helper.
- **Root layout** sets `data-env="preview"` on `<html>`.
- **`globals.css`** retints the primary blue utilities → green under
  `[data-env="preview"]`, using the same flat-selector approach as dark mode
  (incl. dark-mode-safe lighter greens). No component markup changes.
- **`BetaBadge`** turns green and reads **preview** instead of amber **beta**.

### Safety
Every rule is scoped to `[data-env="preview"]`, which is **absent in production
builds**, so production is byte-for-byte unaffected. (The CI e2e suite builds as
production, so it exercises the unchanged blue path; the green path only applies
to preview images.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_