### PR TITLE
fix(projects): role-aware back link on project detail (#616) + 0.9.1-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-07-20
+
+### Fixed
+- **Project detail back link** — the top link on `/projects/[id]` now returns
+  internal viewers to their own project list (`/admin/projects` or
+  `/mentor/projects`) with a clear back arrow, instead of always sending them to
+  the public showcase. Public visitors keep the showcase link.
+
 ## [0.9.0] - 2026-07-20
 
 Admin↔mentor parity and quality-of-life additions on top of the multi-tenancy

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.9.0-beta",
+  "version": "0.9.1-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { getServerSession } from 'next-auth';
-import { GraduationCap, Github, ExternalLink, Trello, CheckCircle2, Circle } from 'lucide-react';
+import { GraduationCap, Github, ExternalLink, Trello, CheckCircle2, Circle, ArrowLeft } from 'lucide-react';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { getServerDictionary } from '@/i18n/server';
@@ -53,8 +53,15 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-50 py-12 px-4">
       <div className="max-w-2xl mx-auto">
-        <Link href="/projects" className="inline-flex items-center gap-2 text-sm text-gray-500 hover:text-gray-700 mb-6">
-          <GraduationCap className="h-4 w-4 text-blue-600" /> {t.projects.showcaseTitle}
+        {/* Back link: internal viewers return to their own project list (where
+            they came from); public visitors get the showcase header link. */}
+        <Link
+          href={role === 'ADMIN' ? '/admin/projects' : role === 'MENTOR' ? '/mentor/projects' : '/projects'}
+          className="inline-flex items-center gap-2 text-sm text-gray-500 hover:text-gray-700 mb-6"
+        >
+          {canInternal
+            ? <><ArrowLeft className="h-4 w-4" /> {t.projects.allProjects}</>
+            : <><GraduationCap className="h-4 w-4 text-blue-600" /> {t.projects.showcaseTitle}</>}
         </Link>
         <div className="bg-white rounded-2xl border border-gray-200 p-8">
           <div className="flex items-center gap-2 flex-wrap">

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,15 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.9.1-beta',
+    date: '2026-07-20',
+    highlights: {
+      en: ['A clearer “back” link on a project’s page — it now takes you back to your project list instead of the public showcase.'],
+      tr: ['Proje sayfasında daha net bir “geri” linki — artık sizi herkese açık vitrin yerine kendi proje listenize götürüyor.'],
+      de: ['Ein klarerer „Zurück“-Link auf der Projektseite — er führt Sie jetzt zu Ihrer Projektliste zurück statt zur öffentlichen Vitrine.'],
+    },
+  },
+  {
     version: '0.9.0-beta',
     date: '2026-07-20',
     highlights: {


### PR DESCRIPTION
The top link on `/projects/[id]` now returns internal viewers (admin → `/admin/projects`, mentor → `/mentor/projects`) to their own list with a back arrow, instead of always sending them to the public showcase. Public visitors keep the showcase link.

Version bump `0.9.1-beta` + CHANGELOG + release notes (EN/TR/DE) per the per-change versioning rule.

`tsc` + `build` + `check:i18n` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUEfLrCiTNW4qXGb2gRA9)_