### PR TITLE
ci: add deploy-prod workflow + CI-independent infra scripts (#636 follow-up)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,47 @@
+name: Deploy prod (self-hosted, manual)
+
+# CI-independent production deploy that RUNS ON THE SERVER via a self-hosted
+# runner (#636). Because self-hosted minutes don't count against the
+# GitHub-hosted quota, this works even while that quota is exhausted — and it
+# can be triggered remotely (e.g. by an agent over the GitHub API) so a deploy
+# no longer needs a human at an SSH prompt.
+#
+# PREREQUISITES (one-time, on the Plesk server):
+#   1. Register a self-hosted runner for this repo (Settings → Actions →
+#      Runners → New self-hosted runner) and install it as a service:
+#        ./config.sh --url https://github.com/mersahin/Internship --token <TOKEN> --labels self-hosted
+#        sudo ./svc.sh install && sudo ./svc.sh start
+#   2. Create /etc/internship-crm/prod.env (chmod 600) with the production
+#      secrets — see infra/README.md. The runner's user must be able to read it
+#      and run docker.
+#
+# After that, dispatch this workflow (UI "Run workflow", or the API) any time.
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch/tag/SHA to deploy (default: main)'
+        required: false
+        default: 'main'
+
+concurrency:
+  group: deploy-prod-self-hosted
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy ${{ inputs.ref }} to production
+    runs-on: self-hosted
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Deploy
+        run: |
+          chmod +x infra/deploy-prod.sh
+          # deploy-prod.sh syncs to origin/<ref>, builds from source, migrates,
+          # seeds, swaps the container and health-checks. Secrets come from the
+          # server-side env file, never from the repo or workflow.
+          BRANCH="${{ inputs.ref }}" ENV_FILE="${ENV_FILE:-/etc/internship-crm/prod.env}" ./infra/deploy-prod.sh --no-pull

--- a/infra/README.md
+++ b/infra/README.md
@@ -122,3 +122,63 @@ the live box. First validation: open a PR from a `…_topicN` branch and confirm
 container comes up, `crm-topicN.ersah.in` serves over TLS, and closing the PR tears
 it down (`docker ps` + `$NGINX_CONF_DIR` clean). Adjust `NGINX_CONF_DIR` /
 `NGINX_RELOAD_CMD` / `CERT_DIR` if paths differ.
+
+---
+
+## CI-independent operations (when the Actions quota is exhausted, #636)
+
+Everything CI does is just scripts, and the server is reachable over SSH — so
+production deploys and the topic-preview foundations can run **without any
+GitHub Actions minutes**.
+
+### One-time: production secrets on the server
+Create an env file (same values as the GitHub secrets), readable only by root:
+
+```bash
+sudo mkdir -p /etc/internship-crm
+sudo tee /etc/internship-crm/prod.env >/dev/null <<'ENV'
+DATABASE_URL=mysql://...
+NEXTAUTH_SECRET=...
+NEXTAUTH_URL=https://crm.ersah.in
+SMTP_HOST=...
+SMTP_PORT=587
+SMTP_USER=...
+SMTP_PASS=...
+SMTP_FROM=...
+ENV
+sudo chmod 600 /etc/internship-crm/prod.env
+```
+
+### Deploy `main` to production (builds from source — no ghcr pull needed)
+```bash
+# from your laptop, in one line:
+ssh <user>@<server> 'cd /path/to/Internship && sudo ENV_FILE=/etc/internship-crm/prod.env ./infra/deploy-prod.sh'
+```
+`deploy-prod.sh` mirrors the `Production Deploy` job exactly: sync `main`, build
+the image (stamping `GIT_SHA`), `prisma db push --accept-data-loss`, seed +
+backfill, swap the `internship-crm` container (host net, :3200), health-check.
+
+### Push-to-deploy without a webhook (optional)
+Add a cron entry on the server — every 5 min it deploys only if `main` moved:
+```cron
+*/5 * * * * cd /path/to/Internship && ENV_FILE=/etc/internship-crm/prod.env ./infra/autodeploy.sh >> /var/log/internship-autodeploy.log 2>&1
+```
+No inbound port, no listener — just `git fetch` + the deploy script, lock-guarded.
+
+### Topic-preview foundations without Actions
+```bash
+# DNS (from anywhere): wildcard *.ersah.in A record
+export CF_Token="<scoped Cloudflare token>"
+SERVER_IP=<server ip> ./infra/setup-dns-cloudflare.sh
+# TLS (on the server): wildcard cert + auto-renew
+export CF_Token="<scoped Cloudflare token>"
+./infra/acme-issue-wildcard.sh
+```
+
+### Permanent fix: self-hosted runner
+The always-on Plesk server can register as a **self-hosted GitHub Actions
+runner** (Settings → Actions → Runners → New self-hosted runner). Self-hosted
+minutes do **not** count against the 2000-min quota, so the existing workflows
+(deploy, e2e, infra-setup) all run again for free — flip `runs-on: ubuntu-latest`
+to `runs-on: self-hosted` on the workflows you want off the hosted quota. This
+is the structural cure; the scripts above are the immediate, dependency-free path.

--- a/infra/autodeploy.sh
+++ b/infra/autodeploy.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# Optional push-to-deploy without GitHub Actions and without an inbound webhook
+# (#636). Polls origin/main; when it moves, runs infra/deploy-prod.sh. No open
+# port, no listener process, no security surface — just git + the deploy script.
+#
+# ONE-SHOT (for cron/systemd-timer — the recommended way):
+#   */5 * * * *  cd /path/to/Internship && ENV_FILE=/etc/internship-crm/prod.env ./infra/autodeploy.sh
+#
+# LOOP (foreground / a systemd service):
+#   INTERVAL=300 ./infra/autodeploy.sh --loop
+#
+# State (last deployed SHA) is kept in .git — the script simply compares the
+# local main to origin/main, so it is safe to run concurrently-guarded by a
+# lockfile.
+#
+set -euo pipefail
+
+REPO_DIR="${REPO_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+BRANCH="${BRANCH:-main}"
+INTERVAL="${INTERVAL:-300}"
+LOCK="/tmp/internship-autodeploy.lock"
+
+cd "$REPO_DIR"
+
+deploy_if_changed() {
+  git fetch origin "$BRANCH" --quiet
+  local local_sha remote_sha
+  local_sha="$(git rev-parse "$BRANCH" 2>/dev/null || echo none)"
+  remote_sha="$(git rev-parse "origin/$BRANCH")"
+  if [ "$local_sha" = "$remote_sha" ]; then
+    return 0
+  fi
+  echo "$(date -u +%FT%TZ) main moved ${local_sha:0:7} → ${remote_sha:0:7}; deploying"
+  # deploy-prod.sh does its own git reset --hard to origin/main.
+  ./infra/deploy-prod.sh
+}
+
+# Prevent overlapping runs (cron every 5 min while a build takes longer).
+exec 9>"$LOCK"
+if ! flock -n 9; then
+  echo "another autodeploy run holds the lock; skipping"
+  exit 0
+fi
+
+if [ "${1:-}" = "--loop" ]; then
+  echo "autodeploy loop every ${INTERVAL}s (Ctrl-C to stop)"
+  while true; do
+    deploy_if_changed || echo "deploy attempt failed (will retry next tick)"
+    sleep "$INTERVAL"
+  done
+else
+  deploy_if_changed
+fi

--- a/infra/deploy-prod.sh
+++ b/infra/deploy-prod.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+#
+# CI-independent production deploy (#636).
+#
+# Does exactly what the `Production Deploy` job in .github/workflows/deploy.yml
+# does — but runs ON THE SERVER (or over SSH from a laptop), so it needs no
+# GitHub Actions minutes. Use it when the Actions quota is exhausted, or as the
+# command a self-hosted runner / auto-deploy poller (infra/autodeploy.sh) calls.
+#
+# WHAT IT DOES
+#   1. sync the working copy to origin/main (unless --no-pull)
+#   2. build the image FROM SOURCE (CI normally builds + pushes to ghcr; here we
+#      build locally so no registry pull is needed), stamping GIT_SHA
+#   3. prisma db push --accept-data-loss  (schema sync, same as CI)
+#   4. seed-templates + backfill-project-members  (idempotent)
+#   5. swap the internship-crm container (host networking, port 3200, restart
+#      unless-stopped) — byte-for-byte the flags deploy.yml uses
+#   6. health-check http://127.0.0.1:3200 and prune old images
+#
+# SECRETS never live in the repo. They are read from an env file on the server
+# (same values as the GitHub secrets): DATABASE_URL, NEXTAUTH_SECRET,
+# NEXTAUTH_URL, SMTP_HOST/PORT/USER/PASS/FROM. Default path /etc/internship-crm/prod.env
+# (override with ENV_FILE=...). Create it once, chmod 600.
+#
+# USAGE
+#   # on the server, from a checkout of the repo:
+#   sudo ENV_FILE=/etc/internship-crm/prod.env ./infra/deploy-prod.sh
+#
+#   # or straight from your laptop over SSH:
+#   ssh user@server 'cd /path/to/Internship && ENV_FILE=/etc/internship-crm/prod.env ./infra/deploy-prod.sh'
+#
+# FLAGS
+#   --no-pull     deploy the current checkout as-is (skip git sync)
+#   --skip-build  reuse the existing internship-crm:local image (fast restart)
+#
+set -euo pipefail
+
+ENV_FILE="${ENV_FILE:-/etc/internship-crm/prod.env}"
+CONTAINER="${CONTAINER:-internship-crm}"
+PORT="${PORT:-3200}"
+IMAGE="${IMAGE:-internship-crm:local}"
+REPO_DIR="${REPO_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+BRANCH="${BRANCH:-main}"
+
+NO_PULL=0
+SKIP_BUILD=0
+for arg in "$@"; do
+  case "$arg" in
+    --no-pull) NO_PULL=1 ;;
+    --skip-build) SKIP_BUILD=1 ;;
+    *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+  esac
+done
+
+log() { printf '\n\033[1;34m==>\033[0m %s\n' "$*"; }
+
+cd "$REPO_DIR"
+
+# ── 0. Preconditions ────────────────────────────────────────────────────────
+command -v docker >/dev/null || { echo "ERROR: docker not found on PATH" >&2; exit 1; }
+if [ ! -f "$ENV_FILE" ]; then
+  echo "ERROR: env file not found: $ENV_FILE" >&2
+  echo "Create it (chmod 600) with the production secrets — see the header of this script." >&2
+  exit 1
+fi
+# shellcheck disable=SC1090
+set -a; . "$ENV_FILE"; set +a
+: "${DATABASE_URL:?DATABASE_URL missing in $ENV_FILE}"
+: "${NEXTAUTH_SECRET:?NEXTAUTH_SECRET missing in $ENV_FILE}"
+: "${NEXTAUTH_URL:?NEXTAUTH_URL missing in $ENV_FILE}"
+
+# ── 1. Sync source ───────────────────────────────────────────────────────────
+if [ "$NO_PULL" -eq 0 ]; then
+  log "Syncing $BRANCH from origin"
+  git fetch origin "$BRANCH"
+  git checkout "$BRANCH"
+  git reset --hard "origin/$BRANCH"
+fi
+GIT_SHA="$(git rev-parse HEAD)"
+log "Deploying $(git rev-parse --short HEAD) — $(node -p "require('./package.json').version" 2>/dev/null || echo '?')"
+
+# ── 2. Build image from source ───────────────────────────────────────────────
+if [ "$SKIP_BUILD" -eq 0 ]; then
+  log "Building $IMAGE (GIT_SHA=$GIT_SHA)"
+  docker build --build-arg GIT_SHA="$GIT_SHA" -t "$IMAGE" .
+fi
+
+run_tool() { # run a one-off tool container on host networking with the prod DB
+  docker run --rm --network=host -e DATABASE_URL="$DATABASE_URL" "$IMAGE" "$@"
+}
+
+# ── 3. Schema sync ────────────────────────────────────────────────────────────
+log "prisma db push"
+run_tool npx prisma db push --accept-data-loss
+
+# ── 4. Idempotent seeds / backfills ──────────────────────────────────────────
+log "seed-templates + project-member backfill (idempotent)"
+run_tool node prisma/seed-templates.mjs || true
+run_tool node prisma/backfill-project-members.mjs || true
+
+# ── 5. Swap the container ────────────────────────────────────────────────────
+log "Restarting $CONTAINER on :$PORT"
+docker stop "$CONTAINER" 2>/dev/null || true
+docker rm   "$CONTAINER" 2>/dev/null || true
+docker run -d \
+  --name "$CONTAINER" \
+  --network=host \
+  --restart=unless-stopped \
+  -e PORT="$PORT" \
+  -e DATABASE_URL="$DATABASE_URL" \
+  -e NEXTAUTH_SECRET="$NEXTAUTH_SECRET" \
+  -e NEXTAUTH_URL="$NEXTAUTH_URL" \
+  -e NEXT_PUBLIC_APP_URL="$NEXTAUTH_URL" \
+  -e SMTP_HOST="${SMTP_HOST:-}" \
+  -e SMTP_PORT="${SMTP_PORT:-}" \
+  -e SMTP_USER="${SMTP_USER:-}" \
+  -e SMTP_PASS="${SMTP_PASS:-}" \
+  -e SMTP_FROM="${SMTP_FROM:-}" \
+  "$IMAGE"
+
+# ── 6. Health check + prune ──────────────────────────────────────────────────
+log "Health check http://127.0.0.1:$PORT"
+ok=0
+for i in $(seq 1 30); do
+  if curl -fsS -o /dev/null "http://127.0.0.1:$PORT"; then ok=1; break; fi
+  sleep 2
+done
+if [ "$ok" -ne 1 ]; then
+  echo "ERROR: app did not answer on :$PORT within 60s. Recent logs:" >&2
+  docker logs --tail 40 "$CONTAINER" >&2 || true
+  exit 1
+fi
+
+docker image prune -af >/dev/null 2>&1 || true
+docker builder prune -af --filter until=72h >/dev/null 2>&1 || true
+log "Done — $CONTAINER is up at :$PORT ($(git rev-parse --short HEAD))"

