### PR TITLE
feat(premium): AI interview-prep assistant for mentees, gated (Faz 2) (#536)

### DIFF
--- a/e2e/interview-prep.spec.ts
+++ b/e2e/interview-prep.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// Faz 2 (#536): interview prep — hidden without a provider (availability
+// endpoint), free for the mentee, gated by the shared AI gate. CI has no key,
+// so POSTs stop at 501 and consume no credit.
+test('interview prep reports unavailability without a provider and consumes no credit', async ({ page }) => {
+  const email = uniqueEmail('prep-mentee');
+  const pw = 'PrepPass123';
+  const user = await seedUser(email, pw, 'MENTEE', 'Prep Mentee');
+  await prisma.user.update({ where: { id: user.id }, data: { targetPosition: 'Backend Developer', skills: ['Java'] } });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', email);
+    await page.fill('input[type="password"]', pw);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/portal'), { timeout: 20_000 });
+
+    // Availability: no key in CI → configured:false → the portal card hides.
+    const avail = await (await page.request.get('/api/interview-prep')).json();
+    expect(avail.configured).toBe(false);
+    await page.goto('/portal');
+    await expect(page.getByTestId('interview-prep')).toHaveCount(0);
+
+    // Direct POST passes the quota gate and stops at the provider, consuming
+    // no credit.
+    const usageBefore = await prisma.aiUsage.count();
+    const res = await page.request.post('/api/interview-prep', { data: {} });
+    expect(res.status()).toBe(501);
+    expect((await res.json()).code).toBe('not_configured');
+    expect(await prisma.aiUsage.count()).toBe(usageBefore);
+
+    // Missing position (profile cleared) → clear 400, not a provider error.
+    await prisma.user.update({ where: { id: user.id }, data: { targetPosition: null } });
+    const noPos = await page.request.post('/api/interview-prep', { data: {} });
+    expect(noPos.status()).toBe(400);
+    expect((await noPos.json()).code).toBe('no_position');
+  } finally {
+    await cleanupByEmail(email);
+  }
+});

--- a/src/app/api/interview-prep/route.ts
+++ b/src/app/api/interview-prep/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { z } from 'zod';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { isAiConfigured } from '@/lib/cvExtractAi';
+import { aiInterviewPrep } from '@/lib/aiInterviewPrep';
+import { runAiGated } from '@/lib/aiGate';
+
+// AI interview-prep assistant (Faz 2, #536) — mentee-facing and FREE for the
+// mentee: cost is metered on the org's AI quota; quota exhaustion surfaces as
+// a neutral "temporarily unavailable", never a paywall. Self-service only —
+// the mentee triggers it for themselves, and only position/skills strings are
+// sent to the provider (no identifiers, no CV).
+
+// GET — availability: the portal card hides itself when no provider is set.
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  return NextResponse.json({ configured: isAiConfigured() });
+}
+
+const schema = z.object({
+  position: z.string().max(120).optional(),
+  focus: z.string().max(300).optional(),
+});
+
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  if (session.user.role !== 'MENTEE') return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+  const parsed = schema.safeParse(await request.json().catch(() => ({})));
+  if (!parsed.success) return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+
+  const me = await prisma.user.findUnique({
+    where: { id: session.user.id },
+    select: { targetPosition: true, skills: true },
+  });
+  const position = (parsed.data.position || me?.targetPosition || '').trim();
+  if (!position) return NextResponse.json({ error: 'No target position', code: 'no_position' }, { status: 400 });
+  const skills = Array.isArray(me?.skills) ? (me!.skills as string[]) : [];
+
+  const gated = await runAiGated({
+    scope: 'interview_prep',
+    userId: session.user.id,
+    call: () => aiInterviewPrep(position, skills, parsed.data.focus),
+  });
+
+  if (!gated.ok) {
+    if (gated.reason === 'quota_exceeded') {
+      return NextResponse.json({ error: 'Temporarily unavailable', code: 'quota_exceeded' }, { status: 429 });
+    }
+    return NextResponse.json({ error: 'AI is not configured', code: 'not_configured' }, { status: 501 });
+  }
+  return NextResponse.json({ prep: gated.result });
+}

--- a/src/app/portal/page.tsx
+++ b/src/app/portal/page.tsx
@@ -7,6 +7,7 @@ import { JourneyTracker } from '@/components/JourneyTracker';
 import { NotesPanel } from '@/components/NotesPanel';
 import { MeetingRequestsPanel } from '@/components/MeetingRequestsPanel';
 import { QuestionsPanel } from '@/components/QuestionsPanel';
+import { InterviewPrep } from '@/components/InterviewPrep';
 import { getServerDictionary } from "@/i18n/server";
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
@@ -35,6 +36,7 @@ async function getMenteeData(menteeId: string) {
         linkedinUrl: true,
         portfolioUrl: true,
         publicProfile: true,
+        targetPosition: true,
         createdAt: true,
       },
     }),
