### PR TITLE
chore(release): 0.4.0-beta — Company Premium + messaging/activity/UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,49 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-07-10
+
+Company Premium (freemium Faz 0 + Faz 1) plus messaging, activity reporting,
+email deliverability and a round of UX fixes — shipped as individual PRs. The
+mentor and mentee experience stays fully free.
+
+### Added
+- **Premium entitlement infrastructure** (Faz 0) — per-company feature flags
+  (`CompanyEntitlement`), a client-safe feature catalogue, `hasFeature` gating,
+  and an admin toggle UI. Row-presence = feature on; nothing on by default so
+  the free core is preserved (#557).
+- **Talent-pool search** (Faz 1) — companies with the entitlement can search a
+  privacy-safe pool of mentees who opted into a public profile (#560).
+- **Verified candidate card** (Faz 1) — gated section on the company candidate
+  view surfacing mentor evaluations + project contributions (#529).
+- **CompanyNeed match alerts** (Faz 1) — a daily scan notifies premium companies
+  when a consenting candidate matches an open position, deduped per candidate
+  (#530).
+- **Early-access window** (Faz 1) — newly-hireable candidates are visible only to
+  early-access companies for a configurable window before opening to all
+  subscribers (#531).
+- **Messaging inbox icon** — a header entry point (admin/mentor) plus a unified
+  `/messages` inbox (#512).
+- **Daily mentee activity report** — page-view/dwell tracking foundation plus a
+  daily digest and in-app view (#513/#514).
+- **Admin email-test tool** — send a probe to any address and see SMTP status,
+  for diagnosing deliverability (#553).
+- **Mentor engagement signals** — a "no open goal" attention-queue badge and a
+  stale-mentee in-app notification, deduped per staleness episode (#571/#572/#573).
+- **Archive view for users** — deactivated accounts drop out of the default
+  Users list and live under an "Archived" tab (#570).
+- **User-selectable accent color** + a fuller preview-green theme (#511).
+- **Inline mentor assignment** from the admin Candidates screen (#564).
+
+### Fixed
+- **P0 mobile account menu** — the responsive drawer no longer closes on the
+  account toggle, so mobile users can reach Sign out (#563).
+- **Company edit validation** — optional fields left empty (NULL in the DB) no
+  longer fail with "Expected string, received null" (#569).
+- **Email deliverability** — plain-text alternative part + a named From header
+  to improve inbox placement (#562).
+- **Company interest note** now auto-saves after typing stops (#532).
+
 ## [0.3.0] - 2026-07-03
 
 Backlog epics A–L plus user-reported feedback, shipped as individual PRs.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.3.0-beta",
+  "version": "0.4.0-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,39 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.4.0-beta',
+    date: '2026-07-10',
+    highlights: {
+      en: [
+        'Company Premium — companies can now search a privacy-safe talent pool of mentees who opted in, see a "verified" candidate card with mentor evaluations and project work, get alerts when a candidate matches an open position, and preview newly-hireable candidates first. Mentor and mentee features stay free.',
+        'Messaging is easier to reach — a new inbox icon in the header and a single Messages page for all your conversations.',
+        'Daily activity report — mentors and admins can get a daily summary of mentee activity (logins, time on site, pages visited, completed to-dos).',
+        'Mentor attention queue — mentees with no open goal are now flagged, and you get an in-app heads-up when a mentee goes quiet.',
+        'Tidier admin — deactivated users move to an "Archived" tab instead of cluttering the list; assign a mentor to a candidate right from the Candidates screen.',
+        'Personalization — pick your own accent color for the app.',
+        'Fixes — mobile users can now reach Sign out from the menu; editing a company with empty optional fields no longer errors; emails land in the inbox more reliably.',
+      ],
+      tr: [
+        'Şirket Premium — şirketler artık rıza vermiş mentee’lerden oluşan gizlilik-güvenli bir yetenek havuzunda arama yapabilir, mentör değerlendirmeleri ve proje çalışmasıyla "doğrulanmış" aday kartını görebilir, açık pozisyona uyan aday çıkınca bildirim alabilir ve yeni işe alınabilir adayları önce görebilir. Mentör ve mentee özellikleri ücretsiz kalır.',
+        'Mesajlaşmaya erişim kolaylaştı — başlıkta yeni bir gelen kutusu ikonu ve tüm sohbetleriniz için tek bir Mesajlar sayfası.',
+        'Günlük aktivite raporu — mentör ve adminler mentee aktivitesinin (giriş, sitede geçen süre, gezilen sayfalar, tamamlanan görevler) günlük özetini alabilir.',
+        'Mentor dikkat kuyruğu — açık hedefi olmayan mentee’ler artık işaretleniyor ve bir mentee sessizleştiğinde uygulama içi uyarı alıyorsunuz.',
+        'Daha derli admin — pasifleştirilen kullanıcılar listeyi doldurmak yerine "Arşiv" sekmesine taşınıyor; adayı doğrudan Adaylar ekranından bir mentöre atayabilirsiniz.',
+        'Kişiselleştirme — uygulama için kendi vurgu renginizi seçin.',
+        'Düzeltmeler — mobil kullanıcılar artık menüden Çıkış’a ulaşabiliyor; opsiyonel alanları boş bir şirketi düzenlemek artık hata vermiyor; e-postalar gelen kutusuna daha güvenilir ulaşıyor.',
+      ],
+      de: [
+        'Unternehmens-Premium — Unternehmen können jetzt in einem datenschutzfreundlichen Talent-Pool von Mentees suchen, die zugestimmt haben, eine „verifizierte" Kandidatenkarte mit Mentor-Bewertungen und Projektarbeit sehen, Benachrichtigungen bei passenden Kandidaten erhalten und neu vermittelbare Kandidaten zuerst sehen. Mentor- und Mentee-Funktionen bleiben kostenlos.',
+        'Nachrichten sind leichter erreichbar — ein neues Posteingang-Symbol in der Kopfzeile und eine einzige Nachrichten-Seite für alle Unterhaltungen.',
+        'Täglicher Aktivitätsbericht — Mentoren und Admins erhalten eine tägliche Zusammenfassung der Mentee-Aktivität (Logins, Verweildauer, besuchte Seiten, erledigte To-dos).',
+        'Mentor-Aufmerksamkeitsliste — Mentees ohne offenes Ziel werden jetzt markiert, und du bekommst einen In-App-Hinweis, wenn ein Mentee still wird.',
+        'Aufgeräumtere Verwaltung — deaktivierte Nutzer wandern in einen „Archiviert"-Tab, statt die Liste zu überladen; weise einem Kandidaten direkt aus der Kandidaten-Ansicht einen Mentor zu.',
+        'Personalisierung — wähle deine eigene Akzentfarbe für die App.',
+        'Korrekturen — Mobile Nutzer erreichen jetzt „Abmelden" im Menü; das Bearbeiten eines Unternehmens mit leeren optionalen Feldern schlägt nicht mehr fehl; E-Mails landen zuverlässiger im Posteingang.',
+      ],
+    },
+  },
+  {
     version: '0.3.0-beta',
     date: '2026-07-03',
     highlights: {


### PR DESCRIPTION
## Why

A notable batch of features has landed since `0.3.0` — per the repo's versioning convention, this bumps the version and records it in both the developer changelog and the user-facing release notes.

## Batch summary (since 0.3.0)

- **Company Premium** — freemium Faz 0 (entitlements + admin toggle) and Faz 1 (talent-pool search, verified candidate card, CompanyNeed match alerts, early-access window). Mentor & mentee stay free.
- **Messaging inbox** icon + unified `/messages`.
- **Daily activity report** (tracking foundation + digest + in-app view).
- **Email deliverability** (plain-text part + named From) and an admin email-test tool.
- **Mentor engagement signals** (no-open-goal badge + stale-mentee notification).
- **Users archive view**, **inline mentor assignment**, **accent colors**.
- **Fixes**: P0 mobile account menu, company-edit null validation.

## Changes

- `package.json`: `0.3.0-beta` → `0.4.0-beta`
- `CHANGELOG.md`: `0.4.0` entry (Added / Fixed)
- `src/lib/releaseNotes.ts`: user-facing `0.4.0-beta` highlights (EN/TR/DE), rendered at `/release-notes`

## Verification

- `tsc --noEmit` ✅ · `npm run build` ✅
- `version-release-notes.spec.ts` reads `package.json` dynamically and asserts the latest release-notes heading matches — now `v0.4.0-beta`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_