### PR TITLE
chore: point board references at the new 21072026 org board (project 1)

### DIFF
--- a/.claude/skills/intern-issue/SKILL.md
+++ b/.claude/skills/intern-issue/SKILL.md
@@ -154,22 +154,26 @@ gh pr view <PR> --json state,mergedAt -q '.state, .mergedAt'   # confirm MERGED
 
 ## 9. Update the GitHub Project board
 
-> ⚠️ **Disabled after the repo transfer (mersahin → 21072026).** GitHub Projects
-> do **not** transfer with a repository, so the old board (`--owner mersahin`,
-> project/field/option IDs below) no longer applies. **Skip this step** until a
-> new Project board is created in the `21072026` org; then update the owner,
-> project number, and the field/option node-IDs here and re-enable it. The IDs
-> below are the *old* board's, kept only as a template for what to replace.
+New board after the repo transfer: **`https://github.com/orgs/21072026/projects/1`**
+(org `21072026`, project number `1`).
+
+> ⚠️ **One-time: refresh the node-IDs.** The `--field-id` / `--project-id` /
+> `--single-select-option-id` below are the *old* mersahin board's and will NOT
+> match the new project 1. Fetch the new board's IDs once and paste them in:
+> ```
+> gh project view 1 --owner 21072026 --format json          # → project node id (PVT_…)
+> gh project field-list 1 --owner 21072026 --format json    # → Status field id (PVTSSF_…) + option ids
+> ```
 
 ```
-# OLD board (mersahin) — replace owner/IDs with the new 21072026 org board first:
-ITEM_ID=$(gh project item-add 2 --owner mersahin --url https://github.com/21072026/Internship/issues/$issue --format json | python3 -c "import json,sys; print(json.load(sys.stdin)['id'])")
-gh project item-edit --id "$ITEM_ID" --field-id PVTSSF_lAHOADrM1M4BbnzxzhWXFDs --project-id PVT_kwHOADrM1M4Bbnzx --single-select-option-id 98236657
+ITEM_ID=$(gh project item-add 1 --owner 21072026 --url https://github.com/21072026/Internship/issues/$issue --format json | python3 -c "import json,sys; print(json.load(sys.stdin)['id'])")
+# Replace <PROJECT_ID> / <STATUS_FIELD_ID> / <DONE_OPTION_ID> with the new board's IDs (see above):
+gh project item-edit --id "$ITEM_ID" --field-id <STATUS_FIELD_ID> --project-id <PROJECT_ID> --single-select-option-id <DONE_OPTION_ID>
 ```
 
-(OLD board: Project 2, "Status" field `PVTSSF_lAHOADrM1M4BbnzxzhWXFDs`, "Done" option
-`98236657`. Other option ids on this field: Backlog `f75ad846`, Ready `61e4505c`, In progress
-`47fc9ee4`, In review `df73e18b`.)
+(OLD mersahin board, for reference only — do NOT reuse: Project 2, "Status" field
+`PVTSSF_lAHOADrM1M4BbnzxzhWXFDs`, "Done" option `98236657`; Backlog `f75ad846`, Ready
+`61e4505c`, In progress `47fc9ee4`, In review `df73e18b`.)
 
 ## 10. Sync and report
 

--- a/e2e/project-board-url.spec.ts
+++ b/e2e/project-board-url.spec.ts
@@ -11,7 +11,7 @@ test('a project can store a board URL and surface it on the public showcase', as
   let projectId = '';
   // Arbitrary fixture URL — the test only checks it round-trips through the API
   // and renders on the showcase; it does not require a real board to exist.
-  const board = 'https://github.com/orgs/21072026/projects/2';
+  const board = 'https://github.com/orgs/21072026/projects/1';
 
   try {
     await page.goto('/auth/signin');


### PR DESCRIPTION
Follow-up to #698, now that the new board exists: **https://github.com/orgs/21072026/projects/1**.

- **`e2e/project-board-url.spec.ts`** — fixture URL → project 1.
- **`.claude/skills/intern-issue/SKILL.md`** — board step now targets `--owner 21072026`, project `1`. The `--field-id` / `--project-id` / `--single-select-option-id` node-IDs are board-specific and can't be fetched from this environment (no `gh`/Projects API), so I documented the exact `gh project view` / `gh project field-list` commands to grab them once and left placeholders. The old mersahin IDs are kept only for reference.

**Can't do from here (no Projects v2 API / `gh` in this sandbox):** add items to the board, or create the "Type/Epic" field + swimlane we discussed. Those need to be done in the board UI (or a session with `gh`).

No runtime change (no version bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ)_