### PR TITLE
feat(candidates): inline "assign mentor" on unassigned candidate cards

### DIFF
--- a/e2e/candidate-assign-mentor.spec.ts
+++ b/e2e/candidate-assign-mentor.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('admin assigns an unassigned candidate to themselves from the Candidates screen', async ({ page }) => {
+  const adminEmail = uniqueEmail('assign-admin');
+  const menteeEmail = uniqueEmail('assign-mentee');
+  const pw = 'AssignPass123';
+  const admin = await seedUser(adminEmail, pw, 'ADMIN', 'Assign Admin');
+  const mentee = await seedUser(menteeEmail, 'x', 'MENTEE', 'Assign Mentee');
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', pw);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    await page.goto('/admin/candidates');
+    // Narrow to just this candidate.
+    await page.getByPlaceholder('Search by name, email, university...').fill(menteeEmail);
+
+    const card = page.getByTestId(`candidate-card-${mentee.id}`);
+    await expect(card).toBeVisible({ timeout: 10_000 });
+
+    const done = page.waitForResponse(
+      (r) => r.url().includes('/api/mentorship') && r.request().method() === 'POST',
+      { timeout: 20_000 }
+    );
+    await card.getByRole('button', { name: 'Assign to me' }).click();
+    const res = await done;
+    expect(res.ok()).toBeTruthy();
+
+    // A relation now exists with this admin as mentor.
+    await expect
+      .poll(async () => prisma.mentorshipRelation.count({ where: { menteeId: mentee.id, mentorId: admin.id } }), { timeout: 10_000 })
+      .toBe(1);
+  } finally {
+    await cleanupByEmail(adminEmail);
+    await cleanupByEmail(menteeEmail);
+  }
+});

--- a/src/app/admin/candidates/page.tsx
+++ b/src/app/admin/candidates/page.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
+import { useSession } from 'next-auth/react';
 import { SavedViews } from '@/components/SavedViews';
+import { AssignMentorInline } from '@/components/admin/AssignMentorInline';
 import { EmptyState } from '@/components/EmptyState';
 import Link from "next/link";
 import { useT, useLocale } from "@/i18n/client";
@@ -45,6 +47,8 @@ const gradYears = Array.from({ length: MAX_GRAD_YEAR - MIN_GRAD_YEAR + 1 }, (_, 
 export default function CandidatesPage() {
   const t = useT();
   const locale = useLocale();
+  const { data: session } = useSession();
+  const [mentors, setMentors] = useState<{ id: string; fullName: string }[]>([]);
   const [candidates, setCandidates] = useState<Candidate[]>([]);
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(1);
@@ -141,6 +145,17 @@ export default function CandidatesPage() {
     fetch('/api/admin/sources')
       .then((r) => (r.ok ? r.json() : { sources: [] }))
       .then((d) => setSources(d.sources ?? []))
+      .catch(() => {});
+    // Mentors available to assign a candidate to (admins can mentor too).
+    fetch('/api/users')
+      .then((r) => (r.ok ? r.json() : { users: [] }))
+      .then((d) =>
+        setMentors(
+          ((d.users ?? []) as { id: string; fullName: string; role: string }[])
+            .filter((u) => u.role === 'MENTOR' || u.role === 'ADMIN')
+            .map((u) => ({ id: u.id, fullName: u.fullName }))
+        )
+      )
       .catch(() => {});
   }, []);
 
@@ -428,6 +443,15 @@ export default function CandidatesPage() {
                     <ExternalLink className="h-3 w-3" />
                     {t.candidates.viewCv}
                   </a>
+                )}
+
+                {!activeRelation && candidate.isActive && (
+                  <AssignMentorInline
+                    menteeId={candidate.id}
+                    mentors={mentors}
+                    meId={session?.user?.id}
+                    onAssigned={fetchCandidates}
+                  />
                 )}
               </Card>
             );

