### PR TITLE
feat(projects): detailed card + internal detail view (#616)

### DIFF
--- a/e2e/project-detail.spec.ts
+++ b/e2e/project-detail.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// #616: /projects/[id] serves two audiences — the public PII-free showcase
+// view (public projects only), and an internal view for admins/owners with
+// members, goals, dates and task progress, including private projects.
+test('project detail: internal section for the admin, PII-free public view, 404 for private+anonymous', async ({ browser }) => {
+  const adminEmail = uniqueEmail('pd-admin');
+  const menteeEmail = uniqueEmail('pd-mentee');
+  const pw = 'DetailPass123';
+  const admin = await seedUser(adminEmail, pw, 'ADMIN', 'Detail Admin');
+  const mentee = await seedUser(menteeEmail, 'x', 'MENTEE', 'Detail Member');
+
+  const priv = await prisma.project.create({
+    data: {
+      name: 'Private Detail Project', ownerType: 'ADMIN', ownerUserId: admin.id, isPublic: false,
+      technologies: ['Rust'], goals: 'Ship the detail view',
+      tasks: { create: [{ title: 'Done task', done: true, order: 1 }, { title: 'Open task', done: false, order: 2 }] },
+    },
+  });
+  const pub = await prisma.project.create({
+    data: { name: 'Public Detail Project', ownerType: 'ADMIN', ownerUserId: admin.id, isPublic: true, technologies: ['Go'] },
+  });
+  const relation = await prisma.mentorshipRelation.create({
+    data: { mentorId: admin.id, menteeId: mentee.id, status: 'ACTIVE', projectId: priv.id },
+  });
+
+  const adminCtx = await browser.newContext();
+  const anonCtx = await browser.newContext();
+  try {
+    // Admin sees the private project with the internal section.
+    const adminPage = await adminCtx.newPage();
+    await adminPage.goto('/auth/signin');
+    await adminPage.fill('input[type="email"], input[name="email"]', adminEmail);
+    await adminPage.fill('input[type="password"]', pw);
+    await adminPage.click('button[type="submit"]');
+    await adminPage.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    await adminPage.goto(`/projects/${priv.id}`);
+    await expect(adminPage.getByRole('heading', { name: 'Private Detail Project' })).toBeVisible({ timeout: 10_000 });
+    const internal = adminPage.getByTestId('project-internal');
+    await expect(internal).toBeVisible();
+    await expect(internal.getByText('Detail Member')).toBeVisible();
+    await expect(internal.getByText('Ship the detail view')).toBeVisible();
+    await expect(internal.getByText('Open task')).toBeVisible();
+
+    // Anonymous: private project 404s; public project renders without the
+    // internal section (no member names — PII-free).
+    const anonPage = await anonCtx.newPage();
+    const res = await anonPage.goto(`/projects/${priv.id}`);
+    expect(res!.status()).toBe(404);
+    await anonPage.goto(`/projects/${pub.id}`);
+    await expect(anonPage.getByRole('heading', { name: 'Public Detail Project' })).toBeVisible({ timeout: 10_000 });
+    await expect(anonPage.getByTestId('project-internal')).toHaveCount(0);
+    await expect(anonPage.getByText('Detail Member')).toHaveCount(0);
+  } finally {
+    await adminCtx.close();
+    await anonCtx.close();
+    await prisma.mentorshipRelation.delete({ where: { id: relation.id } }).catch(() => {});
+    await prisma.project.deleteMany({ where: { id: { in: [priv.id, pub.id] } } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -11,6 +11,12 @@ const include = {
   ownerUser: { select: { id: true, fullName: true, role: true } },
   ownerCompany: { select: { id: true, name: true } },
   tasks: { orderBy: { order: 'asc' } },
+  // Member (mentee) names for the card's "who's on it" row (#616).
+  relations: {
+    where: { status: 'ACTIVE' },
+    select: { mentee: { select: { id: true, fullName: true } } },
+    take: 12,
+  },
   _count: { select: { relations: true } },
 } as const;
 
@@ -25,6 +31,10 @@ export async function GET() {
   else if (session.user.role === 'MENTEE') where = { isPublic: true };
 
   const projects = await prisma.project.findMany({ where, include, orderBy: { updatedAt: 'desc' } });
+  // Mentees only browse the public showcase set — keep it PII-free (count only).
+  if (session.user.role === 'MENTEE') {
+    return NextResponse.json({ projects: projects.map(({ relations: _relations, ...rest }) => rest) });
+  }
   return NextResponse.json({ projects });
 }
 

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -1,26 +1,54 @@
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
-import { GraduationCap, Github, ExternalLink, Trello } from 'lucide-react';
+import { getServerSession } from 'next-auth';
+import { GraduationCap, Github, ExternalLink, Trello, CheckCircle2, Circle } from 'lucide-react';
+import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { getServerDictionary } from '@/i18n/server';
+import { Badge } from '@/components/ui/Badge';
 
 export const dynamic = 'force-dynamic';
 
-// Public, PII-free detail for a project opted into the showcase.
-export default async function PublicProjectPage({ params }: { params: Promise<{ id: string }> }) {
+const STATUS_VARIANT: Record<string, 'success' | 'info' | 'default' | 'warning'> = {
+  DRAFT: 'warning', ACTIVE: 'success', COMPLETED: 'info', ARCHIVED: 'default', CANCELLED: 'default',
+};
+
+// Project detail (#616). Public visitors get the PII-free showcase view of
+// public projects, exactly as before. Signed-in internal viewers — admins,
+// the owning mentor, the owning company — also see private projects plus an
+// internal section: status, dates, goals, members and task progress.
+export default async function ProjectDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   const { t } = await getServerDictionary();
-  const p = await prisma.project.findFirst({
-    where: { id, isPublic: true },
+  const session = await getServerSession(authOptions);
+
+  const p = await prisma.project.findUnique({
+    where: { id },
     select: {
       name: true, description: true, technologies: true, repoUrl: true, demoUrl: true, boardUrl: true, status: true,
-      ownerType: true, ownerUser: { select: { fullName: true } }, ownerCompany: { select: { name: true } },
+      isPublic: true, goals: true, startDate: true, endDate: true,
+      ownerType: true, ownerUserId: true, ownerCompanyId: true,
+      ownerUser: { select: { fullName: true } }, ownerCompany: { select: { name: true } },
+      tasks: { orderBy: { order: 'asc' }, select: { id: true, title: true, done: true } },
+      relations: { where: { status: 'ACTIVE' }, select: { mentee: { select: { id: true, fullName: true } } } },
       _count: { select: { relations: true } },
     },
   });
   if (!p) notFound();
+
+  const role = session?.user.role;
+  const canInternal =
+    role === 'ADMIN' ||
+    (!!session && p.ownerUserId === session.user.id) ||
+    (role === 'COMPANY' && !!session?.user.companyId && p.ownerCompanyId === session.user.companyId);
+  if (!p.isPublic && !canInternal) notFound();
+
   const tech = Array.isArray(p.technologies) ? (p.technologies as string[]) : [];
   const owner = p.ownerType === 'COMPANY' ? p.ownerCompany?.name : p.ownerUser?.fullName;
+  const statusLabel = t.projects[p.status.toLowerCase() as 'draft' | 'active' | 'completed' | 'archived' | 'cancelled'];
+  const done = p.tasks.filter((tk) => tk.done).length;
+  const pct = p.tasks.length ? Math.round((done / p.tasks.length) * 100) : 0;
+  const fmt = (d: Date | null) => (d ? d.toISOString().slice(0, 10) : '…');
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-50 py-12 px-4">
@@ -29,7 +57,11 @@ export default async function PublicProjectPage({ params }: { params: Promise<{ 
           <GraduationCap className="h-4 w-4 text-blue-600" /> {t.projects.showcaseTitle}
         </Link>
         <div className="bg-white rounded-2xl border border-gray-200 p-8">
-          <h1 className="text-2xl font-bold text-gray-900">{p.name}</h1>
+          <div className="flex items-center gap-2 flex-wrap">
+            <h1 className="text-2xl font-bold text-gray-900">{p.name}</h1>
+            {canInternal && <Badge variant={STATUS_VARIANT[p.status]}>{statusLabel}</Badge>}
+            {p.isPublic && canInternal && <Badge variant="purple">{t.projects.public}</Badge>}
+          </div>
           {owner && <p className="text-sm text-gray-500 mt-1">{t.projects.by} {owner}</p>}
           {p.description && <p className="text-gray-700 mt-4 whitespace-pre-wrap">{p.description}</p>}
           {tech.length > 0 && (
@@ -42,7 +74,59 @@ export default async function PublicProjectPage({ params }: { params: Promise<{ 
             {p.demoUrl && <a href={p.demoUrl} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 text-blue-600 hover:underline"><ExternalLink className="h-4 w-4" />{t.projects.demo}</a>}
             {p.boardUrl && <a href={p.boardUrl} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 text-blue-600 hover:underline"><Trello className="h-4 w-4" />{t.projects.board}</a>}
           </div>
-          <p className="text-xs text-gray-400 mt-6">{p._count.relations} {t.projects.members}</p>
+
+          {canInternal ? (
+            <div className="mt-8 border-t border-gray-100 pt-6 space-y-5" data-testid="project-internal">
+              {(p.startDate || p.endDate) && (
+                <p className="text-sm text-gray-500">{fmt(p.startDate)} – {fmt(p.endDate)}</p>
+              )}
+              {p.goals && (
+                <div>
+                  <h2 className="text-sm font-semibold text-gray-900 mb-1">{t.projects.goalsLabel}</h2>
+                  <p className="text-sm text-gray-700 whitespace-pre-wrap">{p.goals}</p>
+                </div>
+              )}
+              <div>
+                <h2 className="text-sm font-semibold text-gray-900 mb-1.5">
+                  {t.projects.members} ({p._count.relations})
+                </h2>
+                {p.relations.length === 0 ? (
+                  <p className="text-sm text-gray-400">{t.projects.noMembers}</p>
+                ) : (
+                  <div className="flex flex-wrap gap-1.5">
+                    {p.relations.map((r) => (
+                      <span key={r.mentee.id} className="px-2.5 py-1 rounded-full bg-gray-100 text-gray-700 text-sm">
+                        {r.mentee.fullName}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </div>
+              {p.tasks.length > 0 && (
+                <div>
+                  <div className="flex justify-between text-xs text-gray-500 mb-1">
+                    <span>{done}/{p.tasks.length} {t.projects.tasksDone}</span>
+                    <span>{pct}%</span>
+                  </div>
+                  <div className="h-1.5 bg-gray-100 rounded-full overflow-hidden mb-2">
+                    <div className="h-full bg-green-500" style={{ width: `${pct}%` }} />
+                  </div>
+                  <ul className="space-y-1">
+                    {p.tasks.map((tk) => (
+                      <li key={tk.id} className="flex items-center gap-2 text-sm">
+                        {tk.done
+                          ? <CheckCircle2 className="h-4 w-4 text-green-500 flex-shrink-0" />
+                          : <Circle className="h-4 w-4 text-gray-300 flex-shrink-0" />}
+                        <span className={tk.done ? 'line-through text-gray-400' : 'text-gray-700'}>{tk.title}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          ) : (
+            <p className="text-xs text-gray-400 mt-6">{p._count.relations} {t.projects.members}</p>
+          )}
         </div>
       </div>
     </div>

--- a/src/components/ProjectsManager.tsx
+++ b/src/components/ProjectsManager.tsx
@@ -6,7 +6,7 @@ import { Input } from '@/components/ui/Input';
 import { Button } from '@/components/ui/Button';
 import { Select } from '@/components/ui/Select';
 import { Badge } from '@/components/ui/Badge';
-import { Github, ExternalLink, Trash2, Pencil, Trello, Plus } from 'lucide-react';
+import { Github, ExternalLink, Trash2, Pencil, Trello, Plus, Eye } from 'lucide-react';
 import { useT, useLocale } from '@/i18n/client';
 import { formatDate } from '@/lib/relativeTime';
 
@@ -33,6 +33,7 @@ interface Project {
   ownerUser?: { id: string; fullName: string } | null;
   ownerCompany?: { id: string; name: string } | null;
   tasks?: Task[];
+  relations?: { mentee: { id: string; fullName: string } }[];
   _count?: { relations: number };
 }
 
@@ -266,6 +267,20 @@ export function ProjectsManager({ isAdmin }: { isAdmin: boolean }) {
                     <p className="text-xs text-gray-500 mt-0.5">
                       {t.projects.owner}: {ownerLabel(p)} · {p._count?.relations ?? 0} {t.projects.members}
                     </p>
+                    {(p.relations?.length ?? 0) > 0 && (
+                      <div className="flex flex-wrap gap-1 mt-1.5" data-testid="project-members">
+                        {p.relations!.slice(0, 6).map((r) => (
+                          <span key={r.mentee.id} className="px-2 py-0.5 rounded-full bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 text-xs">
+                            {r.mentee.fullName}
+                          </span>
+                        ))}
+                        {(p._count?.relations ?? 0) > 6 && (
+                          <span className="px-2 py-0.5 rounded-full bg-gray-100 dark:bg-gray-800 text-gray-500 text-xs">
+                            +{(p._count?.relations ?? 0) - 6}
+                          </span>
+                        )}
+                      </div>
+                    )}
                     {p.description && <p className="text-sm text-gray-600 mt-1 line-clamp-2">{p.description}</p>}
                     <div className="flex flex-wrap gap-1 mt-2">
                       {p.technologies.map((tech) => (
@@ -276,6 +291,7 @@ export function ProjectsManager({ isAdmin }: { isAdmin: boolean }) {
                       {p.repoUrl && <a href={p.repoUrl} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 text-gray-600 hover:text-blue-600"><Github className="h-3.5 w-3.5" />{t.projects.repo}</a>}
                       {p.demoUrl && <a href={p.demoUrl} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 text-gray-600 hover:text-blue-600"><ExternalLink className="h-3.5 w-3.5" />{t.projects.demo}</a>}
                       {p.boardUrl && <a href={p.boardUrl} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 text-gray-600 hover:text-blue-600"><Trello className="h-3.5 w-3.5" />{t.projects.board}</a>}
+                      <a href={`/projects/${p.id}`} className="inline-flex items-center gap-1 text-blue-600 hover:underline" data-testid="project-detail-link"><Eye className="h-3.5 w-3.5" />{t.projects.viewDetail}</a>
                       {(p.startDate || p.endDate) && (
                         <span className="text-gray-400">
                           {p.startDate ? formatDate(p.startDate, locale) : '…'} – {p.endDate ? formatDate(p.endDate, locale) : '…'}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -708,6 +708,9 @@ const en = {
     by: 'by',
     confirmDelete: 'Delete project "{name}"? This cannot be undone.',
     confirmDeleteTask: 'Delete task "{title}"?',
+    viewDetail: 'Detail',
+    noMembers: 'No members yet',
+    goalsLabel: 'Goals',
   },
   evaluation: {
     title: 'Evaluation',
@@ -2073,6 +2076,9 @@ const tr: Dict = {
     by: '·',
     confirmDelete: '"{name}" projesini silmek istiyor musun? Bu işlem geri alınamaz.',
     confirmDeleteTask: '"{title}" görevini silmek istiyor musun?',
+    viewDetail: 'Detay',
+    noMembers: 'Henüz üye yok',
+    goalsLabel: 'Hedefler',
   },
   evaluation: {
     title: 'Değerlendirme',
@@ -3436,6 +3442,9 @@ const de: Dict = {
     by: 'von',
     confirmDelete: 'Projekt "{name}" löschen? Dies kann nicht rückgängig gemacht werden.',
     confirmDeleteTask: 'Aufgabe "{title}" löschen?',
+    viewDetail: 'Detail',
+    noMembers: 'Noch keine Mitglieder',
+    goalsLabel: 'Ziele',
   },
   evaluation: {
     title: 'Bewertung',


### PR DESCRIPTION
## What & why

Story #614, Task 2 — every project answers "what is it, who's on it, how far along" at a glance, on top of the #615 card grid.

## Changes

- **Card**: active member (mentee) names as chips (capped at 6, `+N` overflow, `data-testid="project-members"`) and a **Detail** link per card. Owner, status, tech, links, tasks/progress stay as before.
- **`/api/projects`**: `include` now returns active-relation mentee names for admin/mentor/company callers. **Mentee responses stay count-only** — the public showcase set remains PII-free.
- **`/projects/[id]`** becomes dual-audience:
  - *Public/anonymous*: exactly the old PII-free showcase view (public projects only, private → 404, member count only).
  - *Internal* (admin, owning mentor, owning company): private projects render too, plus an internal section (`data-testid="project-internal"`) with status badge, date range, goals, member chips and the task list with progress bar.
- New i18n keys `projects.viewDetail/noMembers/goalsLabel` (EN/TR/DE, `check:i18n` 1360 × 3 ✅).

## Verification

- New e2e `project-detail.spec.ts`: admin sees the internal section (member name, goals, open task) on a **private** project; anonymous gets 404 for it; the public project renders with **no** internal section and no member names.
- `tsc --noEmit` ✅ · `npm run build` ✅

Closes #616

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_