### PR TITLE
ci: self-hosted deploy-preview workflow (keep preview in step with prod)

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,52 @@
+name: Deploy preview (self-hosted, manual)
+
+# CI-independent PREVIEW deploy — the sibling of deploy-prod.yml. Runs ON THE
+# SERVER via the self-hosted runner (no GitHub-hosted quota cost), so preview
+# (https://crm-preview.ersah.in, container internship-crm-preview on :3201) can
+# be kept in step with prod even while the hosted deploy.yml is paused.
+#
+# It reuses infra/deploy-prod.sh unchanged — that script is fully parameterized
+# (CONTAINER / PORT / IMAGE / ENV_FILE), so preview is just the prod deploy with
+# preview overrides.
+#
+# SECRETS: read from /etc/internship-crm/preview.env on the server (same shape as
+# prod.env: DATABASE_URL[_PREVIEW], NEXTAUTH_SECRET, NEXTAUTH_URL=the preview URL,
+# SMTP_*). If that file is absent, deploy-prod.sh derives it from the currently
+# running internship-crm-preview container, so no manual setup is needed as long
+# as a preview container already exists.
+#
+# ⚠️ The preview DB is SHARED across all previews (see CLAUDE.md) — a schema
+# `db push` here affects every preview. That is unchanged from the old
+# deploy.yml behavior.
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch/tag/SHA to deploy to preview (default: main)'
+        required: false
+        default: 'main'
+
+concurrency:
+  group: deploy-preview-self-hosted
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy ${{ inputs.ref }} to preview
+    runs-on: self-hosted
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Deploy
+        run: |
+          chmod +x infra/deploy-prod.sh
+          # Same script as prod, with preview container/port/image/env overrides.
+          BRANCH="${{ inputs.ref }}" \
+          CONTAINER=internship-crm-preview \
+          PORT=3201 \
+          IMAGE=internship-crm-preview:local \
+          ENV_FILE="${ENV_FILE:-/etc/internship-crm/preview.env}" \
+          ./infra/deploy-prod.sh --no-pull


### PR DESCRIPTION
## Why
Preview (`crm-preview.ersah.in`, container `internship-crm-preview` on :3201) went **stale (0.7.0)** once the hosted `deploy.yml` was paused on the quota. This adds a self-hosted preview deploy so preview can be kept current alongside prod — **no hosted-quota cost**.

## How
`deploy-preview.yml` mirrors `deploy-prod.yml` on the `self-hosted` runner and **reuses `infra/deploy-prod.sh` unchanged** — that script is fully parameterized (`CONTAINER` / `PORT` / `IMAGE` / `ENV_FILE`), so preview is just the prod deploy with preview overrides:

```
CONTAINER=internship-crm-preview PORT=3201 IMAGE=internship-crm-preview:local \
ENV_FILE=/etc/internship-crm/preview.env ./infra/deploy-prod.sh --no-pull
```

- **Secrets**: read from `/etc/internship-crm/preview.env` on the server (same shape as `prod.env`, with the preview DB/URL). If that file is absent, `deploy-prod.sh` already derives the env from the running `internship-crm-preview` container — so no manual setup is needed as long as a preview container exists.
- **Trigger**: `workflow_dispatch` only (like deploy-prod). Run it after a prod deploy to keep both current.

⚠️ The preview DB is **shared** across previews (CLAUDE.md) — a `db push` here affects every preview. Unchanged from the old `deploy.yml` behavior.

CI/infra config only — no runtime change (no version bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ)_