### PR TITLE
feat(premium): CompanyNeed match alerts, gated (Faz 1) (#530)

### DIFF
--- a/e2e/company-need-alerts.spec.ts
+++ b/e2e/company-need-alerts.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import bcrypt from 'bcryptjs';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// Premium Faz 1 (#530): the daily cron alerts a premium company (holding the
+// COMPANY_NEED_MATCH_ALERTS entitlement) when a consenting candidate matches
+// one of its open positions — once per candidate (deduped), and never for a
+// company without the entitlement. Driven through the admin /api/cron endpoint.
+test('need-match alerts fire once for premium companies only, on consenting candidates', async ({ page }) => {
+  const stamp = `${Date.now()}`;
+  const adminEmail = uniqueEmail('need-admin');
+  const premiumUserEmail = uniqueEmail('need-premium-user');
+  const freeUserEmail = uniqueEmail('need-free-user');
+  const menteeEmail = uniqueEmail('need-mentee');
+  const pw = 'NeedAlertPass123';
+  const position = `Backend Developer ${stamp}`;
+
+  await seedUser(adminEmail, pw, 'ADMIN', 'Need Admin');
+  const hash = await bcrypt.hash(pw, 10);
+
+  const premiumCo = await prisma.company.create({
+    data: {
+      name: `Premium Need Co ${stamp}`,
+      entitlements: { create: { feature: 'COMPANY_NEED_MATCH_ALERTS' } },
+      needs: { create: { position, count: 1, period: '2026' } },
+    },
+  });
+  const freeCo = await prisma.company.create({
+    data: {
+      name: `Free Need Co ${stamp}`,
+      needs: { create: { position, count: 1, period: '2026' } },
+    },
+  });
+  const premiumUser = await prisma.user.create({
+    data: { email: premiumUserEmail, password: hash, role: 'COMPANY', fullName: 'Premium Co User', skills: [], companyId: premiumCo.id },
+  });
+  await prisma.user.create({
+    data: { email: freeUserEmail, password: hash, role: 'COMPANY', fullName: 'Free Co User', skills: [], companyId: freeCo.id },
+  });
+
+  // A consenting (publicProfile) mentee whose target position matches the need.
+  const mentee = await prisma.user.create({
+    data: { email: menteeEmail, password: hash, role: 'MENTEE', fullName: 'Matching Mentee', skills: [], targetPosition: position, publicProfile: true },
+  });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', pw);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    const run1 = await page.request.get('/api/cron');
+    expect(run1.ok()).toBeTruthy();
+
+    // Premium company: alert row + in-app notification created exactly once.
+    await expect
+      .poll(async () => prisma.companyNeedAlert.count({ where: { companyId: premiumCo.id, menteeId: mentee.id } }), { timeout: 10_000 })
+      .toBe(1);
+    expect(await prisma.notification.count({ where: { userId: premiumUser.id, type: 'need_match' } })).toBe(1);
+
+    // Free company: no entitlement → no alert.
+    expect(await prisma.companyNeedAlert.count({ where: { companyId: freeCo.id } })).toBe(0);
+
+    // Running again does not re-alert (deduped).
+    const run2 = await page.request.get('/api/cron');
+    expect(run2.ok()).toBeTruthy();
+    expect(await prisma.companyNeedAlert.count({ where: { companyId: premiumCo.id, menteeId: mentee.id } })).toBe(1);
+    expect(await prisma.notification.count({ where: { userId: premiumUser.id, type: 'need_match' } })).toBe(1);
+  } finally {
+    await prisma.notification.deleteMany({ where: { userId: premiumUser.id } });
+    await prisma.companyNeedAlert.deleteMany({ where: { menteeId: mentee.id } });
+    await prisma.companyNeed.deleteMany({ where: { companyId: { in: [premiumCo.id, freeCo.id] } } });
+    await prisma.companyEntitlement.deleteMany({ where: { companyId: premiumCo.id } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(premiumUserEmail);
+    await cleanupByEmail(freeUserEmail);
+    await cleanupByEmail(adminEmail);
+    await prisma.company.delete({ where: { id: premiumCo.id } }).catch(() => {});
+    await prisma.company.delete({ where: { id: freeCo.id } }).catch(() => {});
+  }
+});

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -143,6 +143,7 @@ model User {
   personalNotes           PersonalNote[]
   consents                UserConsent[]
   companyInterests        CompanyInterest[]        @relation("CompanyInterestMentee")
+  companyNeedAlerts       CompanyNeedAlert[]       @relation("CompanyNeedAlertMentee")
   authoredRelationNotes   RelationNote[]           @relation("RelationNoteAuthor")
   pageViews               PageView[]
 
@@ -354,6 +355,7 @@ model Company {
   projects     Project[]            @relation("CompanyProjects")
   interests    CompanyInterest[]
   entitlements CompanyEntitlement[]
+  needAlerts   CompanyNeedAlert[]
 }
 
 // Premium entitlement (freemium — Faz 0). One row per enabled feature per
@@ -370,6 +372,22 @@ model CompanyEntitlement {
   company Company @relation(fields: [companyId], references: [id], onDelete: Cascade)
 
   @@unique([companyId, feature])
+  @@index([companyId])
+}
+
+// Dedupe marker for premium CompanyNeed match alerts (Faz 1, #530). One row per
+// company+mentee: once a matching candidate has triggered an alert for a
+// company, we never re-notify for the same candidate (the "*SentAt" pattern).
+model CompanyNeedAlert {
+  id        String   @id @default(cuid())
+  companyId String
+  menteeId  String
+  createdAt DateTime @default(now())
+
+  company Company @relation(fields: [companyId], references: [id], onDelete: Cascade)
+  mentee  User    @relation("CompanyNeedAlertMentee", fields: [menteeId], references: [id], onDelete: Cascade)
+
+  @@unique([companyId, menteeId])
   @@index([companyId])
 }
 

--- a/src/app/api/cron/route.ts
+++ b/src/app/api/cron/route.ts
@@ -7,6 +7,7 @@ import {
   sendWeeklyMentorDigests,
   checkStageDeadlineReminders,
   checkRetentionReminders,
+  checkCompanyNeedMatches,
 } from '@/services/emailService';
 
 export async function GET() {
@@ -17,12 +18,13 @@ export async function GET() {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const [interactions, meetings, digests, deadlines, retention] = await Promise.all([
+    const [interactions, meetings, digests, deadlines, retention, needMatches] = await Promise.all([
       checkMentorInteractionReminders(),
       sendMeetingReminders(),
       sendWeeklyMentorDigests(),
       checkStageDeadlineReminders(),
       checkRetentionReminders(),
+      checkCompanyNeedMatches(),
     ]);
 
     return NextResponse.json({
@@ -32,6 +34,7 @@ export async function GET() {
       digests,
       deadlines,
       retention,
+      needMatches,
     });
   } catch (error) {
     console.error('Cron error:', error);

--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -607,6 +607,97 @@ export async function checkRetentionReminders() {
   return { checked: users.length, reminded, retentionMonths: months, graceDays: RETENTION_GRACE_DAYS };
 }
 
+// Does a consenting candidate match any of a company's open positions? A match
+// is a loose, case-insensitive overlap between a need's position and the
+// candidate's target position or one of their skills — deliberately generous
+// (the alert is a "worth a look" nudge, not a hard filter).
+function candidateMatchesNeeds(
+  positions: string[],
+  cand: { targetPosition?: string | null; skills: unknown }
+): boolean {
+  const target = (cand.targetPosition || '').toLowerCase().trim();
+  const skills = (Array.isArray(cand.skills) ? cand.skills : []).map((s) => String(s).toLowerCase().trim()).filter(Boolean);
+  return positions.some((pos) => {
+    if (!pos) return false;
+    if (target && (target.includes(pos) || pos.includes(target))) return true;
+    return skills.some((sk) => sk && (pos.includes(sk) || sk.includes(pos)));
+  });
+}
+
+// Premium CompanyNeed match alerts (Faz 1, #530). For every company holding the
+// COMPANY_NEED_MATCH_ALERTS entitlement, scan the consenting talent pool (the
+// same publicProfile-only visibility as talent-pool search) for candidates
+// matching an open position, and notify the company's users once per candidate.
+// Repeat notifications are prevented by the CompanyNeedAlert dedupe row (the
+// unique [companyId, menteeId] insert is the marker — createMany/skipDuplicates
+// makes "insert-or-skip" atomic, so a candidate only ever alerts a company once).
+export async function checkCompanyNeedMatches() {
+  const companies = await prisma.company.findMany({
+    where: {
+      entitlements: { some: { feature: 'COMPANY_NEED_MATCH_ALERTS' } },
+      needs: { some: {} },
+    },
+    select: {
+      id: true,
+      name: true,
+      needs: { select: { position: true } },
+      users: {
+        where: { role: 'COMPANY', isActive: true },
+        select: { id: true, email: true, fullName: true, emailNotifications: true, notificationPrefs: true },
+      },
+    },
+  });
+  if (companies.length === 0) return { companies: 0, alerts: 0 };
+
+  // The consenting talent pool — only mentees who opted into a public profile.
+  const pool = await prisma.user.findMany({
+    where: { role: 'MENTEE', isActive: true, publicProfile: true },
+    select: { id: true, fullName: true, targetPosition: true, skills: true },
+  });
+  if (pool.length === 0) return { companies: companies.length, alerts: 0 };
+
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+  let alerts = 0;
+
+  for (const company of companies) {
+    const positions = company.needs.map((n) => n.position.toLowerCase().trim()).filter(Boolean);
+    if (positions.length === 0) continue;
+
+    for (const cand of pool) {
+      if (!candidateMatchesNeeds(positions, cand)) continue;
+
+      // Atomic dedupe: the insert succeeds only the first time; count 0 means
+      // this company was already alerted about this candidate — skip silently.
+      const created = await prisma.companyNeedAlert.createMany({
+        data: [{ companyId: company.id, menteeId: cand.id }],
+        skipDuplicates: true,
+      });
+      if (created.count === 0) continue;
+
+      alerts += 1;
+      const link = `/p/${cand.id}`;
+      const text = `New candidate matches your open position: ${cand.fullName}`;
+      for (const u of company.users) {
+        await notify(u.id, 'need_match', text, link);
+        if (emailAllowed(u, 'digest')) {
+          await sendEmail({
+            to: u.email,
+            subject: 'A candidate matches your open position',
+            html: `<div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+              <h2 style="color:#2563eb;">New matching candidate</h2>
+              <p>Hi ${u.fullName},</p>
+              <p><strong>${cand.fullName}</strong> matches one of ${company.name}'s open positions${cand.targetPosition ? ` (${cand.targetPosition})` : ''}.</p>
+              <p><a href="${appUrl}${link}">View profile</a></p>
+            </div>`,
+          }).catch(() => {});
+        }
+      }
+    }
+  }
+
+  return { companies: companies.length, alerts };
+}
+
 const scheduledTasks = new Map<string, ReturnType<typeof cron.schedule>>();
 
 export function initCronJobs() {
@@ -622,6 +713,8 @@ export function initCronJobs() {
       console.log(`[Cron] Stage deadline reminders: ${dl.reminded}`);
       const rr = await checkRetentionReminders();
       console.log(`[Cron] Retention re-consent reminders: ${rr.reminded}`);
+      const nm = await checkCompanyNeedMatches();
+      console.log(`[Cron] Company need-match alerts: ${nm.alerts}`);
     } catch (error) {
       console.error('[Cron] Error running reminder check:', error);
     }


### PR DESCRIPTION
## What & why

Premium Faz 1 (#530). `CompanyNeed` used to be a passive record. Now a daily cron scan alerts **premium companies** (holding the `COMPANY_NEED_MATCH_ALERTS` entitlement) when a **consenting** candidate in the public talent pool matches one of their open positions — so companies find out about relevant new talent without polling.

## Changes

- **Schema**: new `CompanyNeedAlert { companyId, menteeId, createdAt }` with a unique `[companyId, menteeId]`. This is the dedupe marker (the "*SentAt" pattern) — an insert-or-skip via `createMany({ skipDuplicates })` makes "have we alerted this company about this candidate?" atomic, so each company is notified **at most once per candidate**.
- **`checkCompanyNeedMatches()`** (`emailService.ts`): loose, case-insensitive match of `CompanyNeed.position` against candidate `targetPosition`/`skills`, scanned over the `publicProfile`-only pool (same privacy rule as talent-pool search — no non-consenting candidate is ever surfaced). Creates an in-app `Notification` for every company user and an opt-in email (`digest` category).
- **Wiring**: added to the daily cron job and the `/api/cron` admin endpoint response.
- **e2e** (`company-need-alerts.spec.ts`): alert fires once for the entitled company, never for a non-entitled company, and does not re-fire on a second cron run.

## Acceptance criteria

- ✅ Matching candidate in the pool → premium company alerted once.
- ✅ Feature-flag off / non-consenting candidate → no alert.
- ✅ `npm run build` passes.

## Verification

- `tsc --noEmit` ✅ · `next lint` (only pre-existing warnings) ✅ · `npm run build` ✅ · `prisma validate` ✅

> Schema change syncs to the DB via `prisma db push --accept-data-loss` on deploy (this project uses db push, no migrations) — additive table, no data loss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_