### PR TITLE
feat(premium): central AI gate — consent + monthly quota metering (Faz 2) (#537)

### DIFF
--- a/e2e/ai-gate.spec.ts
+++ b/e2e/ai-gate.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from '@playwright/test';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// Faz 2 (#537): every AI call goes through the central gate — consent → quota
+// → provider. CI has no ANTHROPIC_API_KEY, so the provider step always denies
+// with 501, which lets us assert each earlier gate precisely, including both
+// quota scenarios (quota=0 and quota consumed by prior usage). Restores the
+// quota setting and cleans its AiUsage rows in finally.
+test('AI gate enforces consent then quota then provider configuration, without consuming credit on failure', async ({ page }) => {
+  const menteeEmail = uniqueEmail('aigate-mentee');
+  const adminEmail = uniqueEmail('aigate-admin');
+  const pw = 'AiGatePass123';
+  const mentee = await seedUser(menteeEmail, pw, 'MENTEE', 'AiGate Mentee');
+  await seedUser(adminEmail, pw, 'ADMIN', 'AiGate Admin');
+
+  const pdf = readFileSync(path.join(__dirname, 'fixtures', 'sample-cv.pdf'));
+  await prisma.cvFile.create({
+    data: { userId: mentee.id, filename: 'cv.pdf', contentType: 'application/pdf', size: pdf.length, data: pdf },
+  });
+
+  const usageBefore = await prisma.aiUsage.count();
+
+  try {
+    // Admin session to flip the quota setting.
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', pw);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+    const adminReq = page.request;
+
+    // Mentee session in a second context.
+    const menteeCtx = await page.context().browser()!.newContext();
+    const menteePage = await menteeCtx.newPage();
+    await menteePage.goto('/auth/signin');
+    await menteePage.fill('input[type="email"], input[name="email"]', menteeEmail);
+    await menteePage.fill('input[type="password"]', pw);
+    await menteePage.click('button[type="submit"]');
+    await menteePage.waitForURL((u) => u.pathname.startsWith('/portal'), { timeout: 20_000 });
+
+    // 1. No consent → denied at the consent gate.
+    let res = await menteePage.request.post(`/api/cv/${mentee.id}/extract-ai`);
+    expect(res.status()).toBe(403);
+    expect((await res.json()).code).toBe('consent_required');
+
+    await menteePage.request.post('/api/consent', { data: { type: 'AI_CV_PARSING', granted: true } });
+
+    // 2. Quota = 0 → AI is off org-wide; denied safely even with consent.
+    await adminReq.put('/api/admin/settings', { data: { aiMonthlyQuota: '0' } });
+    res = await menteePage.request.post(`/api/cv/${mentee.id}/extract-ai`);
+    expect(res.status()).toBe(429);
+    expect((await res.json()).code).toBe('quota_exceeded');
+
+    // 3. Quota = 1 but already consumed this month → still denied.
+    await adminReq.put('/api/admin/settings', { data: { aiMonthlyQuota: '1' } });
+    const marker = await prisma.aiUsage.create({ data: { scope: 'e2e_marker' } });
+    res = await menteePage.request.post(`/api/cv/${mentee.id}/extract-ai`);
+    expect(res.status()).toBe(429);
+    await prisma.aiUsage.delete({ where: { id: marker.id } });
+
+    // 4. Quota available → passes to the provider step (no key in CI → 501).
+    await adminReq.put('/api/admin/settings', { data: { aiMonthlyQuota: '200' } });
+    res = await menteePage.request.post(`/api/cv/${mentee.id}/extract-ai`);
+    expect(res.status()).toBe(501);
+    expect((await res.json()).code).toBe('not_configured');
+
+    // No failed attempt consumed any credit.
+    expect(await prisma.aiUsage.count()).toBe(usageBefore);
+
+    await menteeCtx.close();
+  } finally {
+    await page.request.put('/api/admin/settings', { data: { aiMonthlyQuota: '200' } }).catch(() => {});
+    await prisma.aiUsage.deleteMany({ where: { scope: 'e2e_marker' } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -395,6 +395,21 @@ model CompanyNeedAlert {
   @@index([companyId])
 }
 
+// One row per successful AI provider call (Faz 2, #537) — the metering behind
+// the monthly AI quota (Setting.aiMonthlyQuota). scope identifies the feature
+// (e.g. "cv_extract"); userId/companyId record who consumed it (companyId
+// prepares per-company quotas for multi-tenancy).
+model AiUsage {
+  id        String   @id @default(cuid())
+  scope     String
+  userId    String?
+  companyId String?
+  createdAt DateTime @default(now())
+
+  @@index([createdAt])
+  @@index([scope])
+}
+
 // A company's read/interest signal on a candidate they're linked to via a
 // MentorshipRelation (EPIC: company shortlist). One record per company+mentee
 // pair; re-setting the status updates it in place.

--- a/src/app/api/admin/settings/route.ts
+++ b/src/app/api/admin/settings/route.ts
@@ -21,6 +21,7 @@ const schema = z.object({
   require2fa: z.enum(['off', 'admins', 'admins_mentors']).optional(),
   earlyAccessWindowDays: z.string().regex(/^\d{1,3}$/).optional(),
   premiumAnalytics: z.enum(['true', 'false']).optional(),
+  aiMonthlyQuota: z.string().regex(/^\d{1,6}$/).optional(),
 });
 
 // PUT — upsert one or more settings.

--- a/src/app/api/cv/[userId]/extract-ai/route.ts
+++ b/src/app/api/cv/[userId]/extract-ai/route.ts
@@ -3,13 +3,14 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { canAccessCv } from '@/lib/cvAccess';
-import { hasConsent } from '@/lib/consent';
 import { extractCvText } from '@/lib/cvParse';
-import { aiExtractFromText, isAiConfigured } from '@/lib/cvExtractAi';
+import { aiExtractFromText } from '@/lib/cvExtractAi';
+import { runAiGated } from '@/lib/aiGate';
 
 // POST — AI-assisted extraction of profile fields from the stored CV (EPIC B3).
-// Requires: CV access + active AI_CV_PARSING consent + a configured API key.
-// Only the extracted TEXT is sent to the AI provider, never the file.
+// Runs through the central AI gate (#537): CV-owner consent → configured
+// provider → monthly quota → call (metered). Only the extracted TEXT is sent
+// to the AI provider, never the file.
 export async function POST(_request: Request, { params }: { params: Promise<{ userId: string }> }) {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -18,14 +19,6 @@ export async function POST(_request: Request, { params }: { params: Promise<{ us
   const target = userId === 'me' ? session.user.id : userId;
   if (!(await canAccessCv(session.user, target))) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-  }
-
-  // The consent belongs to the CV owner (the person whose data is processed).
-  if (!(await hasConsent(target, 'AI_CV_PARSING'))) {
-    return NextResponse.json({ error: 'Consent required', code: 'consent_required' }, { status: 403 });
-  }
-  if (!isAiConfigured()) {
-    return NextResponse.json({ error: 'AI extraction is not configured', code: 'not_configured' }, { status: 501 });
   }
 
   const cv = await prisma.cvFile.findUnique({ where: { userId: target } });
@@ -40,8 +33,23 @@ export async function POST(_request: Request, { params }: { params: Promise<{ us
   if (!text.trim()) return NextResponse.json({ suggestions: null, empty: true });
 
   try {
-    const suggestions = await aiExtractFromText(text);
-    return NextResponse.json({ suggestions });
+    const gated = await runAiGated({
+      scope: 'cv_extract',
+      // The consent belongs to the CV owner (the person whose data is processed).
+      consent: { userId: target, type: 'AI_CV_PARSING' },
+      userId: session.user.id,
+      call: () => aiExtractFromText(text),
+    });
+    if (!gated.ok) {
+      if (gated.reason === 'no_consent') {
+        return NextResponse.json({ error: 'Consent required', code: 'consent_required' }, { status: 403 });
+      }
+      if (gated.reason === 'quota_exceeded') {
+        return NextResponse.json({ error: 'Monthly AI quota exhausted', code: 'quota_exceeded' }, { status: 429 });
+      }
+      return NextResponse.json({ error: 'AI extraction is not configured', code: 'not_configured' }, { status: 501 });
+    }
+    return NextResponse.json({ suggestions: gated.result });
   } catch (e) {
     console.error('AI CV extract error:', e);
     return NextResponse.json({ error: 'AI extraction failed' }, { status: 502 });

--- a/src/lib/aiGate.ts
+++ b/src/lib/aiGate.ts
@@ -1,0 +1,58 @@
+import { prisma } from '@/lib/prisma';
+import { getSetting } from '@/lib/settings';
+import { hasConsent } from '@/lib/consent';
+import { isAiConfigured } from '@/lib/cvExtractAi';
+import type { ConsentType } from '@prisma/client';
+
+// Central AI gate (Faz 2, #537) — the single wrapper every AI feature goes
+// through: consent check → provider configured → monthly quota → call →
+// metering. Other AI tasks (#533-#536) build on this; none of them may call
+// the provider directly.
+//
+// Quota: Setting.aiMonthlyQuota calls per calendar month across the org ('0'
+// disables AI). Usage is recorded in AiUsage only AFTER a successful call, so
+// provider failures never consume credit. Quota exhaustion degrades safely:
+// callers get a typed denial and surface a clear message to the operator —
+// mentees are never shown a paywall (core flows never depend on AI).
+
+export type AiDenialReason = 'no_consent' | 'not_configured' | 'quota_exceeded';
+
+export type AiGateResult<T> =
+  | { ok: true; result: T }
+  | { ok: false; reason: AiDenialReason };
+
+export async function getAiQuota(): Promise<{ quota: number; used: number; remaining: number }> {
+  const quota = parseInt(await getSetting('aiMonthlyQuota'), 10) || 0;
+  const now = new Date();
+  const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+  const used = await prisma.aiUsage.count({ where: { createdAt: { gte: monthStart } } });
+  return { quota, used, remaining: Math.max(0, quota - used) };
+}
+
+export async function runAiGated<T>(opts: {
+  // Feature identifier recorded per call, e.g. 'cv_extract'.
+  scope: string;
+  // Whose consent gates the call (the person whose data is processed) — omit
+  // only for features that process no personal data.
+  consent?: { userId: string; type: ConsentType };
+  // Recorded for metering/attribution (companyId prepares per-company quotas).
+  userId?: string | null;
+  companyId?: string | null;
+  call: () => Promise<T>;
+}): Promise<AiGateResult<T>> {
+  if (opts.consent && !(await hasConsent(opts.consent.userId, opts.consent.type))) {
+    return { ok: false, reason: 'no_consent' };
+  }
+  // Quota before configuration (the issue's order: consent → flag → quota →
+  // provider): quota 0 means "AI off" regardless of key, and quota behaviour
+  // stays testable in environments without a provider key.
+  const { quota, used } = await getAiQuota();
+  if (quota <= 0 || used >= quota) return { ok: false, reason: 'quota_exceeded' };
+  if (!isAiConfigured()) return { ok: false, reason: 'not_configured' };
+
+  const result = await opts.call();
+  await prisma.aiUsage
+    .create({ data: { scope: opts.scope, userId: opts.userId ?? null, companyId: opts.companyId ?? null } })
+    .catch(() => {}); // metering must never break a successful call
+  return { ok: true, result };
+}

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -23,6 +23,10 @@ export const SETTING_DEFAULTS = {
   // default — basic analytics stay free. Single-tenant placeholder for real
   // billing; becomes a per-tenant entitlement with Faz 3 multi-tenancy.
   premiumAnalytics: 'false',
+  // Monthly cap on AI provider calls across the org (Faz 2, #537). Every AI
+  // feature consumes from this pool via runAiGated; '0' disables AI calls
+  // entirely. Metered in AiUsage; resets each calendar month.
+  aiMonthlyQuota: '200',
 } as const;
 
 export type SettingKey = keyof typeof SETTING_DEFAULTS;


### PR DESCRIPTION
## What & why

Premium Faz 2 (#537, story #520) — the **shared infrastructure of the AI package**: one wrapper every AI feature must go through, in the order **consent → quota → provider → call → metering**. The other AI tasks (#533–#536) are built on this; none may call the provider directly.

## Design

- **`AiUsage` model** — one row per **successful** provider call (`scope` + user/company attribution; `companyId` prepares per-company quotas for Faz 3 multi-tenancy). Provider failures never consume credit; a metering failure never breaks a successful call.
- **`aiMonthlyQuota` setting** — org-wide calls/month (default `200`; `0` disables AI entirely), editable via the admin settings API. Chose Setting over a new model for the quota value itself (single-tenant today, one knob; per-tenant quotas later hang off the recorded `companyId`s).
- **`runAiGated({scope, consent, call})`** (`src/lib/aiGate.ts`) returns typed denials — `no_consent | quota_exceeded | not_configured` — so callers degrade safely. Core flows never depend on AI, and mentees are never shown a paywall.
- **First consumer wired**: the existing AI CV extraction now runs through the gate (same visible behaviour: 403 `consent_required` / 501 `not_configured`, plus the new 429 `quota_exceeded`).

## Acceptance criteria

- ✅ AI call runs only with consent + quota (+ configured provider).
- ✅ Quota exhaustion denies safely; core flows unaffected.
- ✅ Quota tests (`e2e/ai-gate.spec.ts`, runs in the CI e2e gate): consent gate → quota=0 → quota-consumed → provider step, and failed attempts consume **no** credit. The existing `cv-extract-ai` spec passes unchanged.
- ✅ `npm run build` passes.

> Additive `AiUsage` table syncs via `prisma db push` on deploy — no data loss.

Closes #537

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_