### PR TITLE
feat(mt): enforce plan active-relation limit at add-time (#547) + isolation test (#543)

### DIFF
--- a/e2e/plan-limit-gate.spec.ts
+++ b/e2e/plan-limit-gate.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { planLimits } from '../src/lib/orgPlans';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// Plan-limit gate (#547): a FREE-plan tenant is blocked from adding a NEW active
+// relation past its limit, while existing relations stay untouched; an
+// unlimited (ENTERPRISE) tenant is never gated. Drives the admin create API.
+test('FREE tenant is gated on new active relations; existing are unaffected', async ({ page }) => {
+  const adminEmail = uniqueEmail('gate-admin');
+  const pw = 'GatePass123';
+  const admin = await seedUser(adminEmail, pw, 'ADMIN', 'Gate Admin');
+  const org = await prisma.organization.create({ data: { name: `Gate Org ${adminEmail}`, slug: `gate-${adminEmail.replace(/[^a-z0-9]/gi, '').toLowerCase()}`, plan: 'FREE' } });
+  const cap = planLimits('FREE').maxActiveRelations!;
+
+  const mentor = await seedUser(uniqueEmail('gate-mentor'), 'x', 'MENTOR', 'Gate Mentor');
+  await prisma.user.update({ where: { id: admin.id }, data: { orgId: org.id } });
+  await prisma.user.update({ where: { id: mentor.id }, data: { orgId: org.id } });
+
+  // Fill the org exactly to the FREE cap. Create filler mentees directly (no
+  // bcrypt) for speed, each with its own ACTIVE relation.
+  const stamp = adminEmail.replace(/[^a-z0-9]/gi, '');
+  const menteeIds: string[] = [];
+  for (let i = 0; i < cap; i++) {
+    const m = await prisma.user.create({
+      data: { email: `gatefill.${i}.${stamp}@import.local`, password: '!x', role: 'MENTEE', fullName: `Gate Fill ${i}`, skills: [], orgId: org.id },
+    });
+    menteeIds.push(m.id);
+    await prisma.mentorshipRelation.create({ data: { mentorId: mentor.id, menteeId: m.id, orgId: org.id, status: 'ACTIVE' } });
+  }
+  // The mentee we'll try (and fail) to add — same FREE org.
+  const overflow = await prisma.user.create({
+    data: { email: `gateoverflow.${stamp}@import.local`, password: '!x', role: 'MENTEE', fullName: 'Gate Overflow', skills: [], orgId: org.id },
+  });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', pw);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    // Adding one more active relation is blocked at the plan cap.
+    const res = await page.request.post('/api/mentorship', { data: { mentorId: mentor.id, menteeId: overflow.id } });
+    expect(res.status()).toBe(403);
+    const body = await res.json();
+    expect(body.code).toBe('plan_limit_reached');
+    expect(body.limit).toBe(cap);
+
+    // Existing relations are all still there — nothing was hard-cut.
+    expect(await prisma.mentorshipRelation.count({ where: { orgId: org.id, status: 'ACTIVE' } })).toBe(cap);
+  } finally {
+    await prisma.mentorshipRelation.deleteMany({ where: { orgId: org.id } });
+    for (const id of [...menteeIds, overflow.id]) await prisma.user.delete({ where: { id } }).catch(() => {});
+    await cleanupByEmail(mentor.email);
+    await cleanupByEmail(adminEmail);
+    await prisma.organization.delete({ where: { id: org.id } }).catch(() => {});
+  }
+});

