### PR TITLE
feat(premium): AI CV improvement feedback for mentees, gated (Faz 2) (#535)

### DIFF
--- a/e2e/cv-feedback.spec.ts
+++ b/e2e/cv-feedback.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '@playwright/test';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// Faz 2 (#535): AI CV feedback for the mentee — free for them, gated by their
+// own AI_CV_PARSING consent and the shared AI gate. CI has no provider key, so
+// the availability endpoint reports configured:false (UI hides the feature)
+// and consent-granted POSTs stop at 501.
+test('CV feedback availability and gates behave without a provider key', async ({ page }) => {
+  const email = uniqueEmail('cvfb-mentee');
+  const pw = 'CvFbPass123';
+  const user = await seedUser(email, pw, 'MENTEE', 'CV Feedback Mentee');
+  const pdf = readFileSync(path.join(__dirname, 'fixtures', 'sample-cv.pdf'));
+  await prisma.cvFile.create({
+    data: { userId: user.id, filename: 'cv.pdf', contentType: 'application/pdf', size: pdf.length, data: pdf },
+  });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', email);
+    await page.fill('input[type="password"]', pw);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/portal'), { timeout: 20_000 });
+
+    // Availability: CV present, no key in CI → configured:false (UI hidden).
+    const avail = await (await page.request.get('/api/cv/feedback')).json();
+    expect(avail.hasCv).toBe(true);
+    expect(avail.configured).toBe(false);
+    expect(avail.consent).toBe(false);
+
+    // No consent → consent gate first.
+    let res = await page.request.post('/api/cv/feedback');
+    expect(res.status()).toBe(403);
+    expect((await res.json()).code).toBe('consent_required');
+
+    // With consent → passes to the provider step (no key → 501), and the
+    // failure consumes no AI credit.
+    await page.request.post('/api/consent', { data: { type: 'AI_CV_PARSING', granted: true } });
+    const usageBefore = await prisma.aiUsage.count();
+    res = await page.request.post('/api/cv/feedback');
+    expect(res.status()).toBe(501);
+    expect((await res.json()).code).toBe('not_configured');
+    expect(await prisma.aiUsage.count()).toBe(usageBefore);
+  } finally {
+    await cleanupByEmail(email);
+  }
+});

--- a/src/app/api/cv/feedback/route.ts
+++ b/src/app/api/cv/feedback/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { hasConsent } from '@/lib/consent';
+import { extractCvText } from '@/lib/cvParse';
+import { isAiConfigured } from '@/lib/cvExtractAi';
+import { aiCvFeedback } from '@/lib/aiCvFeedback';
+import { runAiGated } from '@/lib/aiGate';
+
+// AI CV improvement feedback (Faz 2, #535) — the mentee's own CV only, and
+// FREE for the mentee: the cost is metered against the org's AI quota via the
+// central gate, and the mentee is never shown a paywall (quota exhaustion
+// surfaces as "temporarily unavailable").
+
+// GET — availability for the portal UI: the feature stays hidden unless the
+// provider is configured AND a CV is uploaded; consent state drives the hint.
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const [cv, consent] = await Promise.all([
+    prisma.cvFile.findUnique({ where: { userId: session.user.id }, select: { id: true } }),
+    hasConsent(session.user.id, 'AI_CV_PARSING'),
+  ]);
+  return NextResponse.json({ configured: isAiConfigured(), hasCv: !!cv, consent });
+}
+
+// POST — generate feedback for the caller's own uploaded CV.
+export async function POST() {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const cv = await prisma.cvFile.findUnique({ where: { userId: session.user.id } });
+  if (!cv) return NextResponse.json({ error: 'No CV uploaded' }, { status: 404 });
+
+  let text = '';
+  try {
+    text = await extractCvText(Buffer.from(cv.data), cv.contentType);
+  } catch {
+    return NextResponse.json({ error: 'Could not read the CV file' }, { status: 422 });
+  }
+  if (!text.trim()) return NextResponse.json({ feedback: null, empty: true });
+
+  const gated = await runAiGated({
+    scope: 'cv_feedback',
+    consent: { userId: session.user.id, type: 'AI_CV_PARSING' },
+    userId: session.user.id,
+    call: () => aiCvFeedback(text),
+  });
+
+  if (!gated.ok) {
+    if (gated.reason === 'no_consent') {
+      return NextResponse.json({ error: 'Consent required', code: 'consent_required' }, { status: 403 });
+    }
+    if (gated.reason === 'quota_exceeded') {
+      // Never a paywall for the mentee — just "not right now".
+      return NextResponse.json({ error: 'Temporarily unavailable', code: 'quota_exceeded' }, { status: 429 });
+    }
+    return NextResponse.json({ error: 'AI is not configured', code: 'not_configured' }, { status: 501 });
+  }
+  return NextResponse.json({ feedback: gated.result });
+}

