### PR TITLE
feat(projects): owner-only field permissions — API + UI (#619)

### DIFF
--- a/e2e/project-owner-perms.spec.ts
+++ b/e2e/project-owner-perms.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// #619: owner-only field permissions. A non-owner MENTOR member may edit the
+// collaborative fields (description, tech, links, goals, tasks) but gets 403
+// for owner-protected fields (name/status/isPublic/dates/owner) and delete.
+test('owner-only fields: mentor member edits collaborative fields, protected ones are 403', async ({ browser }) => {
+  const ownerEmail = uniqueEmail('perm-owner');
+  const memberEmail = uniqueEmail('perm-member');
+  const pw = 'PermsPass123';
+  const owner = await seedUser(ownerEmail, 'x', 'MENTOR', 'Perm Owner');
+  const member = await seedUser(memberEmail, pw, 'MENTOR', 'Perm Member');
+
+  const project = await prisma.project.create({
+    data: {
+      name: 'Perms Project', ownerType: 'MENTOR', ownerUserId: owner.id, technologies: [],
+      members: {
+        create: [
+          { userId: owner.id, role: 'OWNER' },
+          { userId: member.id, role: 'MENTOR' },
+        ],
+      },
+    },
+  });
+
+  const ctx = await browser.newContext();
+  try {
+    const page = await ctx.newPage();
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', memberEmail);
+    await page.fill('input[type="password"]', pw);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => !u.pathname.startsWith('/auth'), { timeout: 20_000 });
+
+    // Member sees the project in their list (not owner, still a member).
+    const listed = await (await page.request.get('/api/projects')).json();
+    expect((listed.projects as { id: string }[]).some((pr) => pr.id === project.id)).toBe(true);
+
+    // Collaborative edit works…
+    const okEdit = await page.request.put(`/api/projects/${project.id}`, {
+      data: { description: 'Updated by a mentor member', technologies: ['TypeScript'] },
+    });
+    expect(okEdit.ok()).toBeTruthy();
+
+    // …owner-protected fields are rejected with the field list…
+    const blocked = await page.request.put(`/api/projects/${project.id}`, {
+      data: { name: 'Hijacked', status: 'ARCHIVED' },
+    });
+    expect(blocked.status()).toBe(403);
+    const body = await blocked.json();
+    expect(body.code).toBe('owner_only');
+    expect(body.fields).toContain('name');
+
+    // …tasks are collaborative…
+    const task = await page.request.post(`/api/projects/${project.id}/tasks`, { data: { title: 'Member task' } });
+    expect(task.status()).toBe(201);
+
+    // …and deletion is owner-only.
+    const del = await page.request.delete(`/api/projects/${project.id}`);
+    expect(del.status()).toBe(403);
+    expect(await prisma.project.count({ where: { id: project.id } })).toBe(1);
+    const after = await prisma.project.findUnique({ where: { id: project.id }, select: { name: true, description: true } });
+    expect(after!.name).toBe('Perms Project');
+    expect(after!.description).toBe('Updated by a mentor member');
+  } finally {
+    await ctx.close();
+    await prisma.project.deleteMany({ where: { id: project.id } });
+    await cleanupByEmail(memberEmail);
+    await cleanupByEmail(ownerEmail);
+  }
+});

