### PR TITLE
perf(i18n): stop shipping server-only dictionary namespaces to the client (#502)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,7 @@ import { getServerSession } from 'next-auth';
 import './globals.css';
 import { Providers } from './providers';
 import { getLocale } from '@/i18n/server';
-import { getDictionary } from '@/i18n/dictionaries';
+import { getClientDictionary } from '@/i18n/dictionaries';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { resolveAccent } from '@/lib/accent';
@@ -33,7 +33,7 @@ const NO_FLASH = `(function(){try{var m=document.cookie.match(/(?:^|; )theme=([^
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const locale = await getLocale();
-  const dict = getDictionary(locale);
+  const dict = getClientDictionary(locale);
   const cookieStore = await cookies();
   let theme = cookieStore.get('theme')?.value;
   let fontSize = cookieStore.get('fontSize')?.value;

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -6,7 +6,7 @@ import { ToastProvider } from '@/components/ui/Toast';
 import { CookieConsent } from '@/components/CookieConsent';
 import { ActivityTracker } from '@/components/ActivityTracker';
 import type { Locale } from '@/i18n/config';
-import type { Dictionary } from '@/i18n/dictionaries';
+import type { ClientDictionary } from '@/i18n/dictionaries';
 
 export function Providers({
   children,
@@ -15,7 +15,7 @@ export function Providers({
 }: {
   children: React.ReactNode;
   locale: Locale;
-  dict: Dictionary;
+  dict: ClientDictionary;
 }) {
   return (
     <SessionProvider>

--- a/src/i18n/client.tsx
+++ b/src/i18n/client.tsx
@@ -2,9 +2,9 @@
 
 import { createContext, useContext } from 'react';
 import type { Locale } from './config';
-import type { Dictionary } from './dictionaries';
+import type { ClientDictionary } from './dictionaries';
 
-const LocaleContext = createContext<{ locale: Locale; t: Dictionary } | null>(null);
+const LocaleContext = createContext<{ locale: Locale; t: ClientDictionary } | null>(null);
 
 export function LocaleProvider({
   locale,
@@ -12,7 +12,7 @@ export function LocaleProvider({
   children,
 }: {
   locale: Locale;
-  dict: Dictionary;
+  dict: ClientDictionary;
   children: React.ReactNode;
 }) {
   return <LocaleContext.Provider value={{ locale, t: dict }}>{children}</LocaleContext.Provider>;
@@ -24,8 +24,9 @@ function useLocaleContext() {
   return ctx;
 }
 
-// Client-side translation hook — returns the active dictionary.
-export function useT(): Dictionary {
+// Client-side translation hook — returns the active dictionary (client subset;
+// server-only namespaces like `landing` are not shipped to the browser).
+export function useT(): ClientDictionary {
   return useLocaleContext().t;
 }
 

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -3616,3 +3616,16 @@ export type Dictionary = Dict;
 export function getDictionary(locale: Locale): Dict {
   return dictionaries[locale] ?? en;
 }
+
+// Namespaces that are only ever read in server components (via
+// getServerDictionary), never through useT() on the client — e.g. the landing
+// marketing copy. They are stripped from the dictionary serialized into every
+// page's client payload to keep it lean (#502).
+export const SERVER_ONLY_NAMESPACES = ['landing'] as const;
+export type ClientDictionary = Omit<Dictionary, (typeof SERVER_ONLY_NAMESPACES)[number]>;
+
+export function getClientDictionary(locale: Locale): ClientDictionary {
+  const clientDict: Partial<Dictionary> = { ...getDictionary(locale) };
+  for (const ns of SERVER_ONLY_NAMESPACES) delete clientDict[ns];
+  return clientDict as ClientDictionary;
+}


### PR DESCRIPTION
## Summary

The full trilingual dictionary is serialized into every page's client payload via `Providers` → `LocaleProvider`, including namespaces that are only ever read server-side. `landing` (~25 keys of marketing prose per locale) is used solely in `src/app/page.tsx` via `getServerDictionary()`, never through `useT()`.

This strips such namespaces from the client bundle:

- `getClientDictionary()` / `ClientDictionary` (= `Omit<Dictionary, 'landing'>`) in `dictionaries.ts`, driven by a `SERVER_ONLY_NAMESPACES` list.
- `layout.tsx` passes the client dictionary to `Providers`; `LocaleProvider`/`useT()` are typed to `ClientDictionary`.
- Server components (`getServerDictionary`) keep the full dictionary — `page.tsx`'s `t.landing` is unaffected.

`tsc` passing confirms nothing on the client references `landing`. Trims the RSC/flight payload on every authenticated page load, and the saving grows as marketing copy grows.

Closes #502

## Verification
- [x] `npx tsc --noEmit` clean (proves no client `t.landing` usage)
- [x] `npm run check:i18n` passing (1207 keys × 3 locales)
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_