--- a/src/app/portal/profile/page.tsx
+++ b/src/app/portal/profile/page.tsx
@@ -10,6 +10,7 @@ import { Input } from '@/components/ui/Input';
 import { Button } from '@/components/ui/Button';
 import { Select } from '@/components/ui/Select';
 import { CvManager } from '@/components/CvManager';
+import { CvFeedback } from '@/components/CvFeedback';
 import { CvSuggestPanel } from '@/components/CvSuggestPanel';
 import { SkillRating } from '@/components/SkillRating';
 import { AvatarManager } from '@/components/AvatarManager';
@@ -399,6 +400,7 @@ export default function ProfilePage() {
                       onApplySkills={applySuggestedSkills}
                     />
                   )}
+                  {cvUploaded && <CvFeedback />}
                 </div>
               )}
 

--- a/src/components/CvFeedback.tsx
+++ b/src/components/CvFeedback.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { Sparkles } from 'lucide-react';
+import { Button } from '@/components/ui/Button';
+import { useT } from '@/i18n/client';
+
+// AI CV feedback for the mentee (Faz 2, #535). Free for the mentee — quota
+// exhaustion shows a neutral "temporarily unavailable", never a paywall.
+// Entirely hidden unless the provider is configured AND a CV is uploaded;
+// without consent it renders a hint linking to the consent settings.
+export function CvFeedback() {
+  const t = useT();
+  const c = t.cvFeedback;
+  const [state, setState] = useState<{ configured: boolean; hasCv: boolean; consent: boolean } | null>(null);
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    fetch('/api/cv/feedback').then((r) => (r.ok ? r.json() : null)).then(setState).catch(() => {});
+  }, []);
+
+  if (!state || !state.configured || !state.hasCv) return null;
+
+  const run = async () => {
+    setLoading(true);
+    setNotice(null);
+    try {
+      const res = await fetch('/api/cv/feedback', { method: 'POST' });
+      const body = await res.json();
+      if (res.ok) {
+        if (body.empty) setNotice(c.empty);
+        else setFeedback(body.feedback);
+      } else if (body.code === 'consent_required') {
+        setNotice(c.consentRequired);
+      } else {
+        // quota_exceeded / not_configured / anything else: neutral message —
+        // the mentee never sees pricing or quota mechanics.
+        setNotice(c.unavailable);
+      }
+    } catch {
+      setNotice(c.unavailable);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="mt-4 rounded-xl border border-gray-100 dark:border-gray-800 p-4" data-testid="cv-feedback">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <p className="text-sm font-medium text-gray-900 dark:text-gray-100">{c.title}</p>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{c.hint}</p>
+        </div>
+        {state.consent ? (
+          <Button type="button" variant="outline" size="sm" loading={loading} onClick={run}>
+            <Sparkles className="h-4 w-4 mr-1" /> {c.button}
+          </Button>
+        ) : (
+          <Link href="/account" className="text-sm text-blue-600 dark:text-blue-400 hover:underline">
+            {c.consentCta}
+          </Link>
+        )}
+      </div>
+      {notice && <p className="text-xs text-amber-600 dark:text-amber-400 mt-2">{notice}</p>}
+      {feedback && (
+        <div className="mt-3 rounded-lg bg-blue-50 dark:bg-blue-900/10 border border-blue-100 dark:border-blue-900 p-3 text-sm text-gray-800 dark:text-gray-200 whitespace-pre-line">
+          {feedback}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -894,6 +894,16 @@ const en = {
     consentRequired: 'The mentee has not allowed AI summaries. They can enable it under Account → Privacy & consent.',
     quotaExceeded: 'The monthly AI quota is exhausted. An admin can raise it in Settings.',
   },
+  cvFeedback: {
+    title: 'AI CV feedback',
+    hint: 'Get constructive suggestions to improve your CV — strengths, improvements and missing sections.',
+    button: 'Get feedback',
+    consentCta: 'Allow AI CV processing in settings →',
+    empty: 'Your CV appears to be empty or unreadable.',
+    consentRequired: 'AI CV processing is not enabled. You can allow it under Account → Privacy & consent.',
+    unavailable: 'CV feedback is temporarily unavailable. Please try again later.',
+
+  },
   templatesLib: { preview: 'Preview', close: 'Close', pdf: 'Save as PDF', txt: '.txt', md: '.md' },
   documents: {
     title: 'Documents',
@@ -2176,6 +2186,16 @@ const tr: Dict = {
     consentRequired: 'Mentee AI özetlerine izin vermemiş. Hesap → Gizlilik ve onay bölümünden açabilir.',
     quotaExceeded: 'Aylık AI kotası doldu. Admin, Ayarlar’dan artırabilir.',
   },
+  cvFeedback: {
+    title: 'AI CV geri bildirimi',
+    hint: 'CV’ni geliştirmek için yapıcı öneriler al — güçlü yanlar, iyileştirmeler ve eksik bölümler.',
+    button: 'Geri bildirim al',
+    consentCta: 'Ayarlardan AI CV işlemeye izin ver →',
+    empty: 'CV’n boş veya okunamıyor görünüyor.',
+    consentRequired: 'AI CV işleme açık değil. Hesap → Gizlilik ve onay bölümünden izin verebilirsin.',
+    unavailable: 'CV geri bildirimi şu an kullanılamıyor. Lütfen daha sonra tekrar dene.',
+
+  },
   templatesLib: { preview: 'Önizle', close: 'Kapat', pdf: 'PDF kaydet', txt: '.txt', md: '.md' },
   documents: {
     title: 'Dokümanlar',
@@ -3455,6 +3475,16 @@ const de: Dict = {
     empty: 'Noch keine Interaktionen zum Zusammenfassen.',
     consentRequired: 'Der Mentee hat KI-Zusammenfassungen nicht erlaubt. Aktivierbar unter Konto → Datenschutz & Einwilligung.',
     quotaExceeded: 'Das monatliche KI-Kontingent ist aufgebraucht. Ein Admin kann es in den Einstellungen erhöhen.',
+  },
+  cvFeedback: {
+    title: 'KI-Feedback zum Lebenslauf',
+    hint: 'Erhalte konstruktive Vorschläge zur Verbesserung deines Lebenslaufs — Stärken, Verbesserungen und fehlende Abschnitte.',
+    button: 'Feedback erhalten',
+    consentCta: 'KI-Verarbeitung des Lebenslaufs in den Einstellungen erlauben →',
+    empty: 'Dein Lebenslauf scheint leer oder unlesbar zu sein.',
+    consentRequired: 'Die KI-Verarbeitung des Lebenslaufs ist nicht aktiviert. Erlaube sie unter Konto → Datenschutz & Einwilligung.',
+    unavailable: 'Das Lebenslauf-Feedback ist vorübergehend nicht verfügbar. Bitte versuche es später erneut.',
+
   },
   templatesLib: { preview: 'Vorschau', close: 'Schließen', pdf: 'Als PDF speichern', txt: '.txt', md: '.md' },
   documents: {

--- a/src/lib/aiCvFeedback.ts
+++ b/src/lib/aiCvFeedback.ts
@@ -1,0 +1,23 @@
+// AI CV improvement feedback for mentees (Faz 2, #535). Sends only the
+// already-extracted CV TEXT (same rule as cvExtractAi) and returns
+// constructive, structured suggestions. Callers MUST go through runAiGated
+// (consent + quota); this module only talks to the provider.
+
+import Anthropic from '@anthropic-ai/sdk';
+
+const MODEL = process.env.ANTHROPIC_CV_MODEL || 'claude-opus-4-8';
+const MAX_INPUT_CHARS = 24_000;
+
+const SYSTEM = `You review a student/junior CV and give constructive improvement feedback, written directly to the CV owner in the same language the CV is written in. Return three short sections with these exact markdown headers: "**Strengths**", "**Improvements**", "**Missing**". Under each, 2-5 concise bullet points grounded in the actual CV content (never invent experience). Improvements should be specific and actionable (wording, structure, quantification); Missing lists sections or details worth adding. Keep the whole answer under 250 words.`;
+
+export async function aiCvFeedback(text: string): Promise<string> {
+  const client = new Anthropic(); // reads ANTHROPIC_API_KEY
+  const res = await client.messages.create({
+    model: MODEL,
+    max_tokens: 700,
+    system: SYSTEM,
+    messages: [{ role: 'user', content: `CV text:\n\n${text.slice(0, MAX_INPUT_CHARS)}` }],
+  });
+  const block = res.content.find((b) => b.type === 'text');
+  return block && block.type === 'text' ? block.text.trim() : '';
+}


### PR DESCRIPTION
## What & why

Premium Faz 2 (#535, story #520). Mentees get **constructive AI feedback on their uploaded CV** — strengths, improvements, missing sections, in the CV's own language — from the portal profile page.

**Core principle honored: free for the mentee.** The cost is metered against the org's AI quota via the central gate (#537); the mentee never sees pricing or quota mechanics — exhaustion surfaces as a neutral "temporarily unavailable".

## Gating

- The feature is **entirely hidden** unless the provider is configured **and** a CV is uploaded (`GET /api/cv/feedback` availability).
- Without the (existing) `AI_CV_PARSING` consent, the panel shows a hint linking to consent settings instead of the button.
- `POST` runs through `runAiGated` — consent → quota → provider; only extracted CV **text** is sent, never the file (same rule as CV extraction).

## Changes

- lib `aiCvFeedback` (Anthropic, bounded input, structured markdown output).
- API `GET/POST /api/cv/feedback` (own CV only; typed denials 403/429/501).
- UI `CvFeedback` panel under the CV manager on the portal profile (i18n EN/TR/DE, parity green — 1279 × 3).
- e2e (`cv-feedback.spec.ts`): availability flags, consent gate, provider stop (501 in CI), no credit consumed on failure.

> Heads-up: `dictionaries.ts` touches the same region as #601 — whichever merges second may need a trivial rebase.

Closes #535

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_