### PR TITLE
chore(ci): send nightly stress alert to the maintainer by default

### DIFF
--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -50,7 +50,8 @@ jobs:
           retention-days: 14
 
       # Email the team only when the stress test failed. Reuses the app's SMTP_*
-      # secrets; ALERT_EMAIL_TO controls the recipient(s).
+      # secrets. Recipient defaults to the maintainer; set an ALERT_EMAIL_TO
+      # secret to override (e.g. a shared alias / multiple comma-separated addrs).
       - name: Email alert on failure
         if: failure()
         env:
@@ -59,7 +60,7 @@ jobs:
           SMTP_USER: ${{ secrets.SMTP_USER }}
           SMTP_PASS: ${{ secrets.SMTP_PASS }}
           SMTP_FROM: ${{ secrets.SMTP_FROM }}
-          ALERT_EMAIL_TO: ${{ secrets.ALERT_EMAIL_TO }}
+          ALERT_EMAIL_TO: ${{ secrets.ALERT_EMAIL_TO || 'mehmetersahin@gmail.com' }}
           ALERT_SUBJECT: '⚠️ Internship CRM — nightly stress test FAILED'
           ALERT_BODY: |
             The nightly stress test breached its thresholds against ${{ env.BASE_URL }}.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -65,14 +65,15 @@ Actions tab (with an optional target-URL override). It targets the URL in the
 
 If any threshold is breached, the job fails and the **"Email alert on failure"** step
 sends a notification via [`scripts/send-alert-email.mjs`](../scripts/send-alert-email.mjs),
-reusing the app's existing `SMTP_*` secrets. The recipient is the `ALERT_EMAIL_TO`
-secret. When SMTP is not configured the script logs and skips (exit 0) so it never masks
-the underlying failure.
+reusing the app's existing `SMTP_*` secrets. The recipient defaults to the maintainer
+and can be overridden with an `ALERT_EMAIL_TO` secret. When SMTP is not configured the
+script logs a GitHub Actions warning and skips (exit 0) so it never masks the underlying
+failure.
 
 ### Required GitHub secrets for the alert
 
 - `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, `SMTP_FROM` — already used by deploy.
-- `ALERT_EMAIL_TO` — comma-separated recipient(s) for failure alerts. **(new)**
+- `ALERT_EMAIL_TO` — optional; comma-separated recipient(s) for failure alerts. Defaults to the maintainer if unset. **(new)**
 - `STRESS_TARGET_URL` — optional; the env to stress. Defaults to `https://crm.ersah.in`. **(new)**
 
 The same alert script can be reused by any other CI job that wants to email on failure


### PR DESCRIPTION
## Summary

Makes the nightly stress-test failure alert actually deliver an email out of the box. Previously the alert step required an `ALERT_EMAIL_TO` GitHub secret; without it the step emitted a warning and sent nothing. This defaults the recipient to the maintainer, while still allowing an `ALERT_EMAIL_TO` secret to override (e.g. a shared alias or multiple comma-separated addresses).

Closes #

## Changes

- `.github/workflows/stress.yml`: `ALERT_EMAIL_TO: ${{ secrets.ALERT_EMAIL_TO || 'mehmetersahin@gmail.com' }}` so failure alerts reach the maintainer without any secret setup.
- `docs/testing.md`: mark `ALERT_EMAIL_TO` as optional (defaults to the maintainer).

The `SMTP_*` secrets already exist (used by deploy), so no further configuration is needed for the alert to send.

## Verification

- [x] `npm run lint` + `npx tsc --noEmit` clean (workflow/docs-only change)
- [x] Workflow YAML validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZ7JgdBocHYjWfCgyqb9fH

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZ7JgdBocHYjWfCgyqb9fH)_