--- a/infra/setup-dns-cloudflare.sh
+++ b/infra/setup-dns-cloudflare.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# CI-independent wildcard DNS setup (#636 / #583).
+#
+# Creates the wildcard `*.ersah.in` A record via the Cloudflare API so every
+# topic subdomain (crm-topicN.ersah.in) resolves to the server. Idempotent:
+# if a `*` A record already exists it does nothing. This is the same logic as
+# the `dns` step of .github/workflows/infra-setup.yml, extracted so it can run
+# from a laptop without GitHub Actions minutes.
+#
+# USAGE
+#   export CF_Token="<scoped Cloudflare token: Zone:DNS:Edit + Zone:Read, ersah.in>"
+#   SERVER_IP=<server public IP> ./infra/setup-dns-cloudflare.sh
+#   # SERVER_IP optional if you run it ON the server (auto-detected).
+#
+# The cert (wildcard TLS) is issued by infra/acme-issue-wildcard.sh — run that
+# ON the server. Both together complete the topic-preview foundations.
+#
+set -euo pipefail
+
+DOMAIN="${DOMAIN:-ersah.in}"
+: "${CF_Token:?export CF_Token with a scoped Cloudflare API token first}"
+
+SERVER_IP="${SERVER_IP:-}"
+if [ -z "$SERVER_IP" ]; then
+  SERVER_IP="$(curl -fsS https://api.ipify.org 2>/dev/null || true)"
+fi
+[ -n "$SERVER_IP" ] || { echo "ERROR: set SERVER_IP=<public ip>" >&2; exit 1; }
+echo "==> Target server IP: $SERVER_IP"
+
+api() { curl -sS -H "Authorization: Bearer $CF_Token" -H "Content-Type: application/json" "$@"; }
+
+ZONE_ID="$(api "https://api.cloudflare.com/client/v4/zones?name=${DOMAIN}" \
+  | python3 -c "import sys,json;r=json.load(sys.stdin);print(r['result'][0]['id'] if r.get('result') else '')")"
+[ -n "$ZONE_ID" ] || { echo "ERROR: zone ${DOMAIN} not found with this token (needs Zone:Read)" >&2; exit 1; }
+
+EXISTING="$(api "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records?type=A&name=%2A.${DOMAIN}" \
+  | python3 -c "import sys,json;print(len(json.load(sys.stdin).get('result',[])))")"
+
+if [ "$EXISTING" != "0" ]; then
+  echo "==> Wildcard *.${DOMAIN} A record already exists — nothing to do."
+  exit 0
+fi
+
+echo "==> Creating *.${DOMAIN} A → ${SERVER_IP} (proxied)"
+api -X POST "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records" \
+  --data "{\"type\":\"A\",\"name\":\"*\",\"content\":\"${SERVER_IP}\",\"proxied\":true,\"ttl\":1}" \
+  | python3 -c "import sys,json;r=json.load(sys.stdin);assert r.get('success'),r;print('OK — wildcard record created.')"


### PR DESCRIPTION
The #636 squash landed only the four workflow tweaks; the files pushed to the branch afterwards didn't make it onto main. This adds them:

- `.github/workflows/deploy-prod.yml` — `workflow_dispatch`, `runs-on: self-hosted`, calls `infra/deploy-prod.sh`. Lets a production deploy run on the self-hosted runner (no hosted-minute quota) and be triggered remotely.
- `infra/deploy-prod.sh` — build-from-source production deploy mirroring deploy.yml's production job; secrets from a server-side env file.
- `infra/autodeploy.sh` — optional git-poll push-to-deploy (no webhook).
- `infra/setup-dns-cloudflare.sh` — standalone wildcard DNS via the Cloudflare API.
- `infra/README.md` — CI-independent operations runbook.

Config/scripts only; validated with `yaml.safe_load` + `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_