### PR TITLE
feat(account/projects): membership duration indicator — 0.12.0-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-07-20
+
+### Added
+- **Membership duration indicator** — the account page now shows how long you've
+  been a member ("Member for 3 months", from `User.createdAt`), and the project
+  owners/members panel shows how long each person has been on that project (from
+  `ProjectMember.addedAt`). New `durationSince` helper in `src/lib/relativeTime.ts`
+  and a localized `membership` i18n block (EN/TR/DE). `/api/projects` now includes
+  `addedAt` on member rows.
+
 ## [0.11.0] - 2026-07-20
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.11.0-beta",
+  "version": "0.12.0-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -15,7 +15,7 @@ const include = {
   tasks: { orderBy: { order: 'asc' } },
   members: {
     orderBy: { addedAt: 'asc' },
-    select: { role: true, user: { select: { id: true, fullName: true, role: true } } },
+    select: { role: true, addedAt: true, user: { select: { id: true, fullName: true, role: true } } },
   },
 } as const;
 

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -19,7 +19,7 @@ const include = {
   },
   members: {
     orderBy: { addedAt: 'asc' },
-    select: { role: true, user: { select: { id: true, fullName: true, role: true } } },
+    select: { role: true, addedAt: true, user: { select: { id: true, fullName: true, role: true } } },
   },
   _count: { select: { relations: true } },
 } as const;

--- a/src/components/AccountSettings.tsx
+++ b/src/components/AccountSettings.tsx
@@ -11,6 +11,7 @@ import { ConsentSettings } from '@/components/ConsentSettings';
 import { useT } from '@/i18n/client';
 import { locales, LOCALE_COOKIE } from '@/i18n/config';
 import { ACCENT_COLORS, ACCENT_SWATCH, DEFAULT_ACCENT, resolveAccent } from '@/lib/accent';
+import { durationSince } from '@/lib/relativeTime';
 
 // Universal account settings used by every role (admin/mentor/mentee/company):
 // change email, change password, and delete the account.
@@ -30,7 +31,7 @@ export function AccountSettings() {
   const [savingPw, setSavingPw] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
-  const [me, setMe] = useState<{ id: string; fullName: string; avatarUrl: string | null } | null>(null);
+  const [me, setMe] = useState<{ id: string; fullName: string; avatarUrl: string | null; createdAt: string | null } | null>(null);
   const [emailNotifications, setEmailNotifications] = useState(true);
   const [notifPrefs, setNotifPrefs] = useState<Record<string, boolean>>({});
   const [savingPrefs, setSavingPrefs] = useState(false);
@@ -61,7 +62,7 @@ export function AccountSettings() {
         setRole(user.role ?? '');
         setSkills(Array.isArray(user.skills) ? user.skills.join(', ') : '');
         setCapacity(user.mentorCapacity != null ? String(user.mentorCapacity) : '');
-        setMe({ id: user.id, fullName: user.fullName, avatarUrl: user.avatarUrl ?? null });
+        setMe({ id: user.id, fullName: user.fullName, avatarUrl: user.avatarUrl ?? null, createdAt: user.createdAt ?? null });
       });
     fetch('/api/account/2fa').then((r) => r.json()).then((d) => setTwoFaEnabled(!!d.enabled)).catch(() => {});
   }, []);
@@ -267,11 +268,23 @@ export function AccountSettings() {
     }
   };
 
+  // "Member for 3 months" — the magnitude comes from durationSince, the noun
+  // and surrounding phrase from the localized membership block.
+  const membershipLabel = (() => {
+    if (!me?.createdAt) return null;
+    const { count, unit } = durationSince(me.createdAt);
+    const noun = count === 1 ? t.membership[unit] : t.membership[`${unit}s` as 'days' | 'months' | 'years'];
+    return t.membership.inSystemFor.replace('{d}', `${count} ${noun}`);
+  })();
+
   return (
     <div>
       <div className="mb-8">
         <h1 className="text-2xl font-bold text-gray-900">{t.account.title}</h1>
         <p className="text-gray-500 mt-1">{t.account.subtitle}</p>
+        {membershipLabel && (
+          <p className="text-xs text-gray-400 mt-1" data-testid="membership-duration">{membershipLabel}</p>
+        )}
       </div>
 
       {msg && <div className="mb-4 p-3 bg-green-50 border border-green-200 rounded-lg text-green-700 text-sm">✓ {msg}</div>}

--- a/src/components/ProjectsManager.tsx
+++ b/src/components/ProjectsManager.tsx
@@ -8,7 +8,7 @@ import { Select } from '@/components/ui/Select';
 import { Badge } from '@/components/ui/Badge';
 import { Github, ExternalLink, Trash2, Pencil, Trello, Plus, Eye, Users2 } from 'lucide-react';
 import { useT, useLocale } from '@/i18n/client';
-import { formatDate } from '@/lib/relativeTime';
+import { formatDate, durationSince } from '@/lib/relativeTime';
 
 interface Task {
   id: string;
@@ -34,7 +34,7 @@ interface Project {
   ownerCompany?: { id: string; name: string } | null;
   tasks?: Task[];
   relations?: { mentee: { id: string; fullName: string } }[];
-  members?: { role: 'OWNER' | 'MENTOR'; user: { id: string; fullName: string; role: string } }[];
+  members?: { role: 'OWNER' | 'MENTOR'; addedAt?: string; user: { id: string; fullName: string; role: string } }[];
   _count?: { relations: number };
 }
 
@@ -411,7 +411,14 @@ export function ProjectsManager({ isAdmin }: { isAdmin: boolean }) {
                           <Badge variant={m.role === 'OWNER' ? 'info' : 'default'} className="text-xs">
                             {m.role === 'OWNER' ? t.projects.roleOwner : t.projects.roleMentorMember}
                           </Badge>
-                          <span className="flex-1 text-gray-800 dark:text-gray-200">{m.user.fullName}</span>
+                          <span className="flex-1 text-gray-800 dark:text-gray-200">
+                            {m.user.fullName}
+                            {m.addedAt && (() => {
+                              const { count, unit } = durationSince(m.addedAt);
+                              const noun = count === 1 ? t.membership[unit] : t.membership[`${unit}s` as 'days' | 'months' | 'years'];
+                              return <span className="ml-1.5 text-xs text-gray-400">· {t.membership.inProjectFor.replace('{d}', `${count} ${noun}`)}</span>;
+                            })()}
+                          </span>
                           <button onClick={() => memberCall(p.id, 'DELETE', { userId: m.user.id })} aria-label={t.common.delete} className="text-gray-300 hover:text-red-600"><Trash2 className="h-3.5 w-3.5" /></button>
                         </div>
                       ))}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -666,6 +666,13 @@ const en = {
     install: 'Install app',
     iosHint: 'Tap the Share button, then “Add to Home Screen”.',
   },
