### PR TITLE
feat(projects): ProjectMember model — multiple owners & mentors (#617)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -165,6 +165,13 @@ jobs:
             "\$IMAGE" \
             node prisma/seed-templates.mjs || true
 
+          # Backfill ProjectMember OWNER rows (#617, idempotent).
+          docker run --rm \
+            --network=host \
+            -e DATABASE_URL="\$DATABASE_URL" \
+            "\$IMAGE" \
+            node prisma/backfill-project-members.mjs || true
+
           docker stop internship-crm 2>/dev/null || true
           docker rm   internship-crm 2>/dev/null || true
           # Run with host networking so the app reaches the host's MySQL over
@@ -263,6 +270,13 @@ jobs:
             -e DATABASE_URL="\$CONTAINER_DB" \
             "\$IMAGE" \
             node prisma/seed-templates.mjs || true
+
+          # Backfill ProjectMember OWNER rows (#617, idempotent).
+          docker run --rm \
+            --network=host \
+            -e DATABASE_URL="\$DATABASE_URL" \
+            "\$IMAGE" \
+            node prisma/backfill-project-members.mjs || true
 
           docker stop internship-crm-preview 2>/dev/null || true
           docker rm   internship-crm-preview 2>/dev/null || true

--- a/e2e/project-members.spec.ts
+++ b/e2e/project-members.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// #617: multi-owner/multi-mentor membership. Creating a person-owned project
+// writes an OWNER member row; members can be added/promoted/removed via
+// /api/projects/[id]/members; the last OWNER can never be removed or demoted;
+// removing the legacy owner repoints the legacy pointer at a remaining OWNER.
+test('project members: add, promote, last-owner guard, legacy-owner repointing', async ({ browser }) => {
+  const adminEmail = uniqueEmail('pm-admin');
+  const m1Email = uniqueEmail('pm-mentor1');
+  const m2Email = uniqueEmail('pm-mentor2');
+  const pw = 'MembersPass123';
+  await seedUser(adminEmail, pw, 'ADMIN', 'Members Admin');
+  const m1 = await seedUser(m1Email, 'x', 'MENTOR', 'Members Mentor One');
+  const m2 = await seedUser(m2Email, 'x', 'MENTOR', 'Members Mentor Two');
+
+  const ctx = await browser.newContext();
+  let projectId = '';
+  try {
+    const page = await ctx.newPage();
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', pw);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    // Create → the person owner automatically becomes an OWNER member.
+    const created = await page.request.post('/api/projects', {
+      data: { name: 'Members Project', ownerType: 'MENTOR', ownerUserId: m1.id },
+    });
+    expect(created.ok()).toBeTruthy();
+    projectId = (await created.json()).project.id;
+    let members = (await (await page.request.get(`/api/projects/${projectId}/members`)).json()).members as
+      { role: string; user: { id: string } }[];
+    expect(members).toHaveLength(1);
+    expect(members[0]).toMatchObject({ role: 'OWNER', user: { id: m1.id } });
+
+    // Add a second mentor, then promote them to OWNER.
+    const added = await page.request.post(`/api/projects/${projectId}/members`, { data: { userId: m2.id, role: 'MENTOR' } });
+    expect(added.status()).toBe(201);
+    const promoted = await page.request.post(`/api/projects/${projectId}/members`, { data: { userId: m2.id, role: 'OWNER' } });
+    expect(promoted.status()).toBe(201);
+
+    // Remove the original owner → allowed (another OWNER remains) and the
+    // legacy pointer follows.
+    const removed = await page.request.delete(`/api/projects/${projectId}/members`, { data: { userId: m1.id } });
+    expect(removed.ok()).toBeTruthy();
+    const after = await prisma.project.findUnique({ where: { id: projectId }, select: { ownerUserId: true } });
+    expect(after!.ownerUserId).toBe(m2.id);
+
+    // Last-owner guards: neither removal nor demotion may leave zero owners.
+    const lastRemove = await page.request.delete(`/api/projects/${projectId}/members`, { data: { userId: m2.id } });
+    expect(lastRemove.status()).toBe(409);
+    expect((await lastRemove.json()).code).toBe('last_owner');
+    const lastDemote = await page.request.post(`/api/projects/${projectId}/members`, { data: { userId: m2.id, role: 'MENTOR' } });
+    expect(lastDemote.status()).toBe(409);
+
+    members = (await (await page.request.get(`/api/projects/${projectId}/members`)).json()).members;
+    expect(members.filter((m) => m.role === 'OWNER')).toHaveLength(1);
+  } finally {
+    await ctx.close();
+    if (projectId) await prisma.project.deleteMany({ where: { id: projectId } });
+    await cleanupByEmail(m1Email);
+    await cleanupByEmail(m2Email);
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/prisma/backfill-project-members.mjs
+++ b/prisma/backfill-project-members.mjs
@@ -1,0 +1,30 @@
+// Idempotent backfill for #617: every project with a person owner
+// (ownerUserId) gets a ProjectMember(role=OWNER) row, so no project is left
+// ownerless when consumers switch to the members table. Safe to run on every
+// deploy (skipDuplicates) — mirrors the seed-templates.mjs pattern.
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const projects = await prisma.project.findMany({
+    where: { ownerUserId: { not: null } },
+    select: { id: true, ownerUserId: true },
+  });
+  if (projects.length === 0) {
+    console.log('backfill-project-members: no person-owned projects.');
+    return;
+  }
+  const { count } = await prisma.projectMember.createMany({
+    data: projects.map((p) => ({ projectId: p.id, userId: p.ownerUserId, role: 'OWNER' })),
+    skipDuplicates: true,
+  });
+  console.log(`backfill-project-members: ${count} OWNER row(s) created (${projects.length} person-owned projects).`);
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -136,6 +136,7 @@ model User {
   avatarFile              AvatarFile?
   notifications           Notification[]
   ownedProjects           Project[]                @relation("ProjectOwner")
+  projectMemberships      ProjectMember[]          @relation("ProjectMemberships")
   availabilitySlots       AvailabilitySlot[]
   company                 Company?                 @relation("CompanyUsers", fields: [companyId], references: [id])
   source                  Source?                  @relation(fields: [sourceId], references: [id])
@@ -580,9 +581,34 @@ model Project {
   ownerCompany Company?             @relation("CompanyProjects", fields: [ownerCompanyId], references: [id])
   relations    MentorshipRelation[]
   tasks        ProjectTask[]
+  members      ProjectMember[]
 
   @@index([ownerUserId])
   @@index([ownerCompanyId])
+}
+
+// Person-level project membership (#617): a project can have several OWNERs
+// (admins/mentors) and several MENTORs. Company ownership stays on
+// ownerCompanyId; legacy ownerType/ownerUserId are kept in sync with the
+// OWNER rows for backward compatibility until every consumer reads members.
+enum ProjectMemberRole {
+  OWNER
+  MENTOR
+}
+
+model ProjectMember {
+  id        String            @id @default(cuid())
+  projectId String
+  userId    String
+  role      ProjectMemberRole @default(MENTOR)
+  addedAt   DateTime          @default(now())
+
+  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  user    User    @relation("ProjectMemberships", fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([projectId, userId])
+  @@index([userId])
+  @@index([projectId, role])
 }
 
 // A task within a project — supports a task list + progress % (checklist 4).

--- a/prisma/seed.mjs
+++ b/prisma/seed.mjs
@@ -22,6 +22,19 @@ async function main() {
     console.log(`Created ADMIN user: ${email}`);
   }
 
+  // Backfill ProjectMember OWNER rows (#617, idempotent) so no person-owned
+  // project is ever without an OWNER member.
+  const owned = await prisma.project.findMany({
+    where: { ownerUserId: { not: null } },
+    select: { id: true, ownerUserId: true },
+  });
+  if (owned.length > 0) {
+    await prisma.projectMember.createMany({
+      data: owned.map((p) => ({ projectId: p.id, userId: p.ownerUserId, role: 'OWNER' })),
+      skipDuplicates: true,
+    });
+  }
+
   // Idempotent company seed (Company.name is not unique, so check first).
   for (const name of SEED_COMPANIES) {
     const found = await prisma.company.findFirst({ where: { name } });

--- a/src/app/api/projects/[id]/members/route.ts
+++ b/src/app/api/projects/[id]/members/route.ts
@@ -1,0 +1,119 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { z } from 'zod';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { logActivity } from '@/lib/activity';
+import { notify } from '@/lib/notify';
+
+// Person-level project membership management (#617): add/remove OWNERs and
+// MENTORs. Only an admin or a current OWNER may change the list, and the
+// last OWNER can never be removed (no ownerless projects).
+
+const addSchema = z.object({
+  userId: z.string().min(1),
+  role: z.enum(['OWNER', 'MENTOR']).default('MENTOR'),
+});
+const removeSchema = z.object({ userId: z.string().min(1) });
+
+async function loadContext(id: string) {
+  const project = await prisma.project.findUnique({
+    where: { id },
+    select: { id: true, name: true, ownerUserId: true, members: { select: { userId: true, role: true } } },
+  });
+  return project;
+}
+
+function canManageMembers(user: { id: string; role: string }, project: { members: { userId: string; role: string }[] }) {
+  if (user.role === 'ADMIN') return true;
+  return project.members.some((m) => m.userId === user.id && m.role === 'OWNER');
+}
+
+export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role === 'MENTEE') return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const { id } = await params;
+  const members = await prisma.projectMember.findMany({
+    where: { projectId: id },
+    orderBy: { addedAt: 'asc' },
+    select: { role: true, addedAt: true, user: { select: { id: true, fullName: true, role: true } } },
+  });
+  return NextResponse.json({ members });
+}
+
+// POST — add (or re-role) a member. Target must be an active MENTOR or ADMIN.
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const { id } = await params;
+  const project = await loadContext(id);
+  if (!project) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  if (!canManageMembers(session.user, project)) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+  const parsed = addSchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+  const { userId, role } = parsed.data;
+
+  const target = await prisma.user.findUnique({ where: { id: userId }, select: { id: true, role: true, isActive: true } });
+  if (!target || !target.isActive || (target.role !== 'MENTOR' && target.role !== 'ADMIN')) {
+    return NextResponse.json({ error: 'Member must be an active mentor or admin' }, { status: 400 });
+  }
+
+  // Demoting the last OWNER to MENTOR would leave the project ownerless.
+  const owners = project.members.filter((m) => m.role === 'OWNER');
+  if (role === 'MENTOR' && owners.length === 1 && owners[0].userId === userId) {
+    return NextResponse.json({ error: 'A project must keep at least one owner', code: 'last_owner' }, { status: 409 });
+  }
+
+  const member = await prisma.projectMember.upsert({
+    where: { projectId_userId: { projectId: id, userId } },
+    update: { role },
+    create: { projectId: id, userId, role },
+    select: { role: true, user: { select: { id: true, fullName: true } } },
+  });
+  if (userId !== session.user.id) {
+    await notify(userId, 'project', `You were added to project "${project.name}".`, '/projects/' + id);
+  }
+  await logActivity({ action: 'project.member_add', actorId: session.user.id, actorEmail: session.user.email ?? null, targetType: 'project', targetId: id, detail: `${userId} as ${role}` });
+  return NextResponse.json({ member }, { status: 201 });
+}
+
+// DELETE — remove a member; the last OWNER is protected.
+export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const { id } = await params;
+  const project = await loadContext(id);
+  if (!project) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  if (!canManageMembers(session.user, project)) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+  const parsed = removeSchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+  const { userId } = parsed.data;
+
+  const existing = project.members.find((m) => m.userId === userId);
+  if (!existing) return NextResponse.json({ error: 'Not a member' }, { status: 404 });
+
+  const owners = project.members.filter((m) => m.role === 'OWNER');
+  if (existing.role === 'OWNER' && owners.length === 1) {
+    return NextResponse.json({ error: 'A project must keep at least one owner', code: 'last_owner' }, { status: 409 });
+  }
+
+  await prisma.projectMember.delete({ where: { projectId_userId: { projectId: id, userId } } });
+
+  // Keep the legacy single-owner pointer valid: if the removed user was the
+  // legacy owner, repoint it at a remaining OWNER member.
+  if (project.ownerUserId === userId) {
+    const nextOwner = owners.find((o) => o.userId !== userId);
+    if (nextOwner) {
+      const nextUser = await prisma.user.findUnique({ where: { id: nextOwner.userId }, select: { role: true } });
+      await prisma.project.update({
+        where: { id },
+        data: { ownerUserId: nextOwner.userId, ownerType: nextUser?.role === 'ADMIN' ? 'ADMIN' : 'MENTOR' },
+      });
+    }
+  }
+
+  await logActivity({ action: 'project.member_remove', actorId: session.user.id, actorEmail: session.user.email ?? null, targetType: 'project', targetId: id, detail: userId });
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -13,6 +13,10 @@ const include = {
     select: { id: true, pipelineStatus: true, mentee: { select: { id: true, fullName: true } }, mentor: { select: { fullName: true } } },
   },
   tasks: { orderBy: { order: 'asc' } },
+  members: {
+    orderBy: { addedAt: 'asc' },
+    select: { role: true, user: { select: { id: true, fullName: true, role: true } } },
+  },
 } as const;
 
 export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
@@ -82,6 +86,16 @@ export async function PUT(request: Request, { params }: { params: Promise<{ id: 
   }
 
   const updated = await prisma.project.update({ where: { id }, data, include });
+  // Keep the members table in step with a legacy transfer (#617): the new
+  // person owner becomes (or stays) an OWNER member. Previous owners keep
+  // their rows — multi-owner is allowed; removal goes through /members.
+  if (transferred && typeof data.ownerUserId === 'string') {
+    await prisma.projectMember.upsert({
+      where: { projectId_userId: { projectId: id, userId: data.ownerUserId } },
+      update: { role: 'OWNER' },
+      create: { projectId: id, userId: data.ownerUserId, role: 'OWNER' },
+    });
+  }
   if (transferred) {
     await logActivity({ action: 'project.transfer', level: 'warning', actorId: session.user.id, actorEmail: session.user.email ?? null, targetType: 'project', targetId: id, detail: transferred });
   }

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -17,6 +17,10 @@ const include = {
     select: { mentee: { select: { id: true, fullName: true } } },
     take: 12,
   },
+  members: {
+    orderBy: { addedAt: 'asc' },
+    select: { role: true, user: { select: { id: true, fullName: true, role: true } } },
+  },
   _count: { select: { relations: true } },
 } as const;
 
@@ -31,9 +35,12 @@ export async function GET() {
   else if (session.user.role === 'MENTEE') where = { isPublic: true };
 
   const projects = await prisma.project.findMany({ where, include, orderBy: { updatedAt: 'desc' } });
-  // Mentees only browse the public showcase set — keep it PII-free (count only).
+  // Mentees only browse the public showcase set — keep it PII-free
+  // (member/relation names stripped, count only).
   if (session.user.role === 'MENTEE') {
-    return NextResponse.json({ projects: projects.map(({ relations: _relations, ...rest }) => rest) });
+    return NextResponse.json({
+      projects: projects.map(({ relations: _relations, members: _members, ...rest }) => rest),
+    });
   }
   return NextResponse.json({ projects });
 }
@@ -78,6 +85,9 @@ export async function POST(request: Request) {
 
   const project = await prisma.project.create({
     data: {
+      // Person owners also get an OWNER member row (#617) so the members
+      // table is authoritative from day one.
+      ...(owner.ownerUserId ? { members: { create: { userId: owner.ownerUserId, role: 'OWNER' } } } : {}),
       name: d.name,
       description: d.description || null,
       technologies: d.technologies ?? [],


### PR DESCRIPTION
## What & why

Story #614, Task 3 — the data-model foundation for multi-owner/multi-mentor projects, transfer (#618) and owner-only permissions (#619).

## Schema

- `ProjectMemberRole` enum (`OWNER` / `MENTOR`) + `ProjectMember` join model: `@@unique([projectId, userId])`, cascade deletes, `[userId]` + `[projectId, role]` indexes; `Project.members` and a `User` back-relation.
- **Company ownership stays on `ownerCompanyId`**; legacy `ownerType`/`ownerUserId` remain and are kept in sync with OWNER rows so every existing consumer keeps working (rationale in the schema comment).

## Data safety (db-push project — no SQL migrations)

- `prisma/backfill-project-members.mjs` — idempotent (`createMany + skipDuplicates`): every person-owned project gets its OWNER row. Wired into **deploy.yml** (prod + preview, right after the seed-templates step) and into **`prisma db seed`** for CI/local. No project is left ownerless.
- Creating a person-owned project writes the OWNER row in the same create; a legacy admin transfer upserts one.

## API

- `/api/projects` + `/api/projects/[id]` now return `members` (role + user id/name/role); mentee responses stay member-free (public-set PII discipline).
- New **`/api/projects/[id]/members`**: GET list; POST add/re-role (admin or current OWNER only; target must be an active mentor/admin); DELETE remove. **Invariant**: the last OWNER can neither be removed nor demoted (`409 last_owner`). Removing the legacy owner repoints `ownerUserId` at a remaining OWNER. Changes audited + added users notified.

## Verification

- e2e `project-members.spec.ts`: create → auto-OWNER row; add + promote second mentor; remove original owner (legacy pointer repoints); 409 on last-owner removal *and* demotion.
- `prisma validate` ✅ · `tsc --noEmit` ✅ · `npm run build` ✅

Closes #617

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_