### PR TITLE
chore(release): 0.6.0-beta — self-serve intake, support tickets, feature catalogue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,36 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-07-11
+
+Self-serve mentee intake, a built-in support channel, a public feature
+catalogue, and isolated per-topic preview environments for the growing
+contributor team.
+
+### Added
+- **Mentee self-registration** (#589) — the token-less signup now creates a
+  MENTEE (inactive until admin approval) instead of a MENTOR; new mentees land
+  on the portal after activation.
+- **Mentorship requests** (#590, #591) — mentees without an active mentorship
+  request one from the portal (one pending request at a time, rate-limited);
+  admins approve from a queue on /admin/mentorship, picking the mentor —
+  approval creates the relation and notifies both sides. Requests are gated on
+  onboarding: profile basics (university + skills) and an uploaded CV are
+  required, enforced server-side and explained in the UI.
+- **Support tickets** (#592–#594) — every user gets a pinned "Support"
+  conversation in Messages: the first message opens a ticket, replies join the
+  open ticket, closed tickets start fresh ones. Admins work a queue at
+  /admin/support with status filters (open / in progress / closed), inline
+  reply, assignment and status transitions; both sides get notifications.
+- **Feature catalogue** (#587, #588) — public /features page (EN/TR/DE,
+  categorized) backed by a single-source feature list that also feeds the
+  landing cards; "All features" links from the landing header, grid and footer.
+- **Topic-based ephemeral previews** (#583) — branches carrying a `topicN`
+  token deploy to their own `crm-<topic>.ersah.in` container and are torn down
+  when the PR closes; topic-less branches keep the shared preview. Includes a
+  wildcard-TLS/nginx runbook under `infra/`.
+
+
 ## [0.5.0] - 2026-07-11
 
 Premium Faz 1 completion (GDPR consent) and the full Faz 2 tier — premium

--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -129,3 +129,31 @@ yeni bloğunu ekle (python regex ile 3 locale'de tek seferde). `check:i18n` anı
 **CI kırmızısı triage:** "228 passed" + exit 1 → altyapı flake'i (Chromium SIGSEGV, teardown);
 `rerun_failed_jobs` yeterli. Log'da gerçek spec hatası olup olmadığına mutlaka bak; benim
 diff'ime dokunmayan spec'te strict-mode ihlali de tipik flake işareti.
+
+## 2026-07-11 — Ürün turu: self-serve intake, destek sistemi, katalog, topic preview (0.6.0-beta)
+
+**Pipelining artık standart:** PR açar açmaz sıradaki işi kodla; CI sonuçlarını toplu
+"sweep"le kontrol edip yeşilleri merge et. Bekleme molası yok — kullanıcının açık talebi.
+
+**PR "dirty" ise CI hiç tetiklenmez:** #609'da check-run listesi bomboştu; sebep workflow
+değil, PR'ın merge conflict'i (mergeable_state: dirty — GitHub merge commit'i üretemeyince
+pull_request workflow'ları koşmaz). Boş check listesi gördüğünde önce `pull_request_read get`
+ile mergeable_state'e bak; rebase + çöz + push sonrası CI kendiliğinden gelir.
+
+**Ortamdaki GITHUB_TOKEN doğrudan API'ye kapalı:** curl ile api.github.com "GitHub access
+is not enabled for this session" döner — CI izleme/merge yalnızca mcp__github__* araçlarıyla.
+Kendi kendine check-in için `send_later` (claude-code-remote) çalışıyor; Monitor + curl çalışmıyor.
+
+**Aynı dashboard'a ikinci link eklerken mevcut spec'leri tara:** #591'in kapı kutusundaki
+"Upload your CV" linki, onboarding-checklist spec'inin kapsamsız `getByText`'ini strict-mode
+ihlaline düşürdü. Yeni UI metni eklemeden önce `grep -rn "<metin>" e2e/` — çakışan spec'i
+aynı PR'da kapsamlandır (`data-testid` + scoped locator).
+
+**DOM-duplikasyon flake'i tekrar etti:** bazı koşularda sayfa içeriği DOM'da iki kez görünüyor
+(iki `#name`, iki arama kutusu; export-filter/skill-match/sources/api-docs değişen kurbanlar).
+Diff'inle ilgisiz strict-mode "resolved to 2 elements" bunun işareti — rerun yeterli. Kendi
+yeni spec'lerinde DB yan-etki assert'lerini `expect.poll` ile yaz (bubble render ≠ commit bitti).
+
+**E2E'de destek sistemi deseni:** iki browser context (user + admin) tek spec'te tam döngüyü
+(ticket aç → kuyrukta gör → yanıtla → durum geçişi → bildirim) doğrulayabiliyor; API çağrılarını
+`page.request` ile atıp UI'ı yalnızca kritik noktalarda assert etmek hem hızlı hem az kırılgan.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.5.0-beta",
+  "version": "0.6.0-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,30 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.6.0-beta',
+    date: '2026-07-11',
+    highlights: {
+      en: [
+        'Join on your own — you can now sign up directly as a mentee; an admin approves your account and you land in your portal.',
+        'Request a mentor — once your profile basics and CV are in place, ask for a mentor right from your dashboard; admins match you and you are notified the moment it is decided.',
+        'Built-in support — every user has a pinned "Support" conversation in Messages. Write to us anytime; you can follow the status of your request (open, in progress, closed) and get notified on replies.',
+        'New Features page — everything InternshipCRM can do, categorized and in three languages, linked from the landing page.',
+      ],
+      tr: [
+        'Kendi başına katıl — artık doğrudan mentee olarak kaydolabilirsin; hesabını bir admin onaylar ve portalına ulaşırsın.',
+        'Mentör talep et — temel profil bilgilerin ve CV’in hazır olduğunda panelinden mentör isteyebilirsin; adminler eşleştirir ve karar verilir verilmez haberdar olursun.',
+        'Yerleşik destek — her kullanıcının Mesajlar’da sabit bir "Destek" sohbeti var. Bize istediğin an yaz; talebinin durumunu (açık, işlemde, kapalı) takip edebilir ve yanıtlarda bildirim alırsın.',
+        'Yeni Özellikler sayfası — InternshipCRM’in yapabildiği her şey, kategorili ve üç dilde, açılış sayfasından erişilebilir.',
+      ],
+      de: [
+        'Selbst beitreten — du kannst dich jetzt direkt als Mentee registrieren; ein Admin bestätigt dein Konto und du landest in deinem Portal.',
+        'Mentor anfragen — sobald Profilbasics und Lebenslauf vorliegen, fragst du direkt vom Dashboard einen Mentor an; Admins vermitteln und du wirst sofort über die Entscheidung informiert.',
+        'Eingebauter Support — jede*r hat in den Nachrichten eine angeheftete "Support"-Unterhaltung. Schreib uns jederzeit; du verfolgst den Status deiner Anfrage (offen, in Bearbeitung, geschlossen) und wirst bei Antworten benachrichtigt.',
+        'Neue Funktionsseite — alles, was InternshipCRM kann, kategorisiert und in drei Sprachen, verlinkt von der Startseite.',
+      ],
+    },
+  },
+  {
     version: '0.5.0-beta',
     date: '2026-07-11',
     highlights: {


### PR DESCRIPTION
## What & why

Version bump closing out the product-tour batch (stories #584, #585, #586 + infra #583):

- **Mentee self-registration** (#589) — token-less signup now creates a MENTEE pending admin approval.
- **Mentorship requests** (#590, #591) — portal request panel + admin approval queue, gated on onboarding (profile + CV), rate-limited, notified.
- **Support tickets** (#592–#594) — pinned Support chat for every user; admin queue at `/admin/support` with filters, reply, assignment and status flow.
- **Feature catalogue** (#587, #588) — public `/features` page fed from the single-source `features.ts` that also powers the landing cards.
- **Topic-based ephemeral previews** (#583) — `topicN` branches get isolated preview environments with automatic teardown.

## Contents

- `package.json` → `0.6.0-beta`
- `CHANGELOG.md` — developer-facing entry (Keep a Changelog)
- `src/lib/releaseNotes.ts` — user-facing highlights (EN/TR/DE), rendered at `/release-notes`
- `docs/agent-experience.md` — session retrospective (CI trigger vs dirty PRs, DOM-duplication flake pattern, e2e support-loop pattern)

## Verification

- `tsc --noEmit` ✅ — the version is read from `package.json` at build time; no other wiring needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_