### PR TITLE
fix(infra): safely quote derived env values + self-heal preview deploy

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -43,10 +43,16 @@ jobs:
       - name: Deploy
         run: |
           chmod +x infra/deploy-prod.sh
+          ENV_FILE="${ENV_FILE:-/etc/internship-crm/preview.env}"
+          # Preview has no hand-written secrets file; deploy-prod.sh derives one
+          # from the running preview container. Remove any previously-derived
+          # file first so the derivation always regenerates cleanly (self-healing
+          # if an older run wrote a malformed one).
+          rm -f "$ENV_FILE" || true
           # Same script as prod, with preview container/port/image/env overrides.
           BRANCH="${{ inputs.ref }}" \
           CONTAINER=internship-crm-preview \
           PORT=3201 \
           IMAGE=internship-crm-preview:local \
-          ENV_FILE="${ENV_FILE:-/etc/internship-crm/preview.env}" \
+          ENV_FILE="$ENV_FILE" \
           ./infra/deploy-prod.sh --no-pull

--- a/infra/deploy-prod.sh
+++ b/infra/deploy-prod.sh
@@ -68,7 +68,11 @@ if [ ! -f "$ENV_FILE" ] && docker inspect "$CONTAINER" >/dev/null 2>&1; then
   : > "$ENV_FILE"; chmod 600 "$ENV_FILE"
   for k in DATABASE_URL NEXTAUTH_SECRET NEXTAUTH_URL SMTP_HOST SMTP_PORT SMTP_USER SMTP_PASS SMTP_FROM; do
     v=$(docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$CONTAINER" | sed -n "s/^$k=//p" | head -1)
-    [ -n "$v" ] && printf '%s=%s\n' "$k" "$v" >> "$ENV_FILE"
+    # Single-quote the value so `. "$ENV_FILE"` sources it verbatim — a
+    # DATABASE_URL/password can contain characters ($, spaces, @, :) that the
+    # shell would otherwise try to expand or execute. Embedded single quotes are
+    # escaped the standard '\'' way.
+    [ -n "$v" ] && printf "%s='%s'\n" "$k" "$(printf '%s' "$v" | sed "s/'/'\\\\''/g")" >> "$ENV_FILE"
   done
 fi
 if [ ! -f "$ENV_FILE" ]; then


### PR DESCRIPTION
## Why
The first `deploy-preview` run failed in 12s. Root cause: `deploy-prod.sh` derives an env file from the running container when none exists (the preview case), but wrote values **unquoted**. A `DATABASE_URL` whose password contains shell-special characters made `. "$ENV_FILE"` try to *execute* part of the string → exit 127.

Prod was never affected — it uses a hand-written `/etc/internship-crm/prod.env`, so it never takes the derivation path.

## Fix
- **`infra/deploy-prod.sh`** — single-quote derived values (escaping embedded single quotes the standard `'\''` way) so they source verbatim.
- **`deploy-preview.yml`** — `rm -f` any previously-derived preview env file before running, so the derivation regenerates cleanly. This self-heals the malformed file the first failed run left on the server (which I can't delete manually — no SSH from this environment).

## Verification
Shell-logic change; validated by inspection. Will confirm end-to-end by re-dispatching `deploy-preview` and checking `crm-preview.ersah.in/api/health` reaches the current version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ)_