### PR TITLE
feat(mt): tenant-isolation enforcement building blocks (#543)

### DIFF
--- a/docs/tenant-isolation.md
+++ b/docs/tenant-isolation.md
@@ -1,0 +1,58 @@
+# Tenant isolation (multi-tenancy enforcement) — #543
+
+How data is (and will be) separated per `Organization`, and how to turn on
+enforcement safely.
+
+## Where we are
+
+Multi-tenancy shipped in additive phases:
+
+| Slice  | What                                                                 | State |
+|--------|----------------------------------------------------------------------|-------|
+| #543-1 | `Organization` model + nullable `orgId` on tenant-scoped models      | live  |
+| #544   | Super-admin org management                                           | live  |
+| #547   | Per-tenant plan tiers + advisory limits                             | live  |
+| #546   | Per-tenant white-label branding                                    | live  |
+| #545   | Per-tenant SSO config + gating                                    | live  |
+| #543-2 | **Enforcement** — scope every query to the request's org           | **foundation only** |
+
+Every existing row is backfilled to a single `default` org, so the live app is
+effectively single-tenant and **nothing filters by `orgId` yet**.
+
+## The enforcement building blocks (`src/lib/orgScope.ts`)
+
+Rather than a global Prisma middleware that silently rewrites every query
+(easy to get wrong, impossible to verify without a real multi-tenant DB), the
+enforcement primitives are explicit and opt-in:
+
+- `resolveOrgId(session)` — the org a request belongs to (today: the signed-in
+  user's `orgId`, now carried in the JWT/session).
+- `orgScoped(where, orgId)` — merge an `orgId` filter into a Prisma `where`.
+- `requireOrg(session)` — returns the org to scope by; **throws** when
+  enforcement is on but no org resolves (fail-closed).
+- `assertSameOrg(rowOrgId, expectedOrgId)` — post-lookup IDOR guard for
+  find-by-id handlers.
+- `isIsolationEnforced()` — reads `MT_ENFORCE_ISOLATION` (default **off**).
+
+All of this is exercised by `e2e/org-isolation.spec.ts` against a real DB
+(scoped queries return only one tenant's rows; guards fail-closed only when the
+flag is on).
+
+## Turning enforcement on (the guarded rollout)
+
+Do **not** set `MT_ENFORCE_ISOLATION=true` in production until every step below
+is done and verified in a preview/staging environment first:
+
+1. **Assign real orgs.** While there is one `default` org this is a no-op; once
+   multiple tenants exist, ensure every user/row has the correct `orgId`.
+2. **Plumb request→org resolution** everywhere reads/writes happen — either via
+   the session `orgId` (done) or host/subdomain for public routes.
+3. **Adopt the helpers** in each API route and query: wrap list/read `where`
+   with `orgScoped(where, requireOrg(session))`, and call `assertSameOrg` after
+   every find-by-id. Add per-org uniqueness where needed (e.g. slugs).
+4. **Run the full isolation suite** with `MT_ENFORCE_ISOLATION=true` against a
+   seeded two-tenant DB; confirm no cross-tenant read/write passes.
+5. **Flip the flag** in one environment, watch, then production. It is a single
+   env var so rollback is instant.
+
+Until then the flag stays off and the single-tenant production app is unchanged.

--- a/e2e/org-isolation.spec.ts
+++ b/e2e/org-isolation.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from '@playwright/test';
+import { prisma } from './helpers/db';
+import {
+  orgScoped, resolveOrgId, requireOrg, assertSameOrg, isIsolationEnforced,
+} from '../src/lib/orgScope';
+
+// Multi-tenancy enforcement building blocks (#543). Global auto-isolation is NOT
+// switched on (MT_ENFORCE_ISOLATION defaults off), so these tests validate the
+// opt-in scoping helper against a real DB plus the guard semantics — proving the
+// path works before it is wired app-wide. See docs/tenant-isolation.md.
+
+const slugs = ['iso-a', 'iso-b'].map((s) => `${s}-${Date.now()}`);
+
+test.afterAll(async () => {
+  // Remove seeded users first (FK), then the orgs.
+  for (const slug of slugs) {
+    const org = await prisma.organization.findUnique({ where: { slug } });
+    if (org) {
+      await prisma.user.deleteMany({ where: { orgId: org.id } });
+      await prisma.organization.delete({ where: { id: org.id } }).catch(() => {});
+    }
+  }
+  await prisma.$disconnect();
+});
+
+test('orgScoped() filters queries to a single tenant', async () => {
+  const [slugA, slugB] = slugs;
+  const orgA = await prisma.organization.create({ data: { name: 'Iso A', slug: slugA } });
+  const orgB = await prisma.organization.create({ data: { name: 'Iso B', slug: slugB } });
+
+  const mk = (org: string, tag: string) => prisma.user.create({
+    data: {
+      email: `iso-${tag}-${Date.now()}-${Math.round(performance.now())}@e2e.local`,
+      password: 'x', role: 'MENTEE', fullName: `Iso ${tag}`, skills: [], orgId: org,
+    },
+  });
+  await mk(orgA.id, 'a1');
+  await mk(orgA.id, 'a2');
+  await mk(orgB.id, 'b1');
+
+  // Scoped query returns only the requested tenant's rows.
+  const aRows = await prisma.user.findMany({ where: orgScoped({ role: 'MENTEE' as const }, orgA.id) });
+  expect(aRows.length).toBe(2);
+  expect(aRows.every((u) => u.orgId === orgA.id)).toBe(true);
+
+  const bRows = await prisma.user.findMany({ where: orgScoped({ role: 'MENTEE' as const }, orgB.id) });
+  expect(bRows.length).toBe(1);
+  expect(bRows[0].orgId).toBe(orgB.id);
+
+  // A null orgId means "no scoping" — the helper leaves the where unchanged.
+  const scoped = orgScoped({ role: 'MENTEE' as const }, null);
+  expect(scoped).not.toHaveProperty('orgId');
+});
+
+test('guards fail-closed only when enforcement is on', async () => {
+  const session = (orgId: string | null) => ({ user: { orgId } }) as unknown as Parameters<typeof resolveOrgId>[0];
+
+  expect(resolveOrgId(session('org-1'))).toBe('org-1');
+  expect(resolveOrgId(session(null))).toBeNull();
+  expect(resolveOrgId(null)).toBeNull();
+
+  const prev = process.env.MT_ENFORCE_ISOLATION;
+  try {
+    // Enforcement OFF (default): no-ops, never throws.
+    process.env.MT_ENFORCE_ISOLATION = 'false';
+    expect(isIsolationEnforced()).toBe(false);
+    expect(requireOrg(session(null))).toBeNull();
+    expect(() => assertSameOrg('org-2', 'org-1')).not.toThrow();
+
+    // Enforcement ON: requireOrg throws with no org; assertSameOrg blocks mismatch.
+    process.env.MT_ENFORCE_ISOLATION = 'true';
+    expect(isIsolationEnforced()).toBe(true);
+    expect(requireOrg(session('org-1'))).toBe('org-1');
+    expect(() => requireOrg(session(null))).toThrow();
+    expect(() => assertSameOrg('org-1', 'org-1')).not.toThrow();
+    expect(() => assertSameOrg('org-2', 'org-1')).toThrow();
+  } finally {
+    if (prev === undefined) delete process.env.MT_ENFORCE_ISOLATION;
+    else process.env.MT_ENFORCE_ISOLATION = prev;
+  }
+});

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -89,6 +89,7 @@ export const authOptions: NextAuthOptions = {
           role: user.role,
           emailVerified: user.emailVerified,
           companyId: user.companyId,
+          orgId: user.orgId,
         };
       },
     }),
