### PR TITLE
feat(portal): nudge undecided mentees to choose company visibility (#527 follow-up)

### DIFF
--- a/e2e/portal-visibility-nudge.spec.ts
+++ b/e2e/portal-visibility-nudge.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// #527 follow-up: the portal dashboard nudges mentees who have never decided on
+// company visibility. Deciding (grant OR decline) removes the nudge for good.
+test('undecided mentee sees the visibility nudge; deciding hides it', async ({ page }) => {
+  const menteeEmail = uniqueEmail('nudge-mentee');
+  const pw = 'NudgePass123';
+  const mentee = await seedUser(menteeEmail, pw, 'MENTEE', 'Nudge Mentee');
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', menteeEmail);
+    await page.fill('input[type="password"]', pw);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/portal'), { timeout: 20_000 });
+
+    // Undecided → nudge shows, linking to account settings.
+    const nudge = page.getByTestId('visibility-nudge');
+    await expect(nudge).toBeVisible({ timeout: 10_000 });
+    await expect(nudge.getByRole('link')).toHaveAttribute('href', '/account');
+
+    // The mentee declines (a consent row with revokedAt = a decision).
+    await page.request.post('/api/consent', { data: { type: 'TALENT_POOL_VISIBILITY', granted: false } });
+
+    await page.goto('/portal');
+    await expect(page.getByTestId('visibility-nudge')).toHaveCount(0);
+  } finally {
+    await cleanupByEmail(menteeEmail);
+  }
+});

--- a/src/app/portal/page.tsx
+++ b/src/app/portal/page.tsx
@@ -18,7 +18,7 @@ import Link from 'next/link';
 import { formatDate } from '@/lib/relativeTime';
 
 async function getMenteeData(menteeId: string) {
-  const [user, activeRelation] = await Promise.all([
+  const [user, activeRelation, visibilityConsent] = await Promise.all([
     prisma.user.findUnique({
       where: { id: menteeId },
       select: {
@@ -51,9 +51,15 @@ async function getMenteeData(menteeId: string) {
         },
       },
     }),
+    // Has the mentee ever decided on company visibility (#527)? A row means
+    // decided (granted OR revoked) — the nudge below only targets the undecided.
+    prisma.userConsent.findUnique({
+      where: { userId_type: { userId: menteeId, type: 'TALENT_POOL_VISIBILITY' } },
+      select: { id: true },
+    }),
   ]);
 
-  return { user, activeRelation };
+  return { user, activeRelation, visibilityDecided: !!visibilityConsent };
 }
 
 export default async function PortalDashboard() {
@@ -63,7 +69,7 @@ export default async function PortalDashboard() {
   // in which case session is null here — redirect instead of crashing.
   if (!session?.user?.id) redirect('/auth/signin');
   const { t, locale } = await getServerDictionary();
-  const { user, activeRelation } = await getMenteeData(session.user.id);
+  const { user, activeRelation, visibilityDecided } = await getMenteeData(session.user.id);
 
   const profileComplete = user?.university && user?.skills && (user.skills as string[]).length > 0;
 
@@ -90,6 +96,24 @@ export default async function PortalDashboard() {
             className="bg-yellow-500 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-yellow-600 transition-colors flex-shrink-0 ml-4"
           >
             {t.portal.completeProfileCta}
+          </Link>
+        </div>
+      )}
+
+      {/* Company-visibility nudge (#527): shown only while the mentee has never
+          decided on the TALENT_POOL_VISIBILITY consent. Granting OR declining
+          in Account settings makes it disappear — no nagging after a decision. */}
+      {!visibilityDecided && (
+        <div data-testid="visibility-nudge" className="mb-6 p-4 bg-blue-50 border border-blue-200 rounded-xl flex items-center justify-between dark:bg-blue-900/20 dark:border-blue-800">
+          <div>
+            <p className="font-medium text-blue-800 dark:text-blue-200">{t.portal.visibilityNudge}</p>
+            <p className="text-sm text-blue-600 dark:text-blue-300 mt-0.5">{t.portal.visibilityNudgeHint}</p>
+          </div>
+          <Link
+            href="/account"
+            className="bg-blue-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-blue-700 transition-colors flex-shrink-0 ml-4"
+          >
+            {t.portal.visibilityNudgeCta}
           </Link>
         </div>
       )}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -1137,6 +1137,9 @@ const en = {
     assignedCompany: 'Assigned company',
     recentInteractions: 'Recent interactions',
     completeProfileCta: 'Complete profile',
+    visibilityNudge: 'Want partner companies to discover you?',
+    visibilityNudgeHint: 'Turn on company visibility to appear in partner companies’ talent search. Only your public profile is shown — never your email or phone. You decide, and you can change it anytime.',
+    visibilityNudgeCta: 'Choose in settings',
   },
   profileForm: {
     title: 'My Profile',
@@ -2387,6 +2390,9 @@ const tr: Dict = {
     assignedCompany: 'Atanan şirket',
     recentInteractions: 'Son etkileşimler',
     completeProfileCta: 'Profili tamamla',
+    visibilityNudge: 'Partner şirketler seni keşfetsin ister misin?',
+    visibilityNudgeHint: 'Şirketlere görünürlüğü açarsan partner şirketlerin yetenek aramasında görünürsün. Yalnızca herkese açık profilin gösterilir — e-postan veya telefonun asla. Karar senin; istediğin an değiştirebilirsin.',
+    visibilityNudgeCta: 'Ayarlardan seç',
   },
   profileForm: {
     title: 'Profilim',
@@ -3635,6 +3641,9 @@ const de: Dict = {
     assignedCompany: 'Zugewiesenes Unternehmen',
     recentInteractions: 'Letzte Interaktionen',
     completeProfileCta: 'Profil vervollständigen',
+    visibilityNudge: 'Möchtest du von Partnerunternehmen entdeckt werden?',
+    visibilityNudgeHint: 'Aktiviere die Sichtbarkeit für Unternehmen, um in der Talentsuche der Partnerunternehmen zu erscheinen. Nur dein öffentliches Profil wird gezeigt — nie deine E-Mail oder Telefonnummer. Du entscheidest und kannst es jederzeit ändern.',
+    visibilityNudgeCta: 'In den Einstellungen wählen',
   },
   profileForm: {
     title: 'Mein Profil',


### PR DESCRIPTION
## What & why

#527 made company-facing visibility opt-in, so **existing mentees are invisible to companies until they decide**. This is the product side of the consent campaign: the portal dashboard now shows a banner to mentees who have **never decided** on the `TALENT_POOL_VISIBILITY` consent, linking to Account settings where the toggle lives.

Granting **or declining** removes the banner permanently (a consent row — granted or revoked — counts as a decision), so nobody gets nagged after choosing. The copy states plainly what companies would see (public profile only, never email/phone) and that the choice is reversible.

## Changes

- Portal dashboard: consent-existence check in the data fetch + a blue banner (mirrors the existing "complete profile" banner pattern; dark-mode aware; `data-testid="visibility-nudge"`).
- i18n EN/TR/DE (`portal.visibilityNudge*`).
- e2e (`portal-visibility-nudge.spec.ts`): undecided mentee sees the nudge with a link to `/account`; declining via the consent API hides it on reload.

## Verification

- `npm run check:i18n` ✅ (1250 keys × 3) · `tsc --noEmit` ✅ · `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_