### PR TITLE
docs: clarify CSV import script behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ See [`.env.example`](.env.example) for the full list.
 | `npm run check:i18n` | Verify EN/TR/DE dictionary key parity (`scripts/check-i18n.ts`); CI gate |
 | `npm run test:e2e` | Playwright smoke tests (add `:headed` to watch in a browser) |
 | `npm run test:stress` | Load/stress test against the app (`scripts/stress-test.mjs`; see `docs/testing.md`) |
-| `npm run import:csv` | Bulk-import candidates from a CSV file (`scripts/import-csv.mjs`) |
+| `npm run import:csv` | Import legacy mentoring CSV data from a file or URL (`scripts/import-csv.mjs`); dry-run by default, use `--owner=<email> --apply` to write |
 | `npm run seed:templates` | Seed the built-in document templates (`prisma/seed-templates.mjs`) |
 | `npm run db:dev:up` | Start the local dev MySQL via Docker Compose (`docker-compose.dev.yml`) |
 | `npm run db:dev:down` | Stop and remove the local dev MySQL container |


### PR DESCRIPTION
## Summary

- clarified that `import:csv` accepts a local file or published CSV URL
- documented that the command runs in dry-run mode by default
- documented that `--owner=<email> --apply` is required to write to the database

## Validation

- verified the behavior against `scripts/import-csv.mjs`
- ran `git diff --check`

Follow-up documentation improvement to #468.