### PR TITLE
fix(company): auto-save the interest note after typing stops

### DIFF
--- a/src/app/api/company/interests/route.ts
+++ b/src/app/api/company/interests/route.ts
@@ -50,6 +50,14 @@ export async function POST(request: Request) {
 
   const company = await prisma.company.findUnique({ where: { id: session.user.companyId }, select: { name: true } });
 
+  // Was there already an interest, and is this a genuine status change? Note-only
+  // updates (e.g. the debounced note auto-save) must NOT re-notify the mentor.
+  const existing = await prisma.companyInterest.findUnique({
+    where: { companyId_menteeId: { companyId: session.user.companyId, menteeId } },
+    select: { status: true },
+  });
+  const statusChanged = !existing || existing.status !== status;
+
   const interest = await prisma.companyInterest.upsert({
     where: { companyId_menteeId: { companyId: session.user.companyId, menteeId } },
     create: { companyId: session.user.companyId, menteeId, status, note },
@@ -61,13 +69,15 @@ export async function POST(request: Request) {
     SHORTLISTED: 'shortlisted',
     PASS: 'passed on',
   };
-  await prisma.notification.create({
-    data: {
-      userId: relation.mentorId,
-      type: 'company_interest',
-      text: `${company?.name ?? 'A company'} ${STATUS_TEXT[status]} ${relation.mentee.fullName}.`,
-    },
-  });
+  if (statusChanged) {
+    await prisma.notification.create({
+      data: {
+        userId: relation.mentorId,
+        type: 'company_interest',
+        text: `${company?.name ?? 'A company'} ${STATUS_TEXT[status]} ${relation.mentee.fullName}.`,
+      },
+    });
+  }
 
   await logActivity({
     action: 'company.interest.set',

--- a/src/app/company/candidates/[id]/page.tsx
+++ b/src/app/company/candidates/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import { ArrowLeft, FileText, ExternalLink, Star, Bookmark, ThumbsDown, Check } from 'lucide-react';
@@ -47,6 +47,11 @@ export default function CompanyCandidateDetailPage() {
   const [note, setNote] = useState('');
   const [saving, setSaving] = useState<InterestStatus | null>(null);
   const [saved, setSaved] = useState(false);
+  // Debounced note auto-save state (distinct from the status-change "saved").
+  const [noteState, setNoteState] = useState<'idle' | 'saving' | 'saved'>('idle');
+  // The last note value we persisted, so the auto-save effect only fires on a
+  // genuine change (and never on the initial load).
+  const savedNote = useRef('');
 
   useEffect(() => {
     fetch(`/api/company/candidates/${id}`)
@@ -61,23 +66,31 @@ export default function CompanyCandidateDetailPage() {
     fetch(`/api/company/interests?menteeId=${id}`)
       .then((r) => r.json())
       .then((d) => {
-        if (d.interest) { setInterest(d.interest); setNote(d.interest.note ?? ''); }
+        if (d.interest) { setInterest(d.interest); setNote(d.interest.note ?? ''); savedNote.current = d.interest.note ?? ''; }
       })
       .catch(() => {});
   }, [id, t.common.error]);
+
+  // POST the interest (create/update). The server only re-notifies the mentor
+  // when the status actually changes, so note-only saves stay silent.
+  const persist = useCallback(async (status: InterestStatus, noteVal: string): Promise<Interest | null> => {
+    const res = await fetch('/api/company/interests', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ menteeId: id, status, note: noteVal }),
+    });
+    if (!res.ok) return null;
+    const body = await res.json();
+    savedNote.current = noteVal;
+    setInterest(body.interest);
+    return body.interest;
+  }, [id]);
 
   const setStatus = async (status: InterestStatus) => {
     setSaving(status);
     setSaved(false);
     try {
-      const res = await fetch('/api/company/interests', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ menteeId: id, status, note }),
-      });
-      if (res.ok) {
-        const body = await res.json();
-        setInterest(body.interest);
+      if (await persist(status, note)) {
         setSaved(true);
         setTimeout(() => setSaved(false), 2500);
       }
@@ -85,6 +98,22 @@ export default function CompanyCandidateDetailPage() {
       setSaving(null);
     }
   };
+
+  // Auto-save the note after the user pauses typing. Requires an existing
+  // status to attach to (the API needs one); before any status is picked, the
+  // note is saved with the first status click instead. This fixes the case
+  // where a status was chosen first and the note typed afterwards.
+  useEffect(() => {
+    if (!interest) return;
+    if (note === savedNote.current) return;
+    setNoteState('saving');
+    const timer = setTimeout(async () => {
+      const ok = await persist(interest.status, note);
+      setNoteState(ok ? 'saved' : 'idle');
+      if (ok) setTimeout(() => setNoteState('idle'), 2000);
+    }, 800);
+    return () => clearTimeout(timer);
+  }, [note, interest, persist]);
 
   if (loading) return <p className="text-center py-12 text-gray-400">{t.common.loading}</p>;
   if (error || !candidate) return <p className="text-center py-12 text-gray-400">{error || t.common.notFound}</p>;
@@ -218,11 +247,17 @@ export default function CompanyCandidateDetailPage() {
           rows={3}
           className="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2 text-sm mb-2"
         />
-        {saved && (
+        {saved ? (
           <p className="text-xs text-green-600 dark:text-green-400 flex items-center gap-1">
             <Check className="h-3.5 w-3.5" /> {t.company.interestSaved}
           </p>
-        )}
+        ) : noteState === 'saving' ? (
+          <p className="text-xs text-gray-400 flex items-center gap-1">{t.company.noteSaving}</p>
+        ) : noteState === 'saved' ? (
+          <p className="text-xs text-green-600 dark:text-green-400 flex items-center gap-1">
+            <Check className="h-3.5 w-3.5" /> {t.company.noteSaved}
+          </p>
+        ) : null}
       </Card>
     </div>
   );

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -72,6 +72,8 @@ const en = {
     pass: 'Pass',
     notePlaceholder: 'Optional note for the mentor...',
     interestSaved: 'Saved — the mentor has been notified.',
+    noteSaving: 'Saving…',
+    noteSaved: 'Note saved.',
   },
   offline: { title: 'You are offline', body: 'Check your connection and try again. Some pages you have visited may still work.' },
   common: {
@@ -1250,6 +1252,8 @@ const tr: Dict = {
     pass: 'Geç',
     notePlaceholder: 'Mentör için isteğe bağlı not...',
     interestSaved: 'Kaydedildi — mentöre bildirim gönderildi.',
+    noteSaving: 'Kaydediliyor…',
+    noteSaved: 'Not kaydedildi.',
   },
   offline: { title: 'Çevrimdışısın', body: 'Bağlantını kontrol edip tekrar dene. Daha önce ziyaret ettiğin bazı sayfalar yine de çalışabilir.' },
   common: {
@@ -2426,6 +2430,8 @@ const de: Dict = {
     pass: 'Absagen',
     notePlaceholder: 'Optionale Notiz für den Mentor...',
     interestSaved: 'Gespeichert — der Mentor wurde benachrichtigt.',
+    noteSaving: 'Wird gespeichert…',
+    noteSaved: 'Notiz gespeichert.',
   },
   offline: { title: 'Du bist offline', body: 'Prüfe deine Verbindung und versuche es erneut. Bereits besuchte Seiten funktionieren womöglich weiter.' },
   common: {


### PR DESCRIPTION
## Summary

Fixes the "Your interest" note on the company candidate page. Previously the note was **only** persisted when a status button (Interested / Shortlisted / Pass) was clicked. So if you picked a status **first** and typed the note **afterwards**, the note was silently lost. (Typing first, then clicking a status, worked — which matched the reported behavior.)

Now the note **auto-saves ~0.8s after you stop typing**, once a status exists.

## Changes

- **`src/app/company/candidates/[id]/page.tsx`**: debounced note auto-save (fires only when a status is already set and the text actually changed; never on initial load). A subtle "Saving… / Note saved." indicator is shown, distinct from the status-change confirmation. Before any status is picked, the note still saves with the first status click (the API requires a status).
- **`src/app/api/company/interests/route.ts`**: the mentor is now re-notified **only when the status changes**, not on note-only updates — otherwise the debounced auto-save would spam the mentor with a notification per save.
- i18n EN/TR/DE (`noteSaving`, `noteSaved`).

## Verification

- [x] `npm run lint` + `npx tsc --noEmit` clean
- [x] `npm run check:i18n` passing
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_