### PR TITLE
feat(catalog): /features page + single-source feature data feeding the landing (#587, #588)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,9 @@ SMTP_* for email. Seeder: `SEED_ADMIN_EMAIL` / `SEED_ADMIN_PASSWORD` / `SEED_ADM
 - **Work is tracked on a GitHub Project board** (Epics #5–#11, stories #12+). Move the issue
   to the matching column as you work.
 - Co-author trailer on commits: `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+- **Feature catalogue**: when a user-visible feature ships, add/update its entry in
+  `src/lib/features.ts` (+ `featureCatalog` i18n block) — the landing cards and the `/features`
+  page are both fed from that single source. Same discipline as CHANGELOG/releaseNotes.
 - **Versioning**: on a notable batch of merged features (not every PR), bump `package.json`
   `version` (semver), add an entry to `CHANGELOG.md` (developer-facing, Keep a Changelog
   format), and add a matching entry to `src/lib/releaseNotes.ts` (user-facing, EN/TR/DE,

--- a/e2e/features-catalog.spec.ts
+++ b/e2e/features-catalog.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+
+// #584/#587/#588: the /features catalogue and the landing cards share one data
+// source. The landing keeps its exact featured strings (asserted elsewhere)
+// and links to the catalogue from header, grid and footer.
+test('features catalogue renders categorized entries and landing links to it', async ({ page }) => {
+  await page.goto('/features');
+  await expect(page.getByRole('heading', { name: 'Everything InternshipCRM can do' })).toBeVisible();
+  // A featured landing string and a catalogue-only entry both render.
+  await expect(page.getByText('Pipeline tracking', { exact: true })).toBeVisible();
+  await expect(page.getByText('Built-in messaging', { exact: true })).toBeVisible();
+  // Categories exist.
+  await expect(page.getByTestId('feature-cat-collaboration')).toBeVisible();
+  await expect(page.getByTestId('feature-cat-insights')).toBeVisible();
+
+  // Landing links to the catalogue (grid CTA), and the cards still render.
+  await page.goto('/');
+  await expect(page.getByText('Pipeline tracking', { exact: true })).toBeVisible();
+  await page.getByTestId('all-features-link').click();
+  await page.waitForURL('**/features');
+  await expect(page.getByRole('heading', { name: 'Everything InternshipCRM can do' })).toBeVisible();
+});

--- a/src/app/features/page.tsx
+++ b/src/app/features/page.tsx
@@ -1,0 +1,66 @@
+import Link from 'next/link';
+import { ArrowLeft, GraduationCap } from 'lucide-react';
+import { getServerDictionary } from '@/i18n/server';
+import { getFeatures, FEATURE_CATEGORIES } from '@/lib/features';
+import { LanguageSwitcher } from '@/components/LanguageSwitcher';
+import { ThemeToggle } from '@/components/ThemeToggle';
+
+const iconBg: Record<string, string> = {
+  blue: 'bg-blue-100 text-blue-600', green: 'bg-green-100 text-green-600',
+  purple: 'bg-purple-100 text-purple-600', amber: 'bg-amber-100 text-amber-600',
+  teal: 'bg-teal-100 text-teal-600', orange: 'bg-orange-100 text-orange-600',
+  sky: 'bg-sky-100 text-sky-600', rose: 'bg-rose-100 text-rose-600',
+  indigo: 'bg-indigo-100 text-indigo-600',
+};
+
+// Public feature catalogue (#584/#587) — every shipped feature, categorized,
+// fed from the single source in src/lib/features.ts (same data as the landing
+// page's featured cards).
+export default async function FeaturesPage() {
+  const { t, locale } = await getServerDictionary();
+  const F = t.featureCatalog;
+  const features = getFeatures(t);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-indigo-50 dark:from-gray-950 dark:via-gray-900 dark:to-gray-950">
+      <header className="max-w-5xl mx-auto px-6 py-5 flex items-center justify-between">
+        <Link href="/" className="flex items-center gap-2 font-bold text-gray-900 dark:text-gray-100">
+          <GraduationCap className="h-6 w-6 text-blue-600" /> InternshipCRM
+        </Link>
+        <div className="flex items-center gap-2">
+          <LanguageSwitcher current={locale} />
+          <ThemeToggle />
+        </div>
+      </header>
+
+      <main className="max-w-5xl mx-auto px-6 pb-16">
+        <Link href="/" className="inline-flex items-center gap-1.5 text-sm text-blue-600 hover:underline mb-6">
+          <ArrowLeft className="h-4 w-4" /> {F.backHome}
+        </Link>
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-2">{F.title}</h1>
+        <p className="text-gray-500 dark:text-gray-400 mb-10">{F.subtitle}</p>
+
+        {FEATURE_CATEGORIES.map((cat) => {
+          const inCat = features.filter((f) => f.category === cat);
+          if (inCat.length === 0) return null;
+          return (
+            <section key={cat} className="mb-10" data-testid={`feature-cat-${cat}`}>
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">{F.categories[cat]}</h2>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                {inCat.map((f) => (
+                  <div key={f.key} className="rounded-xl border border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900 p-5">
+                    <div className={`w-10 h-10 rounded-lg flex items-center justify-center mb-3 ${iconBg[f.color] ?? iconBg.blue}`}>
+                      <f.icon className="h-5 w-5" />
+                    </div>
+                    <p className="font-semibold text-gray-900 dark:text-gray-100">{f.title}</p>
+                    <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{f.desc}</p>
+                  </div>
+                ))}
+              </div>
+            </section>
+          );
+        })}
+      </main>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,6 @@
 import Link from 'next/link';
-import {
-  GraduationCap, Users, Building2, ArrowRight, CheckCircle,
-  GitBranch, CalendarClock, BarChart3, ShieldCheck,
-  FileText, Target, Sparkles,
-} from 'lucide-react';
+import { GraduationCap, ArrowRight, CheckCircle } from 'lucide-react';
+import { getFeatures } from '@/lib/features';
 import { getServerSession } from 'next-auth';
 import { redirect } from 'next/navigation';
 import { authOptions } from '@/lib/auth';
@@ -22,17 +19,9 @@ export default async function HomePage() {
   const { locale, t } = await getServerDictionary();
   const L = t.landing;
 
-  const features = [
-    { icon: GitBranch, color: 'blue', title: L.fPipelineT, desc: L.fPipelineD },
-    { icon: Users, color: 'green', title: L.fMentorT, desc: L.fMentorD },
-    { icon: Building2, color: 'purple', title: L.fCompanyT, desc: L.fCompanyD },
-    { icon: CalendarClock, color: 'amber', title: L.fCommsT, desc: L.fCommsD },
-    { icon: FileText, color: 'teal', title: L.fDocsT, desc: L.fDocsD },
-    { icon: Target, color: 'orange', title: L.fGrowthT, desc: L.fGrowthD },
-    { icon: BarChart3, color: 'sky', title: L.fAnalyticsT, desc: L.fAnalyticsD },
-    { icon: ShieldCheck, color: 'rose', title: L.fPrivacyT, desc: L.fPrivacyD },
-    { icon: Sparkles, color: 'indigo', title: L.fPlatformT, desc: L.fPlatformD },
-  ];
+  // Fed from the single-source catalogue (#584/#588): the landing shows the
+  // featured subset; /features shows everything.
+  const features = getFeatures(t).filter((f) => f.featured);
   const iconBg: Record<string, string> = {
     blue: 'bg-blue-100 text-blue-600', green: 'bg-green-100 text-green-600',
     purple: 'bg-purple-100 text-purple-600', amber: 'bg-amber-100 text-amber-600',
@@ -67,6 +56,9 @@ export default async function HomePage() {
               <BetaBadge className="flex-shrink-0" />
             </div>
             <div className="flex items-center gap-2 sm:gap-4 flex-shrink-0">
+              <Link href="/features" className="hidden sm:inline text-gray-600 hover:text-gray-900 font-medium transition-colors whitespace-nowrap text-sm sm:text-base">
+                {t.featureCatalog.allFeatures}
+              </Link>
               <LanguageSwitcher current={locale} />
             <ThemeToggle />
               <Link href="/auth/signin" className="text-gray-600 hover:text-gray-900 font-medium transition-colors whitespace-nowrap text-sm sm:text-base">
@@ -106,6 +98,11 @@ export default async function HomePage() {
                 {chip}
               </span>
             ))}
+          </div>
+          <div className="text-center mt-8">
+            <Link href="/features" className="inline-flex items-center gap-1.5 text-blue-600 hover:underline font-medium" data-testid="all-features-link">
+              {t.featureCatalog.allFeatures} <ArrowRight className="h-4 w-4" />
+            </Link>
           </div>
         </div>
       </section>
@@ -232,6 +229,7 @@ export default async function HomePage() {
           </div>
           <p>© {new Date().getFullYear()} InternshipCRM. {L.footer}</p>
           <div className="flex items-center gap-4">
+            <Link href="/features" className="hover:text-gray-700">{t.featureCatalog.allFeatures}</Link>
             <Link href="/privacy" className="hover:text-gray-700">{t.privacy.title}</Link>
             <Link href="/terms" className="hover:text-gray-700">{t.terms.title}</Link>
             <VersionFooter version={APP_VERSION} />

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -907,6 +907,21 @@ const en = {
     approve: 'Approve',
     reject: 'Reject',
   },
+  featureCatalog: {
+    title: 'Everything InternshipCRM can do',
+    subtitle: 'The full feature catalogue — from first contact to hired, for every role.',
+    allFeatures: 'All features',
+    backHome: 'Back to home',
+    categories: { tracking: 'Pipeline & intake', collaboration: 'Mentoring & collaboration', companies: 'For companies', insights: 'Insights & AI', trust: 'Privacy & security', platform: 'Platform' },
+    items: {
+      messaging: { t: 'Built-in messaging', d: 'A unified inbox with per-mentorship threads, attachments and email mirroring — reachable from anywhere in the app.' },
+      activityReport: { t: 'Daily activity reports', d: 'Consent-based mentee activity digests for mentors and admins: logins, time on site, pages visited and completed to-dos.' },
+      talentPool: { t: 'Talent pool & alerts (Premium)', d: 'Companies search a consent-based talent pool, see verified candidate cards, and get alerts when a candidate matches an open position.' },
+      aiPackage: { t: 'AI assistants (Premium)', d: 'CV feedback and interview prep for mentees, interaction-log summaries for mentors, AI-assisted matching — all consent- and quota-gated.' },
+      security: { t: 'Two-factor auth & session control', d: 'Role-based 2FA enforcement, session timeouts and "sign out of all devices".' },
+      selfServe: { t: 'Self-serve mentee intake', d: 'Mentees sign up on their own, complete onboarding and request mentorship; admins approve from a queue.' },
+    },
+  },
   aiSummary: {
     button: 'AI summary',
     hint: 'Summarize this interaction log with AI (uses one AI credit).',
@@ -2229,6 +2244,21 @@ const tr: Dict = {
     approve: 'Onayla',
     reject: 'Reddet',
   },
+  featureCatalog: {
+    title: 'InternshipCRM neler yapabilir',
+    subtitle: 'Tüm özellik kataloğu — ilk temastan işe alıma, her rol için.',
+    allFeatures: 'Tüm özellikler',
+    backHome: 'Ana sayfaya dön',
+    categories: { tracking: 'Süreç & başvuru', collaboration: 'Mentorluk & iş birliği', companies: 'Şirketler için', insights: 'İçgörü & AI', trust: 'Gizlilik & güvenlik', platform: 'Platform' },
+    items: {
+      messaging: { t: 'Yerleşik mesajlaşma', d: 'Mentorluk başına thread’ler, ekler ve e-posta yansıtmalı tek gelen kutusu — uygulamanın her yerinden erişilebilir.' },
+      activityReport: { t: 'Günlük aktivite raporları', d: 'Mentör ve adminler için rıza temelli mentee aktivite özetleri: girişler, sitede geçen süre, gezilen sayfalar ve tamamlanan görevler.' },
+      talentPool: { t: 'Yetenek havuzu & bildirimler (Premium)', d: 'Şirketler rıza temelli yetenek havuzunda arama yapar, doğrulanmış aday kartlarını görür ve açık pozisyona uyan aday çıkınca bildirim alır.' },
+      aiPackage: { t: 'AI asistanları (Premium)', d: 'Mentee’lere CV geri bildirimi ve mülakat hazırlığı, mentörlere etkileşim özeti, AI destekli eşleştirme — hepsi rıza ve kota kapılı.' },
+      security: { t: 'İki adımlı doğrulama & oturum kontrolü', d: 'Rol bazlı 2FA zorlama, oturum zaman aşımı ve "tüm cihazlardan çıkış".' },
+      selfServe: { t: 'Self-servis mentee başvurusu', d: 'Mentee’ler kendileri kaydolur, onboarding’i tamamlar ve mentörlük talep eder; adminler kuyruğundan onaylar.' },
+    },
+  },
   aiSummary: {
     button: 'AI özeti',
     hint: 'Bu etkileşim kaydını AI ile özetle (bir AI kredisi kullanır).',
@@ -3549,6 +3579,21 @@ const de: Dict = {
     approve: 'Genehmigen',
     reject: 'Ablehnen',
   },
+  featureCatalog: {
+    title: 'Alles, was InternshipCRM kann',
+    subtitle: 'Der vollständige Funktionskatalog — vom Erstkontakt bis zur Einstellung, für jede Rolle.',
+    allFeatures: 'Alle Funktionen',
+    backHome: 'Zurück zur Startseite',
+    categories: { tracking: 'Pipeline & Aufnahme', collaboration: 'Mentoring & Zusammenarbeit', companies: 'Für Unternehmen', insights: 'Einblicke & KI', trust: 'Datenschutz & Sicherheit', platform: 'Plattform' },
+    items: {
+      messaging: { t: 'Integrierte Nachrichten', d: 'Ein zentraler Posteingang mit Threads pro Mentoring, Anhängen und E-Mail-Spiegelung — überall in der App erreichbar.' },
+      activityReport: { t: 'Tägliche Aktivitätsberichte', d: 'Einwilligungsbasierte Mentee-Aktivitätsübersichten für Mentoren und Admins: Logins, Verweildauer, besuchte Seiten und erledigte To-dos.' },
+      talentPool: { t: 'Talent-Pool & Benachrichtigungen (Premium)', d: 'Unternehmen durchsuchen einen einwilligungsbasierten Talent-Pool, sehen verifizierte Kandidatenkarten und werden bei passenden Kandidaten benachrichtigt.' },
+      aiPackage: { t: 'KI-Assistenten (Premium)', d: 'Lebenslauf-Feedback und Interviewvorbereitung für Mentees, Interaktionszusammenfassungen für Mentoren, KI-gestütztes Matching — alles einwilligungs- und kontingentgesteuert.' },
+      security: { t: 'Zwei-Faktor-Auth & Sitzungskontrolle', d: 'Rollenbasierte 2FA-Durchsetzung, Sitzungs-Timeouts und „Auf allen Geräten abmelden".' },
+      selfServe: { t: 'Self-Service-Mentee-Aufnahme', d: 'Mentees registrieren sich selbst, durchlaufen das Onboarding und fragen Mentoring an; Admins genehmigen aus einer Warteschlange.' },
+    },
+  },
   aiSummary: {
     button: 'KI-Zusammenfassung',
     hint: 'Dieses Interaktionsprotokoll mit KI zusammenfassen (verbraucht ein KI-Guthaben).',
@@ -3975,7 +4020,7 @@ export function getDictionary(locale: Locale): Dict {
 // getServerDictionary), never through useT() on the client — e.g. the landing
 // marketing copy. They are stripped from the dictionary serialized into every
 // page's client payload to keep it lean (#502).
-export const SERVER_ONLY_NAMESPACES = ['landing'] as const;
+export const SERVER_ONLY_NAMESPACES = ['landing', 'featureCatalog'] as const;
 export type ClientDictionary = Omit<Dictionary, (typeof SERVER_ONLY_NAMESPACES)[number]>;
 
 export function getClientDictionary(locale: Locale): ClientDictionary {

--- a/src/lib/features.ts
+++ b/src/lib/features.ts
@@ -1,0 +1,60 @@
+// Single source of truth for the product's feature catalogue (#584/#587).
+// Both the landing page cards (featured subset) and the /features catalogue
+// page read from here — update THIS list when a new feature ships (see the
+// convention in CLAUDE.md, next to the changelog/releaseNotes discipline).
+//
+// Titles/descriptions live in the i18n dictionary: the nine original landing
+// features keep their `landing.f*` keys (several e2e specs assert those exact
+// strings), newer entries use the `featureCatalog` block. Both namespaces are
+// server-only, so consumers must be server components (landing and /features
+// both are).
+
+import type { LucideIcon } from 'lucide-react';
+import {
+  GitBranch, Users, Building2, CalendarClock, FileText, Target,
+  BarChart3, ShieldCheck, Sparkles, MessageCircle, Activity,
+  Search, Bot, KeyRound, UserPlus,
+} from 'lucide-react';
+import type { Dictionary } from '@/i18n/dictionaries';
+
+export type FeatureCategory = 'tracking' | 'collaboration' | 'companies' | 'insights' | 'trust' | 'platform';
+
+export interface Feature {
+  key: string;
+  category: FeatureCategory;
+  icon: LucideIcon;
+  color: string;
+  // Featured entries render as the landing page's feature cards.
+  featured?: boolean;
+  title: string;
+  desc: string;
+}
+
+export const FEATURE_CATEGORIES: FeatureCategory[] = [
+  'tracking', 'collaboration', 'companies', 'insights', 'trust', 'platform',
+];
+
+// Resolved against the server dictionary so both pages localize identically.
+export function getFeatures(t: Dictionary): Feature[] {
+  const L = t.landing;
+  const C = t.featureCatalog.items;
+  return [
+    // Featured (the original landing cards — exact strings asserted in e2e).
+    { key: 'pipeline', category: 'tracking', icon: GitBranch, color: 'blue', featured: true, title: L.fPipelineT, desc: L.fPipelineD },
+    { key: 'mentors', category: 'collaboration', icon: Users, color: 'green', featured: true, title: L.fMentorT, desc: L.fMentorD },
+    { key: 'companies', category: 'companies', icon: Building2, color: 'purple', featured: true, title: L.fCompanyT, desc: L.fCompanyD },
+    { key: 'comms', category: 'collaboration', icon: CalendarClock, color: 'amber', featured: true, title: L.fCommsT, desc: L.fCommsD },
+    { key: 'docs', category: 'platform', icon: FileText, color: 'teal', featured: true, title: L.fDocsT, desc: L.fDocsD },
+    { key: 'growth', category: 'collaboration', icon: Target, color: 'orange', featured: true, title: L.fGrowthT, desc: L.fGrowthD },
+    { key: 'analytics', category: 'insights', icon: BarChart3, color: 'sky', featured: true, title: L.fAnalyticsT, desc: L.fAnalyticsD },
+    { key: 'privacy', category: 'trust', icon: ShieldCheck, color: 'rose', featured: true, title: L.fPrivacyT, desc: L.fPrivacyD },
+    { key: 'platform', category: 'platform', icon: Sparkles, color: 'indigo', featured: true, title: L.fPlatformT, desc: L.fPlatformD },
+    // Catalogue-only (newer features; strings in featureCatalog.items).
+    { key: 'messaging', category: 'collaboration', icon: MessageCircle, color: 'blue', title: C.messaging.t, desc: C.messaging.d },
+    { key: 'activityReport', category: 'insights', icon: Activity, color: 'green', title: C.activityReport.t, desc: C.activityReport.d },
+    { key: 'talentPool', category: 'companies', icon: Search, color: 'purple', title: C.talentPool.t, desc: C.talentPool.d },
+    { key: 'aiPackage', category: 'insights', icon: Bot, color: 'indigo', title: C.aiPackage.t, desc: C.aiPackage.d },
+    { key: 'security', category: 'trust', icon: KeyRound, color: 'amber', title: C.security.t, desc: C.security.d },
+    { key: 'selfServe', category: 'tracking', icon: UserPlus, color: 'teal', title: C.selfServe.t, desc: C.selfServe.d },
+  ];
+}


### PR DESCRIPTION
## What & why

Story #584 — both tasks in one PR (Task 2 builds directly on Task 1's data file; splitting would create an artificial intermediate state).

**Single source of truth**: `src/lib/features.ts`. The landing's feature cards (featured subset) and the new **categorized `/features` catalogue** both read from it — updating one place refreshes both (no more hardcoded copy in `page.tsx`).

## Changes

- **`src/lib/features.ts`** — 15 features across 6 categories (`tracking / collaboration / companies / insights / trust / platform`). The nine original landing entries keep their exact `landing.f*` strings (**e2e specs assert those** — unchanged); newer entries (messaging, activity reports, talent pool, AI package, 2FA, self-serve intake) use a new `featureCatalog` i18n block.
- **`/features`** — public categorized catalogue following the `/release-notes` pattern (language/theme switchers, dark-mode aware, `data-testid` per category).
- **Landing** — cards now come from `getFeatures(t).filter(featured)`; **"All features"** links in the header, under the grid (CTA), and in the footer.
- **`featureCatalog`** added to `SERVER_ONLY_NAMESPACES` so the client payload stays lean (#502 discipline).
- **CLAUDE.md** — new convention: *feature ships → update `features.ts`*, alongside the changelog/releaseNotes discipline.

## Acceptance criteria

- ✅ `/features` shows all features, categorized, in three languages; reachable from landing header + grid + footer.
- ✅ Landing cards and catalogue read from the same source (no duplicated list).
- ✅ `check:i18n` (1320 × 3) + `npm run build` pass; existing landing-string e2e specs unaffected.

Closes #587
Closes #588

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_