### PR TITLE
docs(backlog): encode GitHub Project board conventions (Katman/Prio, hierarchy)

### DIFF
--- a/.claude/skills/backlog/SKILL.md
+++ b/.claude/skills/backlog/SKILL.md
@@ -65,8 +65,10 @@ not a coder. Author issues; do not implement unless explicitly told to.
    - **Type:** `bug` or `enhancement`.
    - **Junior:** `good first issue` + `stajyer` for small, isolated, well-scoped
      tasks.
-   - **Area (only if it already exists):** `area:infra`, `area:comms`,
-     `area:pipeline`. Don't invent area labels; check with `get_label` if unsure.
+   - **Area (prefer an existing one):** the repo now uses `area:infra`,
+     `area:comms`, `area:pipeline`, `area:admin`, `area:mentor`, `area:ux`,
+     `area:i18n`, `area:testing`, `area:projects`, `area:security`,
+     `area:migration`. Reuse these; only add a new `area:*` when none fits.
    - Note: updating labels via `issue_write` **replaces** the whole set — always
      resend existing labels plus the new one.
 
@@ -84,6 +86,46 @@ not a coder. Author issues; do not implement unless explicitly told to.
 10. **Report** a tight summary: the hierarchy (numbers + titles), priorities, key
     findings from step 2 (especially "already partly exists"), the dependency
     order, and a recommended next item. Do not paste full issue bodies back.