@@ -126,6 +127,7 @@ export const authOptions: NextAuthOptions = {
           // Carry the impersonated user's company so the company portal (and any
           // companyId-scoped data) loads correctly while impersonating.
           companyId: user.companyId,
+          orgId: user.orgId,
           impersonatorId: isStart ? grant.adminId : undefined,
           impersonatorName: isStart ? admin?.fullName ?? 'Admin' : undefined,
         };
@@ -139,6 +141,8 @@ export const authOptions: NextAuthOptions = {
         token.role = (user as unknown as { role: string }).role;
         token.emailVerified = (user as unknown as { emailVerified: boolean }).emailVerified;
         token.companyId = (user as unknown as { companyId?: string | null }).companyId ?? null;
+        // Tenant the user belongs to (multi-tenancy, #543). Null until assigned.
+        token.orgId = (user as unknown as { orgId?: string | null }).orgId ?? null;
         // Set when starting impersonation, absent on a normal/stop sign-in —
         // so this also clears it when returning to the original account.
         const u = user as unknown as { impersonatorId?: string; impersonatorName?: string };
@@ -167,6 +171,7 @@ export const authOptions: NextAuthOptions = {
           token.email = admin.email;
           token.name = admin.fullName;
           token.companyId = admin.companyId;
+          token.orgId = admin.orgId;
           token.emailVerified = admin.emailVerified;
         }
         token.impersonatorId = null;
@@ -184,6 +189,7 @@ export const authOptions: NextAuthOptions = {
           token.role = fresh.role;
           token.emailVerified = fresh.emailVerified;
           token.companyId = fresh.companyId;
+          token.orgId = fresh.orgId;
         }
       }
 
@@ -216,6 +222,7 @@ export const authOptions: NextAuthOptions = {
         session.user.impersonatorId = (token.impersonatorId as string) ?? null;
         session.user.impersonatorName = (token.impersonatorName as string) ?? null;
         session.user.companyId = (token.companyId as string) ?? null;
+        session.user.orgId = (token.orgId as string) ?? null;
         if (token.email) session.user.email = token.email as string;
         if (token.name) session.user.name = token.name as string;
       }
