### PR TITLE
ci: pause auto-triggered hosted workflows (Actions quota exhausted)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,14 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  # PAUSED (GitHub Actions quota exhausted) — auto-triggers disabled so failing
+  # hosted runs stop emailing the team. Re-enable by restoring the push/
+  # pull_request blocks below. Manual runs still work via "Run workflow".
+  workflow_dispatch:
+  # push:
+  #   branches: [main]
+  # pull_request:
+  #   branches: [main]
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,22 +1,21 @@
 name: Deploy to Plesk Server
 
 on:
-  # Previews deploy on every PR (tests run alongside — a broken preview is fine).
-  # Docs-only PRs skip the preview build/deploy — no runtime change to preview
-  # (#636 cost control).
-  pull_request:
-    branches: [main]
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
-      - '.github/**'
-  # Production deploys ONLY after the E2E suite finishes on main. The job below
-  # additionally requires conclusion == success, so a red build never ships.
-  # This is a code-level complement to branch protection (issue #425).
-  workflow_run:
-    workflows: ["E2E Tests"]
-    types: [completed]
-    branches: [main]
+  # PAUSED (GitHub Actions quota exhausted) — this hosted preview/prod deploy is
+  # disabled so failing runs stop emailing the team. Production now deploys via
+  # deploy-prod.yml (self-hosted runner, no hosted-quota cost). Re-enable the
+  # pull_request / workflow_run blocks below once the quota is restored.
+  workflow_dispatch:
+  # pull_request:
+  #   branches: [main]
+  #   paths-ignore:
+  #     - 'docs/**'
+  #     - '**/*.md'
+  #     - '.github/**'
+  # workflow_run:
+  #   workflows: ["E2E Tests"]
+  #   types: [completed]
+  #   branches: [main]
 
 # Cancel a superseded PREVIEW build when a new push lands on the same PR
 # (rapid agent pushes) — the big single win on minutes. Production deploys

--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -13,10 +13,14 @@ name: E2E Full Suite (scheduled)
 # Note: GitHub scheduled workflows can lag a few minutes and are disabled
 # automatically after 60 days without repository activity.
 on:
-  schedule:
-    # Once a day at 03:00 UTC (~05:00 Europe/Berlin in summer).
-    - cron: '0 3 * * *'
+  # PAUSED (GitHub Actions quota exhausted) — the daily schedule is disabled so
+  # failing runs stop emailing the team (this workflow also emails on red via the
+  # notify job). Re-enable the schedule below once the quota is restored. Manual
+  # runs still work via "Run workflow".
   workflow_dispatch:
+  # schedule:
+  #   # Once a day at 03:00 UTC (~05:00 Europe/Berlin in summer).
+  #   - cron: '0 3 * * *'
 
 concurrency:
   group: e2e-full

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,10 +1,14 @@
 name: E2E Tests
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  # PAUSED (GitHub Actions quota exhausted) — auto-triggers disabled so failing
+  # hosted runs stop emailing the team. Re-enable by restoring the push/
+  # pull_request blocks below. Manual runs still work via "Run workflow".
+  workflow_dispatch:
+  # push:
+  #   branches: [main]
+  # pull_request:
+  #   branches: [main]
 
 # Cancel superseded runs on the same ref so the gate stays fast.
 concurrency:

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -4,17 +4,18 @@ name: Nightly Stress Test
 # the team if any latency/error-rate threshold is breached. Can also be run
 # on demand from the Actions tab (with an optional target URL override).
 on:
-  schedule:
-    # 02:30 UTC every Monday (~03:30/04:30 Europe/Berlin depending on DST).
-    # Weekly, not nightly (#636): during pre-launch a nightly load test burns
-    # Actions minutes for little signal; run it weekly + on demand / pre-release.
-    - cron: '30 2 * * 1'
+  # PAUSED (GitHub Actions quota exhausted) — the weekly schedule is disabled so
+  # failing runs stop emailing the team. Re-enable the schedule below once the
+  # quota is restored. Manual runs still work via "Run workflow".
   workflow_dispatch:
     inputs:
       base_url:
         description: 'Target URL to stress (defaults to the STRESS_TARGET_URL secret / production)'
         required: false
         type: string
+  # schedule:
+  #   # 02:30 UTC every Monday (~03:30/04:30 Europe/Berlin depending on DST).
+  #   - cron: '30 2 * * 1'
 
 concurrency:
   group: stress-test

--- a/.github/workflows/topic-preview.yml
+++ b/.github/workflows/topic-preview.yml
@@ -13,9 +13,13 @@ name: Topic Preview
 # preview DB (no per-topic DB, so no DB admin secret needed).
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, closed]
-    branches: [main]
+  # PAUSED (GitHub Actions quota exhausted) — auto-triggers disabled so failing
+  # hosted runs stop emailing the team. Re-enable the pull_request block below
+  # once the quota is restored. Manual runs still work via "Run workflow".
+  workflow_dispatch:
+  # pull_request:
+  #   types: [opened, synchronize, reopened, closed]
+  #   branches: [main]
 
 # One in-flight run per PR; a new push cancels the previous deploy.
 concurrency:


### PR DESCRIPTION
## Why

Every **hosted** workflow (`ci`, `e2e`, `deploy` preview/prod, `e2e-full`, `stress`, `topic-preview`) fails immediately on the exhausted GitHub Actions quota and emails the team on each run. This turns off the noise.

## What

- All six hosted workflows are now **`workflow_dispatch`-only** (manual). Their original auto-triggers (`push` / `pull_request` / `schedule` / `workflow_run`) are preserved as comments for a one-line re-enable when the quota resets.
- `deploy-prod.yml` (self-hosted runner — **no hosted-quota cost**) and `infra-setup.yml` (already manual) are untouched. Production keeps deploying via the self-hosted path.

## No new emails from this PR

`pull_request` workflows are read from the PR **head** commit — since the head removes those triggers, the disabled workflows don't run on this PR. Merging leaves `main` quiet going forward.

## Re-enabling

Uncomment the trigger block in each workflow (or run any of them manually via **Actions → Run workflow**) once the monthly quota resets or a plan with more minutes is in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_