--- a/e2e/tenant-isolation.spec.ts
+++ b/e2e/tenant-isolation.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { orgScoped, assertSameOrg, requireOrg, isIsolationEnforced } from '../src/lib/orgScope';
+
+// Tenant isolation building blocks (#543). These prove that the orgScope
+// helpers genuinely separate two tenants at the DB level — the guarantee the
+// guarded MT_ENFORCE_ISOLATION rollout depends on. They exercise the helpers +
+// Prisma directly (no HTTP), so they pass regardless of the server's flag.
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('orgScoped isolates one tenant’s relations from another’s', async () => {
+  const stamp = uniqueEmail('iso').replace(/[^a-z0-9]/gi, '').toLowerCase();
+  const orgA = await prisma.organization.create({ data: { name: `Org A ${stamp}`, slug: `orga-${stamp}` } });
+  const orgB = await prisma.organization.create({ data: { name: `Org B ${stamp}`, slug: `orgb-${stamp}` } });
+
+  const mentorA = await seedUser(uniqueEmail('iso-mentorA'), 'x', 'MENTOR', 'Iso MentorA');
+  const menteeA = await seedUser(uniqueEmail('iso-menteeA'), 'x', 'MENTEE', 'Iso MenteeA');
+  const mentorB = await seedUser(uniqueEmail('iso-mentorB'), 'x', 'MENTOR', 'Iso MentorB');
+  const menteeB = await seedUser(uniqueEmail('iso-menteeB'), 'x', 'MENTEE', 'Iso MenteeB');
+
+  const relA = await prisma.mentorshipRelation.create({ data: { mentorId: mentorA.id, menteeId: menteeA.id, orgId: orgA.id } });
+  const relB = await prisma.mentorshipRelation.create({ data: { mentorId: mentorB.id, menteeId: menteeB.id, orgId: orgB.id } });
+
+  try {
+    // Scoped to A → only A's relation; B is invisible.
+    const seenByA = await prisma.mentorshipRelation.findMany({
+      where: orgScoped({ id: { in: [relA.id, relB.id] } }, orgA.id),
+    });
+    expect(seenByA.map((r) => r.id)).toEqual([relA.id]);
+    expect(seenByA.some((r) => r.id === relB.id)).toBe(false);
+
+    // Scoped to B → only B's relation.
+    const seenByB = await prisma.mentorshipRelation.findMany({
+      where: orgScoped({ id: { in: [relA.id, relB.id] } }, orgB.id),
+    });
+    expect(seenByB.map((r) => r.id)).toEqual([relB.id]);
+  } finally {
+    await prisma.mentorshipRelation.deleteMany({ where: { id: { in: [relA.id, relB.id] } } });
+    await cleanupByEmail(mentorA.email); await cleanupByEmail(menteeA.email);
+    await cleanupByEmail(mentorB.email); await cleanupByEmail(menteeB.email);
+    await prisma.organization.deleteMany({ where: { id: { in: [orgA.id, orgB.id] } } });
+  }
+});
+
+test('assertSameOrg blocks cross-tenant access when enforcement is on', () => {
+  const prev = process.env.MT_ENFORCE_ISOLATION;
+  process.env.MT_ENFORCE_ISOLATION = 'true';
+  try {
+    expect(isIsolationEnforced()).toBe(true);
+    // Same tenant → allowed.
+    expect(() => assertSameOrg('org-1', 'org-1')).not.toThrow();
+    // Cross tenant → denied.
+    expect(() => assertSameOrg('org-2', 'org-1')).toThrow(/Cross-tenant/);
+    // requireOrg fails closed when no org resolves under enforcement.
+    expect(() => requireOrg({ user: {} } as never)).toThrow(/enforced/);
+    // Resolves the org when present.
+    expect(requireOrg({ user: { orgId: 'org-9' } } as never)).toBe('org-9');
+  } finally {
+    process.env.MT_ENFORCE_ISOLATION = prev;
+  }
+});
+
+test('with enforcement off, helpers are no-ops (single-tenant unchanged)', () => {
+  const prev = process.env.MT_ENFORCE_ISOLATION;
+  delete process.env.MT_ENFORCE_ISOLATION;
+  try {
+    expect(isIsolationEnforced()).toBe(false);
+    // No throw even across "different" orgs when the flag is off.
+    expect(() => assertSameOrg('org-2', 'org-1')).not.toThrow();
+    // requireOrg returns null instead of throwing.
+    expect(requireOrg({ user: {} } as never)).toBeNull();
+  } finally {
+    if (prev !== undefined) process.env.MT_ENFORCE_ISOLATION = prev;
+  }
+});

--- a/src/app/api/admin/mentorship-requests/route.ts
+++ b/src/app/api/admin/mentorship-requests/route.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { notify } from '@/lib/notify';
+import { checkActiveRelationLimitForMentee, planLimitError } from '@/lib/planGate';
 
 // Admin queue for mentee mentorship requests (#590): list PENDING requests,
 // approve (pick a mentor → MentorshipRelation) or reject. The mentee is
@@ -72,8 +73,14 @@ export async function PUT(request: Request) {
       return NextResponse.json({ error: 'Mentee already has an active mentorship', code: 'already_mentored' }, { status: 409 });
     }
 
