### PR TITLE
fix(infra): parameterize network mode so preview deploy can reach its DB

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -50,9 +50,13 @@ jobs:
           # if an older run wrote a malformed one).
           rm -f "$ENV_FILE" || true
           # Same script as prod, with preview container/port/image/env overrides.
+          # NETWORK=bridge: the preview DB user is granted from the docker
+          # gateway (host.docker.internal), not localhost, so preview uses bridge
+          # networking + a published port instead of host networking.
           BRANCH="${{ inputs.ref }}" \
           CONTAINER=internship-crm-preview \
           PORT=3201 \
           IMAGE=internship-crm-preview:local \
+          NETWORK=bridge \
           ENV_FILE="$ENV_FILE" \
           ./infra/deploy-prod.sh --no-pull

--- a/infra/deploy-prod.sh
+++ b/infra/deploy-prod.sh
@@ -102,8 +102,24 @@ if [ "$SKIP_BUILD" -eq 0 ]; then
   docker build --build-arg GIT_SHA="$GIT_SHA" -t "$IMAGE" .
 fi
 
-run_tool() { # run a one-off tool container on host networking with the prod DB
-  docker run --rm --network=host -e DATABASE_URL="$DATABASE_URL" "$IMAGE" "$@"
+# Networking mode (#preview): prod runs on host networking with the DB at
+# localhost. Preview's DB user is only granted from the docker gateway (not
+# localhost), so preview must use bridge networking + host.docker.internal and
+# a published port. Default 'host' keeps prod behavior byte-for-byte.
+NETWORK="${NETWORK:-host}"
+if [ "$NETWORK" = host ]; then
+  APP_NET_ARGS=(--network=host)
+  APP_PORT_ARGS=(-e PORT="$PORT")
+  TOOL_NET_ARGS=(--network=host)
+else
+  # bridge: reach the host DB via host.docker.internal, publish the app port.
+  APP_NET_ARGS=(--add-host=host.docker.internal:host-gateway -p "$PORT:3000")
+  APP_PORT_ARGS=()
+  TOOL_NET_ARGS=(--add-host=host.docker.internal:host-gateway)
+fi
+
+run_tool() { # run a one-off tool container against the DB (network per $NETWORK)
+  docker run --rm "${TOOL_NET_ARGS[@]}" -e DATABASE_URL="$DATABASE_URL" "$IMAGE" "$@"
 }
 
 # ── 3. Schema sync ────────────────────────────────────────────────────────────
@@ -122,9 +138,9 @@ docker stop "$CONTAINER" 2>/dev/null || true
 docker rm   "$CONTAINER" 2>/dev/null || true
 docker run -d \
   --name "$CONTAINER" \
-  --network=host \
+  "${APP_NET_ARGS[@]}" \
   --restart=unless-stopped \
-  -e PORT="$PORT" \
+  "${APP_PORT_ARGS[@]}" \
   -e DATABASE_URL="$DATABASE_URL" \
   -e NEXTAUTH_SECRET="$NEXTAUTH_SECRET" \
   -e NEXTAUTH_URL="$NEXTAUTH_URL" \


### PR DESCRIPTION
## Why
Second `deploy-preview` failure (after the env-quoting fix): the build succeeded but `prisma db push` failed with **P1001: Can't reach database server at `host.docker.internal:3306`**.

`deploy-prod.sh` ran the tool + app containers on `--network=host`, where the DB is at `localhost`. That's correct for prod, but the **preview** DB user is granted only from the docker gateway (`host.docker.internal`), **not** `localhost` — so under host networking the gateway hostname is unreachable. The old `deploy.yml` handled preview with bridge networking + `--add-host` for exactly this reason.

## Fix
Add a `NETWORK` env to `deploy-prod.sh`:
- **`host`** (default) — unchanged prod behavior: `--network=host`, `-e PORT`.
- **`bridge`** (set by `deploy-preview.yml`) — `--add-host=host.docker.internal:host-gateway` on the tool + app containers and `-p $PORT:3000` to publish the app, matching how the old `deploy.yml` deployed preview.

Prod defaults are byte-for-byte identical (verified by simulating the arg arrays; `bash -n` clean).

## Verification
Shell-logic; will confirm end-to-end by re-dispatching `deploy-preview` and checking `crm-preview.ersah.in/api/health` reaches the current version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ)_