### PR TITLE
feat(mt): Organization model + nullable orgId foundation (#543)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -183,7 +183,12 @@ jobs:
             --network=host \
             -e DATABASE_URL="\$DATABASE_URL" \
             "\$IMAGE" \
-            node prisma/backfill-project-members.mjs || true
+            node prisma/backfill-project-members.mjs || true           # Backfill default Organization + orgId (#543, idempotent).
+          docker run --rm \
+            --network=host \
+            -e DATABASE_URL="\$DATABASE_URL" \
+            "\$IMAGE" \
+            node prisma/backfill-organization.mjs || true
 
           docker stop internship-crm 2>/dev/null || true
           docker rm   internship-crm 2>/dev/null || true
@@ -289,7 +294,12 @@ jobs:
             --network=host \
             -e DATABASE_URL="\$DATABASE_URL" \
             "\$IMAGE" \
-            node prisma/backfill-project-members.mjs || true
+            node prisma/backfill-project-members.mjs || true           # Backfill default Organization + orgId (#543, idempotent).
+          docker run --rm \
+            --network=host \
+            -e DATABASE_URL="\$DATABASE_URL" \
+            "\$IMAGE" \
+            node prisma/backfill-organization.mjs || true
 
           docker stop internship-crm-preview 2>/dev/null || true
           docker rm   internship-crm-preview 2>/dev/null || true

--- a/docs/legal/README.md
+++ b/docs/legal/README.md
@@ -1,0 +1,22 @@
+# Ticarileşme ön-koşulları — kararlar ve taslaklar
+
+> **Uyarı:** Bu klasördeki metinler hukuki tavsiye değildir; ürünü ticarileştirmeden
+> önceki belirsizliği azaltmak için hazırlanmış **karar dokümanları ve taslaklardır**.
+> İlk premium satıştan / ilk imzadan önce bir avukat ve mali müşavir tarafından
+> gözden geçirilmelidir. Bağlam: ürün, Almanya merkezli **bcsit GmbH** üzerinden
+> yürütülüyor (kurucu e-postası `@bcsit-gmbh.de`); kararlar bu yapıya göre verildi.
+
+Story #523 (Epic #517) kapsamındaki kod-dışı ön koşullar. Her biri ayrı dosyada,
+somut bir **karar** ve gerekçesiyle.
+
+| Konu | Issue | Karar (özet) | Dosya |
+|------|-------|--------------|-------|
+| Katkı sözleşmesi (CLA) | #548 | Kısa yazılı IP-devri; tüm mevcut+gelecek katkıcı mentee'lere imzalatılır, onboarding'e eklenir | [cla-contributor-agreement.md](cla-contributor-agreement.md) |
+| Hukuki/vergisel çerçeve | #549 | Mevcut **bcsit GmbH** üzerinden; SaaS abonelik faturalaması (KDV/USt dahil); klasik success-fee'den kaçın (AÜG riski) | [legal-tax-framework.md](legal-tax-framework.md) |
+| Mentee görünürlük rızası | #551 | Yalnızca kamuya-açık alanlar (ad, üniversite, beceri, hedef pozisyon); e-posta/telefon asla; anında geri çekilebilir | [talent-pool-consent-policy.md](talent-pool-consent-policy.md) |
+| Ödeme altyapısı | #552 | Faz 1 manuel fatura (GmbH); ölçeklenince Stripe Billing + webhook → entitlement | [payment-infrastructure.md](payment-infrastructure.md) |
+
+## Veri erişim kuralı (#523 kalemi — zaten uygulandı)
+Katkı veren mentee'ler gerçek/preview PII'ye erişmez; geliştirme sentetik seed ile
+yapılır. Bkz. [../DATA_ACCESS_POLICY.md](../DATA_ACCESS_POLICY.md) — bu kalem koda
+bağlanmış durumda (demo seeder yerel-olmayan `DATABASE_URL`'i reddediyor).

--- a/docs/legal/cla-contributor-agreement.md
+++ b/docs/legal/cla-contributor-agreement.md
@@ -1,0 +1,68 @@
+# Katkı Sözleşmesi (CLA) — mevcut & gelecek mentee'ler (#548)
+
+> Hukuki tavsiye değildir; imzadan önce avukat gözden geçirmesi gerekir.
+
+## Karar
+Mentee'ler mentorluk anlaşması gereği projeye emek/kod katkısı veriyor. Ticarileşme
+anında bu katkıların fikri mülkiyetinin **bcsit GmbH**'ye ait olduğu **yazılı** olmalı;
+sözlü anlaşma yeterli değildir ve geriye dönük toplanamaz.
+
+**Uygulanacak model:** Kısa bir **fikri hak devri + katkı lisansı** sözleşmesi (CLA
+benzeri). Tüm **mevcut** katkıcılara imzalatılır; **yeni** katılımcılar için
+onboarding'in zorunlu adımı yapılır. İmza durumu basit bir kayıtla (aşağıda opsiyonel
+şema önerisi) izlenir.
+
+**Neden devir (assignment) + geri-lisans, yalnız lisans değil:** Ürün tek elden
+ticarileştirileceği ve yatırımcı/Enterprise müşteri "IP kimde?" diye soracağı için
+net sahiplik gerekir. Katkıcıya, kendi katkısını portföyünde kullanabilmesi için
+geniş bir geri-lisans verilir (adil ve motive edici).
+
+## Sözleşme taslağı (TR)
+
+**KATKI VE FİKRİ HAK DEVRİ SÖZLEŞMESİ**
+
+1. **Taraflar.** bcsit GmbH ("Şirket") ve aşağıda imzası bulunan katkı veren
+   ("Katkıcı").
+2. **Kapsam.** Katkıcı'nın "Internship CRM" projesine sağladığı tüm kod, tasarım,
+   doküman ve diğer eserler ("Katkılar").
+3. **Devir.** Katkıcı, Katkılar üzerindeki tüm dünya çapındaki fikri mülkiyet
+   haklarını, mevzuatın izin verdiği azami ölçüde, süresiz ve bedelsiz olarak
+   Şirket'e devreder. Almanya telif hukukunda eserin kendisi devredilemediğinden
+   (§ 29 UrhG), Katkıcı Şirket'e **münhasır, süresiz, dünya çapında, alt-lisans
+   verilebilir kullanım hakkı** (ausschließliches Nutzungsrecht) tanır.
+4. **Geri-lisans.** Şirket, Katkıcı'ya kendi Katkılarını kişisel portföy/eğitim
+   amacıyla ticari olmayan biçimde sergileme hakkı tanır.
+5. **Taahhütler.** Katkıcı, Katkıların özgün olduğunu ve üçüncü kişi haklarını
+   ihlal etmediğini beyan eder.
+6. **Ücret.** Katkılar mentorluk ilişkisi kapsamında karşılıksız verilmiştir;
+   ek ücret doğurmaz.
+7. **Uygulanacak hukuk.** Alman hukuku; yetkili mahkeme Şirket'in merkezi.
+
+İmza / Tarih / Ad-Soyad.
+
+## Contribution & IP Assignment Agreement (EN, short form)
+The Contributor grants bcsit GmbH an exclusive, perpetual, worldwide,
+sub-licensable right to use all contributions to the "Internship CRM" project
+(assignment where permitted; exclusive exploitation right under German © law,
+§ 31 UrhG), with a non-exclusive grant-back to the Contributor for
+non-commercial portfolio use. Contributions are made without additional
+remuneration within the mentorship. Governed by German law.
+
+## Opsiyonel: imza takibi (ileride, gerekirse)
+Zorunlu değil (kağıt/DocuSign yeterli). İstenirse basit bir model:
+
+```prisma
+model ContributorAgreement {
+  id        String   @id @default(cuid())
+  userId    String   @unique
+  version   String   // sözleşme metni sürümü
+  signedAt  DateTime @default(now())
+  ipHash    String?  // imza anındaki IP (kanıt)
+}
+```
+Onboarding akışına "sözleşmeyi okudum ve kabul ediyorum" adımı eklenebilir.
+
+## Aksiyon listesi
+- [ ] Metni avukata onaylat (özellikle § 31/29 UrhG ifadeleri).
+- [ ] Mevcut katkıcı mentee'lere imzalat (kağıt/e-imza).
+- [ ] Onboarding'e imza adımı ekle (kod işi; ayrı issue açılabilir).

--- a/docs/legal/legal-tax-framework.md
+++ b/docs/legal/legal-tax-framework.md
@@ -1,0 +1,45 @@
+# Hukuki / vergisel çerçeve kararı (#549)
+
+> Hukuki/mali tavsiye değildir; mali müşavir (Steuerberater) ve avukat onayı gerekir.
+
+## Karar
+Ticarileşme **mevcut bcsit GmbH** (Almanya) üzerinden yürütülür. Yeni bir tüzel yapı
+kurulmaz — GmbH zaten var, sınırlı sorumluluk sağlıyor ve B2B SaaS faturalaması için
+uygun.
+
+### 1. Tüzel yapı
+- **Yürütücü:** bcsit GmbH (Almanya). Gelir, sözleşmeler ve faturalar GmbH üzerinden.
+- Gerekçe: hazır yapı, sınırlı sorumluluk, kurumsal müşterinin (Enterprise) sözleşme
+  yapmak isteyeceği tüzel kişilik.
+
+### 2. Vergi / faturalama
+- **KDV (Umsatzsteuer):** GmbH KDV mükellefi; faturalarda %19 USt gösterilir.
+  - AB içi B2B müşteride **reverse-charge** (alıcının VAT-ID'si ile), fatura üzerinde
+    "Steuerschuldnerschaft des Leistungsempfängers" notu.
+  - AB dışı müşteride yerel kurallara göre.
+- **Fatura zorunlu alanları** (§ 14 UStG): GmbH adı/adresi, vergi no (USt-IdNr),
+  fatura no, tarih, hizmet tanımı, net + KDV + brüt.
+- Muhasebe Steuerberater ile; SaaS geliri düzenli (aylık/yıllık abonelik) tanınır.
+
+### 3. Gelir modeli seçimi — **success-fee'den kaçın**
+- **Karar:** Gelir **SaaS abonelik / yazılım lisans ücreti** olarak yapılandırılır
+  (şirketler yetenek havuzu erişimi için; kurumlar programı yürütmek için öder).
+- **Neden success-fee (yerleştirme başına komisyon) DEĞİL:** Almanya'da bir adayı
+  bir işverene yerleştirip başarı ücreti almak **iş aracılığı (Arbeitsvermittlung)**
+  sayılabilir; bu, Arbeitnehmerüberlassungsgesetz (AÜG) / SGB III kapsamında ek
+  yükümlülük, kayıt ve — bazı kurgularda — lisans gerektirebilir. Erken aşamada bu
+  karmaşıklık ve risk gereksiz.
+- Success-fee ileride istenirse: ayrı hukuki değerlendirme + muhtemelen ayrı sözleşme
+  yapısı gerekir; SaaS gelirinden bağımsız ele alınmalı.
+
+### 4. Sözleşme şablonları (ihtiyaç listesi)
+- **B2B SaaS Abonelik Sözleşmesi** (şirket/kurum müşteri): kapsam, ücret, süre, SLA
+  (Enterprise), fesih.
+- **DPA (Auftragsverarbeitungsvertrag, Art. 28 GDPR):** kurum müşteri kişisel veri
+  işlettiği için zorunlu (özellikle multi-tenancy/Enterprise'da).
+- **Kullanım Şartları + Gizlilik** (mevcut `/terms`, `/privacy` ile uyumlu).
+
+## Aksiyon listesi
+- [ ] Steuerberater ile KDV/reverse-charge faturalama akışını netleştir.
+- [ ] Avukatla B2B SaaS sözleşme + DPA şablonları hazırlat.
+- [ ] Success-fee kullanılacaksa AÜG/SGB III değerlendirmesi (ayrı, ertelenebilir).

--- a/docs/legal/payment-infrastructure.md
+++ b/docs/legal/payment-infrastructure.md
@@ -1,0 +1,33 @@
+# Ödeme altyapısı kararı (#552)
+
+## Karar — iki fazlı
+Erken karmaşıklık eklemeden gelir doğrulaması için:
+
+### Faz 1 — Manuel faturalama (kod gerekmez) ✅ şimdi
+- Entitlement (`hasFeature` / premium Setting) **elle** açılır (admin).
+- Fatura bcsit GmbH tarafından elle kesilir (bkz. [legal-tax-framework.md](legal-tax-framework.md)).
+- Uygun çünkü: ilk müşteri sayısı az; amaç ödeme akışını değil **değeri** doğrulamak.
+- Gereken: yok (mevcut entitlement katmanı yeterli).
+
+### Faz 2 — Stripe Billing (ölçeklenince)
+- **Sağlayıcı: Stripe** (abonelik/Billing + Customer Portal + Tax). Gerekçe: en olgun
+  SaaS abonelik altyapısı, güçlü webhook, AB KDV/`Stripe Tax` desteği, düşük entegrasyon
+  maliyeti.
+- **Akış:** Checkout/Customer Portal ile abonelik → **webhook** (`checkout.session.completed`,
+  `customer.subscription.updated/deleted`) → entitlement'ı otomatik senkronla
+  (premium Setting / `hasFeature` kaydı). İmza doğrulaması (`Stripe-Signature`) zorunlu.
+- **Entitlement eşlemesi:** Stripe `price`/`product` → tenant plan (Free/Pro/Enterprise);
+  webhook geldiğinde ilgili tenant'ın entitlement'ı güncellenir. Multi-tenancy (#543)
+  sonrası tenant-seviyesine bağlanır.
+- **Uygulama ayrı bir issue** olacak (Faz 3 multi-tenancy + plan limitleri #547 ile
+  birlikte anlamlı).
+
+## Neden şimdi Stripe entegre etmiyoruz
+- Gelir/pilot doğrulanmadan webhook+abonelik+vergi entegrasyonu bakım yükü getirir.
+- Faz 1 manuel akış ilk gelirleri toplamak için yeterli; Stripe, tekrar eden müşteri
+  ve otomatik yenileme ihtiyacı doğunca devreye alınır.
+
+## Aksiyon listesi
+- [ ] Faz 1: premium açılışını elle yönet (mevcut admin toggle).
+- [ ] Faz 2 tetikleyici: tekrar eden ödeme / birden çok müşteri olunca Stripe entegrasyon
+      issue'su aç (Checkout + webhook → entitlement + Stripe Tax).

--- a/docs/legal/talent-pool-consent-policy.md
+++ b/docs/legal/talent-pool-consent-policy.md
@@ -1,0 +1,56 @@
+# Mentee görünürlük rızası — politika & metinler (#551)
+
+> Bu politika, koddaki teknik rıza mekanizmasını (#527, `UserConsent` +
+> `TALENT_POOL_VISIBILITY`) **tanımlar/gerekçelendirir**. Metinler `/privacy` ve
+> consent UI ile tutarlı olmalıdır.
+
+## Karar — rıza kapsamı
+Yetenek havuzu görünürlüğü **açık, özgür (opt-in) ve geri-alınabilir** rızaya bağlıdır
+(GDPR Art. 6(1)(a) + Art. 7). Varsayılan **kapalı**.
+
+### Şirkete görünen alanlar (yalnız bunlar)
+- Ad-soyad, üniversite/bölüm, beceriler (+ self-assessment seviyeleri), hedef pozisyon,
+  mentor değerlendirme **özeti** (ham yorum değil), tamamlanan proje katkıları.
+
+### Asla paylaşılmayan
+- E-posta, telefon, adres, ham iletişim bilgisi
+- Mentor-özel notlar (`RelationNote`), kişisel notlar, ham değerlendirme yorumları
+- CV dosyasının kendisi (yalnız rıza kapsamındaki türetilmiş alanlar)
+
+### Kimlerle
+- Yalnızca **entitlement'ı açık** (premium) şirket kullanıcıları; yalnızca rıza vermiş
+  mentee'ler havuzda görünür.
+
+### Süre & geri çekme
+- Rıza istendiği an geri çekilebilir; geri çekilince mentee **anında** havuz
+  aramasından ve eşleşme uyarılarından çıkar (mevcut davranış).
+- Saklama: rıza kaydı retention politikasıyla uyumlu tutulur; görünürlük yalnızca rıza
+  aktifken vardır.
+
+## Rıza metni (UI — EN/TR/DE)
+Koddaki `consent.items.talentPoolVisibility` ile birebir aynı olmalı:
+
+- **TR:** "Şirketlere görünürlük (yetenek havuzu) — Partner şirketlerin profilini
+  yetenek havuzu aramasında bulmasına ve açık pozisyonları için eşleşme uyarısı
+  almasına izin ver. Yalnızca kamuya açık profilini görürler (ad, üniversite,
+  beceriler, hedef pozisyon) — e-posta veya telefonunu asla. Varsayılan kapalı;
+  istediğin an geri çekebilirsin ve şirket aramasından anında çıkarsın."
+- **EN:** "Visibility to companies (talent pool) — Allow partner companies to find
+  your profile in talent-pool search and receive match alerts. They see your public
+  profile (name, university, skills, target position) — never your email or phone.
+  Off by default; withdraw anytime and you disappear from company search immediately."
+- **DE:** "Sichtbarkeit für Unternehmen (Talentpool) — Erlaube Partnerunternehmen,
+  dein Profil in der Talentpool-Suche zu finden und Match-Hinweise zu erhalten. Sie
+  sehen dein öffentliches Profil (Name, Universität, Fähigkeiten, Zielposition) —
+  niemals E-Mail oder Telefon. Standardmäßig aus; jederzeit widerrufbar, du
+  verschwindest sofort aus der Unternehmenssuche."
+
+## /privacy güncellemesi (gerekli cümleler)
+- Yetenek havuzu paylaşımı ve kapsamı (yukarıdaki alanlar)
+- Hukuki dayanak: açık rıza (Art. 6(1)(a))
+- Geri çekme hakkı ve etkisi (anında çıkış)
+- Alıcı kategorisi: rıza kapsamında partner şirketler
+
+## Aksiyon listesi
+- [ ] `/privacy` metnine yukarıdaki paragrafı ekle (küçük kod işi; ayrı issue).
+- [ ] consent UI metinleriyle bu politikayı senkron tut (değişirse ikisini birlikte).

--- a/infra/deploy-prod.sh
+++ b/infra/deploy-prod.sh
@@ -110,6 +110,7 @@ run_tool npx prisma db push --accept-data-loss
 log "seed-templates + project-member backfill (idempotent)"
 run_tool node prisma/seed-templates.mjs || true
 run_tool node prisma/backfill-project-members.mjs || true
+run_tool node prisma/backfill-organization.mjs || true
 
 # ── 5. Swap the container ────────────────────────────────────────────────────
 log "Restarting $CONTAINER on :$PORT"

--- a/prisma/backfill-organization.mjs
+++ b/prisma/backfill-organization.mjs
@@ -1,0 +1,32 @@
+// Idempotent backfill for multi-tenancy Phase 1 (#543): ensure a single default
+// Organization exists and every tenant-scoped row points at it. Additive and
+// safe — nothing enforces isolation yet, so this only fills the new nullable
+// orgId columns. Runs on deploy (deploy-prod.sh / deploy.yml) and in db seed.
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+const DEFAULT_SLUG = process.env.DEFAULT_ORG_SLUG || 'default';
+const DEFAULT_NAME = process.env.DEFAULT_ORG_NAME || 'Default Organization';
+
+async function main() {
+  const org = await prisma.organization.upsert({
+    where: { slug: DEFAULT_SLUG },
+    update: {},
+    create: { slug: DEFAULT_SLUG, name: DEFAULT_NAME },
+    select: { id: true },
+  });
+
+  const models = ['user', 'source', 'cohort', 'company', 'project', 'mentorshipRelation'];
+  let total = 0;
+  for (const m of models) {
+    const res = await prisma[m].updateMany({ where: { orgId: null }, data: { orgId: org.id } });
+    if (res.count) console.log(`backfill-organization: ${m} +${res.count}`);
+    total += res.count;
+  }
+  console.log(`backfill-organization: default org ${DEFAULT_SLUG}; ${total} row(s) assigned.`);
+}
+
+main()
+  .catch((e) => { console.error(e); process.exit(1); })
+  .finally(() => prisma.$disconnect());

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -46,19 +46,40 @@ enum PipelineStatus {
   INTERNSHIP_FOUND_ELSEWHERE_800 // 800 tr: başka yerde staj buldu
 }
 
+// Tenant/organization for multi-tenancy (#543). Phase 1: additive & nullable —
+// every tenant-scoped row is backfilled to a single default org and nothing
+// enforces isolation yet, so behaviour is unchanged. Enforcement (query
+// filtering, per-org uniqueness) lands in a later, guarded slice.
+model Organization {
+  id        String   @id @default(cuid())
+  name      String
+  slug      String   @unique
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  users     User[]
+  sources   Source[]
+  cohorts   Cohort[]
+  companies Company[]
+  projects  Project[]
+  relations MentorshipRelation[]
+}
+
 model User {
-  id                      String    @id @default(cuid())
-  email                   String    @unique
+  orgId                   String?
+  org                     Organization? @relation(fields: [orgId], references: [id])
+  id                      String        @id @default(cuid())
+  email                   String        @unique
   password                String
-  role                    Role      @default(MENTEE)
+  role                    Role          @default(MENTEE)
   fullName                String
   phone                   String?
   university              String?
   department              String?
   graduationYear          Int?
-  skills                  Json      @default("[]")
+  skills                  Json          @default("[]")
   // Mentee self-assessment: { "<skill>": 1..5 }
-  skillLevels             Json      @default("{}")
+  skillLevels             Json          @default("{}")
   cvUrl                   String?
   avatarUrl               String?
   whatsapp                String?
@@ -67,29 +88,29 @@ model User {
   referralSource          String?
   // Extended profile (all optional; safe to add to existing rows).
   displayName             String?
-  bio                     String?   @db.Text
+  bio                     String?       @db.Text
   country                 String?
   timezone                String?
   linkedinUrl             String?
   githubUrl               String?
   portfolioUrl            String?
   // Mentee: interests / target position. Mentor: max concurrent mentees.
-  interests               String?   @db.Text
+  interests               String?       @db.Text
   targetPosition          String?
   mentorCapacity          Int?
   // Default true so existing rows stay writable after the column is added;
   // new self-registrations are created with false until they verify by email.
-  emailVerified           Boolean   @default(true)
+  emailVerified           Boolean       @default(true)
   // Admin can deactivate a user; inactive users cannot sign in.
-  isActive                Boolean   @default(true)
+  isActive                Boolean       @default(true)
   // Opt-in: expose a limited, PII-free public profile at /p/[id].
-  publicProfile           Boolean   @default(false)
+  publicProfile           Boolean       @default(false)
   // For COMPANY-role users: which company they observe (read-only).
   companyId               String?
   // Mentee's referral source (where they came from).
   sourceId                String?
   // How many times this user's public profile has been viewed.
-  profileViews            Int       @default(0)
+  profileViews            Int           @default(0)
   // When the user accepted the privacy/data terms (consent). Also the anchor
   // for retention re-consent: data is kept no longer than retentionMonths past
   // this date without renewal.
@@ -99,12 +120,12 @@ model User {
   retentionReminderSentAt DateTime?
   // Opt-out switch for transactional email (messages, announcements). In-app
   // notifications are always created regardless.
-  emailNotifications      Boolean   @default(true)
+  emailNotifications      Boolean       @default(true)
   // Per-category email toggles, e.g. {"messages":false}. Nullable so existing
   // rows aren't touched (avoids MariaDB json_valid CHECK issues); unset = on.
   notificationPrefs       Json?
   // Optional TOTP two-factor auth. The secret is only meaningful once enabled.
-  twoFactorEnabled        Boolean   @default(false)
+  twoFactorEnabled        Boolean       @default(false)
   twoFactorSecret         String?
   // "Sign out of all devices": any JWT issued before this instant is rejected at
   // the session callback. Null = never revoked. Set to now() to invalidate every
@@ -124,8 +145,8 @@ model User {
   lastLoginAt             DateTime?
   // Last time the user was seen active (page-view heartbeat, consent-gated).
   lastSeenAt              DateTime?
-  createdAt               DateTime  @default(now())
-  updatedAt               DateTime  @updatedAt
+  createdAt               DateTime      @default(now())
+  updatedAt               DateTime      @updatedAt
 
   mentorRelations         MentorshipRelation[]     @relation("MentorRelations")
   menteeRelations         MentorshipRelation[]     @relation("MenteeRelations")
@@ -214,11 +235,13 @@ model UserConsent {
 // A referral source — the education/agency a mentee came from. Admin-managed
 // so reporting can group mentees by where they were sourced.
 model Source {
-  id           String   @id @default(cuid())
-  name         String   @unique
+  orgId        String?
+  org          Organization? @relation(fields: [orgId], references: [id])
+  id           String        @id @default(cuid())
+  name         String        @unique
   contactName  String?
   contactEmail String?
-  createdAt    DateTime @default(now())
+  createdAt    DateTime      @default(now())
 
   users User[]
 
@@ -350,7 +373,9 @@ model Document {
 }
 
 model Company {
-  id           String   @id @default(cuid())
+  orgId        String?
+  org          Organization? @relation(fields: [orgId], references: [id])
+  id           String        @id @default(cuid())
   name         String
   description  String?
   contactEmail String?
@@ -359,8 +384,8 @@ model Company {
   size         String?
   address      String?
   quota        Int?
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  createdAt    DateTime      @default(now())
+  updatedAt    DateTime      @updatedAt
 
   needs        CompanyNeed[]
   mentorships  MentorshipRelation[]
@@ -559,6 +584,8 @@ enum ProjectOwnerType {
 // community project owned by an admin/mentor. Mentees are assigned via
 // MentorshipRelation.projectId. Ownership is transferable (audited).
 model Project {
+  orgId          String?
+  org            Organization?    @relation(fields: [orgId], references: [id])
   id             String           @id @default(cuid())
   name           String
   description    String?          @db.Text
@@ -641,10 +668,12 @@ model AvailabilitySlot {
 
 // A cohort groups mentees/internships by intake period for comparison.
 model Cohort {
-  id        String   @id @default(cuid())
+  orgId     String?
+  org       Organization? @relation(fields: [orgId], references: [id])
+  id        String        @id @default(cuid())
   name      String
   term      String?
-  createdAt DateTime @default(now())
+  createdAt DateTime      @default(now())
 
   relations MentorshipRelation[]
 }
@@ -660,6 +689,8 @@ model CompanyNeed {
 }
 
 model MentorshipRelation {
+  orgId                   String?
+  org                     Organization?    @relation(fields: [orgId], references: [id])
   id                      String           @id @default(cuid())
   mentorId                String
   menteeId                String

--- a/prisma/seed.mjs
+++ b/prisma/seed.mjs
@@ -35,6 +35,17 @@ async function main() {
     });
   }
 
+  // Backfill default Organization + orgId (#543, idempotent).
+  const defaultOrg = await prisma.organization.upsert({
+    where: { slug: 'default' },
+    update: {},
+    create: { slug: 'default', name: 'Default Organization' },
+    select: { id: true },
+  });
+  for (const m of ['user', 'source', 'cohort', 'company', 'project', 'mentorshipRelation']) {
+    await prisma[m].updateMany({ where: { orgId: null }, data: { orgId: defaultOrg.id } });
+  }
+
   // Idempotent company seed (Company.name is not unique, so check first).
   for (const name of SEED_COMPANIES) {
     const found = await prisma.company.findFirst({ where: { name } });


### PR DESCRIPTION
Phase 1 of multi-tenancy (#543 / #522) — **additive and reversible, zero behaviour change**. The deliberate first slice: put the data model in place without enforcing isolation, so single-tenant production keeps working exactly as today.

## Changes
- **`Organization`** model (name, unique `slug`, timestamps) + back-relations.
- **nullable `orgId` + `org` relation** on the six tenant-scoped models: `User`, `Source`, `Cohort`, `Company`, `Project`, `MentorshipRelation`.
- **No enforcement yet** — no query filtering, no per-org uniqueness. Those land in a later, guarded slice (with an isolation test) so nothing breaks now.
- **Idempotent backfill** (`prisma/backfill-organization.mjs`): upserts one default org and assigns every existing row to it. Wired into `db seed` and both deploy paths (`deploy-prod.sh` + `deploy.yml` prod & preview), same pattern as the project-member backfill.

## Verification
- `prisma validate` ✅ · `tsc --noEmit` ✅ · `npm run build` ✅
- `db push` only adds a table + nullable columns (safe, additive); backfill fills them.

Refs #543 · #522. Enforcement + tenant onboarding + plan limits follow in subsequent PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_