### PR TITLE
chore(release): 0.7.0-beta — smoke CI gate + projects redesign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,37 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-07-11
+
+A faster CI feedback loop and a rebuilt Projects experience with true
+multi-owner/multi-mentor collaboration.
+
+### Added
+- **Projects redesign** (#614): card-first screen — the create/edit form only
+  opens via "Add project" or a card's edit action (#615); detailed cards with
+  member chips + a Detail link, and an internal `/projects/[id]` view for
+  admins/owners (status, dates, goals, members, task progress) while the
+  public showcase stays PII-free (#616).
+- **Multiple owners & mentors per project** (#617) — new `ProjectMember`
+  model with an idempotent backfill on deploy/seed; `/api/projects/[id]/members`
+  with a last-owner guard; legacy single-owner pointer kept in sync.
+- **Owner management & transfer UI** (#618) — per-card panel to add/remove
+  members, change roles and transfer ownership in one flow; mentors get a
+  minimal PII-free directory for the picker.
+- **Owner-only field permissions** (#619) — name/status/visibility/dates and
+  deletion are owner-only (server-enforced 403 + disabled inputs); description,
+  technologies, links, goals and tasks are collaborative for all members, and
+  mentors now see projects they are members of.
+- **One-time infra-setup workflow** (#583 follow-up) — wildcard DNS, wildcard
+  TLS (acme.sh over SSH) and nginx-permission verification as a manual,
+  idempotent Actions run.
+
+### Changed
+- **PR quality gate now runs the `@smoke` subset** (17 tagged critical-path
+  tests, ~3.5 min instead of ~10) (#621–#623); the **full suite runs 4× a day**
+  via `e2e-full.yml` (4-way sharded) and emails the team on failure (#624).
+
+
 ## [0.6.0] - 2026-07-11
 
 Self-serve mentee intake, a built-in support channel, a public feature

--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -157,3 +157,25 @@ yeni spec'lerinde DB yan-etki assert'lerini `expect.poll` ile yaz (bubble render
 **E2E'de destek sistemi deseni:** iki browser context (user + admin) tek spec'te tam döngüyü
 (ticket aç → kuyrukta gör → yanıtla → durum geçişi → bildirim) doğrulayabiliyor; API çağrılarını
 `page.request` ile atıp UI'ı yalnızca kritik noktalarda assert etmek hem hızlı hem az kırılgan.
+
+## 2026-07-11 (2. tur) — CI hızlandırma + Projeler yenileme (0.7.0-beta)
+
+**Smoke gate kanıtlandı:** PR gate @smoke setine indirildikten sonra Playwright
+job'ı ~10 dk'dan ~3,5 dk'ya düştü (ilk kanıt: #630'un kendi CI'ı). Yeni kritik
+akış spec'i yazarken `{ tag: '@smoke' }` eklemeyi unutma; tam suite güvenlik ağı
+`e2e-full.yml` (4×/gün, 4 shard, kırmızıda tek mail).
+
+**Stacked PR ritmi oturdu:** base merge → `git rebase --onto origin/main <eski-base>
+<branch>` → force-push-with-lease → PR. Aynı include bloğuna dokunan paralel
+branch'lerde (örn. /api/projects include) conflict beklenen durum; iki tarafı da
+tutup birleştir.
+
+**Owner-perms deseni (#619):** sunucu tarafında alan-bazlı yetki için "owner
+değilse gönderilen korumalı alanları 403 + alan listesiyle reddet" yaklaşımı,
+UI'da da aynı alanları disabled yapıp payload'dan çıkarmakla eşleşiyor — UI'a
+güvenmeden net hata mesajı veriyor.
+
+**Actions runner'ı sunucu eli olarak kullan:** bu konteynerde SSH anahtarı yok ama
+runner'da var — tek seferlik sunucu işleri (wildcard cert, izin doğrulama) için
+`workflow_dispatch` + deploy.yml'in SSH deseni yeterli (infra-setup.yml). Adımları
+ayrı ayrı atlanabilir ve idempotent yap; root gerektiren işleri deneme, TODO yaz.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.6.0-beta",
+  "version": "0.7.0-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,27 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.7.0-beta',
+    date: '2026-07-11',
+    highlights: {
+      en: [
+        'Projects, rebuilt — the screen now opens with rich project cards (who is on it, tech, links, progress); the form appears only when you add or edit. Every project has a detail page.',
+        'Share project ownership — projects can now have several owners and several mentors. Owners add or remove people from the card and can hand a project over in one step.',
+        'Clear roles — the project name, status, visibility and dates can only be changed by an owner; everyone on the project can work on the description, links, goals and tasks.',
+      ],
+      tr: [
+        'Projeler yenilendi — ekran artık zengin proje kartlarıyla açılıyor (kimler var, teknolojiler, linkler, ilerleme); form yalnızca ekleme/düzenlemede geliyor. Her projenin bir detay sayfası var.',
+        'Proje sahipliğini paylaş — projelerde artık birden çok owner ve birden çok mentör olabiliyor. Owner’lar kart üzerinden kişi ekleyip çıkarabiliyor ve projeyi tek adımda devredebiliyor.',
+        'Net roller — proje adı, durumu, görünürlüğü ve tarihlerini yalnızca owner değiştirebilir; projedeki herkes açıklama, linkler, hedefler ve görevler üzerinde çalışabilir.',
+      ],
+      de: [
+        'Projekte, neu gebaut — der Bildschirm öffnet jetzt mit reichhaltigen Projektkarten (wer dabei ist, Technologien, Links, Fortschritt); das Formular erscheint nur beim Anlegen/Bearbeiten. Jedes Projekt hat eine Detailseite.',
+        'Geteilte Projektverantwortung — Projekte können jetzt mehrere Owner und mehrere Mentoren haben. Owner fügen Personen direkt auf der Karte hinzu und übergeben ein Projekt in einem Schritt.',
+        'Klare Rollen — Name, Status, Sichtbarkeit und Termine ändert nur ein Owner; an Beschreibung, Links, Zielen und Aufgaben arbeiten alle Projektmitglieder.',
+      ],
+    },
+  },
+  {
     version: '0.6.0-beta',
     date: '2026-07-11',
     highlights: {


### PR DESCRIPTION
## What & why

Version bump closing out today's second batch:

- **CI (#621–#624)**: PR gate runs the 17-test `@smoke` subset (~3.5 min, was ~10); full suite runs 4×/day sharded with an email alert on failure; plus the one-time `infra-setup` workflow (#583 follow-up).
- **Projects redesign (#614–#619)**: card-first screen, detail view, `ProjectMember` multi-owner/multi-mentor model with safe backfill, owner management & one-step transfer, owner-only field permissions.

## Contents

- `package.json` → `0.7.0-beta`
- `CHANGELOG.md` — developer-facing entry
- `src/lib/releaseNotes.ts` — user-facing highlights (EN/TR/DE; CI work kept out — not user-visible)
- `docs/agent-experience.md` — retrospective (smoke-gate speedup proof, stacked-PR rhythm, owner-perms pattern, Actions-runner-as-server-hand)

## Verification

- Version is read from `package.json` at build time; no other wiring needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_