### PR TITLE
fix(email): plain-text part + named From header for deliverability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,10 @@ SMTP_USER="noreply@crm.ersah.in"
 # Real password only in .env — never commit secrets to git
 SMTP_PASS="your-smtp-password"
 SMTP_FROM="noreply@crm.ersah.in"
+# Optional display name for the From header ("Internship CRM <noreply@…>").
+# A named sender improves inbox placement vs a bare address. Defaults to
+# "Internship CRM" when unset.
+MAIL_FROM_NAME="Internship CRM"
 
 # Automated-test alerts — these are consumed ONLY by the nightly stress GitHub
 # Actions workflow (.github/workflows/stress.yml), NOT by the running app. Set

--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -20,6 +20,33 @@ const transporter = nodemailer.createTransport({
   },
 });
 
+// Best-effort HTML → plain text for the multipart alternative. A message with
+// only an HTML part scores worse with spam filters (e.g. Gmail); shipping a
+// text/plain alternative alongside improves inbox placement.
+function htmlToText(html: string): string {
+  return html
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<a\b[^>]*href=["']([^"']+)["'][^>]*>(.*?)<\/a>/gi, '$2 ($1)')
+    .replace(/<\/(p|div|h[1-6]|li|tr)>/gi, '\n')
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/\n{3,}/g, '\n\n')
+    .replace(/[ \t]{2,}/g, ' ')
+    .trim();
+}
+
+// A From header with a display name ("Internship CRM <noreply@…>") looks less
+// like bulk/spam than a bare address. Honor an address that already includes a
+// name; otherwise wrap the configured address.
+function fromHeader(): string {
+  const addr = process.env.SMTP_FROM || process.env.SMTP_USER || '';
+  if (addr.includes('<') || !addr) return addr;
+  const name = process.env.MAIL_FROM_NAME || 'Internship CRM';
+  return `${name} <${addr}>`;
+}
+
 export async function sendEmail({
   to,
   subject,
@@ -37,10 +64,11 @@ export async function sendEmail({
   }
 
   await transporter.sendMail({
-    from: process.env.SMTP_FROM || process.env.SMTP_USER,
+    from: fromHeader(),
     to,
     subject,
     html,
+    text: htmlToText(html),
     ...(replyTo ? { replyTo } : {}),
   });
 }


### PR DESCRIPTION
## Summary

Outgoing mail was **HTML-only** with a **bare From address** (`noreply@crm.ersah.in`). Both are known spam signals — an HTML-only message with no `text/plain` alternative and an unnamed sender score worse with filters like Gmail and can land transactional mail (invites, resets) in Spam, even when SPF/DKIM/DMARC all pass (they do — verified via port25).

Changes to `sendEmail`:
- Adds a **`text/plain` alternative** derived from the HTML (`htmlToText`) so every message is multipart.
- Uses a **display-named From** — `Internship CRM <noreply@crm.ersah.in>` — overridable via a new optional `MAIL_FROM_NAME` env (documented in `.env.example`).

This won't change domain reputation on its own, but removes two avoidable spam-scoring factors so legitimate mail is more likely to hit the inbox.

## Verification
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_