### PR TITLE
chore(release): 0.9.0-beta — admin/candidate meetings, mentor archive, plan-limit gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-07-20
+
+Admin↔mentor parity and quality-of-life additions on top of the multi-tenancy
+foundations.
+
+### Added
+- **Admin meetings** (#661): a `/admin/meetings` page (shared `MeetingsManager`
+  with the mentor screen) so admins can schedule/see meetings, plus a **one-click
+  "Copy link"** on every meeting (mentors benefit too). AdminNav entry added.
+- **Schedule a meeting from the candidate screen** (#661): a meeting scheduler +
+  copyable-link panel on `/admin/candidates/[id]`, scoped to the candidate's
+  mentorship relation.
+- **Archive/restore mentors** from the Mentors list — Active/Archived view + a
+  per-row deactivate/activate action, reusing the Users archive mechanism (#570).
+
+### Changed
+- **Plan limits are now enforced** (#547): the FREE/PRO active-mentorship limit
+  is a real gate at the four relation-create paths (existing mentees are never
+  affected; the grandfathered default org is ENTERPRISE/unlimited so single-
+  tenant prod is unchanged).
+
 ## [0.8.0] - 2026-07-17
 
 Multi-tenancy foundations (an operator can now run several programs on one

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,12 +165,15 @@ SMTP_* for email. Seeder: `SEED_ADMIN_EMAIL` / `SEED_ADMIN_PASSWORD` / `SEED_ADM
 - **Feature catalogue**: when a user-visible feature ships, add/update its entry in
   `src/lib/features.ts` (+ `featureCatalog` i18n block) — the landing cards and the `/features`
   page are both fed from that single source. Same discipline as CHANGELOG/releaseNotes.
-- **Versioning**: on a notable batch of merged features (not every PR), bump `package.json`
-  `version` (semver), add an entry to `CHANGELOG.md` (developer-facing, Keep a Changelog
-  format), and add a matching entry to `src/lib/releaseNotes.ts` (user-facing, EN/TR/DE,
-  rendered at `/release-notes`, linked from the sidebar version footer). The app version is
-  read from `package.json` at build time (`src/lib/version.ts`); the git SHA is baked into the
-  Docker image via a build arg — no other wiring is needed.
+- **Versioning (maintainer instruction, 2026-07-20): bump the version + changelog on EVERY
+  shipped change**, not just notable batches — the maintainer tracks "what changed / what's
+  live" from the version. For each user-visible PR: bump `package.json` `version` (semver —
+  patch for fixes/small tweaks, minor for features), add a `CHANGELOG.md` entry (developer-
+  facing, Keep a Changelog format), and add a matching `src/lib/releaseNotes.ts` entry (user-
+  facing, EN/TR/DE, rendered at `/release-notes`, linked from the sidebar version footer). The
+  app version is read from `package.json` at build time (`src/lib/version.ts`); the git SHA is
+  baked into the Docker image via a build arg — no other wiring is needed. (Trivial non-user-
+  facing changes — pure docs, CI config — don't need a bump.)
 - **E2E locator pitfalls** (hit repeatedly): `AdminNav` renders its own sidebar
   `input[type="search"]` filter box present on every admin page — an unscoped
   `input[type="search"]` selector in a new test will hit that instead of a page-level search

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.8.0-beta",
+  "version": "0.9.0-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,30 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.9.0-beta',
+    date: '2026-07-20',
+    highlights: {
+      en: [
+        'Meetings for admins — admins can now schedule and see meetings from a dedicated page, and every meeting has a one-click “Copy link” button (mentors get this too).',
+        'Schedule a meeting straight from a candidate’s page — no need to leave the profile you’re looking at.',
+        'Archive mentors — hide inactive mentors from the Mentors list (and bring them back) without losing any of their history.',
+        'Plan limits now apply — programs on a limited plan are gently stopped from adding new mentorships past their limit; existing mentees are never affected.',
+      ],
+      tr: [
+        'Adminler için toplantılar — adminler artık ayrı bir sayfadan toplantı planlayıp görebiliyor ve her toplantıda tek tıkla “Bağlantıyı kopyala” butonu var (mentörler de faydalanıyor).',
+        'Adayın sayfasından doğrudan toplantı planla — baktığın profilden ayrılmana gerek yok.',
+        'Mentör arşivle — pasif mentörleri geçmişlerini kaybetmeden Mentörler listesinden gizle (ve geri getir).',
+        'Plan limitleri artık geçerli — sınırlı plandaki programlar limit üstü yeni mentorluk eklemede nazikçe durduruluyor; mevcut mentee’ler asla etkilenmiyor.',
+      ],
+      de: [
+        'Meetings für Admins — Admins können Meetings jetzt über eine eigene Seite planen und einsehen, und jedes Meeting hat einen „Link kopieren“-Button mit einem Klick (auch für Mentoren).',
+        'Meeting direkt von der Kandidatenseite planen — ohne das Profil zu verlassen.',
+        'Mentoren archivieren — inaktive Mentoren aus der Mentorenliste ausblenden (und zurückholen), ohne ihre Historie zu verlieren.',
+        'Plan-Limits greifen jetzt — Programme mit begrenztem Tarif werden am Anlegen neuer Mentorships über dem Limit sanft gehindert; bestehende Mentees sind nie betroffen.',
+      ],
+    },
+  },
+  {
     version: '0.8.0-beta',
     date: '2026-07-17',
     highlights: {


### PR DESCRIPTION
Catch-up version bump: these shipped since 0.8.0 without their own bump —
- Admin meetings page + copy link (#661)
- Schedule-from-candidate meeting panel (#661)
- Archive/restore mentors
- Plan-limit enforcement (#547)

Bumps `package.json` → `0.9.0-beta`, adds `CHANGELOG.md` `[0.9.0]` + `releaseNotes.ts` (EN/TR/DE). Also records the maintainer instruction (2026-07-20) in CLAUDE.md: bump version + changelog on **every** shipped change.

`tsc` + `build` + `check:i18n` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_