### PR TITLE
feat(messages): header inbox icon + unified conversations list

### DIFF
--- a/e2e/email-templates.spec.ts
+++ b/e2e/email-templates.spec.ts
@@ -22,7 +22,7 @@ test('selecting an email template fills the subject and body', async ({ page }) 
     // Subject input now carries the template subject.
     const subject = page.getByLabel('Subject');
     await expect(subject).toHaveValue(/Welcome to the program/i);
-    await expect(page.getByLabel('Message')).toHaveValue(/\{name\}/);
+    await expect(page.getByLabel('Message', { exact: true })).toHaveValue(/\{name\}/);
   } finally {
     await cleanupByEmail(email);
   }

--- a/e2e/mentor-email.spec.ts
+++ b/e2e/mentor-email.spec.ts
@@ -24,7 +24,7 @@ test('mentor emails a mentee and it is logged as an interaction', async ({ page 
     await page.goto('/mentor/email');
     await page.getByText('Select all').click();
     await page.getByLabel('Subject').fill('Weekly check-in');
-    await page.getByLabel('Message').fill('Hi, let us sync this week.');
+    await page.getByLabel('Message', { exact: true }).fill('Hi, let us sync this week.');
     const sent = page.waitForResponse(
       (r) => r.url().includes('/api/mentor/email') && r.request().method() === 'POST'
     );

--- a/e2e/messages-inbox.spec.ts
+++ b/e2e/messages-inbox.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+async function signIn(page: import('@playwright/test').Page, email: string, pw: string, home: string) {
+  await page.goto('/auth/signin');
+  await page.fill('input[type="email"], input[name="email"]', email);
+  await page.fill('input[type="password"]', pw);
+  await page.click('button[type="submit"]');
+  await page.waitForURL((u) => u.pathname.startsWith(home), { timeout: 20_000 });
+}
+
+test('a mentor reaches messages from the header icon and sees their thread', async ({ page }) => {
+  const mentorEmail = uniqueEmail('msgmentor');
+  const menteeEmail = uniqueEmail('msgmentee');
+  const pw = 'MsgPass123';
+  const mentor = await seedUser(mentorEmail, pw, 'MENTOR', 'Msg Mentor');
+  const mentee = await seedUser(menteeEmail, pw, 'MENTEE', 'Msg Mentee');
+  const relation = await prisma.mentorshipRelation.create({
+    data: { mentorId: mentor.id, menteeId: mentee.id },
+  });
+  // An unread incoming message from the mentee.
+  await prisma.message.create({
+    data: { relationId: relation.id, senderId: mentee.id, body: 'Hello mentor, quick question!' },
+  });
+
+  try {
+    await signIn(page, mentorEmail, pw, '/mentor');
+
+    // The header messaging shortcut is reachable from anywhere in the shell.
+    // (It renders in both the mobile top bar and the desktop strip; target the
+    // one visible at this viewport.)
+    const icon = page.locator('a[href="/messages"]:visible').first();
+    await expect(icon).toBeVisible({ timeout: 10_000 });
+    await icon.click();
+
+    await page.waitForURL((u) => u.pathname === '/messages', { timeout: 20_000 });
+    // The thread lists the other participant and a preview of the last message.
+    await expect(page.getByText('Msg Mentee')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText(/quick question/i)).toBeVisible();
+
+    // Opening the thread navigates into the conversation.
+    await page.getByText('Msg Mentee').click();
+    await page.waitForURL((u) => u.pathname === `/messages/${relation.id}`, { timeout: 20_000 });
+  } finally {
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(menteeEmail);
+  }
+});

--- a/src/app/messages/page.tsx
+++ b/src/app/messages/page.tsx
@@ -1,0 +1,98 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { redirect } from 'next/navigation';
+import Link from 'next/link';
+import { MessageSquare } from 'lucide-react';
+import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
+import { prisma } from '@/lib/prisma';
+import { getServerDictionary } from '@/i18n/server';
+import { relativeTime } from '@/lib/relativeTime';
+
+// Unified message inbox for every role: lists the viewer's conversation
+// threads (mentor side or mentee side) with the other participant, a preview
+// of the latest message, and an unread count — reachable from the header icon.
+export default async function MessagesInboxPage() {
+  const session = await getServerSession(authOptions);
+  if (!session) redirect('/auth/signin');
+  const { locale, t } = await getServerDictionary();
+  const me = session.user.id;
+
+  const relations = await prisma.mentorshipRelation.findMany({
+    where: { OR: [{ mentorId: me }, { menteeId: me }] },
+    select: {
+      id: true,
+      mentorId: true,
+      mentor: { select: { fullName: true } },
+      mentee: { select: { fullName: true } },
+      messages: {
+        orderBy: { createdAt: 'desc' },
+        take: 1,
+        select: { body: true, createdAt: true, senderId: true },
+      },
+      _count: { select: { messages: { where: { readAt: null, senderId: { not: me } } } } },
+    },
+  });
+
+  // Sort by latest activity (most recent message first; then start order).
+  const threads = relations
+    .map((r) => {
+      const last = r.messages[0] ?? null;
+      const otherName = (r.mentorId === me ? r.mentee?.fullName : r.mentor?.fullName) ?? '—';
+      return { id: r.id, otherName, last, unread: r._count.messages };
+    })
+    .sort((a, b) => {
+      const at = a.last?.createdAt?.getTime() ?? 0;
+      const bt = b.last?.createdAt?.getTime() ?? 0;
+      return bt - at;
+    });
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.messages.title}</h1>
+        <p className="text-gray-500 mt-1">{t.messages.inboxSubtitle}</p>
+      </div>
+      <Card>
+        <CardHeader><CardTitle>{t.messages.threads}</CardTitle></CardHeader>
+        {threads.length === 0 ? (
+          <p className="text-center py-10 text-gray-400">{t.messages.noThreads}</p>
+        ) : (
+          <div className="divide-y divide-gray-50">
+            {threads.map((th) => {
+              const preview = th.last
+                ? `${th.last.senderId === me ? `${t.messages.you}: ` : ''}${th.last.body}`
+                : t.messages.empty;
+              return (
+                <Link
+                  key={th.id}
+                  href={`/messages/${th.id}`}
+                  className="flex items-center gap-3 py-3 hover:bg-gray-50 rounded-lg px-2"
+                >
+                  <div className="w-9 h-9 shrink-0 rounded-full bg-blue-100 flex items-center justify-center">
+                    <MessageSquare className="h-4 w-4 text-blue-600" />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center justify-between gap-2">
+                      <span className={`text-sm truncate ${th.unread > 0 ? 'font-bold text-gray-900' : 'font-medium text-gray-900'}`}>
+                        {th.otherName}
+                      </span>
+                      {th.last && (
+                        <span className="text-xs text-gray-400 shrink-0">{relativeTime(th.last.createdAt, locale)}</span>
+                      )}
+                    </div>
+                    <p className={`text-xs truncate mt-0.5 ${th.unread > 0 ? 'text-gray-700' : 'text-gray-400'}`}>{preview}</p>
+                  </div>
+                  {th.unread > 0 && (
+                    <span className="ml-1 shrink-0 min-w-[20px] h-5 px-1.5 rounded-full bg-red-500 text-white text-[11px] font-bold flex items-center justify-center">
+                      {th.unread > 9 ? '9+' : th.unread}
+                    </span>
+                  )}
+                </Link>
+              );
+            })}
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/src/components/MessagesButton.tsx
+++ b/src/components/MessagesButton.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useSession } from 'next-auth/react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { MessageSquare } from 'lucide-react';
+import { useT } from '@/i18n/client';
+
+// Header shortcut to the message inbox, with an unread badge. Mentors/admins
+// previously had to drill into a mentee's detail page to find conversations;
+// this makes messaging reachable from anywhere in one click.
+export function MessagesButton() {
+  const t = useT();
+  const { status } = useSession();
+  const pathname = usePathname();
+  const [unread, setUnread] = useState(0);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch('/api/messages/unread');
+      if (!res.ok) return;
+      const d = await res.json();
+      setUnread(d.count ?? 0);
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  useEffect(() => {
+    if (status !== 'authenticated') return;
+    load();
+    const id = setInterval(load, 60_000);
+    return () => clearInterval(id);
+  }, [status, load]);
+
+  // Re-check when navigating (e.g. after opening a thread and reading it).
+  useEffect(() => {
+    if (status === 'authenticated') load();
+  }, [pathname, status, load]);
+
+  if (status !== 'authenticated') return null;
+
+  return (
+    <Link
+      href="/messages"
+      aria-label={t.messages.title}
+      title={t.messages.title}
+      className="relative p-2 text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white"
+    >
+      <MessageSquare className="h-5 w-5" />
+      {unread > 0 && (
+        <span className="absolute -top-0.5 -right-0.5 min-w-[18px] h-[18px] px-1 rounded-full bg-red-500 text-white text-[10px] font-bold flex items-center justify-center">
+          {unread > 9 ? '9+' : unread}
+        </span>
+      )}
+    </Link>
+  );
+}

--- a/src/components/ResponsiveShell.tsx
+++ b/src/components/ResponsiveShell.tsx
@@ -5,6 +5,7 @@ import { Menu, X } from 'lucide-react';
 import { EmailVerificationBanner } from '@/components/EmailVerificationBanner';
 import { ImpersonationBanner } from '@/components/ImpersonationBanner';
 import { NotificationBell } from '@/components/NotificationBell';
+import { MessagesButton } from '@/components/MessagesButton';
 import { BetaBadge } from '@/components/BetaBadge';
 
 // App shell: sidebar is a static column on desktop and an off-canvas drawer
@@ -27,6 +28,7 @@ export function ResponsiveShell({
         <span className="font-bold text-gray-900 dark:text-gray-100">InternshipCRM</span>
         <BetaBadge className="ml-2" />
         <div className="flex items-center gap-1">
+          <MessagesButton />
           <NotificationBell />
           <button onClick={() => setOpen(true)} aria-label="Open menu" className="p-2 -mr-2 text-gray-600 hover:text-gray-900">
             <Menu className="h-6 w-6" />
@@ -62,6 +64,7 @@ export function ResponsiveShell({
         {/* Desktop-only top strip for search + notifications */}
         <div className="hidden lg:flex items-center justify-end gap-3 px-8 pt-4 no-print">
           {headerExtra}
+          <MessagesButton />
           <NotificationBell />
         </div>
         <div className="p-4 lg:p-8 lg:pt-2">

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -796,6 +796,8 @@ const en = {
   messages: {
     title: 'Messages',
     listSubtitle: 'Your conversations with your mentor',
+    inboxSubtitle: 'Your conversations',
+    you: 'You',
     threads: 'Conversations',
     noThreads: 'No conversations yet',
     empty: 'No messages yet. Say hello!',
@@ -1969,6 +1971,8 @@ const tr: Dict = {
   messages: {
     title: 'Mesajlar',
     listSubtitle: 'Mentorunla yazışmaların',
+    inboxSubtitle: 'Yazışmaların',
+    you: 'Sen',
     threads: 'Görüşmeler',
     noThreads: 'Henüz görüşme yok',
     empty: 'Henüz mesaj yok. Merhaba de!',
@@ -3140,6 +3144,8 @@ const de: Dict = {
   messages: {
     title: 'Nachrichten',
     listSubtitle: 'Deine Unterhaltungen mit deinem Mentor',
+    inboxSubtitle: 'Deine Unterhaltungen',
+    you: 'Du',
     threads: 'Unterhaltungen',
     noThreads: 'Noch keine Unterhaltungen',
     empty: 'Noch keine Nachrichten. Sag Hallo!',


### PR DESCRIPTION
## Summary

Makes messaging easy to reach for **admins/mentors**. Previously the only way to a conversation was to drill into a specific mentee's detail page. This adds a **messages icon (with an unread badge) to the app-shell header** — both the mobile top bar and the desktop strip — that opens a new unified inbox.

## Changes

- **`/messages`** (new): a unified inbox for any role. Lists the viewer's conversation threads (mentor side *or* mentee side) with the other participant, a preview of the last message, relative timestamp, and per-thread unread count, sorted by latest activity. Rendered inside the existing `/messages` layout (auth-guarded, back link).
- **`MessagesButton`** (new): the header shortcut. Polls `/api/messages/unread` (already existed) every 60s and refreshes on navigation so the badge clears after a thread is read.
- **`ResponsiveShell`**: renders `MessagesButton` next to the notification bell in both the mobile and desktop headers (so it shows for admin/mentor layouts).
- i18n EN/TR/DE (`inboxSubtitle`, `you`).
- e2e: `e2e/messages-inbox.spec.ts` — a mentor with an unread incoming message reaches messages via the header icon, sees the thread + preview, and opens it.

## Verification

- [x] `npm run lint` + `npx tsc --noEmit` clean
- [x] `npm run check:i18n` passing (1165 keys × 3 locales)
- [x] `npm run build` succeeds (`/messages` route generated)
- [x] Added an e2e test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_