### PR TITLE
chore(ci): bump checkout/setup-node/upload-artifact to their node24 majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
       # Prisma client instantiates lazily; build never connects, but a valid-format URL is required.
       DATABASE_URL: 'mysql://user:pass@127.0.0.1:3306/db'
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # For workflow_run, build the exact commit the E2E suite validated
           # (github.sha would be the branch tip, which may have moved).

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,10 +42,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -70,7 +70,7 @@ jobs:
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: playwright-report/

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -31,9 +31,9 @@ jobs:
       STRESS_MAX_P95_MS: '2500'
       STRESS_SUMMARY_FILE: stress-summary.json
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
 
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload stress summary
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: stress-summary
           path: stress-summary.json


### PR DESCRIPTION
## Summary
- Every CI job was logging: "Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-node@v4, actions/upload-artifact@v4".
- Bumped to `actions/checkout@v7`, `actions/setup-node@v6`, `actions/upload-artifact@v7` across `ci.yml`, `deploy.yml`, `stress.yml`, `e2e.yml` — confirmed each new major's `action.yml` declares `using: node24`.
- No input changes needed for how this repo calls them (`node-version`, `cache`, `name`, `path`, `retention-days`, `ref` are all unaffected between these majors).

## Test plan
- [x] Diff reviewed — version-tag-only change, no other lines touched
- [ ] CI (Lint/Typecheck/Build, Playwright smoke, Preview Deploy) — should additionally confirm the deprecation warning is gone from the logs