### PR TITLE
feat(premium): weekly scheduled analytics report email, gated (Faz 2) (#541)

### DIFF
--- a/e2e/scheduled-analytics-report.spec.ts
+++ b/e2e/scheduled-analytics-report.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// Premium Faz 2 (#541): the weekly analytics report email job is a no-op while
+// the premiumAnalytics setting is off, and reports sends once enabled (SMTP is
+// unset in CI, so sendEmail no-ops — the job still counts recipients). Restores
+// the flag in finally.
+test('weekly analytics report is locked by default and sends to admins once enabled', async ({ page }) => {
+  const adminEmail = uniqueEmail('wa-admin');
+  const pw = 'WeeklyPass123';
+  await seedUser(adminEmail, pw, 'ADMIN', 'Weekly Admin');
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', pw);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    // Flag off → the job reports itself locked and sends nothing.
+    const off = await page.request.get('/api/cron');
+    expect(off.ok()).toBeTruthy();
+    const lockedReport = (await off.json()).analyticsReport;
+    expect(lockedReport.locked).toBe(true);
+    expect(lockedReport.sent).toBe(0);
+
+    // Enable the tier → the job runs and counts at least this admin.
+    await page.request.put('/api/admin/settings', { data: { premiumAnalytics: 'true' } });
+    const on = await page.request.get('/api/cron');
+    expect(on.ok()).toBeTruthy();
+    const report = (await on.json()).analyticsReport;
+    expect(report.locked).toBe(false);
+    expect(report.sent).toBeGreaterThanOrEqual(1);
+  } finally {
+    await page.request.put('/api/admin/settings', { data: { premiumAnalytics: 'false' } }).catch(() => {});
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/src/app/api/cron/route.ts
+++ b/src/app/api/cron/route.ts
@@ -8,6 +8,7 @@ import {
   checkStageDeadlineReminders,
   checkRetentionReminders,
   checkCompanyNeedMatches,
+  sendWeeklyAnalyticsReport,
 } from '@/services/emailService';
 
 export async function GET() {
@@ -18,13 +19,14 @@ export async function GET() {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const [interactions, meetings, digests, deadlines, retention, needMatches] = await Promise.all([
+    const [interactions, meetings, digests, deadlines, retention, needMatches, analyticsReport] = await Promise.all([
       checkMentorInteractionReminders(),
       sendMeetingReminders(),
       sendWeeklyMentorDigests(),
       checkStageDeadlineReminders(),
       checkRetentionReminders(),
       checkCompanyNeedMatches(),
+      sendWeeklyAnalyticsReport(),
     ]);
 
     return NextResponse.json({
@@ -35,6 +37,7 @@ export async function GET() {
       deadlines,
       retention,
       needMatches,
+      analyticsReport,
     });
   } catch (error) {
     console.error('Cron error:', error);

--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -729,6 +729,55 @@ export async function checkCompanyNeedMatches() {
   return { companies: companies.length, alerts };
 }
 
+// Weekly scheduled analytics report email (Faz 2, #541). Premium: only runs
+// when the premiumAnalytics setting is on. Sends every active admin a compact
+// pipeline summary — total relations, hired conversion, stage counts and the
+// last 7 days' activity — honoring the per-user digest email opt-out.
+export async function sendWeeklyAnalyticsReport() {
+  if ((await getSetting('premiumAnalytics')) !== 'true') return { locked: true, sent: 0 };
+
+  const weekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+  const [byStage, newRelations, interactions, admins] = await Promise.all([
+    prisma.mentorshipRelation.groupBy({ by: ['pipelineStatus'], _count: { _all: true } }),
+    prisma.mentorshipRelation.count({ where: { startDate: { gte: weekAgo } } }),
+    prisma.interactionLog.count({ where: { date: { gte: weekAgo } } }),
+    prisma.user.findMany({
+      where: { role: 'ADMIN', isActive: true },
+      select: { id: true, email: true, fullName: true, emailNotifications: true, notificationPrefs: true },
+    }),
+  ]);
+
+  const total = byStage.reduce((n, s) => n + s._count._all, 0);
+  const hired = byStage
+    .filter((s) => s.pipelineStatus === 'HIRED_660' || s.pipelineStatus === 'EMPLOYED_700')
+    .reduce((n, s) => n + s._count._all, 0);
+  const conversion = total ? Math.round((hired / total) * 100) : 0;
+  const stageRows = byStage
+    .sort((a, b) => b._count._all - a._count._all)
+    .map((s) => `<tr><td style="padding:4px 12px 4px 0;">${s.pipelineStatus}</td><td style="padding:4px 0;"><strong>${s._count._all}</strong></td></tr>`) // eslint-disable-line
+    .join('');
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+
+  let sent = 0;
+  for (const a of admins) {
+    if (!emailAllowed(a, 'digest')) continue;
+    await sendEmail({
+      to: a.email,
+      subject: 'Weekly analytics report — Internship CRM',
+      html: `<div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+        <h2 style="color:#2563eb;">Weekly analytics report</h2>
+        <p>Hi ${a.fullName},</p>
+        <p><strong>${total}</strong> mentorship relations · <strong>${conversion}%</strong> hired conversion ·
+        last 7 days: <strong>${newRelations}</strong> new relations, <strong>${interactions}</strong> interactions.</p>
+        <table style="font-size:14px;border-collapse:collapse;">${stageRows}</table>
+        <p><a href="${appUrl}/admin/analytics">Open the analytics dashboard</a></p>
+      </div>`,
+    }).catch(() => {});
+    sent++;
+  }
+  return { locked: false, sent };
+}
+
 const scheduledTasks = new Map<string, ReturnType<typeof cron.schedule>>();
 
 export function initCronJobs() {
@@ -774,6 +823,18 @@ export function initCronJobs() {
     }
   });
   scheduledTasks.set('weekly-digest', digestTask);
+
+  // Weekly premium analytics report — Mondays 8:15 (no-op while the
+  // premiumAnalytics setting is off).
+  const analyticsTask = cron.schedule('15 8 * * 1', async () => {
+    try {
+      const r = await sendWeeklyAnalyticsReport();
+      if (!r.locked) console.log(`[Cron] Weekly analytics reports sent: ${r.sent}`);
+    } catch (e) {
+      console.error('[Cron] Analytics report error:', e);
+    }
+  });
+  scheduledTasks.set('analytics-report', analyticsTask);
 
   // Daily mentee-activity digest — every day at 7:30.
   const activityTask = cron.schedule('30 7 * * *', async () => {


### PR DESCRIPTION
## What & why

Premium Faz 2 (#541, story #521). A **weekly analytics report email** (Mondays 08:15, on the existing node-cron infrastructure) to active admins: total relations, hired conversion, per-stage counts, and the last 7 days' activity (new relations + interactions), linking to the dashboard.

## Gating & behavior

- **No-op while the `premiumAnalytics` setting is off** — returns `{ locked: true, sent: 0 }`; nothing is sent.
- Honors the per-user **digest email opt-out** (`emailAllowed`), like the other digests.
- Also wired into the admin `/api/cron` endpoint (`analyticsReport` in the response) so it's manually triggerable and testable.

## Verification

- `tsc --noEmit` ✅ · `npm run build` ✅
- e2e (`scheduled-analytics-report.spec.ts`): flag off → `locked: true, sent: 0`; flag on → `sent ≥ 1`; flag restored in `finally`. (SMTP is unset in CI, so `sendEmail` no-ops safely.)

Closes #541

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_