### PR TITLE
chore(release): 0.5.0-beta — Faz 1 consent completion + full Faz 2 (analytics & AI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,39 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-07-11
+
+Premium Faz 1 completion (GDPR consent) and the full Faz 2 tier — premium
+analytics and the AI package — plus small admin/mentor improvements. Mentor
+and mentee experience stays free; mentees never see a paywall.
+
+### Added
+- **Talent-pool visibility consent** (Faz 1, #527) — company-facing exposure now
+  requires an explicit, revocable mentee consent in addition to publicProfile;
+  talent-pool search and need-match alerts enforce it. A portal banner nudges
+  undecided mentees (decision — grant or decline — dismisses it permanently).
+- **Premium analytics tier** (Faz 2, gated by the new premiumAnalytics setting;
+  basic analytics stay free):
+  - Cohort comparison — conversion, time-to-hire, engagement side by side (#538)
+  - Source conversion report — hire rate per referral source (#539)
+  - Full report export — multi-sheet Excel + print/PDF report page (#540)
+  - Weekly scheduled analytics email to admins (#541)
+- **AI package** (Faz 2, all through the central AI gate):
+  - Central AI gate — consent → monthly quota (aiMonthlyQuota setting, AiUsage
+    metering; only successful calls consume credit) → provider (#537)
+  - AI summary of interaction logs for mentors, gated by a new mentee consent (#534)
+  - AI CV improvement feedback for mentees — free for the mentee (#535)
+  - AI interview-prep assistant on the mentee portal — free for the mentee (#536)
+  - AI-deepened mentor matching with rationale + graceful rule-based fallback;
+    no personal identifiers ever reach the provider (#533)
+- **Free-core regression shield** (#526) — e2e proving every core mentor/mentee
+  flow works with zero entitlements.
+- **Synthetic demo seed + contributor data-access policy** (#550) — `npm run
+  seed:demo`, local-only guard, docs/DATA_ACCESS_POLICY.md.
+
+### Fixed
+- Company edit no longer fails on empty optional fields (#569).
+
 ## [0.4.0] - 2026-07-10
 
 Company Premium (freemium Faz 0 + Faz 1) plus messaging, activity reporting,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.4.0-beta",
+  "version": "0.5.0-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,36 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.5.0-beta',
+    date: '2026-07-11',
+    highlights: {
+      en: [
+        'You decide who sees you — companies can only find you in talent search after your explicit consent, and a friendly banner helps you choose. Withdrawing hides you immediately.',
+        'AI helpers for mentees (free for you): constructive CV feedback and an interview-prep assistant with realistic questions and tips for your target position.',
+        'AI helpers for mentors: one-click summary of your interaction log with a mentee — progress, themes, risks and next steps (with the mentee’s permission).',
+        'Smarter mentor matching — suggestions now come with a short AI rationale; without AI they gracefully fall back to skill overlap.',
+        'Premium analytics for admins: cohort comparison, conversion per referral source, a full printable/Excel report and a weekly report email.',
+        'Fair AI usage — a monthly AI quota managed in Settings; mentees never see pricing or quotas.',
+      ],
+      tr: [
+        'Seni kimin göreceğine sen karar verirsin — şirketler seni ancak açık iznin sonrasında yetenek aramasında bulabilir; dostça bir banner seçim yapmana yardım eder. İzni geri çekince anında gizlenirsin.',
+        'Mentee’lere AI yardımcıları (senin için ücretsiz): yapıcı CV geri bildirimi ve hedef pozisyonuna uygun gerçekçi sorular + ipuçlarıyla mülakat hazırlık asistanı.',
+        'Mentörlere AI yardımcıları: bir mentee ile etkileşim kaydının tek tıkla özeti — ilerleme, temalar, riskler ve sonraki adımlar (mentee’nin izniyle).',
+        'Daha akıllı mentör eşleştirme — öneriler artık kısa bir AI gerekçesiyle geliyor; AI yoksa yetenek örtüşmesine zarifçe düşüyor.',
+        'Adminlere premium analitik: cohort karşılaştırması, kaynak bazlı dönüşüm, yazdırılabilir/Excel tam rapor ve haftalık rapor e-postası.',
+        'Adil AI kullanımı — Ayarlar’dan yönetilen aylık AI kotası; mentee’ler asla fiyat veya kota görmez.',
+      ],
+      de: [
+        'Du entscheidest, wer dich sieht — Unternehmen finden dich in der Talentsuche erst nach deiner ausdrücklichen Einwilligung; ein freundlicher Hinweis hilft dir bei der Wahl. Ein Widerruf verbirgt dich sofort.',
+        'KI-Helfer für Mentees (für dich kostenlos): konstruktives Lebenslauf-Feedback und ein Interview-Vorbereitungsassistent mit realistischen Fragen und Tipps für deine Zielposition.',
+        'KI-Helfer für Mentoren: Ein-Klick-Zusammenfassung des Interaktionsprotokolls mit einem Mentee — Fortschritt, Themen, Risiken und nächste Schritte (mit Einwilligung des Mentees).',
+        'Intelligenteres Mentoren-Matching — Vorschläge kommen jetzt mit einer kurzen KI-Begründung; ohne KI greift die Fähigkeiten-Überschneidung.',
+        'Premium-Analytik für Admins: Cohort-Vergleich, Konversion pro Quelle, ein druckbarer/Excel-Gesamtbericht und eine wöchentliche Berichts-E-Mail.',
+        'Faire KI-Nutzung — ein monatliches KI-Kontingent in den Einstellungen; Mentees sehen nie Preise oder Kontingente.',
+      ],
+    },
+  },
+  {
     version: '0.4.0-beta',
     date: '2026-07-10',
     highlights: {


### PR DESCRIPTION
## Why

Another notable batch has landed since `0.4.0` (this morning): the Faz 1 GDPR consent completion and the **entire Faz 2 tier** — premium analytics and the AI package. Per the versioning convention: bump + changelog + user-facing release notes.

## Batch summary (since 0.4.0)

- **Talent-pool visibility consent** (#527) + portal nudge for undecided mentees.
- **Premium analytics** (`premiumAnalytics` setting; basic stays free): cohort comparison (#538), source conversion (#539), full Excel/PDF report (#540), weekly report email (#541).
- **AI package** (all through the central gate #537 — consent → monthly quota → provider; only successful calls consume credit): interaction-log summaries (#534), CV feedback (#535), interview prep (#536), AI-deepened mentor matching with graceful fallback (#533). Mentees never see a paywall; no personal identifiers reach the provider.
- **Free-core regression shield** (#526), **demo seed + data-access policy** (#550), company-edit fix (#569).

## Changes

- `package.json`: `0.4.0-beta` → `0.5.0-beta`
- `CHANGELOG.md`: `0.5.0` entry
- `src/lib/releaseNotes.ts`: EN/TR/DE highlights (rendered at `/release-notes`)

## Verification

- `tsc --noEmit` ✅ · `npm run build` ✅ · `version-release-notes` e2e reads `package.json` dynamically and matches the newest entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_