### PR TITLE
ci: PR gate runs the @smoke subset only (#623)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -65,8 +65,10 @@ jobs:
       - name: Install Playwright browser
         run: npx playwright install --with-deps chromium
 
+      # PR gate runs the @smoke subset only (#623); the FULL suite runs 4x a
+      # day via e2e-full.yml (sharded, email on failure) and on demand.
       - name: Run E2E smoke tests
-        run: npm run test:e2e
+        run: npm run test:e2e:smoke
 
       - name: Upload Playwright report
         if: always()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,8 +34,9 @@ npm run test:e2e:smoke   # critical-path subset only (tests tagged @smoke)
 npm run test:e2e:headed  # full suite, with a visible browser
 ```
 
-**E2E tests** (Playwright) live in `e2e/` and run as a CI quality gate on every PR
-(`.github/workflows/e2e.yml`, isolated MySQL service). The **smoke set** is the tests
+**E2E tests** (Playwright) live in `e2e/`. The PR quality gate
+(`.github/workflows/e2e.yml`, isolated MySQL service) runs **only the `@smoke` subset**;
+the full suite is the scheduled safety net (see below). The **smoke set** is the tests
 tagged `@smoke` (`test('…', { tag: '@smoke' }, …)`) — boot, auth, landing i18n, invite,
 pipeline, free-core regression. When you add a spec for a *critical* flow, tag it
 `@smoke`; keep the set small (~15-20 tests) so the PR gate stays fast. Locally `test:e2e`


### PR DESCRIPTION
## What & why

Story #621, Task 2 — the final piece: with #622 (the `@smoke` set + script) and #624 (scheduled full suite + alert email) both on main, the PR gate can safely drop to smoke-only.

## Changes

- `e2e.yml` test step: `npm run test:e2e` → **`npm run test:e2e:smoke`** (17 tests instead of ~240 — minutes instead of ~10).
- Job name intentionally **unchanged** (`Playwright smoke` — it was always called that, now it's finally accurate), so any required-check reference in branch protection keeps working.
- Comment in the workflow + CLAUDE.md point at the smoke/full split (full suite: 4×/day via `e2e-full.yml`, red runs email `ALERT_EMAIL_TO`).

## Safety net status

#624 is merged, so there is no coverage gap: full suite runs on schedule and via `workflow_dispatch`. This PR's own CI is the last full-suite PR run.

Closes #623

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_