### PR TITLE
fix(auth): Safari post-login loop + normalize email on lookup

### DIFF
--- a/src/app/api/auth/forgot/route.ts
+++ b/src/app/api/auth/forgot/route.ts
@@ -19,7 +19,11 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Invalid email' }, { status: 400 });
     }
 
-    const user = await prisma.user.findUnique({ where: { email: parsed.data.email } });
+    // Normalize (trim + lowercase) so a casing/whitespace difference from what
+    // was stored at registration can't silently miss the account — which would
+    // otherwise show "email sent" while no reset mail is ever dispatched.
+    const email = parsed.data.email.trim().toLowerCase();
+    const user = await prisma.user.findUnique({ where: { email } });
     if (user) {
       const token = await createPasswordResetToken(user.id, 'RESET');
       try {

--- a/src/app/api/register/route.ts
+++ b/src/app/api/register/route.ts
@@ -36,7 +36,12 @@ export async function POST(request: Request) {
       );
     }
 
-    const { token, email, password, fullName } = parsed.data;
+    const { token, password, fullName } = parsed.data;
+    // Normalize email (trim + lowercase) so the account is looked up
+    // consistently everywhere afterwards (sign-in, forgot-password) — a
+    // casing/whitespace difference otherwise creates a "can't find my account"
+    // dead-end and silent forgot-password no-ops.
+    const email = parsed.data.email.trim().toLowerCase();
 
     // If consent was explicitly provided, it must be affirmative.
     if (parsed.data.consent === false) {

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -101,9 +101,22 @@ export default function SignInPage() {
       return;
     }
 
-    const res = await fetch('/api/auth/session');
-    const fresh = await res.json();
-    router.push(roleHome(fresh?.user?.role));
+    // Safari (and other strict-cookie browsers) can lag applying the Set-Cookie
+    // that signIn() just issued, so an immediate /api/auth/session read returned
+    // no user → we redirected to the default (/portal) or bounced back to
+    // sign-in, i.e. an apparent "login does nothing / page repeats" loop. Poll
+    // briefly for the session to settle, then do a FULL-PAGE navigation so the
+    // freshly-committed cookie is guaranteed to accompany the next request
+    // (client-side router.push could run before the cookie is readable).
+    let role: string | undefined;
+    for (let i = 0; i < 6; i++) {
+      const res = await fetch('/api/auth/session', { cache: 'no-store' });
+      const fresh = await res.json().catch(() => null);
+      role = fresh?.user?.role;
+      if (role) break;
+      await new Promise((r) => setTimeout(r, 200));
+    }
+    window.location.assign(roleHome(role));
   });
 
   return (

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -31,10 +31,13 @@ export const authOptions: NextAuthOptions = {
           throw new Error('Email and password are required');
         }
 
-        const failKey = `login-fail:${credentials.email.toLowerCase()}`;
+        // Normalize (trim + lowercase) to match how emails are stored at
+        // registration, so sign-in never misses on a casing/whitespace diff.
+        const email = credentials.email.trim().toLowerCase();
+        const failKey = `login-fail:${email}`;
 
         const user = await prisma.user.findUnique({
-          where: { email: credentials.email },
+          where: { email },
         });
 
         const isPasswordValid = user


### PR DESCRIPTION
## Reported (from Safari)

> Safari kayıt aşamasından sonra sayfayı tekrarlıyor giriş sağlanmıyor. … Passwortu unuttum dediğimde link … 5 dakikadır link gelmedi.

Two distinct auth issues:

### 1. Safari sign-in "loop" (Chrome fine)
After `signIn({ redirect: false })` the page read `/api/auth/session` **immediately** and `router.push()`ed. Safari lags committing the `Set-Cookie` that `signIn` just issued, so that read returned **no user** → redirect to the default (`/portal`) or a bounce back to sign-in — the apparent loop, and the wrong dashboard for non-mentees. Chrome commits the cookie fast enough to dodge it.

**Fix**: poll briefly for the session to settle, then do a **full-page navigation** (`window.location.assign`) so the freshly-committed cookie is guaranteed to accompany the next request (client-side `router.push` could run before the cookie is readable).

### 2. "Forgot password says sent, no email arrives"
Prod SMTP is healthy (`/api/health?smtp=1` → `smtp: ok`), so this isn't delivery. The lookup used the email **verbatim**; a casing/whitespace difference from what was stored at registration silently missed the account — and the endpoint still returns 200 (anti-enumeration), so no mail is ever dispatched and the user waits forever.

**Fix**: normalize email (`trim().toLowerCase()`) consistently at **register** (storage), **sign-in** and **forgot-password** lookups.

## Notes
- No schema change.
- Self-registration remains **email-verify + admin-approval gated** by design — a freshly self-registered account genuinely cannot sign in until approved; that's separate from the loop fixed here.
- Local e2e couldn't run (no DB in sandbox; hosted CI minutes exhausted). `tsc --noEmit` + `npm run build` green; existing `e2e/auth.spec.ts` exercises the register→signin path and will validate on the next full run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_