+  membership: {
+    inSystemFor: 'Member for {d}',
+    inProjectFor: 'On this project for {d}',
+    day: 'day', days: 'days',
+    month: 'month', months: 'months',
+    year: 'year', years: 'years',
+  },
   projects: {
     title: 'Projects',
     subtitle: 'Internship projects — company-backed or community',
@@ -2097,6 +2104,13 @@ const tr: Dict = {
     install: 'Uygulamayı kur',
     iosHint: 'Paylaş düğmesine, sonra “Ana Ekrana Ekle”ye dokun.',
   },
+  membership: {
+    inSystemFor: 'Üyelik süresi: {d}',
+    inProjectFor: 'Projede: {d}',
+    day: 'gün', days: 'gün',
+    month: 'ay', months: 'ay',
+    year: 'yıl', years: 'yıl',
+  },
   projects: {
     title: 'Projeler',
     subtitle: 'Staj projeleri — şirket destekli veya topluluk',
@@ -3525,6 +3539,13 @@ const de: Dict = {
   pwa: {
     install: 'App installieren',
     iosHint: 'Tippe auf die Teilen-Schaltfläche und dann auf „Zum Home-Bildschirm“.',
+  },
+  membership: {
+    inSystemFor: 'Mitglied seit {d}',
+    inProjectFor: 'Im Projekt seit {d}',
+    day: 'Tag', days: 'Tagen',
+    month: 'Monat', months: 'Monaten',
+    year: 'Jahr', years: 'Jahren',
   },
   projects: {
     title: 'Projekte',

--- a/src/lib/relativeTime.ts
+++ b/src/lib/relativeTime.ts
@@ -33,3 +33,17 @@ export function formatDateTime(date: Date | string, locale: string): string {
     year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit',
   }).format(d);
 }
+
+// How long ago a date is, as a positive duration ("15 days", "3 months"), for
+// membership/tenure labels like "member for 3 months". Unlike relativeTime this
+// returns just the magnitude — the caller supplies the surrounding phrase.
+// Returns { count, unit } where unit ∈ 'day' | 'month' | 'year' so callers can
+// localize the noun (day/month/year) themselves; anything under a day is a
+// single day so a brand-new member never reads as "0 days".
+export function durationSince(date: Date | string): { count: number; unit: 'day' | 'month' | 'year' } {
+  const d = typeof date === 'string' ? new Date(date) : date;
+  const days = Math.max(1, Math.floor((Date.now() - d.getTime()) / 86400000));
+  if (days >= 365) return { count: Math.floor(days / 365), unit: 'year' };
+  if (days >= 30) return { count: Math.floor(days / 30), unit: 'month' };
+  return { count: days, unit: 'day' };
+}

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,24 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.12.0-beta',
+    date: '2026-07-20',
+    highlights: {
+      en: [
+        'See how long you’ve been a member — your account page now shows “Member for 3 months”.',
+        'Project members now show how long each person has been on the project.',
+      ],
+      tr: [
+        'Ne zamandır üye olduğunu gör — hesap sayfanda artık “Üyelik süresi: 3 ay” yazıyor.',
+        'Proje üyelerinde her kişinin projede ne kadar süredir olduğu görünüyor.',
+      ],
+      de: [
+        'Sieh, wie lange du schon Mitglied bist — deine Kontoseite zeigt jetzt „Mitglied seit 3 Monaten“.',
+        'Bei Projektmitgliedern wird jetzt angezeigt, wie lange jede Person schon im Projekt ist.',
+      ],
+    },
+  },
+  {
     version: '0.11.0-beta',
     date: '2026-07-20',
     highlights: {


### PR DESCRIPTION
## What
Adds a "how long have you been here" indicator in two places:

- **Account page** — under the title, a small line: *"Member for 3 months"* (from `User.createdAt`, already returned by `GET /api/profile`).
- **Project owners/members panel** (`ProjectsManager`) — each member row shows *"· On this project for 2 months"* (from `ProjectMember.addedAt`).

## How
- New helper `durationSince(date)` in `src/lib/relativeTime.ts` — returns `{ count, unit }` (day/month/year), min 1 day so a brand-new member never reads "0 days". The noun and surrounding phrase are localized, not the helper.
- New localized `membership` i18n block (EN/TR/DE): `inSystemFor` / `inProjectFor` + day(s)/month(s)/year(s) nouns.
- `GET /api/projects` and `GET /api/projects/[id]` now include `addedAt` on member rows (previously only `role` + `user`).

No schema change, no new endpoint.

## Verification
`npm run check:i18n` (1429 × 3) and `npm run build` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ)_