+    // Plan gate (#547): approving a request creates a new active relation.
+    const gate = await checkActiveRelationLimitForMentee(req.menteeId);
+    if (!gate.allowed) {
+      return NextResponse.json(planLimitError(gate), { status: 403 });
+    }
+
     const [relation] = await prisma.$transaction([
-      prisma.mentorshipRelation.create({ data: { mentorId, menteeId: req.menteeId } }),
+      prisma.mentorshipRelation.create({ data: { mentorId, menteeId: req.menteeId, orgId: gate.orgId } }),
       prisma.mentorshipRequest.update({
         where: { id: req.id },
         data: { status: 'APPROVED', decidedById: session.user.id, decidedAt: new Date() },

--- a/src/app/api/apply/route.ts
+++ b/src/app/api/apply/route.ts
@@ -6,6 +6,7 @@ import { createPasswordResetToken } from '@/lib/passwordReset';
 import { sendPasswordResetEmail, sendEmail } from '@/services/emailService';
 import { notify } from '@/lib/notify';
 import { dispatchWebhook } from '@/lib/webhooks';
+import { checkActiveRelationLimit, planLimitError } from '@/lib/planGate';
 
 // GET ?mentorId= — public: validate the link and return the mentor's name so
 // the application page can greet the applicant.
@@ -52,12 +53,21 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'An account with this email already exists' }, { status: 409 });
   }
 
+  // Plan gate (#547): a public application creates a new active relation in the
+  // mentor's tenant. Gate before creating the account. No-op for the unlimited
+  // default org.
+  const gate = await checkActiveRelationLimit(mentor.orgId);
+  if (!gate.allowed) {
+    return NextResponse.json(planLimitError(gate), { status: 403 });
+  }
+
   const mentee = await prisma.user.create({
     data: {
       email,
       password: '!apply-no-login',
       role: 'MENTEE',
       fullName,
+      orgId: mentor.orgId,
       emailVerified: false,
       phone: phone || null,
       city: city || null,
@@ -67,7 +77,7 @@ export async function POST(request: Request) {
     },
   });
 
-  await prisma.mentorshipRelation.create({ data: { mentorId: mentor.id, menteeId: mentee.id } });
+  await prisma.mentorshipRelation.create({ data: { mentorId: mentor.id, menteeId: mentee.id, orgId: mentor.orgId } });
   await notify(mentor.id, 'application', `${fullName} applied to be your mentee.`, '/mentor/mentees');
   await dispatchWebhook('application.created', { mentorId: mentor.id, menteeName: fullName, email });
 

--- a/src/app/api/mentor/mentees/route.ts
+++ b/src/app/api/mentor/mentees/route.ts
@@ -7,6 +7,8 @@ import { z } from 'zod';
 import { createPasswordResetToken } from '@/lib/passwordReset';
 import { sendPasswordResetEmail } from '@/services/emailService';
 import { slugify } from '@/lib/transliterate';
+import { checkActiveRelationLimit, planLimitError } from '@/lib/planGate';
+import { resolveOrgId } from '@/lib/orgScope';
 
 const schema = z.object({
   fullName: z.string().min(1),
@@ -44,12 +46,22 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'A user with this email already exists' }, { status: 409 });
     }
 
+    // Plan gate (#547): a new mentee here means a new active relation. Gate on
+    // the creating user's tenant before creating anything. No-op for the
+    // unlimited default org.
+    const orgId = resolveOrgId(session);
+    const gate = await checkActiveRelationLimit(orgId);
+    if (!gate.allowed) {
+      return NextResponse.json(planLimitError(gate), { status: 403 });
+    }
+
     const mentee = await prisma.user.create({
       data: {
         email: finalEmail,
         password: '!created-no-login',
         role: 'MENTEE',
         fullName,
+        orgId,
         skills: [],
         phone: rest.phone || null,
         whatsapp: rest.whatsapp || null,
@@ -61,7 +73,7 @@ export async function POST(request: Request) {
     });
 
     await prisma.mentorshipRelation.create({
-      data: { mentorId: session.user.id, menteeId: mentee.id },
+      data: { mentorId: session.user.id, menteeId: mentee.id, orgId },
     });
 
     // If the mentee has a real email, send a "set your password" link so they

--- a/src/app/api/mentorship/route.ts
+++ b/src/app/api/mentorship/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { z } from 'zod';
 import { dispatchWebhook } from '@/lib/webhooks';
+import { checkActiveRelationLimit, planLimitError } from '@/lib/planGate';
 
 const createRelationSchema = z.object({
   mentorId: z.string().min(1),
@@ -137,10 +138,19 @@ export async function POST(request: Request) {
       );
     }
 
+    // Plan gate (#547): block a new active relation once the tenant is at its
+    // plan limit. No-op for the unlimited default org; existing mentees are
+    // never affected.
+    const gate = await checkActiveRelationLimit(mentee.orgId);
+    if (!gate.allowed) {
+      return NextResponse.json(planLimitError(gate), { status: 403 });
+    }
+
     const relation = await prisma.mentorshipRelation.create({
       data: {
         mentorId,
         menteeId,
+        orgId: mentee.orgId,
         companyId: companyId || null,
         projectId: projectId || null,
         startDate: startDate ? new Date(startDate) : new Date(),

--- a/src/lib/planGate.ts
+++ b/src/lib/planGate.ts
@@ -1,0 +1,59 @@
+// Plan-limit enforcement gate (#547). Server-only (imports prisma), unlike the
+// pure orgPlans catalogue which is client-safe.
+//
+// This turns the ADVISORY plan limits into a real gate at the "add a new active
+// mentorship" chokepoints — WITHOUT ever touching existing data. Only the act of
+// creating one more active relation is gated; current mentees/mentors always
+// stay fully accessible (the core mentee/mentor loop is never hard-cut, per the
+// premium model's non-negotiable rule).
+//
+// Safe for the live single-tenant install: the grandfathered "default" org is
+// ENTERPRISE (maxActiveRelations = null = unlimited), so the gate is a no-op
+// there. A null/unassigned org also fails open. It only bites FREE/PRO tenants.
+
+import { prisma } from '@/lib/prisma';
+import { planLimits, isOrgPlan, type OrgPlan } from '@/lib/orgPlans';
+
+export interface PlanGateResult {
+  allowed: boolean;
+  plan: OrgPlan | null;
+  limit: number | null;
+  usage: number;
+}
+
+// Can one more ACTIVE relation be added to this org under its plan?
+// Fail-open when no org resolves or the plan is unlimited.
+export async function checkActiveRelationLimit(orgId: string | null | undefined): Promise<PlanGateResult> {
+  if (!orgId) return { allowed: true, plan: null, limit: null, usage: 0 };
+  const org = await prisma.organization.findUnique({ where: { id: orgId }, select: { plan: true } });
+  const plan = org && isOrgPlan(org.plan) ? org.plan : null;
+  if (!plan) return { allowed: true, plan: null, limit: null, usage: 0 };
+
+  const limit = planLimits(plan).maxActiveRelations;
+  if (limit == null) return { allowed: true, plan, limit: null, usage: 0 };
+
+  const usage = await prisma.mentorshipRelation.count({ where: { orgId, status: 'ACTIVE' } });
+  return { allowed: usage < limit, plan, limit, usage };
+}
+
+// Resolve the tenant from the mentee, then check the active-relation limit.
+export async function checkActiveRelationLimitForMentee(
+  menteeId: string,
+): Promise<PlanGateResult & { orgId: string | null }> {
+  const mentee = await prisma.user.findUnique({ where: { id: menteeId }, select: { orgId: true } });
+  const orgId = mentee?.orgId ?? null;
+  return { ...(await checkActiveRelationLimit(orgId)), orgId };
+}
+
+// Standard 403 payload for a blocked add, so every call site returns the same
+// machine-readable shape (code + limit/usage/plan) the UI can turn into an
+// upgrade prompt.
+export function planLimitError(gate: PlanGateResult) {
+  return {
+    error: `Plan limit reached: ${gate.usage}/${gate.limit} active mentorships on the ${gate.plan} plan. Existing mentees are unaffected — upgrade to add more.`,
+    code: 'plan_limit_reached' as const,
+    limit: gate.limit,
+    usage: gate.usage,
+    plan: gate.plan,
+  };
+}


### PR DESCRIPTION
## What

**#547 — turns the advisory plan limit into a real gate.** The FREE/PRO active-mentorship limit is now enforced at the four "new active relation" chokepoints (admin create, mentor add-mentee, request approval, public apply). Only the act of adding *one more* is gated — **existing mentees are never touched** (the core mentee/mentor loop is never hard-cut, per the premium model's non-negotiable rule). New relations/mentees now inherit the tenant's `orgId` so per-tenant counts stay accurate.

Blocked adds return `403 { code: 'plan_limit_reached', limit, usage, plan }` for an upgrade prompt.

**Safe for single-tenant prod:** the grandfathered default org is ENTERPRISE (unlimited) → the gate is a **no-op** there; a null/unassigned org fails open. Only FREE/PRO tenants are constrained.

**#543 — strengthened with an isolation integration test** proving `orgScoped()` separates two orgs' rows at the DB level, and that `assertSameOrg`/`requireOrg` fail closed when `MT_ENFORCE_ISOLATION` is on and are no-ops when off (single-tenant unchanged). Global prod enforcement remains the deliberate, supervised flag-flip (per `docs/tenant-isolation.md`) — this PR does not flip it.

## Files
- `src/lib/planGate.ts` (server): `checkActiveRelationLimit` / `…ForMentee` / `planLimitError`.
- 4 API routes wired + `orgId` set on create.
- `e2e/plan-limit-gate.spec.ts`, `e2e/tenant-isolation.spec.ts`.

## Acceptance (#547)
- [x] Free tenant limit warns/blocks on new mentee add; existing mentees unaffected.
- [x] Pro/Enterprise loosen/remove the limit (ENTERPRISE unlimited).
- [x] `npm run build` passes.

## Verification
`tsc --noEmit` + `npm run build` green locally. The new e2e specs require a live DB to run; CI is paused on the Actions quota, so they were not executed in this environment (documented limitation) — logic is straightforward and type-checked.

Refs #547 #543

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_