### PR TITLE
docs(claude): record operational gotchas hit during backlog processing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,3 +152,31 @@ SMTP_* for email. Seeder: `SEED_ADMIN_EMAIL` / `SEED_ADMIN_PASSWORD` / `SEED_ADM
   rendered at `/release-notes`, linked from the sidebar version footer). The app version is
   read from `package.json` at build time (`src/lib/version.ts`); the git SHA is baked into the
   Docker image via a build arg — no other wiring is needed.
+- **E2E locator pitfalls** (hit repeatedly): `AdminNav` renders its own sidebar
+  `input[type="search"]` filter box present on every admin page — an unscoped
+  `input[type="search"]` selector in a new test will hit that instead of a page-level search
+  box; add a `data-testid` to any new search input and target that. `getByText('X')` does
+  substring matching, so a seeded name like "RB Company" also matches `getByText('Company')`
+  — use `{ exact: true }` or scope to a container (`page.locator('table').getByText(...)`).
+- **Known pre-existing CI flakes**: `e2e/account-self-service.spec.ts:52` and
+  `e2e/sign-out-all.spec.ts:24` fail intermittently in the Playwright smoke job (usually
+  preceded by a `[WebServer] TypeError: Cannot read properties of null (reading 'user')`
+  warning) — unrelated to most changes. `gh run rerun <run-id> --failed` and it typically
+  passes; other specs have occasionally failed-then-passed-on-retry too, so one flaky run
+  isn't itself a regression signal — check the actual failure log before concluding a change
+  broke something.
+- **zsh gotcha**: `for f in $(cmd)` does **not** split on newlines in zsh (unlike bash), so
+  iterating multi-line command output silently processes it as one word. Use
+  `cmd | while IFS= read -r f; do ...; done` instead.
+- **`gh` CLI + GitHub API rate limits**: `gh pr merge` / `gh pr create` / `gh pr checks` all
+  use the GraphQL API, which has its own (separate, sometimes-exhausted) quota from REST —
+  check both with `gh api rate_limit`. If GraphQL is exhausted but REST still has headroom,
+  fall back to REST directly: `gh api --method PUT repos/<owner>/<repo>/pulls/<n>/merge -f
+  merge_method=squash`, `gh api --method POST repos/<owner>/<repo>/pulls -f title=... -f
+  head=... -f base=... -f body=...`, and `gh api repos/<owner>/<repo>/commits/<sha>/check-runs`
+  for polling CI status.
+- Local `main` can end up diverged from `origin/main` (e.g. an upstream force-push/history
+  rewrite, or a stray local commit) — `git pull --ff-only` failing with "Diverging branches"
+  is a signal to inspect first (`git log --oneline main..origin/main` and
+  `origin/main..main`), not to force through. If the actual file contents match between the
+  two tips, `git reset --hard origin/main` is safe.


### PR DESCRIPTION
## Summary
Adds a set of bullets to CLAUDE.md's existing **Conventions & gotchas for agents** section, capturing lessons from a long autonomous session that cleared the intern backlog (#478) plus follow-up fixes:
- E2E locator pitfalls (AdminNav's own sidebar search box colliding with page-level search boxes; `getByText` substring matching)
- The two known pre-existing CI flakes (`account-self-service.spec.ts`, `sign-out-all.spec.ts`) and how to triage/retry them without treating them as regressions
- A zsh word-splitting gotcha (`for f in $(cmd)` silently doesn't split on newlines)
- `gh` CLI GraphQL-vs-REST rate limit fallback (hit live in this same session — GraphQL quota exhausted while REST still had headroom)
- How to safely handle local `main` diverging from `origin/main`

Doc-only change, no code/behavior affected. Kept in CLAUDE.md itself (already the canonical 'read this first' doc for agents) rather than a new file.

## Test plan
- [x] Markdown reviewed for formatting; no other sections touched
