### PR TITLE
ci: re-enable PR gate (ci + e2e smoke) after quota reset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,15 @@
 name: CI
 
 on:
-  # PAUSED (GitHub Actions quota exhausted) — auto-triggers disabled so failing
-  # hosted runs stop emailing the team. Re-enable by restoring the push/
-  # pull_request blocks below. Manual runs still work via "Run workflow".
+  # Re-enabled 2026-07-21 after the repo transfer reset the Actions quota
+  # (clean 2000h/month). PR gate is cheap (~2 min); the heavy scheduled
+  # workflows (e2e-full, stress, topic-preview) stay workflow_dispatch-only to
+  # keep the monthly budget comfortable.
   workflow_dispatch:
-  # push:
-  #   branches: [main]
-  # pull_request:
-  #   branches: [main]
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,14 +1,14 @@
 name: E2E Tests
 
 on:
-  # PAUSED (GitHub Actions quota exhausted) — auto-triggers disabled so failing
-  # hosted runs stop emailing the team. Re-enable by restoring the push/
-  # pull_request blocks below. Manual runs still work via "Run workflow".
+  # Re-enabled 2026-07-21 after the repo transfer reset the Actions quota. This
+  # is the @smoke-only PR gate (~3.5 min) — cheap enough to run per PR. The full
+  # suite (e2e-full) stays workflow_dispatch-only to protect the monthly budget.
   workflow_dispatch:
-  # push:
-  #   branches: [main]
-  # pull_request:
-  #   branches: [main]
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 # Cancel superseded runs on the same ref so the gate stays fast.
 concurrency:


### PR DESCRIPTION
The repo transfer reset the GitHub Actions quota (clean ~2000h/month), so the cheap per-PR quality gates are back:

- **`ci.yml`** (lint · typecheck · build, ~2 min) — `push` + `pull_request` on `main`.
- **`e2e.yml`** (Playwright **@smoke** subset, ~3.5 min) — `push` + `pull_request` on `main`.

Kept **workflow_dispatch-only** to protect the monthly budget (the heavy consumers):
- `e2e-full.yml` (full suite, 4×/day × 4 shards ≈ the bulk of prior usage)
- `stress.yml`, `topic-preview.yml`

`deploy.yml` (hosted preview/prod) stays paused — production deploys via the **self-hosted `deploy-prod` runner**, which doesn't touch the hosted quota.

CI-config only, no runtime change (no version bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ)_