### PR TITLE
refactor(test): harden stress test + strengthen XSS test (review follow-ups to #480)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,11 +19,12 @@ SMTP_USER="noreply@crm.ersah.in"
 SMTP_PASS="your-smtp-password"
 SMTP_FROM="noreply@crm.ersah.in"
 
-# Automated-test alerts (used by the nightly stress workflow — set as GitHub secrets)
-# ALERT_EMAIL_TO: comma-separated recipient(s) emailed when an automated test fails
-# STRESS_TARGET_URL: env the nightly stress test hits (defaults to production)
-ALERT_EMAIL_TO="team@example.com"
-STRESS_TARGET_URL="https://crm.ersah.in"
+# Automated-test alerts — these are consumed ONLY by the nightly stress GitHub
+# Actions workflow (.github/workflows/stress.yml), NOT by the running app. Set
+# them as GitHub repo secrets, not in a runtime .env. Listed here for discovery.
+#   ALERT_EMAIL_TO     comma-separated recipient(s) emailed when a test fails
+#   STRESS_TARGET_URL  env the nightly stress test hits (defaults to production)
+# For a local stress run use BASE_URL instead: BASE_URL=... npm run test:stress
 
 # Inbound email (mentee/mentor replies routed back into a message thread)
 # INBOUND_EMAIL_DOMAIN: domain used in the generated reply-to address

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -66,5 +66,7 @@ jobs:
             Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           ALERT_SUMMARY_FILE: stress-summary.json
         run: |
-          npm install nodemailer@^7 --no-save --no-audit --no-fund
+          # Install from the lockfile so nodemailer matches the version the app
+          # pins (single source of truth); skip postinstall (prisma generate).
+          npm ci --ignore-scripts --no-audit --no-fund
           node scripts/send-alert-email.mjs

--- a/e2e/xss-injection.spec.ts
+++ b/e2e/xss-injection.spec.ts
@@ -96,7 +96,8 @@ test('XSS payload in a profile display name is escaped in the admin users list',
     await page.goto('/admin/users');
     // Filter to the victim by its plain-text marker so it renders regardless of
     // how many other users exist / pagination — otherwise the assertion is vacuous.
-    await page.locator('input[type="search"]').fill('hello-xss');
+    // Target the users search specifically (the sidebar has its own search box).
+    await page.getByPlaceholder(/name or email/i).fill('hello-xss');
 
     // The payload-bearing name must actually appear as text before we can claim
     // it wasn't executed.

--- a/e2e/xss-injection.spec.ts
+++ b/e2e/xss-injection.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
 
 /**
@@ -14,41 +14,53 @@ test.afterAll(async () => {
   await prisma.$disconnect();
 });
 
-// A payload that would pop a dialog if the string were ever evaluated as HTML/JS.
+// A payload that would pop a dialog / set a global flag if the string were ever
+// evaluated as HTML/JS. 'hello-xss' is a plain-text marker used to locate it.
 const XSS_PAYLOAD = '<img src=x onerror="window.__xss=1"><script>window.__xss=1</script>hello-xss';
 
-test('stored note with an XSS payload is rendered as inert text, not executed', async ({ page }) => {
-  const email = uniqueEmail('xss-mentee');
-  await seedUser(email, 'XssPass123', 'MENTEE', 'XSS Mentee');
-  let noteId = '';
+async function signIn(page: Page, email: string, password: string) {
+  await page.goto('/auth/signin');
+  await page.fill('input[type="email"], input[name="email"]', email);
+  await page.fill('input[type="password"]', password);
+  await page.click('button[type="submit"]');
+  await page.waitForURL((u) => !u.pathname.includes('/auth/signin'), { timeout: 20_000 });
+}
 
-  // If any injected script actually runs, this flips the page flag / opens a dialog.
+// Returns a getter for whether any injected script actually executed (flipped the
+// page flag or triggered a dialog).
+function trackExecution(page: Page) {
   let dialogFired = false;
   page.on('dialog', async (d) => {
     dialogFired = true;
     await d.dismiss().catch(() => {});
   });
+  return async () => {
+    const flag = await page.evaluate(() => (window as unknown as { __xss?: number }).__xss === 1);
+    return { executed: flag, dialogFired };
+  };
+}
+
+test('stored note with an XSS payload is rendered as inert text, not executed', async ({ page }) => {
+  const email = uniqueEmail('xss-mentee');
+  await seedUser(email, 'XssPass123', 'MENTEE', 'XSS Mentee');
+  const executionState = trackExecution(page);
+  let noteId = '';
 
   try {
-    await page.goto('/auth/signin');
-    await page.fill('input[type="email"], input[name="email"]', email);
-    await page.fill('input[type="password"]', 'XssPass123');
-    await page.click('button[type="submit"]');
+    await signIn(page, email, 'XssPass123');
     await page.waitForURL((u) => u.pathname.startsWith('/portal'), { timeout: 20_000 });
 
     const created = await page.request.post('/api/notes', { data: { body: XSS_PAYLOAD } });
     expect(created.status()).toBe(201);
     noteId = (await created.json()).note.id;
 
-    // Render the notes page and let any (mis)injected script attempt to run.
     await page.goto('/portal/notes');
-    await page.waitForTimeout(500);
 
-    // 1. The payload must appear verbatim as text content.
+    // The note body must render as visible *text* — this also proves the row
+    // exists before we assert nothing executed (guards against a vacuous pass).
     await expect(page.getByText('hello-xss')).toBeVisible();
 
-    // 2. No <script> or <img> element was actually parsed from the note body —
-    //    it must live as a text node only.
+    // No <script>/<img onerror> node carrying the payload should have been parsed.
     const injectedNodes = await page.evaluate(() => {
       const marker = 'window.__xss';
       const scripts = Array.from(document.querySelectorAll('script')).filter((s) =>
@@ -57,14 +69,13 @@ test('stored note with an XSS payload is rendered as inert text, not executed', 
       const imgs = Array.from(document.querySelectorAll('img')).filter((i) =>
         (i.getAttribute('onerror') || '').includes(marker)
       ).length;
-      // @ts-expect-error - runtime flag set only if the payload executed
-      const executed = window.__xss === 1;
-      return { scripts, imgs, executed };
+      return { scripts, imgs };
     });
-
     expect(injectedNodes.scripts, 'no injected <script> node should be parsed').toBe(0);
     expect(injectedNodes.imgs, 'no injected <img onerror> node should be parsed').toBe(0);
-    expect(injectedNodes.executed, 'injected script must not execute').toBe(false);
+
+    const { executed, dialogFired } = await executionState();
+    expect(executed, 'injected script must not execute').toBe(false);
     expect(dialogFired, 'no dialog should be triggered by the payload').toBe(false);
   } finally {
     if (noteId) await prisma.personalNote.deleteMany({ where: { id: noteId } }).catch(() => {});
@@ -77,27 +88,21 @@ test('XSS payload in a profile display name is escaped in the admin users list',
   const adminPassword = process.env.ADMIN_PASSWORD || 'ChangeMe123!';
   const victimEmail = uniqueEmail('xss-name');
   await seedUser(victimEmail, 'x', 'MENTEE', XSS_PAYLOAD);
-
-  let dialogFired = false;
-  page.on('dialog', async (d) => {
-    dialogFired = true;
-    await d.dismiss().catch(() => {});
-  });
+  const executionState = trackExecution(page);
 
   try {
-    await page.goto('/auth/signin');
-    await page.fill('input[type="email"], input[name="email"]', adminEmail);
-    await page.fill('input[type="password"]', adminPassword);
-    await page.click('button[type="submit"]');
-    await page.waitForURL((u) => !u.pathname.includes('/auth/signin'), { timeout: 20_000 });
+    await signIn(page, adminEmail, adminPassword);
 
     await page.goto('/admin/users');
-    await page.waitForTimeout(500);
+    // Filter to the victim by its plain-text marker so it renders regardless of
+    // how many other users exist / pagination — otherwise the assertion is vacuous.
+    await page.locator('input[type="search"]').fill('hello-xss');
 
-    const executed = await page.evaluate(() => {
-      // @ts-expect-error - runtime flag
-      return window.__xss === 1;
-    });
+    // The payload-bearing name must actually appear as text before we can claim
+    // it wasn't executed.
+    await expect(page.getByText('hello-xss')).toBeVisible();
+
+    const { executed, dialogFired } = await executionState();
     expect(executed, 'name payload must not execute').toBe(false);
     expect(dialogFired, 'no dialog should be triggered by the name payload').toBe(false);
   } finally {

--- a/scripts/send-alert-email.mjs
+++ b/scripts/send-alert-email.mjs
@@ -19,15 +19,21 @@
 import nodemailer from 'nodemailer';
 import { readFileSync } from 'node:fs';
 
-const to = process.env.ALERT_EMAIL_TO;
-if (!to) {
-  console.error('ALERT_EMAIL_TO is not set — cannot send alert. Skipping.');
+// Surface a skip as a GitHub Actions warning annotation (visible on the run)
+// rather than a silent green step, so a missing secret can't quietly disable
+// alerting. Still exits 0 so it never masks the original test failure.
+function skip(reason) {
+  console.log(`::warning title=Alert email not sent::${reason}`);
   process.exit(0);
 }
 
+const to = process.env.ALERT_EMAIL_TO;
+if (!to) {
+  skip('ALERT_EMAIL_TO secret is not set — no failure alert was delivered.');
+}
+
 if (!process.env.SMTP_HOST || !process.env.SMTP_USER) {
-  console.log(`[alert email skipped — no SMTP config] would notify: ${to}`);
-  process.exit(0);
+  skip(`SMTP is not configured (SMTP_HOST/SMTP_USER) — no failure alert delivered to ${to}.`);
 }
 
 const subject = process.env.ALERT_SUBJECT || '⚠️ Internship CRM — automated test failure';

--- a/scripts/stress-test.mjs
+++ b/scripts/stress-test.mjs
@@ -24,22 +24,38 @@
  * Usage:
  *   BASE_URL=https://crm-preview.ersah.in node scripts/stress-test.mjs
  */
+import { writeFileSync } from 'node:fs';
+
+// Read a numeric env var, honouring an explicit 0 (a plain `Number(x) || d`
+// would silently drop 0 back to the default — wrong for e.g. a zero-tolerance
+// error threshold or a disabled warmup).
+function numEnv(name, def) {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return def;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : def;
+}
 
 const BASE_URL = (process.env.BASE_URL || 'http://localhost:3000').replace(/\/$/, '');
 const PATHS = (process.env.STRESS_PATHS || '/,/auth/signin,/api/health')
   .split(',')
   .map((p) => p.trim())
   .filter(Boolean);
-const CONCURRENCY = Number(process.env.STRESS_CONCURRENCY) || 20;
-const DURATION_MS = Number(process.env.STRESS_DURATION_MS) || 20_000;
-const TIMEOUT_MS = Number(process.env.STRESS_TIMEOUT_MS) || 10_000;
-const WARMUP_MS = Number(process.env.STRESS_WARMUP_MS) || 1_000;
-const MAX_ERROR_RATE = Number(process.env.STRESS_MAX_ERROR_RATE) || 0.02;
-const MAX_P95_MS = Number(process.env.STRESS_MAX_P95_MS) || 2_000;
-const MIN_RPS = Number(process.env.STRESS_MIN_RPS) || 0;
+const CONCURRENCY = numEnv('STRESS_CONCURRENCY', 20);
+const DURATION_MS = numEnv('STRESS_DURATION_MS', 20_000);
+const TIMEOUT_MS = numEnv('STRESS_TIMEOUT_MS', 10_000);
+const WARMUP_MS = numEnv('STRESS_WARMUP_MS', 1_000);
+const MAX_ERROR_RATE = numEnv('STRESS_MAX_ERROR_RATE', 0.02);
+const MAX_P95_MS = numEnv('STRESS_MAX_P95_MS', 2_000);
+const MIN_RPS = numEnv('STRESS_MIN_RPS', 0);
 
-/** @type {{ ok: boolean; status: number; ms: number; path: string; error?: string }[]} */
-const samples = [];
+// Aggregate incrementally so memory stays flat (~a few counters) regardless of
+// how many requests a long soak fires, instead of retaining one object each.
+const okLatencies = []; // latency samples for successful responses only
+let totalCount = 0;
+let failCount = 0;
+/** @type {Record<string, { total: number; failures: number }>} */
+const byPath = {};
 let warmupUntil = 0;
 
 function percentile(sortedMs, p) {
@@ -48,11 +64,29 @@ function percentile(sortedMs, p) {
   return sortedMs[Math.max(0, idx)];
 }
 
+function record(path, ok, ms) {
+  totalCount++;
+  const agg = (byPath[path] ??= { total: 0, failures: 0 });
+  agg.total++;
+  if (ok) {
+    // Only successful responses feed the latency percentiles — otherwise a
+    // timeout (recorded at ~TIMEOUT_MS) or a fast connection-refused would
+    // distort the p95 latency gate.
+    okLatencies.push(ms);
+  } else {
+    failCount++;
+    agg.failures++;
+  }
+}
+
 async function hit(path) {
   const url = BASE_URL + path;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
   const start = performance.now();
+  // Warmup is keyed off request *start* so a slow cold-start request that
+  // begins during warmup is excluded even if it completes after the window.
+  const counted = start >= warmupUntil;
   try {
     const res = await fetch(url, {
       signal: controller.signal,
@@ -61,25 +95,20 @@ async function hit(path) {
     });
     // Drain the body so the connection can be reused and timing reflects a full response.
     await res.arrayBuffer().catch(() => {});
-    const ms = performance.now() - start;
     // 2xx and 3xx are healthy for these public routes (signin may redirect).
     const ok = res.status >= 200 && res.status < 400;
-    if (performance.now() >= warmupUntil) {
-      samples.push({ ok, status: res.status, ms, path });
-    }
-  } catch (err) {
-    const ms = performance.now() - start;
-    if (performance.now() >= warmupUntil) {
-      samples.push({ ok: false, status: 0, ms, path, error: err?.name || String(err) });
-    }
+    if (counted) record(path, ok, performance.now() - start);
+  } catch {
+    if (counted) record(path, false, performance.now() - start);
   } finally {
     clearTimeout(timer);
   }
 }
 
-async function worker(deadline, counter) {
+let pathIndex = 0;
+async function worker(deadline) {
   while (performance.now() < deadline) {
-    const path = PATHS[counter.i++ % PATHS.length];
+    const path = PATHS[pathIndex++ % PATHS.length];
     await hit(path);
   }
 }
@@ -95,20 +124,18 @@ async function main() {
       (MIN_RPS ? ` rps>=${MIN_RPS}` : '')
   );
 
+  const startedAt = new Date().toISOString();
   const testStart = performance.now();
   warmupUntil = testStart + WARMUP_MS;
   const deadline = testStart + DURATION_MS;
-  const counter = { i: 0 };
 
-  await Promise.all(
-    Array.from({ length: CONCURRENCY }, () => worker(deadline, counter))
-  );
+  await Promise.all(Array.from({ length: CONCURRENCY }, () => worker(deadline)));
 
-  const measuredMs = DURATION_MS - WARMUP_MS;
-  const total = samples.length;
-  const failures = samples.filter((s) => !s.ok);
-  const errorRate = total === 0 ? 1 : failures.length / total;
-  const latencies = samples.map((s) => s.ms).sort((a, b) => a - b);
+  // Guard against warmup >= duration, which would divide by zero / go negative.
+  const measuredMs = Math.max(1, DURATION_MS - WARMUP_MS);
+  const total = totalCount;
+  const errorRate = total === 0 ? 1 : failCount / total;
+  const latencies = okLatencies.sort((a, b) => a - b);
   const rps = total / (measuredMs / 1000);
 
   const p50 = percentile(latencies, 50);
@@ -117,20 +144,12 @@ async function main() {
   const avg = latencies.reduce((a, b) => a + b, 0) / (latencies.length || 1);
   const max = latencies[latencies.length - 1] || 0;
 
-  // Per-path status-code breakdown for quick diagnosis.
-  const byPath = {};
-  for (const s of samples) {
-    byPath[s.path] ??= { total: 0, failures: 0 };
-    byPath[s.path].total++;
-    if (!s.ok) byPath[s.path].failures++;
-  }
-
   console.log(`\n── Results (${(measuredMs / 1000).toFixed(1)}s measured window) ──`);
   console.log(`  requests:   ${total}`);
   console.log(`  throughput: ${rps.toFixed(1)} req/s`);
-  console.log(`  errors:     ${failures.length} (${(errorRate * 100).toFixed(2)}%)`);
+  console.log(`  errors:     ${failCount} (${(errorRate * 100).toFixed(2)}%)`);
   console.log(
-    `  latency ms: avg=${avg.toFixed(0)} p50=${p50.toFixed(0)} p95=${p95.toFixed(0)} p99=${p99.toFixed(0)} max=${max.toFixed(0)}`
+    `  latency ms (successful responses): avg=${avg.toFixed(0)} p50=${p50.toFixed(0)} p95=${p95.toFixed(0)} p99=${p99.toFixed(0)} max=${max.toFixed(0)}`
   );
   for (const [path, agg] of Object.entries(byPath)) {
     console.log(`    ${path}: ${agg.total} reqs, ${agg.failures} errors`);
@@ -153,9 +172,9 @@ async function main() {
   // Emit a machine-readable summary for the CI/cron job and email alert.
   const summary = {
     baseUrl: BASE_URL,
-    startedAt: new Date().toISOString(),
+    startedAt,
     total,
-    errors: failures.length,
+    errors: failCount,
     errorRate: Number(errorRate.toFixed(4)),
     rps: Number(rps.toFixed(1)),
     latencyMs: { avg: Math.round(avg), p50: Math.round(p50), p95: Math.round(p95), p99: Math.round(p99), max: Math.round(max) },
@@ -165,7 +184,6 @@ async function main() {
   };
 
   if (process.env.STRESS_SUMMARY_FILE) {
-    const { writeFileSync } = await import('node:fs');
     writeFileSync(process.env.STRESS_SUMMARY_FILE, JSON.stringify(summary, null, 2));
     console.log(`\n  summary written to ${process.env.STRESS_SUMMARY_FILE}`);
   }


### PR DESCRIPTION
## Summary

Follow-up to the merged #480 (stress/load test + XSS test + health probe + nightly cron). Applies the fixes surfaced by a code review of that PR — all robustness/correctness hardening of the test tooling, no behavior change to the app.

Closes #

## Changes

- **stress-test**: honor an explicit `0` for numeric env thresholds (`numEnv` helper) — a plain `Number(x) || default` silently reverted a zero-tolerance error rate or a disabled warmup back to the default
- **stress-test**: compute latency percentiles from successful responses only, so timeouts (~`TIMEOUT_MS`) / connection errors no longer distort the p95 gate
- **stress-test**: key warmup off request *start* time (excludes slow cold-start requests that finish after the window); guard `measuredMs` against `warmup >= duration` (no more divide-by-zero → Infinity rps)
- **stress-test**: aggregate incrementally (flat memory) instead of retaining one object per request — avoids OOM on long local soak runs; record the actual start time in the summary (was end time); static `fs` import; drop the unused counter object
- **xss test**: assert the payload row actually renders (filter the admin list by a plain-text marker; assert note text visible) so the test can't pass vacuously; factor out shared `signIn`/dialog-tracking helpers
- **stress.yml**: install nodemailer from the lockfile (single source of truth) instead of a hard-coded version range
- **alert email**: emit a GitHub Actions `::warning::` annotation when SMTP/recipient is unconfigured, so a missing secret is visible instead of a silent green step
- **.env.example**: clarify the alert vars are CI-only GitHub secrets, not app runtime env

## Verification

- [x] `npm run lint` + `npx tsc --noEmit` clean
- [x] `npm run test:e2e` passing (or CI green)
- [x] Tested the change manually / added an e2e test — re-ran the stress harness against a local dev server: confirmed `STRESS_MAX_ERROR_RATE=0` / `STRESS_WARMUP_MS=0` are now honored, a clean pass exits 0 with correct start time, percentiles exclude failures, and both alert-skip paths emit the warning annotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZ7JgdBocHYjWfCgyqb9fH

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZ7JgdBocHYjWfCgyqb9fH)_