### PR TITLE
fix(company): accept null in optional edit fields (#569)

### DIFF
--- a/e2e/company-edit-optional-nulls.spec.ts
+++ b/e2e/company-edit-optional-nulls.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// #569: editing a company whose optional columns are NULL in the DB (size,
+// logoUrl, address, description, contactEmail) used to fail zod validation with
+// "Expected string, received null" and block saving. The form now accepts null
+// and normalizes it, so the edit opens clean and saves.
+test('a company with empty optional fields edits and saves without a null validation error', async ({ page }) => {
+  const adminEmail = uniqueEmail('co-edit-admin');
+  const pw = 'CoEditPass123';
+  await seedUser(adminEmail, pw, 'ADMIN', 'Company Edit Admin');
+  // Only a name — every optional column stays NULL in the DB.
+  const company = await prisma.company.create({ data: { name: `NullFields Co ${Date.now()}` } });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', pw);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    await page.goto('/admin/companies');
+    await page.getByTestId(`edit-company-${company.id}`).click();
+
+    // Edit form opens with the name pre-filled; no null-validation error shows.
+    await expect(page.getByRole('button', { name: 'Update Company' })).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('received null')).toHaveCount(0);
+
+    // Saving succeeds (PUT returns 2xx).
+    const done = page.waitForResponse(
+      (r) => r.url().includes(`/api/companies/${company.id}`) && r.request().method() === 'PUT',
+      { timeout: 20_000 }
+    );
+    await page.getByRole('button', { name: 'Update Company' }).click();
+    const res = await done;
+    expect(res.ok()).toBeTruthy();
+  } finally {
+    await prisma.company.delete({ where: { id: company.id } }).catch(() => {});
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/src/app/admin/companies/page.tsx
+++ b/src/app/admin/companies/page.tsx
@@ -269,6 +269,7 @@ export default function CompaniesPage() {
                     </button>
                     <button
                       onClick={() => setEditingCompany(company)}
+                      data-testid={`edit-company-${company.id}`}
                       className="p-1.5 rounded-lg hover:bg-gray-100 text-gray-400 hover:text-gray-700 transition-colors"
                     >
                       <Pencil className="h-4 w-4" />

--- a/src/components/forms/CompanyForm.tsx
+++ b/src/components/forms/CompanyForm.tsx
@@ -9,15 +9,22 @@ import { Button } from '@/components/ui/Button';
 import { Plus, Trash2 } from 'lucide-react';
 import { useT } from '@/i18n/client';
 
+// Optional free-text field. Prisma returns `null` for empty nullable columns,
+// so when editing an existing company those nulls reach the form. Plain
+// `.optional()` only accepts `undefined` and rejected `null` with
+// "Expected string, received null" (#569). Accept `undefined`/`null` and
+// normalize to '' so validation passes AND the API always receives a string.
+const optionalText = z.string().nullish().transform((v) => v ?? '');
+
 const companySchema = z.object({
   name: z.string().min(1, 'Company name is required'),
-  description: z.string().optional(),
-  contactEmail: z.string().email('Invalid email').optional().or(z.literal('')),
-  industry: z.string().optional(),
-  logoUrl: z.string().url('Enter a valid URL').optional().or(z.literal('')),
-  size: z.string().optional(),
-  address: z.string().optional(),
-  quota: z.coerce.number().int().min(0).optional().or(z.literal(0)),
+  description: optionalText,
+  contactEmail: z.string().email('Invalid email').or(z.literal('')).nullish().transform((v) => v ?? ''),
+  industry: optionalText,
+  logoUrl: z.string().url('Enter a valid URL').or(z.literal('')).nullish().transform((v) => v ?? ''),
+  size: optionalText,
+  address: optionalText,
+  quota: z.coerce.number().int().min(0).nullish(),
   needs: z.array(
     z.object({
       position: z.string().min(1, 'Position is required'),


### PR DESCRIPTION
## Bug

Editing a company whose optional columns are empty (`NULL` in the DB — Şirket Büyüklüğü, Logo URL, Adres, and empty İletişim E-postası / Açıklama) showed `Expected string, received null` and could block saving. Root cause: the form's zod `.optional()` accepts only `undefined`, not the `null` Prisma returns for empty nullable columns, while the edit flow passes the raw DB object straight into `defaultValues`.

## Fix (schema-side, the issue's preferred option)

- Optional text fields (`description`, `industry`, `size`, `address`) use a shared `optionalText = z.string().nullish().transform(v => v ?? '')` — accepts `undefined`/`null` and normalizes to `''`, so validation passes **and** the API always receives a string (both create + update APIs accept `''`).
- `contactEmail` / `logoUrl` keep their real validation (`.email()` / `.url()`) plus the existing `.or(z.literal(''))`, extended with `.nullish()` + normalize — a bad URL or bad email still errors.
- `quota` accepts `null` (`.nullish()`); the create/update APIs already accept nullable quota.
- Added a `data-testid` to the per-company edit button for stable e2e targeting.

## Acceptance criteria

- ✅ A company with empty optional fields edits and saves — no false `null` error.
- ✅ Real invalid input still fails validation (bad Logo URL, invalid email).
- ✅ Create flow unchanged.
- ✅ `npm run build` + `npm run lint` pass.

## Verification

- `tsc --noEmit` ✅ · `next lint` (only pre-existing warnings) ✅ · `npm run build` ✅
- e2e `company-edit-optional-nulls.spec.ts`: NULL-optional company opens edit form with no null error and PUT returns 2xx.

Closes #569

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_