--- a/src/components/admin/AssignMentorInline.tsx
+++ b/src/components/admin/AssignMentorInline.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/Button';
+import { useT } from '@/i18n/client';
+
+interface MentorOption {
+  id: string;
+  fullName: string;
+}
+
+// Inline "assign a mentor" control shown on an unassigned candidate card, so an
+// admin can bind the candidate to themselves or to another mentor without
+// leaving the Candidates screen. Calls POST /api/mentorship.
+export function AssignMentorInline({
+  menteeId,
+  mentors,
+  meId,
+  onAssigned,
+}: {
+  menteeId: string;
+  mentors: MentorOption[];
+  meId?: string | null;
+  onAssigned: () => void;
+}) {
+  const t = useT();
+  const a = t.assignMentor;
+  const [choice, setChoice] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState('');
+
+  const assign = async (mentorId: string) => {
+    if (!mentorId) return;
+    setBusy(true);
+    setErr('');
+    try {
+      const res = await fetch('/api/mentorship', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mentorId, menteeId }),
+      });
+      if (res.ok) {
+        onAssigned();
+        return;
+      }
+      const d = await res.json().catch(() => ({}));
+      setErr(res.status === 409 ? a.alreadyAssigned : d.error || t.common.error);
+    } catch {
+      setErr(t.common.error);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // Other mentors (exclude self — self is the dedicated button).
+  const others = mentors.filter((m) => m.id !== meId);
+
+  return (
+    <div className="mt-3 pt-3 border-t border-gray-100 dark:border-gray-800">
+      <p className="text-xs font-medium text-gray-500 mb-1.5">{a.label}</p>
+      <div className="flex flex-wrap items-center gap-2">
+        {meId && (
+          <Button size="sm" loading={busy} onClick={() => assign(meId)}>
+            {a.assignToMe}
+          </Button>
+        )}
+        <select
+          value={choice}
+          onChange={(e) => setChoice(e.target.value)}
+          disabled={busy}
+          aria-label={a.chooseMentor}
+          className="flex-1 min-w-[8rem] rounded-lg border border-gray-300 dark:border-gray-700 dark:bg-gray-800 px-2.5 py-1.5 text-sm"
+        >
+          <option value="">{a.chooseMentor}</option>
+          {others.map((m) => (
+            <option key={m.id} value={m.id}>{m.fullName}</option>
+          ))}
+        </select>
+        <Button size="sm" variant="outline" loading={busy} disabled={!choice} onClick={() => assign(choice)}>
+          {a.assign}
+        </Button>
+      </div>
+      {err && <p className="text-xs text-red-600 mt-1.5">{err}</p>}
+    </div>
+  );
+}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -118,6 +118,13 @@ const en = {
     lockedTitle: 'Talent pool is a premium feature',
     lockedBody: 'Ask your administrator to enable talent-pool search for your company.',
   },
+  assignMentor: {
+    label: 'Assign a mentor',
+    assignToMe: 'Assign to me',
+    chooseMentor: 'Choose a mentor…',
+    assign: 'Assign',
+    alreadyAssigned: 'This candidate already has an active mentor.',
+  },
   offline: { title: 'You are offline', body: 'Check your connection and try again. Some pages you have visited may still work.' },
   common: {
     loading: 'Loading...',
@@ -1347,6 +1354,13 @@ const tr: Dict = {
     lockedTitle: 'Yetenek havuzu premium bir özelliktir',
     lockedBody: 'Şirketiniz için yetenek havuzu aramasını etkinleştirmesi için yöneticinizle görüşün.',
   },
+  assignMentor: {
+    label: 'Mentör ata',
+    assignToMe: 'Bana ata',
+    chooseMentor: 'Mentör seç…',
+    assign: 'Ata',
+    alreadyAssigned: 'Bu adayın zaten aktif bir mentörü var.',
+  },
   offline: { title: 'Çevrimdışısın', body: 'Bağlantını kontrol edip tekrar dene. Daha önce ziyaret ettiğin bazı sayfalar yine de çalışabilir.' },
   common: {
     loading: 'Yükleniyor...',
@@ -2573,6 +2587,13 @@ const de: Dict = {
     viewProfile: 'Profil ansehen',
     lockedTitle: 'Der Talentpool ist eine Premium-Funktion',
     lockedBody: 'Bitte deinen Administrator, die Talentpool-Suche für dein Unternehmen zu aktivieren.',
+  },
+  assignMentor: {
+    label: 'Mentor zuweisen',
+    assignToMe: 'Mir zuweisen',
+    chooseMentor: 'Mentor wählen…',
+    assign: 'Zuweisen',
+    alreadyAssigned: 'Dieser Kandidat hat bereits einen aktiven Mentor.',
   },
   offline: { title: 'Du bist offline', body: 'Prüfe deine Verbindung und versuche es erneut. Bereits besuchte Seiten funktionieren womöglich weiter.' },
   common: {


### PR DESCRIPTION
## Summary

On the admin **Candidates** screen you can now bind an **unassigned** candidate to a mentor right from the card — no need to go to the Mentorships page:

- **"Assign to me"** — one click assigns the candidate to the current admin (admins can mentor).
- **Mentor picker** — a `<select>` of every other mentor + an "Assign" button.

Calls the existing admin `POST /api/mentorship` and refreshes the list so the card flips to *Assigned*. If the candidate already has an active mentor (409), a clean inline message is shown.

## Changes
- `AssignMentorInline` component (self button + mentor select).
- `candidates/page.tsx`: loads the mentor list (`MENTOR`/`ADMIN` from `/api/users`) and renders the control on active, unassigned cards.
- i18n EN/TR/DE.
- e2e (`e2e/candidate-assign-mentor.spec.ts`): admin filters to a candidate, clicks "Assign to me", and the relation is created.

## Verification
- [x] `npx tsc --noEmit` + `npm run lint` clean
- [x] `npm run check:i18n` passing (1231 keys × 3 locales)
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_