+
+11. **Put every new issue on the board (see conventions below).** After creating
+    an issue: (a) link it as a sub-issue of its parent Story/Epic; (b) it needs a
+    board **Katman** (Epic/Story/Task) and **Prio** (P1–P3) value. The agent's
+    GitHub App usually **cannot write GitHub Projects** ("Resource not accessible
+    by integration") — sub-issue linking and labels DO work, but field/board
+    writes must be done with `gh` on a human's machine. So: do the linking +
+    labels yourself, and hand the maintainer the ready-to-run `gh` block from the
+    board section to set Katman/Prio and add items.
+
+## GitHub Project board — conventions (org `21072026`, project `1`)
+
+Board: **https://github.com/orgs/21072026/projects/1**. Keep issues organized so
+the board stays legible as it grows.
+
+- **Hierarchy = native sub-issues**, not labels: **Epic → Story → Task** via
+  `mcp__github__sub_issue_write` (method `add`, needs the child's internal `id`).
+  Stajyer tasks hang off the stajyer epic **#478**; premium work off **#517**
+  (→ story #522 for Faz-3 MT tasks); messaging off #663; dark-mode off #657.
+  When a cluster of orphan tasks shares a theme but has no home, create a small
+  umbrella **Story** and nest them (e.g. #704 pipeline, #705 comms). Don't force
+  artificial parents, and don't make one mega-parent — "No Parent" always holds
+  the top-level epics/stories, and that's correct (a tree always has roots).
+- **Two CUSTOM single-select fields drive the board** (the built-in "Type" and
+  "Priority" are derived/empty — do NOT use them):
+  - **Katman** = `Epic` / `Story` / `Task` → the board groups by this for a clean
+    epic/story/task split (better than group-by-Parent, which lumps all
+    parentless epics together).
+  - **Prio** = `P1` / `P2` / `P3` → mirrors the priority label; the Priority-board
+    view groups/sorts by it.
+- **Derive field values from labels/title:** `epic` label → Katman=Epic; title
+  contains `] Story` → Story; else Task. Prio from the `P1|P2|P3` label. Move P1
+  bugs to **Status=Ready** so they surface.
+- **`gh` block for the maintainer** (fresh GraphQL quota; bash-3.2 safe; idempotent).
+  IDs: project `PVT_kwDOElD6r84Bd9cf`, Status field `PVTSSF_lADOElD6r84Bd9cfzhYbJt4`.
+  Re-run any time — creates missing fields, adds all open issues, sets Katman+Prio,
+  P1→Ready. (Full script lives in `docs/agent-experience.md` 2026-07-21 entry.)
+- **Env limits:** this sandbox has **no `gh`** and the App lacks Projects write
+  scope; GraphQL quota is the *human's* (`gh api rate_limit`), exhausted by bursts
+  of `gh project` mutations — add `sleep 0.5` between edits and retry after reset.
 
 ## Repo facts to reuse (verify, don't assume they're still true)
 

--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -15,6 +15,60 @@ Newest entries on top.
 **Repo `mersahin/Internship` → `21072026/Internship`'e taşındı.** Bu oturumun büyük
 teması transfer artıklarını temizlemek + kotanın reset'inden faydalanmak oldu.
 
+**GitHub Project board düzeni (standing convention — yeni board org `21072026`
+proje `1`):** İş üretirken (bkz. `backlog` skill) hiyerarşi **native sub-issue**
+ile kurulur (Epic→Story→Task), etiketle değil. Board iki **custom** single-select
+alanla düzenlenir — yerleşik "Type"/"Priority" türetilmiş/boş, KULLANMA:
+- **Katman** = Epic/Story/Task → board bunu `Group by` yapınca temiz şeritler
+  (group-by-Parent tüm parent'sız epic'leri bir araya yığdığı için daha kötü).
+- **Prio** = P1/P2/P3 → priority etiketini yansıtır.
+Değerler etiket/başlıktan türetilir: `epic` label→Epic; başlıkta `] Story`→Story;
+değilse Task. P1 bug'lar Status=Ready'ye alınır. Sub-issue linkleme + etiketleme
+**agent'ın App'iyle çalışır**; ama **Projects yazma yetkisi yok** ("Resource not
+accessible by integration") — alan/board yazımı `gh` ile (insan makinesinde). Bu
+sandbox'ta `gh` yok. GraphQL kotası **insanın** (`gh api rate_limit`); `gh project`
+mutation patlaması onu tüketir → editler arası `sleep 0.5` + reset sonrası tekrar.
+
+Maintainer'ın tek-paste board script'i (kota tazeyken; bash-3.2 güvenli; idempotent —
+custom alanları yaratır, tüm açık issue'ları ekler, Katman+Prio doldurur, P1→Ready):
+```bash
+cat > ~/board.sh <<'SH'
+#!/usr/bin/env bash
+set -uo pipefail
+OWNER=21072026; PROJ=1; REPO=21072026/Internship
+PID=PVT_kwDOElD6r84Bd9cf
+gh project field-create $PROJ --owner $OWNER --name "Prio" \
+  --data-type SINGLE_SELECT --single-select-options "P1,P2,P3" >/dev/null 2>&1 || true
+gh project field-create $PROJ --owner $OWNER --name "Katman" \
+  --data-type SINGLE_SELECT --single-select-options "Epic,Story,Task" >/dev/null 2>&1 || true
+gh issue list -R $REPO --state open --limit 200 --json url -q '.[].url' \
+  | while IFS= read -r u; do gh project item-add $PROJ --owner $OWNER --url "$u" >/dev/null 2>&1; done
+F=$(gh project field-list $PROJ --owner $OWNER --format json)
+PRIO=$(echo "$F" | jq -r '.fields[]|select(.name=="Prio")|.id')
+KAT=$(echo "$F"  | jq -r '.fields[]|select(.name=="Katman")|.id')
+STAT=$(echo "$F" | jq -r '.fields[]|select(.name=="Status")|.id')
+oid(){ echo "$F" | jq -r --arg f "$1" --arg o "$2" '.fields[]|select(.name==$f)|.options[]?|select(.name==$o)|.id'; }
+IT=$(gh project item-list $PROJ --owner $OWNER --format json --limit 200)
+iid(){ echo "$IT" | jq -r --argjson n "$1" '.items[]|select(.content.number==$n)|.id'; }
+setf(){ [ -n "$1" ]&&[ -n "$2" ]&&[ -n "$3" ]&& gh project item-edit --id "$1" --project-id "$PID" --field-id "$2" --single-select-option-id "$3" >/dev/null 2>&1; }
+gh issue list -R $REPO --state open --limit 200 --json number,labels,title | jq -c '.[]' | while read -r r; do
+  n=$(jq .number <<<"$r"); t=$(jq -r .title <<<"$r"); L=$(jq -r '.labels[].name' <<<"$r")
+  I=$(iid "$n"); [ -z "$I" ] && continue
+  K=Task; grep -qx epic <<<"$L" && K=Epic; [ "$K" = Task ] && case "$t" in *"] Story"*) K=Story;; esac
+  setf "$I" "$KAT" "$(oid Katman "$K")"
+  P=$(grep -E '^P[123]$' <<<"$L" | head -1); [ -n "$P" ] && setf "$I" "$PRIO" "$(oid Prio "$P")"
+  echo "#$n → Katman=$K${P:+, Prio=$P}"; sleep 0.5
+done
+READY=$(oid Status "Ready"); for n in 689 678; do setf "$(iid $n)" "$STAT" "$READY"; done
+echo "done."
+SH
+bash ~/board.sh
+```
+Sonra board UI'da **Group by → Katman** (yerleşik boş "Type" yerine). `date -r <reset>`
+ile kota reset saati görülür; `#!/usr/bin/env` içeren script'i **doğrudan** interaktif
+zsh'e yapıştırma (`event not found` — `!` history expansion); `<<'SH'` heredoc'la dosyaya
+yaz. macOS `/bin/bash` 3.2 → `declare -A` YOK.
+
 **Transfer yazma yolunu AÇTI (önceki oturum 403 alıyordu):** yeni repoya scoped
 oturumda `git push` + `mcp__github__*` sorunsuz çalıştı. Transfer sonrası ilk iş:
 repo-path referanslarını güncelle (ONBOARDING clone URL, CHANGELOG footer link'leri,


### PR DESCRIPTION
Persists this session's board-organization workflow so **future work-item generation follows it automatically**.

## `.claude/skills/backlog/SKILL.md`
- New **step 11** + a **"GitHub Project board — conventions"** section: native sub-issue hierarchy (Epic→Story→Task), the two **custom** board fields **Katman** (Epic/Story/Task) and **Prio** (P1–P3) that drive grouping — the built-in Type/Priority are derived/empty and unused — deriving values from labels/title, P1→Ready, small umbrella stories for orphan clusters (no mega-parent), and the env limit (the App can't write Projects; sub-issue + labels do work, field/board writes need `gh` on a human machine).
- Expanded the **`area:*` label list** to the taxonomy that now exists (`area:admin`, `area:ux`, `area:i18n`, `area:testing`, `area:projects`, `area:security`, `area:migration`, … alongside infra/comms/pipeline).

## `docs/agent-experience.md`
- Added the board conventions + the **full ready-to-run `gh` script** (bash-3.2 safe, idempotent) to the 2026-07-21 entry, plus the gotchas (zsh `!` history-expansion when pasting `#!/usr/bin/env`, macOS bash 3.2 has no `declare -A`, the human's GraphQL quota + `sleep 0.5` between mutations).

Docs/skill only — no runtime change (no version bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ)_