### PR TITLE
fix(mobile): account menu no longer closes the whole drawer (P0)

### DIFF
--- a/e2e/mobile-account-menu.spec.ts
+++ b/e2e/mobile-account-menu.spec.ts
@@ -30,8 +30,9 @@ test('mobile: tapping the account menu opens sign-out without closing the drawer
     // Tapping the account toggle opens the popover — the drawer stays open.
     await accountToggle.click();
 
-    const signOut = page.getByRole('link', { name: 'Sign Out' });
-    await expect(signOut).toBeVisible();
+    // The sign-out item is role="menuitem" (not a plain link).
+    const signOut = page.getByRole('menuitem', { name: 'Sign Out' });
+    await expect(signOut).toBeVisible({ timeout: 10_000 });
     // The drawer is still open (the account toggle remains visible).
     await expect(accountToggle).toBeVisible();
   } finally {

--- a/e2e/mobile-account-menu.spec.ts
+++ b/e2e/mobile-account-menu.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+import { seedUser, cleanupByEmail, uniqueEmail, prisma } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// P0 regression guard: on mobile the sidebar is an off-canvas drawer. Tapping
+// the account menu must open its popover (with sign-out) — it used to close the
+// whole drawer, leaving mobile users unable to reach sign-out.
+test('mobile: tapping the account menu opens sign-out without closing the drawer', async ({ page }) => {
+  const adminEmail = uniqueEmail('mobile-acct');
+  const pw = 'MobilePass123';
+  await seedUser(adminEmail, pw, 'ADMIN', 'Mobile Admin');
+
+  try {
+    await page.setViewportSize({ width: 390, height: 820 });
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', pw);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    // Open the off-canvas drawer.
+    await page.getByRole('button', { name: 'Open menu' }).click();
+
+    const accountToggle = page.getByRole('button', { name: 'Account', exact: true });
+    await expect(accountToggle).toBeVisible({ timeout: 10_000 });
+
+    // Tapping the account toggle opens the popover — the drawer stays open.
+    await accountToggle.click();
+
+    const signOut = page.getByRole('link', { name: 'Sign Out' });
+    await expect(signOut).toBeVisible();
+    // The drawer is still open (the account toggle remains visible).
+    await expect(accountToggle).toBeVisible();
+  } finally {
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/src/components/ResponsiveShell.tsx
+++ b/src/components/ResponsiveShell.tsx
@@ -54,8 +54,17 @@ export function ResponsiveShell({
         >
           <X className="h-5 w-5" />
         </button>
-        {/* Close the drawer when a nav link is tapped */}
-        <div className="h-full" onClick={() => setOpen(false)}>
+        {/* Close the drawer only when a navigation link is tapped — NOT on any
+            click. A blanket handler also caught the account-menu toggle button,
+            closing the whole drawer before its popover (with sign-out) could
+            show, so mobile users couldn't reach sign-out. Buttons (account
+            toggle, theme/language/font-size) now keep the drawer open. */}
+        <div
+          className="h-full"
+          onClick={(e) => {
+            if ((e.target as HTMLElement).closest('a')) setOpen(false);
+          }}
+        >
           {sidebar}
         </div>
       </div>


### PR DESCRIPTION
## Summary (P0)

On mobile, the sidebar is an off-canvas drawer. Its wrapper in `ResponsiveShell` closed on **any** click (intended as "close when a nav link is tapped"). That blanket handler also caught the **account-menu toggle button**, so tapping it closed the entire drawer *before* the account popover could render — **mobile users could not reach Sign out** (or the language/theme/font controls).

## Fix

Close the drawer only when a navigation `<a>` is tapped (`e.target.closest('a')`), not on button clicks. Nav links still close the drawer (good UX); the account toggle and the theme/language/font-size buttons now keep it open so the popover is usable. The sign-out link inside the popover is an `<a>`, so tapping it still closes the drawer as it navigates.

## Verification
- [x] `npx tsc --noEmit` + `npm run lint` clean
- [x] `npm run build` succeeds
- [x] e2e (`e2e/mobile-account-menu.spec.ts`): at a 390px viewport, open the drawer, tap the account toggle → the Sign out link is visible and the drawer stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_