### PR TITLE
feat(premium): full analytics report export — Excel + print/PDF, gated (Faz 2) (#540)

### DIFF
--- a/e2e/analytics-full-report.spec.ts
+++ b/e2e/analytics-full-report.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// Premium Faz 2 (#540): the full analytics report page is locked until the
+// premiumAnalytics setting is on; enabled, it renders funnel/trends/mentor/
+// cohort sections ready for the browser's print-to-PDF pipeline. Restores the
+// flag in finally.
+test('full report page is locked by default and renders once premium analytics is enabled', async ({ page }) => {
+  const adminEmail = uniqueEmail('report-admin');
+  const pw = 'ReportPass123';
+  await seedUser(adminEmail, pw, 'ADMIN', 'Report Admin');
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', pw);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    // Locked by default — and the premium export buttons are hidden on the
+    // analytics page.
+    await page.goto('/admin/analytics/report');
+    await expect(page.getByTestId('report-locked')).toBeVisible({ timeout: 10_000 });
+    await page.goto('/admin/analytics');
+    await expect(page.getByTestId('full-report-link')).toHaveCount(0);
+
+    // Enable the tier → report renders, buttons appear.
+    await page.request.put('/api/admin/settings', { data: { premiumAnalytics: 'true' } });
+
+    await page.goto('/admin/analytics/report');
+    await expect(page.getByTestId('full-report')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByRole('heading', { name: /Full analytics report/i })).toBeVisible();
+
+    await page.goto('/admin/analytics');
+    await expect(page.getByTestId('full-report-link')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId('full-report-excel')).toBeVisible();
+  } finally {
+    await page.request.put('/api/admin/settings', { data: { premiumAnalytics: 'false' } }).catch(() => {});
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -71,6 +71,9 @@ export default function AdminAnalyticsPage() {
   const [aging, setAging] = useState<Aging | null>(null);
   const [loading, setLoading] = useState(true);
   const [range, setRange] = useState<RangePreset>('6m');
+  // Premium tier state (#540): drives the full-report export buttons. Detected
+  // via the (server-gated) cohorts endpoint — 403 means the tier is off.
+  const [premium, setPremium] = useState(false);
 
   useEffect(() => {
     const qs = rangeQuery(range);
@@ -85,6 +88,10 @@ export default function AdminAnalyticsPage() {
       .catch(() => {});
   }, [range]);
 
+  useEffect(() => {
+    fetch('/api/admin/analytics/cohorts').then((r) => setPremium(r.ok)).catch(() => {});
+  }, []);
+
   const maxFunnel = data ? Math.max(1, ...PIPELINE_STATUSES.map((s) => data.funnel[s] || 0)) : 1;
 
   const exportExcel = async () => {
@@ -92,6 +99,32 @@ export default function AdminAnalyticsPage() {
     const { exportXlsx } = await import('@/lib/excel');
     const rows = PIPELINE_STATUSES.map((s) => [pipelineLabel(s, locale), data.funnel[s] || 0]);
     await exportXlsx(`analytics-${new Date().toISOString().slice(0, 10)}`, ['Stage', 'Count'], rows, 'Funnel');
+  };
+
+  // Premium full-report Excel (#540): one workbook covering funnel, trends,
+  // mentor workload plus the premium cohort/source reports.
+  const exportFullExcel = async () => {
+    if (!data) return;
+    const [cohortsRes, sourcesRes] = await Promise.all([
+      fetch('/api/admin/analytics/cohorts'),
+      fetch('/api/admin/analytics/sources'),
+    ]);
+    if (!cohortsRes.ok || !sourcesRes.ok) return; // tier switched off mid-session
+    const cohorts = (await cohortsRes.json()).cohorts as { name: string; term?: string | null; total: number; inProgress: number; hired: number; conversionToHired: number; avgDaysToHired: number | null; interactionsPerRelation: number }[];
+    const sources = (await sourcesRes.json()).sources as { name: string; mentees: number; inPipeline: number; hired: number; conversionToHired: number }[];
+    const { exportXlsxSheets } = await import('@/lib/excel');
+    const a = t.analytics;
+    await exportXlsxSheets(`analytics-full-${new Date().toISOString().slice(0, 10)}`, [
+      { name: 'Funnel', columns: ['Stage', 'Count'], rows: PIPELINE_STATUSES.map((s) => [pipelineLabel(s, locale), data.funnel[s] || 0]) },
+      ...(data.trends ? [{
+        name: 'Trends',
+        columns: [a.fullReportMonth, a.trendNewRelations, a.trendInteractions],
+        rows: data.trends.months.map((m, i) => [m, data.trends!.newRelations[i], data.trends!.interactions[i]]),
+      }] : []),
+      { name: 'Mentors', columns: ['Mentor', a.active, a.hired], rows: data.mentorWorkload.map((m) => [m.fullName, m.active, m.hired]) },
+      { name: 'Cohorts', columns: [a.cohortName, a.cohortTotal, a.cohortInProgress, a.cohortHired, a.cohortConversion, a.cohortAvgDays, a.cohortInteractions], rows: cohorts.map((r) => [r.term ? `${r.name} (${r.term})` : r.name, r.total, r.inProgress, r.hired, `${r.conversionToHired}%`, r.avgDaysToHired ?? '—', r.interactionsPerRelation]) },
+      { name: 'Sources', columns: [a.sourceName, a.cohortTotal, a.sourceInPipeline, a.cohortHired, a.cohortConversion], rows: sources.map((r) => [r.name, r.mentees, r.inPipeline, r.hired, `${r.conversionToHired}%`]) },
+    ]);
   };
 
   return (
@@ -117,6 +150,14 @@ export default function AdminAnalyticsPage() {
           />
           <Button variant="outline" size="sm" onClick={exportExcel} disabled={!data}>{t.analytics.exportExcel}</Button>
           <Button variant="outline" size="sm" onClick={() => window.print()}>{t.analytics.print}</Button>
+          {premium && (
+            <>
+              <Button variant="outline" size="sm" onClick={exportFullExcel} disabled={!data} data-testid="full-report-excel">{t.analytics.fullReportExcel}</Button>
+              <Link href="/admin/analytics/report" className="inline-flex items-center px-3 py-1.5 rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700 transition-colors" data-testid="full-report-link">
+                {t.analytics.fullReport}
+              </Link>
+            </>
+          )}
         </div>
       </div>
 

--- a/src/app/admin/analytics/report/page.tsx
+++ b/src/app/admin/analytics/report/page.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { ArrowLeft, Lock, Printer } from 'lucide-react';
+import { Button } from '@/components/ui/Button';
+import { PIPELINE_STATUSES, pipelineLabel } from '@/lib/pipeline';
+import { useT, useLocale } from '@/i18n/client';
+
+interface Analytics {
+  funnel: Record<string, number>;
+  totalRelations: number;
+  conversionToHired: number;
+  mentorWorkload: { id: string; fullName: string; active: number; hired: number }[];
+  trends?: { months: string[]; newRelations: number[]; interactions: number[] };
+  range?: { from: string; to: string };
+}
+interface CohortRow { id: string; name: string; term?: string | null; total: number; inProgress: number; hired: number; conversionToHired: number; avgDaysToHired: number | null; interactionsPerRelation: number }
+interface SourceRow { id: string; name: string; mentees: number; inPipeline: number; hired: number; conversionToHired: number }
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="mb-8 break-inside-avoid">
+      <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-3">{title}</h2>
+      {children}
+    </section>
+  );
+}
+
+const th = 'text-left text-xs text-gray-500 py-1.5 pr-4 border-b border-gray-200';
+const td = 'py-1.5 pr-4 text-sm border-b border-gray-100';
+
+// Premium full analytics report (Faz 2, #540) — a print-friendly page covering
+// funnel, trends, mentor workload, cohort comparison and source conversion.
+// PDF is produced via the browser's print pipeline (#357 pattern — no
+// server-side binary). Locked until the premiumAnalytics setting is enabled.
+export default function AnalyticsReportPage() {
+  const t = useT();
+  const locale = useLocale();
+  const c = t.analytics;
+  const [data, setData] = useState<Analytics | null>(null);
+  const [cohorts, setCohorts] = useState<CohortRow[] | null>(null);
+  const [sources, setSources] = useState<SourceRow[] | null>(null);
+  const [locked, setLocked] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    Promise.all([
+      fetch('/api/admin/analytics').then((r) => (r.ok ? r.json() : null)),
+      fetch('/api/admin/analytics/cohorts').then(async (r) => (r.status === 403 ? 'locked' : r.ok ? (await r.json()).cohorts : null)),
+      fetch('/api/admin/analytics/sources').then(async (r) => (r.status === 403 ? 'locked' : r.ok ? (await r.json()).sources : null)),
+    ])
+      .then(([a, co, so]) => {
+        if (co === 'locked' || so === 'locked') { setLocked(true); return; }
+        setData(a);
+        setCohorts(co ?? []);
+        setSources(so ?? []);
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) return <p className="text-center py-12 text-gray-400">{t.common.loading}</p>;
+
+  if (locked) {
+    return (
+      <div className="max-w-xl" data-testid="report-locked">
+        <Link href="/admin/analytics" className="inline-flex items-center gap-1.5 text-sm text-blue-600 hover:underline mb-4">
+          <ArrowLeft className="h-4 w-4" /> {c.title}
+        </Link>
+        <div className="rounded-xl border border-gray-200 dark:border-gray-800 p-6 flex items-start gap-3">
+          <Lock className="h-5 w-5 text-gray-400 mt-0.5" />
+          <div>
+            <p className="font-medium text-gray-900 dark:text-gray-100">{c.fullReportTitle}</p>
+            <p className="text-sm text-gray-500 mt-1">{c.cohortCompareLocked}</p>
+            <Link href="/admin/settings" className="text-sm text-blue-600 hover:underline mt-1 inline-block">{c.cohortCompareUnlockCta}</Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) return <p className="text-center py-12 text-gray-400">{t.common.notFound}</p>;
+
+  return (
+    <div className="max-w-4xl" data-testid="full-report">
+      <div className="flex items-center justify-between mb-6 no-print">
+        <Link href="/admin/analytics" className="inline-flex items-center gap-1.5 text-sm text-blue-600 hover:underline">
+          <ArrowLeft className="h-4 w-4" /> {c.title}
+        </Link>
+        <Button size="sm" onClick={() => window.print()}>
+          <Printer className="h-4 w-4 mr-1" /> {c.print}
+        </Button>
+      </div>
+
+      <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-1">{c.fullReportTitle}</h1>
+      <p className="text-sm text-gray-500 mb-8">
+        {data.range ? `${data.range.from} → ${data.range.to} · ` : ''}{new Date().toLocaleDateString(locale)}
+      </p>
+
+      <Section title={c.funnel}>
+        <table className="w-full"><thead><tr>
+          <th className={th}>{c.funnel}</th><th className={th}>#</th>
+        </tr></thead><tbody>
+          {PIPELINE_STATUSES.map((s) => (
+            <tr key={s}><td className={td}>{pipelineLabel(s, locale)}</td><td className={td}>{data.funnel[s] || 0}</td></tr>
+          ))}
+        </tbody></table>
+      </Section>
+
+      {data.trends && (
+        <Section title={c.trends}>
+          <table className="w-full"><thead><tr>
+            <th className={th}>{c.fullReportMonth}</th><th className={th}>{c.trendNewRelations}</th><th className={th}>{c.trendInteractions}</th>
+          </tr></thead><tbody>
+            {data.trends.months.map((m, i) => (
+              <tr key={m}><td className={td}>{m}</td><td className={td}>{data.trends!.newRelations[i]}</td><td className={td}>{data.trends!.interactions[i]}</td></tr>
+            ))}
+          </tbody></table>
+        </Section>
+      )}
+
+      <Section title={c.mentorWorkload}>
+        <table className="w-full"><thead><tr>
+          <th className={th}>Mentor</th><th className={th}>{c.active}</th><th className={th}>{c.hired}</th>
+        </tr></thead><tbody>
+          {data.mentorWorkload.map((m) => (
+            <tr key={m.id}><td className={td}>{m.fullName}</td><td className={td}>{m.active}</td><td className={td}>{m.hired}</td></tr>
+          ))}
+        </tbody></table>
+      </Section>
+
+      <Section title={c.cohortCompareTitle}>
+        {cohorts && cohorts.length > 0 ? (
+          <table className="w-full"><thead><tr>
+            <th className={th}>{c.cohortName}</th><th className={th}>{c.cohortTotal}</th><th className={th}>{c.cohortInProgress}</th>
+            <th className={th}>{c.cohortHired}</th><th className={th}>{c.cohortConversion}</th><th className={th}>{c.cohortAvgDays}</th>
+          </tr></thead><tbody>
+            {cohorts.map((r) => (
+              <tr key={r.id}>
+                <td className={td}>{r.name}{r.term ? ` (${r.term})` : ''}</td><td className={td}>{r.total}</td><td className={td}>{r.inProgress}</td>
+                <td className={td}>{r.hired}</td><td className={td}>{r.conversionToHired}%</td><td className={td}>{r.avgDaysToHired ?? '—'}</td>
+              </tr>
+            ))}
+          </tbody></table>
+        ) : <p className="text-sm text-gray-400">{c.cohortCompareEmpty}</p>}
+      </Section>
+
+      <Section title={c.sourceConversionTitle}>
+        {sources && sources.length > 0 ? (
+          <table className="w-full"><thead><tr>
+            <th className={th}>{c.sourceName}</th><th className={th}>{c.cohortTotal}</th><th className={th}>{c.sourceInPipeline}</th>
+            <th className={th}>{c.cohortHired}</th><th className={th}>{c.cohortConversion}</th>
+          </tr></thead><tbody>
+            {sources.map((r) => (
+              <tr key={r.id}>
+                <td className={td}>{r.name}</td><td className={td}>{r.mentees}</td><td className={td}>{r.inPipeline}</td>
+                <td className={td}>{r.hired}</td><td className={td}>{r.conversionToHired}%</td>
+              </tr>
+            ))}
+          </tbody></table>
+        ) : <p className="text-sm text-gray-400">{c.sourceConversionEmpty}</p>}
+      </Section>
+    </div>
+  );
+}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -1031,6 +1031,10 @@ const en = {
     sourceName: 'Source',
     sourceInPipeline: 'In pipeline',
     sourceUnsourced: '{n} mentee(s) have no source and are not shown above.',
+    fullReportTitle: 'Full analytics report',
+    fullReport: 'Full report',
+    fullReportExcel: 'Full report (Excel)',
+    fullReportMonth: 'Month',
   },
   apply: {
     title: 'Apply for mentorship',
@@ -2302,6 +2306,10 @@ const tr: Dict = {
     sourceName: 'Kaynak',
     sourceInPipeline: 'Süreçte',
     sourceUnsourced: '{n} mentee’nin kaynağı yok ve yukarıda gösterilmiyor.',
+    fullReportTitle: 'Tam analitik raporu',
+    fullReport: 'Tam rapor',
+    fullReportExcel: 'Tam rapor (Excel)',
+    fullReportMonth: 'Ay',
   },
   apply: {
     title: 'Mentorluk başvurusu',
@@ -3571,6 +3579,10 @@ const de: Dict = {
     sourceName: 'Quelle',
     sourceInPipeline: 'In der Pipeline',
     sourceUnsourced: '{n} Mentee(s) ohne Quelle werden oben nicht angezeigt.',
+    fullReportTitle: 'Vollständiger Analytik-Bericht',
+    fullReport: 'Vollständiger Bericht',
+    fullReportExcel: 'Vollständiger Bericht (Excel)',
+    fullReportMonth: 'Monat',
   },
   apply: {
     title: 'Für ein Mentoring bewerben',

--- a/src/lib/excel.ts
+++ b/src/lib/excel.ts
@@ -6,10 +6,20 @@ export async function exportXlsx(
   rows: (string | number | null | undefined)[][],
   sheetName = 'Sheet1'
 ) {
+  await exportXlsxSheets(filename, [{ name: sheetName, columns, rows }]);
+}
+
+// Multi-sheet variant (premium full report, #540): one workbook, one sheet per
+// section. Sheet names are capped at Excel's 31-char limit.
+export async function exportXlsxSheets(
+  filename: string,
+  sheets: { name: string; columns: string[]; rows: (string | number | null | undefined)[][] }[]
+) {
   const XLSX = await import('xlsx');
-  const data = [columns, ...rows.map((r) => r.map((c) => (c == null ? '' : c)))];
-  const ws = XLSX.utils.aoa_to_sheet(data);
   const wb = XLSX.utils.book_new();
-  XLSX.utils.book_append_sheet(wb, ws, sheetName);
+  for (const s of sheets) {
+    const data = [s.columns, ...s.rows.map((r) => r.map((c) => (c == null ? '' : c)))];
+    XLSX.utils.book_append_sheet(wb, XLSX.utils.aoa_to_sheet(data), s.name.slice(0, 31));
+  }
   XLSX.writeFile(wb, filename.endsWith('.xlsx') ? filename : `${filename}.xlsx`);
 }


### PR DESCRIPTION
## What & why

Premium Faz 2 (#540, story #521). Free exports stay free (funnel Excel + page print). The premium tier adds a **full report** in two formats:

- **Full report (Excel)** — one multi-sheet workbook: Funnel, Trends, Mentor workload, **Cohorts**, **Sources** — via a new `exportXlsxSheets` helper (SheetJS, dynamically imported as before; `exportXlsx` now delegates to it).
- **Full report (PDF)** — a print-friendly page at `/admin/analytics/report` covering the same sections; PDF is produced via the browser's print pipeline (the #357 document pattern — Docker-safe, no server-side binary). Shows a locked teaser (with a settings link) while the tier is off.

## Gating

- The export buttons are **hidden** until the `premiumAnalytics` setting is on; premium state is detected via the **server-gated** cohorts endpoint, so the gate is enforced server-side (the buttons are just UX — the underlying premium data can't be fetched without the flag).
- Basic analytics + existing free exports are untouched.

## Acceptance criteria

- ✅ Funnel/trend/cohort (and source) reports downloadable as Excel and printable to PDF.
- ✅ Export locked/hidden while the flag is off.
- ✅ `npm run build` passes.

## Verification

- `check:i18n` ✅ (1272 × 3) · `tsc --noEmit` ✅ (re-verified after rebase onto main post-#597) · `npm run build` ✅
- e2e (`analytics-full-report.spec.ts`): report page locked + buttons hidden by default; enabling the setting renders the report and reveals the buttons; flag restored in `finally`.

Closes #540

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_