### PR TITLE
chore(release): 0.8.0-beta — multi-tenancy, benchmark, calendar, auth fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,51 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-07-17
+
+Multi-tenancy foundations (an operator can now run several programs on one
+instance), a cross-program benchmark, a Google Calendar integration surface,
+and a production sign-in fix.
+
+### Added
+- **Multi-tenancy — organizations** (#543/#544): `Organization` model +
+  nullable `orgId` on the tenant-scoped models with an idempotent backfill to a
+  default org; super-admin **Organizations** screen (create tenants, per-tenant
+  row counts). Additive and reversible — single-tenant behaviour unchanged.
+- **Per-tenant plan tiers** (#547): `OrgPlan` (FREE/PRO/ENTERPRISE) with an
+  in-code limits catalogue (`src/lib/orgPlans.ts`); the admin screen shows
+  usage-vs-limit and a per-tenant plan selector. Limits are advisory this phase;
+  the legacy default org is grandfathered to ENTERPRISE.
+- **Per-tenant white-label branding** (#546): name/logo/accent/support overrides
+  on `Organization` + resolver (`src/lib/branding.ts`) + admin editor.
+  Documented in `docs/white-label.md` (applied once tenant resolution lands).
+- **Per-tenant enterprise SSO config** (#545): SAML/OIDC config + validation +
+  gating (`src/lib/sso.ts`); admin editor; the certificate is never returned to
+  the client. Login wiring documented in `docs/sso-saml.md`.
+- **Tenant-isolation enforcement building blocks** (#543): `src/lib/orgScope.ts`
+  (`orgScoped`/`requireOrg`/`assertSameOrg`) behind `MT_ENFORCE_ISOLATION`
+  (default off) + `orgId` carried in the session; `docs/tenant-isolation.md`
+  describes the guarded roll-out.
+- **Cross-program benchmark** (#542): anonymized, aggregated funnel conversion
+  vs. platform average with a k-anonymity floor; gated by `premiumAnalytics`.
+- **Google Calendar integration surface** (#417): config detection + admin
+  status card + `docs/google-calendar.md` runbook (OAuth wiring deferred until
+  operator credentials exist). In-app calendar/.ics/reminders unchanged.
+
+### Fixed
+- **Safari sign-in loop**: after `signIn`, the immediate session read could miss
+  the just-set cookie in Safari, redirecting to the wrong place or bouncing back
+  to sign-in. Now polls for the session then does a full-page navigation.
+- **Forgot-password never arriving**: email lookups are now normalized
+  (trim + lowercase) at register/sign-in/forgot, so a casing/whitespace
+  difference can't silently miss the account (SMTP itself was healthy).
+
+### Changed
+- **CI cost control**: hosted workflows (ci, e2e, deploy preview/prod, e2e-full,
+  stress, topic-preview) paused to `workflow_dispatch`-only while the GitHub
+  Actions quota is exhausted; production deploys via the self-hosted
+  `deploy-prod.yml`. Re-enable by restoring the commented triggers.
+
 ## [0.7.0] - 2026-07-11
 
 A faster CI feedback loop and a rebuilt Projects experience with true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.7.0-beta",
+  "version": "0.8.0-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,33 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.8.0-beta',
+    date: '2026-07-17',
+    highlights: {
+      en: [
+        'Run several programs on one platform — a new Organizations area lets an administrator create and manage separate programs, each with its own plan, and see how much data each holds.',
+        'Your own look — each program can set its name, logo, accent color and support email (white-label), and configure enterprise single sign-on (SAML/OIDC).',
+        'Know where you stand — a new benchmark compares your hiring-funnel conversion against the anonymized platform average; no other program’s data is ever shown.',
+        'Google Calendar — the groundwork is in: administrators can see the integration status and follow the setup guide to connect it.',
+        'Sign-in fixes — resolved a Safari sign-in loop, and “forgot password” now reliably finds your account regardless of capitalization or spaces in your email.',
+      ],
+      tr: [
+        'Tek platformda birden çok program — yeni Organizasyonlar alanı, yöneticinin her biri kendi planına sahip ayrı programlar oluşturup yönetmesini ve her birinin ne kadar veri tuttuğunu görmesini sağlar.',
+        'Kendi görünümün — her program kendi adını, logosunu, vurgu rengini ve destek e-postasını belirleyebilir (white-label) ve kurumsal tek oturum açmayı (SAML/OIDC) yapılandırabilir.',
+        'Nerede olduğunu bil — yeni kıyaslama, işe alım huni dönüşümünü anonimleştirilmiş platform ortalamasıyla karşılaştırır; başka hiçbir programın verisi gösterilmez.',
+        'Google Takvim — altyapı hazır: yöneticiler entegrasyon durumunu görebilir ve kurulum kılavuzunu izleyerek bağlayabilir.',
+        'Giriş düzeltmeleri — Safari’deki giriş döngüsü giderildi ve “şifremi unuttum” artık e-postandaki büyük/küçük harf veya boşluk farkına bakmaksızın hesabını güvenilir biçimde buluyor.',
+      ],
+      de: [
+        'Mehrere Programme auf einer Plattform — im neuen Bereich Organisationen kann eine Administratorin separate Programme mit je eigenem Tarif anlegen und verwalten und sehen, wie viele Daten jedes enthält.',
+        'Ihr eigenes Erscheinungsbild — jedes Programm kann Name, Logo, Akzentfarbe und Support-E-Mail festlegen (White-Label) und Enterprise-Single-Sign-on (SAML/OIDC) konfigurieren.',
+        'Standortbestimmung — ein neuer Benchmark vergleicht Ihre Einstellungs-Funnel-Conversion mit dem anonymisierten Plattformdurchschnitt; Daten anderer Programme werden nie angezeigt.',
+        'Google Kalender — die Grundlage steht: Administratoren sehen den Integrationsstatus und können ihn per Anleitung verbinden.',
+        'Anmelde-Fixes — eine Safari-Anmeldeschleife wurde behoben, und „Passwort vergessen“ findet Ihr Konto jetzt zuverlässig, unabhängig von Groß-/Kleinschreibung oder Leerzeichen in der E-Mail.',
+      ],
+    },
+  },
+  {
     version: '0.7.0-beta',
     date: '2026-07-11',
     highlights: {


### PR DESCRIPTION
## What

Version bump for the notable batch shipped this session:

- Multi-tenancy foundations — organizations (#543/#544), plan tiers (#547), white-label (#546), SSO config (#545), isolation building blocks (#543).
- Cross-program benchmark (#542).
- Google Calendar integration surface + runbook (#417).
- Production auth fix: Safari sign-in loop + email normalization.

Bumps `package.json` to **0.8.0-beta**, adds a `CHANGELOG.md` `[0.8.0]` entry (developer-facing) and a `src/lib/releaseNotes.ts` entry (user-facing, EN/TR/DE, rendered at `/release-notes`).

## Verification

`tsc --noEmit` + `npm run build` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_