### PR TITLE
docs(readme): complete the npm scripts table (#468)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,18 @@ See [`.env.example`](.env.example) for the full list.
 
 | Command | Description |
 |---------|-------------|
-| `npm run dev` | Dev server |
+| `npm run dev` | Dev server (http://localhost:3000) |
 | `npm run build` | Production build |
 | `npm run start` | Serve production build |
 | `npm run lint` | Lint (`next lint`) |
-| `npm run test:e2e` | Playwright smoke tests (add `:headed` to watch) |
+| `npm run check:i18n` | Verify EN/TR/DE dictionary key parity (`scripts/check-i18n.ts`); CI gate |
+| `npm run test:e2e` | Playwright smoke tests (add `:headed` to watch in a browser) |
+| `npm run test:stress` | Load/stress test against the app (`scripts/stress-test.mjs`; see `docs/testing.md`) |
+| `npm run import:csv` | Bulk-import candidates from a CSV file (`scripts/import-csv.mjs`) |
+| `npm run seed:templates` | Seed the built-in document templates (`prisma/seed-templates.mjs`) |
+| `npm run db:dev:up` | Start the local dev MySQL via Docker Compose (`docker-compose.dev.yml`) |
+| `npm run db:dev:down` | Stop and remove the local dev MySQL container |
+| `npm run postinstall` | Regenerate the Prisma client (runs automatically after `npm install`) |
 | `npx prisma db push` | Sync schema to DB |
 | `npx prisma db seed` | Seed first admin |
 


### PR DESCRIPTION
## Summary

Several `package.json` scripts were missing from the README scripts table. Added them, each described from what the underlying script actually does (verified by reading the targets):

- `check:i18n`, `test:stress`, `import:csv`, `seed:templates`, `db:dev:up`, `db:dev:down`, `postinstall`

ONBOARDING already covers `dev` and the e2e commands inline and has no dedicated script table, so no gap to fill there.

Closes #468

## Acceptance criteria
- [x] Every `package.json` script appears in the README table with a short description
- [x] Descriptions written by reading the actual scripts, not guessed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_