@@ -329,6 +331,8 @@ export default async function PortalDashboard() {
       <div className="mt-6">
         <NotesPanel />
       </div>
+
+      <InterviewPrep defaultPosition={user?.targetPosition} />
     </div>
   );
 }

--- a/src/components/InterviewPrep.tsx
+++ b/src/components/InterviewPrep.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { GraduationCap, Sparkles } from 'lucide-react';
+import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
+import { Button } from '@/components/ui/Button';
+import { useT } from '@/i18n/client';
+
+// AI interview-prep card on the mentee portal (Faz 2, #536). Free for the
+// mentee (quota problems surface as a neutral "unavailable", never a paywall).
+// Hides itself entirely when the provider isn't configured.
+export function InterviewPrep({ defaultPosition }: { defaultPosition?: string | null }) {
+  const t = useT();
+  const c = t.interviewPrep;
+  const [configured, setConfigured] = useState<boolean | null>(null);
+  const [position, setPosition] = useState(defaultPosition ?? '');
+  const [focus, setFocus] = useState('');
+  const [prep, setPrep] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    fetch('/api/interview-prep')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => setConfigured(!!d?.configured))
+      .catch(() => setConfigured(false));
+  }, []);
+
+  if (!configured) return null;
+
+  const run = async () => {
+    setLoading(true);
+    setNotice(null);
+    try {
+      const res = await fetch('/api/interview-prep', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ position: position.trim() || undefined, focus: focus.trim() || undefined }),
+      });
+      const body = await res.json();
+      if (res.ok) setPrep(body.prep);
+      else if (body.code === 'no_position') setNotice(c.noPosition);
+      else setNotice(c.unavailable);
+    } catch {
+      setNotice(c.unavailable);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Card className="mt-6" data-testid="interview-prep">
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <GraduationCap className="h-5 w-5 text-blue-600" />
+          <CardTitle>{c.title}</CardTitle>
+        </div>
+      </CardHeader>
+      <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">{c.hint}</p>
+      <div className="flex flex-col sm:flex-row gap-2 mb-2">
+        <input
+          type="text"
+          value={position}
+          onChange={(e) => setPosition(e.target.value)}
+          placeholder={c.positionPlaceholder}
+          className="flex-1 rounded-lg border border-gray-300 dark:border-gray-700 dark:bg-gray-800 px-3 py-2 text-sm"
+        />
+        <input
+          type="text"
+          value={focus}
+          onChange={(e) => setFocus(e.target.value)}
+          placeholder={c.focusPlaceholder}
+          className="flex-1 rounded-lg border border-gray-300 dark:border-gray-700 dark:bg-gray-800 px-3 py-2 text-sm"
+        />
+        <Button type="button" size="sm" loading={loading} onClick={run}>
+          <Sparkles className="h-4 w-4 mr-1" /> {c.button}
+        </Button>
+      </div>
+      {notice && <p className="text-xs text-amber-600 dark:text-amber-400">{notice}</p>}
+      {prep && (
+        <div className="mt-3 rounded-lg bg-blue-50 dark:bg-blue-900/10 border border-blue-100 dark:border-blue-900 p-4 text-sm text-gray-800 dark:text-gray-200 whitespace-pre-line">
+          {prep}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -904,6 +904,16 @@ const en = {
     unavailable: 'CV feedback is temporarily unavailable. Please try again later.',
 
   },
+  interviewPrep: {
+    title: 'Interview preparation (AI)',
+    hint: 'Get realistic example questions and preparation tips for your target position. Your skills from your profile are taken into account.',
+    positionPlaceholder: 'Target position (from your profile if empty)',
+    focusPlaceholder: 'Optional focus, e.g. "system design"',
+    button: 'Prepare me',
+    noPosition: 'Set a target position first (in your profile) or type one above.',
+    unavailable: 'Interview prep is temporarily unavailable. Please try again later.',
+
+  },
   templatesLib: { preview: 'Preview', close: 'Close', pdf: 'Save as PDF', txt: '.txt', md: '.md' },
   documents: {
     title: 'Documents',
@@ -2196,6 +2206,16 @@ const tr: Dict = {
     unavailable: 'CV geri bildirimi şu an kullanılamıyor. Lütfen daha sonra tekrar dene.',
 
   },
+  interviewPrep: {
+    title: 'Mülakat hazırlığı (AI)',
+    hint: 'Hedef pozisyonun için gerçekçi örnek sorular ve hazırlık ipuçları al. Profilindeki yetenekler dikkate alınır.',
+    positionPlaceholder: 'Hedef pozisyon (boşsa profilinden alınır)',
+    focusPlaceholder: 'İsteğe bağlı odak, ör. "system design"',
+    button: 'Beni hazırla',
+    noPosition: 'Önce (profilinde) bir hedef pozisyon belirle ya da yukarıya yaz.',
+    unavailable: 'Mülakat hazırlığı şu an kullanılamıyor. Lütfen daha sonra tekrar dene.',
+
+  },
   templatesLib: { preview: 'Önizle', close: 'Kapat', pdf: 'PDF kaydet', txt: '.txt', md: '.md' },
   documents: {
     title: 'Dokümanlar',
@@ -3484,6 +3504,16 @@ const de: Dict = {
     empty: 'Dein Lebenslauf scheint leer oder unlesbar zu sein.',
     consentRequired: 'Die KI-Verarbeitung des Lebenslaufs ist nicht aktiviert. Erlaube sie unter Konto → Datenschutz & Einwilligung.',
     unavailable: 'Das Lebenslauf-Feedback ist vorübergehend nicht verfügbar. Bitte versuche es später erneut.',
+
+  },
+  interviewPrep: {
+    title: 'Interviewvorbereitung (KI)',
+    hint: 'Erhalte realistische Beispielfragen und Vorbereitungstipps für deine Zielposition. Deine Fähigkeiten aus dem Profil werden berücksichtigt.',
+    positionPlaceholder: 'Zielposition (leer = aus deinem Profil)',
+    focusPlaceholder: 'Optionaler Fokus, z. B. „System Design“',
+    button: 'Bereite mich vor',
+    noPosition: 'Lege zuerst (im Profil) eine Zielposition fest oder gib oben eine ein.',
+    unavailable: 'Die Interviewvorbereitung ist vorübergehend nicht verfügbar. Bitte versuche es später erneut.',
 
   },
   templatesLib: { preview: 'Vorschau', close: 'Schließen', pdf: 'Als PDF speichern', txt: '.txt', md: '.md' },

--- a/src/lib/aiInterviewPrep.ts
+++ b/src/lib/aiInterviewPrep.ts
@@ -1,0 +1,25 @@
+// AI interview-prep assistant for mentees (Faz 2, #536). Generates tailored
+// example questions + preparation tips from the target position and skills.
+// Privacy by design: only the position/skills strings are sent — no name, no
+// contact data, no CV. Callers MUST go through runAiGated (quota).
+
+import Anthropic from '@anthropic-ai/sdk';
+
+const MODEL = process.env.ANTHROPIC_CV_MODEL || 'claude-opus-4-8';
+
+const SYSTEM = `You are an interview preparation coach for a student/junior candidate. Given a target position and skills, produce, in the same language as the input: (1) "**Questions**" — 6-8 realistic interview questions for that position (mix of technical and behavioral, ordered easy→hard); (2) "**Tips**" — 3-5 short, concrete preparation tips specific to the position and skills. Keep the whole answer under 350 words. Do not invent facts about the candidate.`;
+
+export async function aiInterviewPrep(targetPosition: string, skills: string[], focus?: string): Promise<string> {
+  const client = new Anthropic(); // reads ANTHROPIC_API_KEY
+  const res = await client.messages.create({
+    model: MODEL,
+    max_tokens: 900,
+    system: SYSTEM,
+    messages: [{
+      role: 'user',
+      content: `Target position: ${targetPosition}\nSkills: ${skills.join(', ') || '—'}${focus ? `\nSpecial focus: ${focus.slice(0, 300)}` : ''}`,
+    }],
+  });
+  const block = res.content.find((b) => b.type === 'text');
+  return block && block.type === 'text' ? block.text.trim() : '';
+}


### PR DESCRIPTION
## What & why

Premium Faz 2 (#536, story #520) — the last item of the AI package. Mentees get **realistic example interview questions** (technical + behavioral, easy→hard) and **concrete preparation tips** for their target position, taking their profile skills into account. Optional position/focus overrides on the card.

## Principles honored

- **Free for the mentee** — cost metered on the org's AI quota via the central gate (#537); exhaustion surfaces as a neutral "temporarily unavailable", never a paywall.
- **Hidden without a provider** — the portal card checks the availability endpoint and doesn't render at all when `ANTHROPIC_API_KEY` is unset.
- **Privacy by design** — only position/skills strings go to the provider; no identifiers, no CV. Self-service only.

## Changes

- lib `aiInterviewPrep` · API `GET/POST /api/interview-prep` (MENTEE-only POST; `400 no_position` / `429 quota_exceeded` / `501 not_configured`).
- UI `InterviewPrep` card on the portal dashboard (i18n EN/TR/DE, parity green — 1279 × 3).
- e2e (`interview-prep.spec.ts`): hidden without provider, 501 stop consumes no credit, missing position is a clear 400.

## Verification

- `check:i18n` ✅ · `tsc --noEmit` ✅ · `npm run build` ✅

> Heads-up: `dictionaries.ts` touches the same region as #602 — whichever merges second may need a trivial rebase.

Closes #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_