### PR TITLE
chore: reconcile board references after repo transfer (mersahin → 21072026)

### DIFF
--- a/.claude/skills/intern-issue/SKILL.md
+++ b/.claude/skills/intern-issue/SKILL.md
@@ -154,13 +154,21 @@ gh pr view <PR> --json state,mergedAt -q '.state, .mergedAt'   # confirm MERGED
 
 ## 9. Update the GitHub Project board
 
+> ⚠️ **Disabled after the repo transfer (mersahin → 21072026).** GitHub Projects
+> do **not** transfer with a repository, so the old board (`--owner mersahin`,
+> project/field/option IDs below) no longer applies. **Skip this step** until a
+> new Project board is created in the `21072026` org; then update the owner,
+> project number, and the field/option node-IDs here and re-enable it. The IDs
+> below are the *old* board's, kept only as a template for what to replace.
+
 ```
+# OLD board (mersahin) — replace owner/IDs with the new 21072026 org board first:
 ITEM_ID=$(gh project item-add 2 --owner mersahin --url https://github.com/21072026/Internship/issues/$issue --format json | python3 -c "import json,sys; print(json.load(sys.stdin)['id'])")
 gh project item-edit --id "$ITEM_ID" --field-id PVTSSF_lAHOADrM1M4BbnzxzhWXFDs --project-id PVT_kwHOADrM1M4Bbnzx --single-select-option-id 98236657
 ```
 
-(Project 2, "Status" field `PVTSSF_lAHOADrM1M4BbnzxzhWXFDs`, "Done" option `98236657`. Other
-option ids on this field if ever needed: Backlog `f75ad846`, Ready `61e4505c`, In progress
+(OLD board: Project 2, "Status" field `PVTSSF_lAHOADrM1M4BbnzxzhWXFDs`, "Done" option
+`98236657`. Other option ids on this field: Backlog `f75ad846`, Ready `61e4505c`, In progress
 `47fc9ee4`, In review `df73e18b`.)
 
 ## 10. Sync and report

--- a/e2e/project-board-url.spec.ts
+++ b/e2e/project-board-url.spec.ts
@@ -9,7 +9,9 @@ test('a project can store a board URL and surface it on the public showcase', as
   const adminEmail = uniqueEmail('pb-admin');
   const admin = await seedUser(adminEmail, 'AdminPass123', 'ADMIN', 'PB Admin');
   let projectId = '';
-  const board = 'https://github.com/users/mersahin/projects/2';
+  // Arbitrary fixture URL — the test only checks it round-trips through the API
+  // and renders on the showcase; it does not require a real board to exist.
+  const board = 'https://github.com/orgs/21072026/projects/2';
 
   try {
     await page.goto('/auth/signin');


### PR DESCRIPTION
GitHub Projects don't transfer with a repository, so the old `mersahin` board no longer applies. This reconciles the two remaining board pointers:

- **`e2e/project-board-url.spec.ts`** — the `board` value is just a fixture string the test stores as a project's `boardUrl` and asserts round-trips through the API/showcase; it doesn't require a live board. Updated `mersahin` → `21072026` org form for consistency (added a comment noting it's an arbitrary fixture).
- **`.claude/skills/intern-issue/SKILL.md`** — the `gh project item-add … --owner mersahin` step points at the dead board. Documented it as **disabled until a new board is created in the `21072026` org**; the old project/field/option node-IDs are kept only as a template for what to replace.

Also (via API, not in this diff): the new stajyer issues #680–#684 were linked as sub-issues of the stajyer epic #478, and #478's body link was updated to the new org.

No runtime change (no version bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ)_