### PR TITLE
ci: cut GitHub Actions minute consumption (#636)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,8 +2,14 @@ name: Deploy to Plesk Server
 
 on:
   # Previews deploy on every PR (tests run alongside — a broken preview is fine).
+  # Docs-only PRs skip the preview build/deploy — no runtime change to preview
+  # (#636 cost control).
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.github/**'
   # Production deploys ONLY after the E2E suite finishes on main. The job below
   # additionally requires conclusion == success, so a red build never ships.
   # This is a code-level complement to branch protection (issue #425).
@@ -11,6 +17,13 @@ on:
     workflows: ["E2E Tests"]
     types: [completed]
     branches: [main]
+
+# Cancel a superseded PREVIEW build when a new push lands on the same PR
+# (rapid agent pushes) — the big single win on minutes. Production deploys
+# (workflow_run) get a per-run group so they never cancel one another.
+concurrency:
+  group: deploy-${{ github.event_name }}-${{ github.event.workflow_run.head_sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -1,16 +1,21 @@
 name: E2E Full Suite (scheduled)
 
 # The PR gate (e2e.yml) runs only the @smoke subset; this workflow is the
-# safety net behind it (#621/#624): the FULL Playwright suite, 4× a day,
-# sharded for speed, with an email alert to the team when a run goes red.
-# Can also be run on demand from the Actions tab.
+# safety net behind it (#621/#624): the FULL Playwright suite, once a day, with
+# an email alert to the team when it goes red. Can also be run on demand.
+#
+# Cost note (#636): a single job, NOT sharded. Sharding cuts wall-clock but
+# MULTIPLIES billed minutes — each shard repeats the whole setup (npm ci +
+# prisma + build + browser install, several minutes) before running its slice.
+# For a daily safety net wall-clock doesn't matter, so one serial run is the
+# cheapest. Frequency dropped from 4×/day to 1×/day for the same reason.
 #
 # Note: GitHub scheduled workflows can lag a few minutes and are disabled
 # automatically after 60 days without repository activity.
 on:
   schedule:
-    # 4× a day at 03/09/15/21 UTC (~05/11/17/23 Europe/Berlin in summer).
-    - cron: '0 3,9,15,21 * * *'
+    # Once a day at 03:00 UTC (~05:00 Europe/Berlin in summer).
+    - cron: '0 3 * * *'
   workflow_dispatch:
 
 concurrency:
@@ -19,12 +24,8 @@ concurrency:
 
 jobs:
   e2e-full:
-    name: Playwright full (shard ${{ matrix.shard }}/4)
+    name: Playwright full
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [1, 2, 3, 4]
 
     services:
       mysql:
@@ -72,22 +73,29 @@ jobs:
       - name: Build app
         run: npm run build
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: playwright-${{ runner.os }}-
+
       - name: Install Playwright browser
         run: npx playwright install --with-deps chromium
 
-      - name: Run full E2E suite (shard ${{ matrix.shard }}/4)
-        run: npx playwright test --shard=${{ matrix.shard }}/4
+      - name: Run full E2E suite
+        run: npm run test:e2e
 
       - name: Upload Playwright report
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: playwright-report-full-shard-${{ matrix.shard }}
+          name: playwright-report-full
           path: playwright-report/
           retention-days: 7
 
-  # Single alert for the whole run (not one per shard). Reuses the app's
-  # SMTP_* secrets via scripts/send-alert-email.mjs, same as stress.yml.
+  # Single alert when the run goes red. Reuses the app's SMTP_* secrets via
+  # scripts/send-alert-email.mjs, same as stress.yml.
   notify:
     name: Email alert on failure
     runs-on: ubuntu-latest
@@ -110,10 +118,9 @@ jobs:
           ALERT_EMAIL_TO: ${{ secrets.ALERT_EMAIL_TO || 'mehmetersahin@gmail.com' }}
           ALERT_SUBJECT: '⚠️ Internship CRM — scheduled full e2e FAILED'
           ALERT_BODY: |
-            The scheduled full Playwright suite failed (at least one shard red).
+            The scheduled full Playwright suite failed.
             Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-            Per-shard reports are attached to the run as artifacts
-            (playwright-report-full-shard-N).
+            The report is attached to the run as the playwright-report-full artifact.
         run: |
           # Install from the lockfile so nodemailer matches the version the app
           # pins (single source of truth); skip postinstall (prisma generate).

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -62,6 +62,13 @@ jobs:
       - name: Build app
         run: npm run build
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: playwright-${{ runner.os }}-
+
       - name: Install Playwright browser
         run: npx playwright install --with-deps chromium
 

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -5,8 +5,10 @@ name: Nightly Stress Test
 # on demand from the Actions tab (with an optional target URL override).
 on:
   schedule:
-    # 02:30 UTC every night (~03:30/04:30 Europe/Berlin depending on DST).
-    - cron: '30 2 * * *'
+    # 02:30 UTC every Monday (~03:30/04:30 Europe/Berlin depending on DST).
+    # Weekly, not nightly (#636): during pre-launch a nightly load test burns
+    # Actions minutes for little signal; run it weekly + on demand / pre-release.
+    - cron: '30 2 * * 1'
   workflow_dispatch:
     inputs:
       base_url:


### PR DESCRIPTION
## Neden

Aylık 2000 dk'lık Actions kotası, yüksek agent-tabanlı PR hacmi × push başına pahalı job'lar yüzünden tükendi ve şu an **hiçbir workflow runner alamıyor** (job'lar `runner_id: 0` ile ~4 sn'de düşüyor). Bu PR, tekrarlayan en büyük maliyet kalemlerini kaldıran **sıfır-riskli config değişiklikleridir**.

## Değişiklikler

| Dosya | Değişiklik | Kazanç |
|-------|-----------|--------|
| **deploy.yml** | Preview build'lerine `cancel-in-progress` (aynı PR'a hızlı push'lar Docker-build+SSH-deploy'u yığmıyor); docs/md/.github-only PR'lar preview'ı tamamen atlıyor (`paths-ignore`). Production (`workflow_run`) per-run grupla korunuyor, asla iptal edilmiyor. | En büyük tek kazanç — her push'ta imaj build + deploy |
| **e2e-full.yml** | 4×/gün → **1×/gün** ve sharding kaldırıldı (tek job). Sharding wall-clock'u kısaltır ama **faturalanan dakikayı çarpar** — her shard `npm ci`+build+browser install'ı tekrarlar. Günlük güvenlik ağında wall-clock önemsiz → tek serial koşu en ucuzu. | ~4× → ~1× kurulum maliyeti |
| **stress.yml** | Gecelik → **haftalık (Pazartesi)**. Pre-launch'ta gecelik yük testi az sinyal için dakika yakıyor. | 7×/hafta → 1×/hafta |
| **e2e.yml / e2e-full.yml** | `~/.cache/ms-playwright` cache'i — tarayıcı indirmesi her job'da tekrar etmiyor. | Her koşuda birkaç dk |

## Zaten yerinde olanlar (değişiklik gerekmedi)

E-postadaki bazı öneriler #621–#630'da hâllolmuştu (loglar o merge'lerden önceydi): `ci.yml`/`e2e.yml`'de concurrency+cancel ✅, npm cache ✅, PR gate'in gerçekten `test:e2e:smoke` çalıştırması (#623) ✅, `infra-setup.yml`'in yalnızca `workflow_dispatch` olması ✅. "Aynı gün birçok kez koşan Infra Setup / E2E Attempt #2" gözlemleri benim **elle rerun**'larımdı, otomatik retry değil.

## ⚠️ Merge notu

Bu PR'ın CI'ı **yeşile dönemez** — runner'lar billing yüzünden ayağa kalkmıyor ve düzeltmenin kendisi bu. Değişiklikler config-only (YAML), `yaml.safe_load` ile doğrulandı. Kota geri gelince asıl kazancı bu PR sağlayacağı için, admin'in (senin) checks beklemeden merge etmesi mantıklı. Uzun vadeli öneriler (self-hosted runner, %80 kullanım alarmı) ayrı bir issue'ya bırakıldı.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_