@@ -248,6 +255,7 @@ declare module 'next-auth' {
       impersonatorId?: string | null;
       impersonatorName?: string | null;
       companyId?: string | null;
+      orgId?: string | null;
     };
   }
 }

--- a/src/lib/orgScope.ts
+++ b/src/lib/orgScope.ts
@@ -1,0 +1,66 @@
+// Tenant (org) scoping helpers for multi-tenancy enforcement (#543).
+//
+// Phase-1 of MT was additive: every tenant-scoped row carries a nullable orgId
+// backfilled to a single "default" org, and NOTHING filters by it — so the live
+// single-tenant app is unchanged. This module is the *enforcement building
+// block*: an explicit, opt-in way to scope a query to one tenant, plus the guard
+// that decides whether global enforcement is on.
+//
+// It deliberately does NOT install a global Prisma middleware that auto-injects
+// orgId into every query. That flip must not happen on a live single-tenant prod
+// until (a) request→org resolution is plumbed everywhere and (b) it is exercised
+// end-to-end by the isolation test with a real DB. Until then callers opt in via
+// orgScoped()/assertSameOrg(), and MT_ENFORCE_ISOLATION stays off.
+//
+// See docs/tenant-isolation.md for the turn-it-on checklist.
+
+import type { Session } from 'next-auth';
+
+// Is global tenant isolation enforcement switched on for this deployment?
+// Defaults OFF. A single env flag so the rollout is reversible and observable.
+export function isIsolationEnforced(): boolean {
+  return process.env.MT_ENFORCE_ISOLATION === 'true';
+}
+
+// Resolve the org a request belongs to. Today that is simply the signed-in
+// user's orgId (added in #543 phase 1). When host/subdomain-based tenancy lands
+// this is where that resolution goes. Null when unknown (e.g. public routes or a
+// user not yet assigned to an org).
+export function resolveOrgId(session: Session | null | undefined): string | null {
+  const orgId = (session?.user as { orgId?: string | null } | undefined)?.orgId;
+  return orgId ?? null;
+}
+
+// Merge an orgId filter into a Prisma `where`. The building block enforcement
+// consumers use: `prisma.user.findMany({ where: orgScoped(where, orgId) })`.
+// A null orgId returns the where unchanged (no scoping) — callers that must
+// enforce should check `requireOrg` first.
+export function orgScoped<W extends Record<string, unknown>>(
+  where: W | undefined,
+  orgId: string | null,
+): W & { orgId?: string } {
+  if (!orgId) return (where ?? {}) as W & { orgId?: string };
+  return { ...(where ?? {}), orgId } as W & { orgId?: string };
+}
+
+// Guard for write/read handlers that must be tenant-scoped once enforcement is
+// on. Returns the orgId to scope by, or throws when enforcement is on but no org
+// resolves (fail-closed). When enforcement is off it returns the resolved orgId
+// (possibly null) so callers behave exactly as before.
+export function requireOrg(session: Session | null | undefined): string | null {
+  const orgId = resolveOrgId(session);
+  if (isIsolationEnforced() && !orgId) {
+    throw new Error('Tenant isolation is enforced but no organization resolved for this request');
+  }
+  return orgId;
+}
+
+// Assert a fetched row belongs to the expected tenant. Use after a lookup by id
+// to prevent cross-tenant access (IDOR) once enforcement is on. No-op when
+// enforcement is off or the expected org is unknown.
+export function assertSameOrg(rowOrgId: string | null | undefined, expectedOrgId: string | null): void {
+  if (!isIsolationEnforced() || !expectedOrgId) return;
+  if (rowOrgId !== expectedOrgId) {
+    throw new Error('Cross-tenant access denied');
+  }
+}


### PR DESCRIPTION
## What

Enforcement foundation for multi-tenancy — deliberately **not** global auto-filtering. Explicit opt-in primitives + a reversible flag, so turning isolation on later is a verified rollout, not a risky query-rewrite on live single-tenant prod.

- **`src/lib/orgScope.ts`** — `resolveOrgId(session)`, `orgScoped(where, orgId)`, `requireOrg` (fail-closed when enforced), `assertSameOrg` (IDOR guard), `isIsolationEnforced()` reading `MT_ENFORCE_ISOLATION` (default off).
- **Auth**: carry the user's `orgId` in the JWT + session (login, impersonation, session-update paths) + next-auth type augmentation. Additive.
- **`e2e/org-isolation.spec.ts`** — `orgScoped()` returns only one tenant's rows against a real DB; guards no-op when the flag is off and fail-closed when on.
- **`docs/tenant-isolation.md`** — current state + the guarded turn-it-on checklist.

## Safety

**No schema change.** `MT_ENFORCE_ISOLATION` stays off → single-tenant production behaviour is unchanged.

## Verification

`tsc --noEmit` + `npm run build` green locally.

Refs #543 · #522

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_