--- a/src/app/api/project-tasks/[taskId]/route.ts
+++ b/src/app/api/project-tasks/[taskId]/route.ts
@@ -3,12 +3,14 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { z } from 'zod';
-import { canManageProject } from '@/lib/projectAccess';
+import { canManageProject, isProjectMember } from '@/lib/projectAccess';
 
 async function taskIfManageable(userId: string, role: string, companyId: string | null | undefined, taskId: string) {
   const task = await prisma.projectTask.findUnique({ where: { id: taskId }, include: { project: true } });
   if (!task) return null;
-  return canManageProject({ id: userId, role, companyId }, task.project) ? task : null;
+  // Tasks are collaborative (#619): owners AND mentor members may edit.
+  if (canManageProject({ id: userId, role, companyId }, task.project)) return task;
+  return (await isProjectMember({ id: userId, role, companyId }, task.projectId)) ? task : null;
 }
 
 const schema = z.object({

--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -3,7 +3,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { z } from 'zod';
-import { canViewProject, canManageProject, resolveOwner } from '@/lib/projectAccess';
+import { canViewProject, resolveOwner, isProjectOwner, isProjectMember } from '@/lib/projectAccess';
 import { logActivity } from '@/lib/activity';
 
 const include = {
@@ -53,11 +53,26 @@ export async function PUT(request: Request, { params }: { params: Promise<{ id: 
   const { id } = await params;
   const project = await prisma.project.findUnique({ where: { id } });
   if (!project) return NextResponse.json({ error: 'Not found' }, { status: 404 });
-  if (!canManageProject(session.user, project)) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  // Owner-only fields (#619): owners (admin / OWNER member / legacy owner)
+  // edit everything; other MENTOR members only the collaborative fields.
+  const owner = await isProjectOwner(session.user, id);
+  const member = owner || (session.user.role === 'MENTOR' && (await isProjectMember(session.user, id)));
+  if (!member) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
 
   const parsed = schema.safeParse(await request.json());
   if (!parsed.success) return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 });
   const d = parsed.data;
+
+  if (!owner) {
+    const protectedSent = (['name', 'status', 'isPublic', 'startDate', 'endDate', 'ownerType', 'ownerUserId', 'ownerCompanyId'] as const)
+      .filter((k) => d[k] !== undefined);
+    if (protectedSent.length > 0) {
+      return NextResponse.json(
+        { error: 'Only a project owner may change these fields', fields: protectedSent, code: 'owner_only' },
+        { status: 403 }
+      );
+    }
+  }
 
   const data: Record<string, unknown> = {};
   if (d.name !== undefined) data.name = d.name;
@@ -108,7 +123,8 @@ export async function DELETE(_req: Request, { params }: { params: Promise<{ id: 
   const { id } = await params;
   const project = await prisma.project.findUnique({ where: { id } });
   if (!project) return NextResponse.json({ error: 'Not found' }, { status: 404 });
-  if (!canManageProject(session.user, project)) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  // Deletion is owner-only (#619).
+  if (!(await isProjectOwner(session.user, id))) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
 
   // Detach mentees, then delete.
   await prisma.mentorshipRelation.updateMany({ where: { projectId: id }, data: { projectId: null } });

--- a/src/app/api/projects/[id]/tasks/route.ts
+++ b/src/app/api/projects/[id]/tasks/route.ts
@@ -3,7 +3,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { z } from 'zod';
-import { canManageProject } from '@/lib/projectAccess';
+import { canManageProject, isProjectMember } from '@/lib/projectAccess';
 
 const schema = z.object({ title: z.string().min(1).max(300) });
 
@@ -15,7 +15,10 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
 
   const project = await prisma.project.findUnique({ where: { id } });
   if (!project) return NextResponse.json({ error: 'Not found' }, { status: 404 });
-  if (!canManageProject(session.user, project)) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  // Tasks are collaborative (#619): owners AND mentor members may edit.
+  if (!canManageProject(session.user, project) && !(await isProjectMember(session.user, id))) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
 
   const parsed = schema.safeParse(await request.json());
   if (!parsed.success) return NextResponse.json({ error: 'Validation failed' }, { status: 400 });

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -30,7 +30,10 @@ export async function GET() {
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
   let where: Prisma.ProjectWhereInput = {};
-  if (session.user.role === 'MENTOR') where = { ownerUserId: session.user.id };
+  // Mentors see projects they own OR are members of (#617/#619).
+  if (session.user.role === 'MENTOR') {
+    where = { OR: [{ ownerUserId: session.user.id }, { members: { some: { userId: session.user.id } } }] };
+  }
   else if (session.user.role === 'COMPANY') where = { ownerCompanyId: session.user.companyId ?? '__none__' };
   else if (session.user.role === 'MENTEE') where = { isPublic: true };
 

--- a/src/components/ProjectsManager.tsx
+++ b/src/components/ProjectsManager.tsx
@@ -78,25 +78,31 @@ export function ProjectsManager({ isAdmin }: { isAdmin: boolean }) {
     fetch('/api/companies').then((r) => r.json()).then((d) => setCompanies(d.companies ?? []));
   }, [isAdmin]);
 
-  const reset = () => { setForm({ ...blank }); setEditingId(null); setOwnerType('ADMIN'); setOwnerUserId(''); setOwnerCompanyId(''); setShowForm(false); };
+  const reset = () => { setForm({ ...blank }); setEditingId(null); setEditingOwner(true); setOwnerType('ADMIN'); setOwnerUserId(''); setOwnerCompanyId(''); setShowForm(false); };
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
     setSaving(true); setError('');
     try {
       const payload: Record<string, unknown> = {
-        name: form.name,
         description: form.description,
         technologies: form.technologies.split(',').map((s) => s.trim()).filter(Boolean),
         repoUrl: form.repoUrl,
         demoUrl: form.demoUrl,
         boardUrl: form.boardUrl,
-        status: form.status,
-        isPublic: form.isPublic,
         goals: form.goals,
-        startDate: form.startDate || null,
-        endDate: form.endDate || null,
       };
+      // Owner-protected fields (#619) — the server rejects them from
+      // non-owners, so a limited editor simply doesn't send them.
+      if (editingOwner || !editingId) {
+        Object.assign(payload, {
+          name: form.name,
+          status: form.status,
+          isPublic: form.isPublic,
+          startDate: form.startDate || null,
+          endDate: form.endDate || null,
+        });
+      }
       // Admin sets/changes ownership (create or transfer-on-edit), preserving
       // the "exactly one owner" invariant.
       if (isAdmin) {
@@ -131,6 +137,7 @@ export function ProjectsManager({ isAdmin }: { isAdmin: boolean }) {
   const edit = (p: Project) => {
     setShowForm(true);
     setEditingId(p.id);
+    setEditingOwner(isOwnerOf(p));
     setForm({
       name: p.name, description: p.description ?? '', technologies: p.technologies.join(', '),
       repoUrl: p.repoUrl ?? '', demoUrl: p.demoUrl ?? '', boardUrl: p.boardUrl ?? '', status: p.status, isPublic: p.isPublic,
@@ -180,6 +187,10 @@ export function ProjectsManager({ isAdmin }: { isAdmin: boolean }) {
   const [memberErr, setMemberErr] = useState('');
   const canManageMembers = (p: Project) =>
     isAdmin || (p.members ?? []).some((m) => m.user.id === meId && m.role === 'OWNER');
+  // Owner-only fields (#619): non-owner mentor members get a limited form.
+  const isOwnerOf = (p: Project) =>
+    isAdmin || p.ownerUser?.id === meId || (p.members ?? []).some((m) => m.user.id === meId && m.role === 'OWNER');
+  const [editingOwner, setEditingOwner] = useState(true);
 
   const memberCall = async (projectId: string, method: 'POST' | 'DELETE', body: Record<string, unknown>) => {
     setMemberErr('');
@@ -226,7 +237,8 @@ export function ProjectsManager({ isAdmin }: { isAdmin: boolean }) {
         <CardHeader><CardTitle>{editingId ? t.projects.editProject : t.projects.newProject}</CardTitle></CardHeader>
         {error && <div className="mb-3 p-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">{error}</div>}
         <form onSubmit={submit} className="space-y-3">
-          <Input label={t.projects.name} required value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} />
+          <Input label={t.projects.name} required disabled={!editingOwner && !!editingId} value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} />
+          {!editingOwner && !!editingId && <p className="text-xs text-gray-400 -mt-2">{t.projects.ownerOnlyHint}</p>}
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1.5">{t.projects.description}</label>
             <textarea value={form.description} onChange={(e) => setForm({ ...form, description: e.target.value })}
@@ -239,7 +251,7 @@ export function ProjectsManager({ isAdmin }: { isAdmin: boolean }) {
             <Input label={t.projects.boardUrl} type="url" placeholder="https://github.com/users/you/projects/2" hint={t.projects.boardUrlHint} value={form.boardUrl} onChange={(e) => setForm({ ...form, boardUrl: e.target.value })} />
           </div>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <Select label={t.projects.status} value={form.status} onChange={(e) => setForm({ ...form, status: e.target.value })}
+            <Select label={t.projects.status} disabled={!editingOwner && !!editingId} value={form.status} onChange={(e) => setForm({ ...form, status: e.target.value })}
               options={[
                 { value: 'DRAFT', label: t.projects.draft },
                 { value: 'ACTIVE', label: t.projects.active },
@@ -248,13 +260,13 @@ export function ProjectsManager({ isAdmin }: { isAdmin: boolean }) {
                 { value: 'CANCELLED', label: t.projects.cancelled },
               ]} />
             <label className="flex items-center gap-2 text-sm text-gray-700 mt-7">
-              <input type="checkbox" checked={form.isPublic} onChange={(e) => setForm({ ...form, isPublic: e.target.checked })} />
+              <input type="checkbox" disabled={!editingOwner && !!editingId} checked={form.isPublic} onChange={(e) => setForm({ ...form, isPublic: e.target.checked })} />
               {t.projects.isPublic}
             </label>
           </div>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <Input label={t.projects.startDate} type="date" value={form.startDate} onChange={(e) => setForm({ ...form, startDate: e.target.value })} />
-            <Input label={t.projects.endDate} type="date" value={form.endDate} onChange={(e) => setForm({ ...form, endDate: e.target.value })} />
+            <Input label={t.projects.startDate} type="date" disabled={!editingOwner && !!editingId} value={form.startDate} onChange={(e) => setForm({ ...form, startDate: e.target.value })} />
+            <Input label={t.projects.endDate} type="date" disabled={!editingOwner && !!editingId} value={form.endDate} onChange={(e) => setForm({ ...form, endDate: e.target.value })} />
           </div>
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1.5">{t.projects.goals}</label>
@@ -383,7 +395,9 @@ export function ProjectsManager({ isAdmin }: { isAdmin: boolean }) {
                       <button onClick={() => { setManageId(manageId === p.id ? null : p.id); setAddUserId(''); setMemberErr(''); }} aria-label={t.projects.manageOwners} data-testid="manage-owners" className="p-2 text-gray-400 hover:text-blue-600"><Users2 className="h-4 w-4" /></button>
                     )}
                     <button onClick={() => edit(p)} aria-label={t.projects.editProject} className="p-2 text-gray-400 hover:text-blue-600"><Pencil className="h-4 w-4" /></button>
-                    <button onClick={() => remove(p)} aria-label={t.projects.deleteProject} className="p-2 text-gray-400 hover:text-red-600"><Trash2 className="h-4 w-4" /></button>
+                    {isOwnerOf(p) && (
+                      <button onClick={() => remove(p)} aria-label={t.projects.deleteProject} className="p-2 text-gray-400 hover:text-red-600"><Trash2 className="h-4 w-4" /></button>
+                    )}
                   </div>
                 </div>
 

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -716,6 +716,7 @@ const en = {
     roleMentorMember: 'Mentor',
     transfer: 'Transfer to selected',
     lastOwnerError: 'A project must keep at least one owner.',
+    ownerOnlyHint: 'Only a project owner can change the name, status, visibility and dates.',
   },
   evaluation: {
     title: 'Evaluation',
@@ -2089,6 +2090,7 @@ const tr: Dict = {
     roleMentorMember: 'Mentör',
     transfer: 'Seçilene devret',
     lastOwnerError: 'Projede en az bir owner kalmalı.',
+    ownerOnlyHint: 'Ad, durum, görünürlük ve tarihleri yalnızca proje owner’ı değiştirebilir.',
   },
   evaluation: {
     title: 'Değerlendirme',
@@ -3460,6 +3462,7 @@ const de: Dict = {
     roleMentorMember: 'Mentor',
     transfer: 'An Auswahl übertragen',
     lastOwnerError: 'Ein Projekt braucht mindestens einen Owner.',
+    ownerOnlyHint: 'Name, Status, Sichtbarkeit und Termine kann nur ein Projekt-Owner ändern.',
   },
   evaluation: {
     title: 'Bewertung',

--- a/src/lib/projectAccess.ts
+++ b/src/lib/projectAccess.ts
@@ -30,6 +30,30 @@ export function canManageProject(user: SessionUser, p: ProjectOwner) {
   return false;
 }
 
+// Owner check against the members table (#619): admins and OWNER members.
+// The legacy ownerUserId is honoured too (backfill safety net).
+export async function isProjectOwner(user: SessionUser, projectId: string) {
+  if (user.role === 'ADMIN') return true;
+  const [member, legacy] = await Promise.all([
+    prisma.projectMember.findUnique({
+      where: { projectId_userId: { projectId, userId: user.id } },
+      select: { role: true },
+    }),
+    prisma.project.findUnique({ where: { id: projectId }, select: { ownerUserId: true } }),
+  ]);
+  return member?.role === 'OWNER' || legacy?.ownerUserId === user.id;
+}
+
+// A MENTOR member (any role) may edit the collaborative fields; owners edit
+// everything. Used by the PUT route to split the field set.
+export async function isProjectMember(user: SessionUser, projectId: string) {
+  const member = await prisma.projectMember.findUnique({
+    where: { projectId_userId: { projectId, userId: user.id } },
+    select: { role: true },
+  });
+  return !!member;
+}
+
 // Validate + normalise an owner triplet so exactly one target is set and it
 // matches ownerType, and the referenced entity exists. Returns null if invalid.
 export async function resolveOwner(input: {


### PR DESCRIPTION
## What & why

Story #614, Task 5 (final) — owners keep full control; mentor members get real but bounded editing rights. Server-side enforcement first, UI mirrors it.

## Field classification (rationale in code)

- **Owner-protected**: `name`, `status`, `isPublic`, `startDate`/`endDate`, owner change, **delete**.
- **Collaborative** (any project member): `description`, `technologies`, `repoUrl`/`demoUrl`/`boardUrl`, `goals`, **tasks**.

## Changes

- `projectAccess`: `isProjectOwner` (admin / OWNER member / legacy `ownerUserId`) + `isProjectMember`.
- `PUT /api/projects/[id]`: non-owner members sending any protected field get **403 `owner_only` with the offending field list**; `DELETE` is owner-only. Task routes accept mentor members.
- Mentors' `/api/projects` list now includes projects they're **members** of, not only ones they own.
- **UI**: editing as a non-owner disables the protected inputs (with an i18n hint) and omits them from the payload; delete button renders only for owners. `check:i18n` 1366 × 3 ✅.

## Verification

- e2e `project-owner-perms.spec.ts`: member sees the project in their list; collaborative PUT 200; `{name, status}` PUT → 403 `owner_only` (+`fields` contains `name`); task create 201; DELETE 403 and the project + original name survive.
- `tsc --noEmit` ✅ · `npm run build` ✅

Closes #619

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_