### PR TITLE
ci: scheduled full e2e suite — 4× daily, sharded, email on failure (#624)

### DIFF
--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -1,0 +1,121 @@
+name: E2E Full Suite (scheduled)
+
+# The PR gate (e2e.yml) runs only the @smoke subset; this workflow is the
+# safety net behind it (#621/#624): the FULL Playwright suite, 4× a day,
+# sharded for speed, with an email alert to the team when a run goes red.
+# Can also be run on demand from the Actions tab.
+#
+# Note: GitHub scheduled workflows can lag a few minutes and are disabled
+# automatically after 60 days without repository activity.
+on:
+  schedule:
+    # 4× a day at 03/09/15/21 UTC (~05/11/17/23 Europe/Berlin in summer).
+    - cron: '0 3,9,15,21 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-full
+  cancel-in-progress: false
+
+jobs:
+  e2e-full:
+    name: Playwright full (shard ${{ matrix.shard }}/4)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: internship_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -proot"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=15
+
+    env:
+      DATABASE_URL: "mysql://root:root@127.0.0.1:3306/internship_test"
+      NEXTAUTH_SECRET: "ci-test-secret-not-for-production"
+      NEXTAUTH_URL: "http://localhost:3000"
+      # Seeded admin used by the smoke tests
+      SEED_ADMIN_EMAIL: "admin@example.com"
+      SEED_ADMIN_PASSWORD: "ChangeMe123!"
+      ADMIN_EMAIL: "admin@example.com"
+      ADMIN_PASSWORD: "ChangeMe123!"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Apply DB schema
+        run: npx prisma db push
+
+      - name: Seed admin user
+        run: npx prisma db seed
+
+      - name: Build app
+        run: npm run build
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run full E2E suite (shard ${{ matrix.shard }}/4)
+        run: npx playwright test --shard=${{ matrix.shard }}/4
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report-full-shard-${{ matrix.shard }}
+          path: playwright-report/
+          retention-days: 7
+
+  # Single alert for the whole run (not one per shard). Reuses the app's
+  # SMTP_* secrets via scripts/send-alert-email.mjs, same as stress.yml.
+  notify:
+    name: Email alert on failure
+    runs-on: ubuntu-latest
+    needs: [e2e-full]
+    if: failure()
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Send alert email
+        env:
+          SMTP_HOST: ${{ secrets.SMTP_HOST }}
+          SMTP_PORT: ${{ secrets.SMTP_PORT }}
+          SMTP_USER: ${{ secrets.SMTP_USER }}
+          SMTP_PASS: ${{ secrets.SMTP_PASS }}
+          SMTP_FROM: ${{ secrets.SMTP_FROM }}
+          ALERT_EMAIL_TO: ${{ secrets.ALERT_EMAIL_TO || 'mehmetersahin@gmail.com' }}
+          ALERT_SUBJECT: '⚠️ Internship CRM — scheduled full e2e FAILED'
+          ALERT_BODY: |
+            The scheduled full Playwright suite failed (at least one shard red).
+            Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            Per-shard reports are attached to the run as artifacts
+            (playwright-report-full-shard-N).
+        run: |
+          # Install from the lockfile so nodemailer matches the version the app
+          # pins (single source of truth); skip postinstall (prisma generate).
+          npm ci --ignore-scripts --no-audit --no-fund
+          node scripts/send-alert-email.mjs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,8 @@ npm run test:e2e:headed  # same, with a visible browser
 server; set `BASE_URL=https://crm-preview.ersah.in` to run against a deployed env instead.
 After switching branches, run `npx prisma generate` so the client matches the schema —
 a stale client causes schema-drift 500s (the smoke test will catch these).
+The **full suite** also runs on a schedule, 4× a day (`.github/workflows/e2e-full.yml`,
+4-way sharded); a red scheduled run emails the team (`ALERT_EMAIL_TO`, stress.yml pattern).
 
 ## Architecture
 


### PR DESCRIPTION
## What & why

Story #621, Task 3 — the safety net that must exist **before** the PR gate drops to smoke-only (#623): the full 240-test Playwright suite keeps running automatically, 4× a day, and a red run emails the team.

## Design

- **`e2e-full.yml`**: `schedule: 0 3,9,15,21 * * *` + `workflow_dispatch`. Job skeleton copied from `e2e.yml` (isolated MySQL service, `db push`, seed, build).
- **4-way sharding**: matrix `shard: [1..4]`, `npx playwright test --shard=N/4` — no config change needed; `workers: 1` still applies within a shard, so total wall-clock ≈ ¼ of the serial run. `fail-fast: false` so every shard reports.
- **One alert per run, not per shard**: separate `notify` job (`needs: [e2e-full]`, `if: failure()`) reuses `scripts/send-alert-email.mjs` + `SMTP_*` secrets + `ALERT_EMAIL_TO` fallback — the exact `stress.yml` pattern. Run link in the body; per-shard reports are uploaded as artifacts (`playwright-report-full-shard-N`).
- Alarm fatigue: `retries: 1` in `playwright.config.ts` already absorbs the known flakes; green runs send nothing.
- CLAUDE.md documents the scheduled run + alert flow.

## Verification

- YAML validated; sharding uses Playwright's built-in `--shard` (v1.61).
- First live validation: manual `workflow_dispatch` after merge (schedules only fire from the default branch).

⚠️ Merge order per the story: this lands **before** #623 switches the gate to smoke.

Closes #624

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_