### PR TITLE
test: define the @smoke set + test:e2e:smoke script (#622)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,13 +29,18 @@ npx prisma generate  # regenerate client (also runs on postinstall)
 npx prisma db push   # sync schema to DB (this project uses db push, NOT migrations)
 npx prisma db seed   # create first ADMIN (see seed env vars below)
 
-npm run test:e2e         # Playwright smoke tests (starts the app itself)
-npm run test:e2e:headed  # same, with a visible browser
+npm run test:e2e         # full Playwright suite (starts the app itself)
+npm run test:e2e:smoke   # critical-path subset only (tests tagged @smoke)
+npm run test:e2e:headed  # full suite, with a visible browser
 ```
 
 **E2E tests** (Playwright) live in `e2e/` and run as a CI quality gate on every PR
-(`.github/workflows/e2e.yml`, isolated MySQL service). Locally `test:e2e` boots the dev
-server; set `BASE_URL=https://crm-preview.ersah.in` to run against a deployed env instead.
+(`.github/workflows/e2e.yml`, isolated MySQL service). The **smoke set** is the tests
+tagged `@smoke` (`test('…', { tag: '@smoke' }, …)`) — boot, auth, landing i18n, invite,
+pipeline, free-core regression. When you add a spec for a *critical* flow, tag it
+`@smoke`; keep the set small (~15-20 tests) so the PR gate stays fast. Locally `test:e2e`
+boots the dev server; set `BASE_URL=https://crm-preview.ersah.in` to run against a
+deployed env instead.
 After switching branches, run `npx prisma generate` so the client matches the schema —
 a stale client causes schema-drift 500s (the smoke test will catch these).
 

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -3,13 +3,13 @@ import { test, expect } from '@playwright/test';
 const ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@example.com';
 const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'ChangeMe123!';
 
-test('unauthenticated access to /admin redirects to sign in', async ({ page }) => {
+test('unauthenticated access to /admin redirects to sign in', { tag: '@smoke' }, async ({ page }) => {
   await page.goto('/admin');
   await page.waitForURL((u) => u.pathname.includes('/auth/signin'), { timeout: 15_000 });
   await expect(page.locator('input[type="password"]')).toBeVisible();
 });
 
-test('wrong credentials keep the user on the sign-in page', async ({ page }) => {
+test('wrong credentials keep the user on the sign-in page', { tag: '@smoke' }, async ({ page }) => {
   await page.goto('/auth/signin');
   await page.fill('input[type="email"], input[name="email"]', 'nobody@e2e.local');
   await page.fill('input[type="password"]', 'wrong-password-123');
@@ -18,7 +18,7 @@ test('wrong credentials keep the user on the sign-in page', async ({ page }) => 
   expect(page.url()).toContain('/auth/signin');
 });
 
-test('authenticated admin sees a Sign Out control', async ({ page }) => {
+test('authenticated admin sees a Sign Out control', { tag: '@smoke' }, async ({ page }) => {
   await page.goto('/auth/signin');
   await page.fill('input[type="email"], input[name="email"]', ADMIN_EMAIL);
   await page.fill('input[type="password"]', ADMIN_PASSWORD);
@@ -30,7 +30,7 @@ test('authenticated admin sees a Sign Out control', async ({ page }) => {
   await expect(page.getByRole('menuitem', { name: /sign out/i })).toBeVisible();
 });
 
-test('admin sidebar links to the invite page', async ({ page }) => {
+test('admin sidebar links to the invite page', { tag: '@smoke' }, async ({ page }) => {
   await page.goto('/auth/signin');
   await page.fill('input[type="email"], input[name="email"]', ADMIN_EMAIL);
   await page.fill('input[type="password"]', ADMIN_PASSWORD);

--- a/e2e/free-core-regression.spec.ts
+++ b/e2e/free-core-regression.spec.ts
@@ -17,7 +17,7 @@ async function signIn(page: import('@playwright/test').Page, email: string, pw: 
 // with ZERO premium entitlements anywhere (none are created here; nothing is on
 // by default), every core mentor/mentee flow must keep working. If a future
 // change accidentally gates a core route behind hasFeature(), this fails.
-test('core mentor/mentee flows work with no premium entitlement anywhere', async ({ browser }) => {
+test('core mentor/mentee flows work with no premium entitlement anywhere', { tag: '@smoke' }, async ({ browser }) => {
   const mentorEmail = uniqueEmail('freecore-mentor');
   const menteeEmail = uniqueEmail('freecore-mentee');
   const pw = 'FreeCorePass123';

--- a/e2e/health.spec.ts
+++ b/e2e/health.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 
 // The /api/health probe backs uptime monitoring and the nightly stress test.
 // It must stay public, cheap, and side-effect free.
-test('health endpoint reports ok without a DB check', async ({ request }) => {
+test('health endpoint reports ok without a DB check', { tag: '@smoke' }, async ({ request }) => {
   const res = await request.get('/api/health');
   expect(res.status()).toBe(200);
   const body = await res.json();
@@ -12,7 +12,7 @@ test('health endpoint reports ok without a DB check', async ({ request }) => {
   expect(typeof body.responseMs).toBe('number');
 });
 
-test('health endpoint verifies DB connectivity when asked', async ({ request }) => {
+test('health endpoint verifies DB connectivity when asked', { tag: '@smoke' }, async ({ request }) => {
   const res = await request.get('/api/health?db=1');
   // 200 when the DB is reachable (CI/preview), 503 if it is degraded.
   expect([200, 503]).toContain(res.status());

--- a/e2e/invite.spec.ts
+++ b/e2e/invite.spec.ts
@@ -8,7 +8,7 @@ test.afterAll(async () => {
   await prisma.$disconnect();
 });
 
-test('admin invite surfaces a shareable registration link', async ({ page }) => {
+test('admin invite surfaces a shareable registration link', { tag: '@smoke' }, async ({ page }) => {
   const email = uniqueEmail('invitee');
   try {
     // Sign in as admin and open the invite page

--- a/e2e/landing-i18n.spec.ts
+++ b/e2e/landing-i18n.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-test('landing page shows features, pipeline and CTAs in English by default', async ({ page }) => {
+test('landing page shows features, pipeline and CTAs in English by default', { tag: '@smoke' }, async ({ page }) => {
   await page.goto('/');
   await expect(page.getByRole('heading', { name: /Connect Talent with/i })).toBeVisible();
   await expect(page.getByText('Everything you need')).toBeVisible();
@@ -13,7 +13,7 @@ test('landing page shows features, pipeline and CTAs in English by default', asy
   await expect(getStarted).toHaveAttribute('href', '/auth/register');
 });
 
-test('landing page switches to Turkish via the locale cookie', async ({ page }) => {
+test('landing page switches to Turkish via the locale cookie', { tag: '@smoke' }, async ({ page }) => {
   await page.goto('/');
   await page.evaluate(() => { document.cookie = 'locale=tr;path=/'; });
   await page.reload();
@@ -21,7 +21,7 @@ test('landing page switches to Turkish via the locale cookie', async ({ page }) 
   await expect(page.getByText('İhtiyacın olan her şey')).toBeVisible();
 });
 
-test('public sign-in page is internationalized', async ({ page }) => {
+test('public sign-in page is internationalized', { tag: '@smoke' }, async ({ page }) => {
   await page.goto('/auth/signin');
   await expect(page.getByRole('link', { name: /Forgot password/i })).toBeVisible();
   await expect(page.getByRole('link', { name: /Register here/i })).toBeVisible();

--- a/e2e/mentor-add-mentee.spec.ts
+++ b/e2e/mentor-add-mentee.spec.ts
@@ -5,7 +5,7 @@ test.afterAll(async () => {
   await prisma.$disconnect();
 });
 
-test('mentor can add a mentee and it is assigned to them', async ({ page }) => {
+test('mentor can add a mentee and it is assigned to them', { tag: '@smoke' }, async ({ page }) => {
   const mentorEmail = uniqueEmail('mentor');
   const password = 'MentorPass123!';
   const mentor = await seedUser(mentorEmail, password, 'MENTOR', 'AddMentee Mentor');

--- a/e2e/pipeline.spec.ts
+++ b/e2e/pipeline.spec.ts
@@ -5,7 +5,7 @@ test.afterAll(async () => {
   await prisma.$disconnect();
 });
 
-test('mentor can change a mentee pipeline stage and it persists', async ({ page }) => {
+test('mentor can change a mentee pipeline stage and it persists', { tag: '@smoke' }, async ({ page }) => {
   const mentorEmail = uniqueEmail('mentor');
   const menteeEmail = uniqueEmail('mentee');
   const password = 'StagePass123!';

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -27,7 +27,7 @@ async function login(page: Page) {
   await page.waitForURL((u) => !u.pathname.includes('/auth/signin'), { timeout: 20_000 });
 }
 
-test('home page loads with favicon and no console errors', async ({ page }) => {
+test('home page loads with favicon and no console errors', { tag: '@smoke' }, async ({ page }) => {
   const diag: string[] = [];
   attachDiagnostics(page, diag);
   const res = await page.goto('/');
@@ -38,19 +38,19 @@ test('home page loads with favicon and no console errors', async ({ page }) => {
   expect(diag, `unexpected diagnostics: ${diag.join(' | ')}`).toEqual([]);
 });
 
-test('signin page renders the credentials form', async ({ page }) => {
+test('signin page renders the credentials form', { tag: '@smoke' }, async ({ page }) => {
   await page.goto('/auth/signin');
   await expect(page.locator('input[type="email"], input[name="email"]')).toBeVisible();
   await expect(page.locator('input[type="password"]')).toBeVisible();
   await expect(page.locator('button[type="submit"]')).toBeVisible();
 });
 
-test('admin can log in and lands off the signin page', async ({ page }) => {
+test('admin can log in and lands off the signin page', { tag: '@smoke' }, async ({ page }) => {
   await login(page);
   expect(page.url()).not.toContain('/auth/signin');
 });
 
-test('admin pages load without server errors', async ({ page }) => {
+test('admin pages load without server errors', { tag: '@smoke' }, async ({ page }) => {
   await login(page);
   const paths = ['/admin', '/admin/candidates', '/admin/mentorship', '/admin/companies', '/admin/invite'];
   for (const path of paths) {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint": "next lint",
     "check:i18n": "node --experimental-strip-types scripts/check-i18n.ts",
     "test:e2e": "playwright test",
+    "test:e2e:smoke": "playwright test --grep @smoke",
     "test:e2e:headed": "playwright test --headed",
     "test:stress": "node scripts/stress-test.mjs",
     "import:csv": "node scripts/import-csv.mjs",


### PR DESCRIPTION
## What & why

Story #621, Task 1 — the sustainable definition of the PR-gate smoke set, using Playwright's first-class tag mechanism (v1.61).

## Changes

- **17 critical-path tests tagged `@smoke`** across 8 specs: `smoke` (boot + login + admin pages), `auth` (4), `health` (2), `landing-i18n` (3 — the e2e-asserted landing strings), `free-core-regression`, `pipeline` (stage change persists), `invite`, `mentor-add-mentee`. Tag syntax: `test('…', { tag: '@smoke' }, …)`.
- **`test:e2e:smoke`** script: `playwright test --grep @smoke`. Verified with `--list`: exactly 17 tests in 8 files. `test:e2e` unchanged (full suite).
- **CLAUDE.md**: smoke vs full commands + the convention — new spec for a critical flow gets `@smoke`; keep the set ~15-20 tests.

## Verification

- `npx playwright test --grep @smoke --list` → 17 tests / 8 files ✅
- `npm run build` ✅ (this PR's own CI still runs the full suite — the gate switch is #623, which lands only after #624's scheduled full run exists)

Closes #622

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_