### PR TITLE
docs: revert board over-engineering — stay GitHub-standard (drop Katman/Prio)

### DIFF
--- a/.claude/skills/backlog/SKILL.md
+++ b/.claude/skills/backlog/SKILL.md
@@ -87,45 +87,36 @@ not a coder. Author issues; do not implement unless explicitly told to.
     findings from step 2 (especially "already partly exists"), the dependency
     order, and a recommended next item. Do not paste full issue bodies back.
 
-11. **Put every new issue on the board (see conventions below).** After creating
-    an issue: (a) link it as a sub-issue of its parent Story/Epic; (b) it needs a
-    board **Katman** (Epic/Story/Task) and **Prio** (P1–P3) value. The agent's
-    GitHub App usually **cannot write GitHub Projects** ("Resource not accessible
-    by integration") — sub-issue linking and labels DO work, but field/board
-    writes must be done with `gh` on a human's machine. So: do the linking +
-    labels yourself, and hand the maintainer the ready-to-run `gh` block from the
-    board section to set Katman/Prio and add items.
+11. **Link it into the hierarchy — that's all the board needs.** After creating an
+    issue, link it as a sub-issue of its parent Story/Epic with
+    `mcp__github__sub_issue_write`. Do **not** add custom board fields — the
+    board stays **GitHub-standard** (see below). Sub-issue linking + labels both
+    work with the agent's App; that's everything the board needs.
 
 ## GitHub Project board — conventions (org `21072026`, project `1`)
 
-Board: **https://github.com/orgs/21072026/projects/1**. Keep issues organized so
-the board stays legible as it grows.
+Board: **https://github.com/orgs/21072026/projects/1**. Keep it **GitHub-standard —
+no custom fields to maintain.** (We tried custom `Katman`/`Prio` single-selects +
+a bulk `gh` script + an auto-field workflow; it was over-engineering — everything
+they encoded is already carried natively. Reverted. Don't reintroduce them.)
 
-- **Hierarchy = native sub-issues**, not labels: **Epic → Story → Task** via
+- **Hierarchy = native sub-issues** (Epic → Story → Task) via
   `mcp__github__sub_issue_write` (method `add`, needs the child's internal `id`).
-  Stajyer tasks hang off the stajyer epic **#478**; premium work off **#517**
-  (→ story #522 for Faz-3 MT tasks); messaging off #663; dark-mode off #657.
-  When a cluster of orphan tasks shares a theme but has no home, create a small
-  umbrella **Story** and nest them (e.g. #704 pipeline, #705 comms). Don't force
-  artificial parents, and don't make one mega-parent — "No Parent" always holds
-  the top-level epics/stories, and that's correct (a tree always has roots).
-- **Two CUSTOM single-select fields drive the board** (the built-in "Type" and
-  "Priority" are derived/empty — do NOT use them):
-  - **Katman** = `Epic` / `Story` / `Task` → the board groups by this for a clean
-    epic/story/task split (better than group-by-Parent, which lumps all
-    parentless epics together).
-  - **Prio** = `P1` / `P2` / `P3` → mirrors the priority label; the Priority-board
-    view groups/sorts by it.
-- **Derive field values from labels/title:** `epic` label → Katman=Epic; title
-  contains `] Story` → Story; else Task. Prio from the `P1|P2|P3` label. Move P1
-  bugs to **Status=Ready** so they surface.
-- **`gh` block for the maintainer** (fresh GraphQL quota; bash-3.2 safe; idempotent).
-  IDs: project `PVT_kwDOElD6r84Bd9cf`, Status field `PVTSSF_lADOElD6r84Bd9cfzhYbJt4`.
-  Re-run any time — creates missing fields, adds all open issues, sets Katman+Prio,
-  P1→Ready. (Full script lives in `docs/agent-experience.md` 2026-07-21 entry.)
-- **Env limits:** this sandbox has **no `gh`** and the App lacks Projects write
-  scope; GraphQL quota is the *human's* (`gh api rate_limit`), exhausted by bursts
-  of `gh project` mutations — add `sleep 0.5` between edits and retry after reset.
+  The board's **Group by → Parent issue** then gives the epic/story/task swimlanes
+  for free — no "layer"/type field needed. Stajyer tasks hang off epic **#478**;
+  premium off **#517** (→ story #522 for Faz-3 MT tasks); messaging #663;
+  dark-mode #657; pipeline #704; comms #705. For an orphan cluster with a shared
+  theme, create a small umbrella **Story** and nest them. Never a mega-parent —
+  "No Parent" always holds the top-level epics/stories, and that's correct
+  (a tree always has roots).
+- **Priority = the `P1`/`P2`/`P3` label.** Don't create a priority field — the
+  label already carries it and the board can group/sort/filter by label.
+- **Status** = the built-in workflow column (Backlog → Ready → In progress →
+  In review → Done). Move a P1 bug to Ready so it surfaces.
+- **Env note:** the agent's App can't write GitHub Projects fields and this sandbox
+  has no `gh` — but with the standard approach nothing needs writing: labels +
+  sub-issues go through the normal issue API, and grouping is a one-time board
+  setting the maintainer makes in the UI.
 
 ## Repo facts to reuse (verify, don't assume they're still true)
 

--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -15,59 +15,19 @@ Newest entries on top.
 **Repo `mersahin/Internship` → `21072026/Internship`'e taşındı.** Bu oturumun büyük
 teması transfer artıklarını temizlemek + kotanın reset'inden faydalanmak oldu.
 
-**GitHub Project board düzeni (standing convention — yeni board org `21072026`
-proje `1`):** İş üretirken (bkz. `backlog` skill) hiyerarşi **native sub-issue**
-ile kurulur (Epic→Story→Task), etiketle değil. Board iki **custom** single-select
-alanla düzenlenir — yerleşik "Type"/"Priority" türetilmiş/boş, KULLANMA:
-- **Katman** = Epic/Story/Task → board bunu `Group by` yapınca temiz şeritler
-  (group-by-Parent tüm parent'sız epic'leri bir araya yığdığı için daha kötü).
-- **Prio** = P1/P2/P3 → priority etiketini yansıtır.
-Değerler etiket/başlıktan türetilir: `epic` label→Epic; başlıkta `] Story`→Story;
-değilse Task. P1 bug'lar Status=Ready'ye alınır. Sub-issue linkleme + etiketleme
-**agent'ın App'iyle çalışır**; ama **Projects yazma yetkisi yok** ("Resource not
-accessible by integration") — alan/board yazımı `gh` ile (insan makinesinde). Bu
-sandbox'ta `gh` yok. GraphQL kotası **insanın** (`gh api rate_limit`); `gh project`
-mutation patlaması onu tüketir → editler arası `sleep 0.5` + reset sonrası tekrar.
-
-Maintainer'ın tek-paste board script'i (kota tazeyken; bash-3.2 güvenli; idempotent —
-custom alanları yaratır, tüm açık issue'ları ekler, Katman+Prio doldurur, P1→Ready):
-```bash
-cat > ~/board.sh <<'SH'
-#!/usr/bin/env bash
-set -uo pipefail
-OWNER=21072026; PROJ=1; REPO=21072026/Internship
-PID=PVT_kwDOElD6r84Bd9cf
-gh project field-create $PROJ --owner $OWNER --name "Prio" \
-  --data-type SINGLE_SELECT --single-select-options "P1,P2,P3" >/dev/null 2>&1 || true
-gh project field-create $PROJ --owner $OWNER --name "Katman" \
-  --data-type SINGLE_SELECT --single-select-options "Epic,Story,Task" >/dev/null 2>&1 || true
-gh issue list -R $REPO --state open --limit 200 --json url -q '.[].url' \
-  | while IFS= read -r u; do gh project item-add $PROJ --owner $OWNER --url "$u" >/dev/null 2>&1; done
-F=$(gh project field-list $PROJ --owner $OWNER --format json)
-PRIO=$(echo "$F" | jq -r '.fields[]|select(.name=="Prio")|.id')
-KAT=$(echo "$F"  | jq -r '.fields[]|select(.name=="Katman")|.id')
-STAT=$(echo "$F" | jq -r '.fields[]|select(.name=="Status")|.id')
-oid(){ echo "$F" | jq -r --arg f "$1" --arg o "$2" '.fields[]|select(.name==$f)|.options[]?|select(.name==$o)|.id'; }
-IT=$(gh project item-list $PROJ --owner $OWNER --format json --limit 200)
-iid(){ echo "$IT" | jq -r --argjson n "$1" '.items[]|select(.content.number==$n)|.id'; }
-setf(){ [ -n "$1" ]&&[ -n "$2" ]&&[ -n "$3" ]&& gh project item-edit --id "$1" --project-id "$PID" --field-id "$2" --single-select-option-id "$3" >/dev/null 2>&1; }
-gh issue list -R $REPO --state open --limit 200 --json number,labels,title | jq -c '.[]' | while read -r r; do
-  n=$(jq .number <<<"$r"); t=$(jq -r .title <<<"$r"); L=$(jq -r '.labels[].name' <<<"$r")
-  I=$(iid "$n"); [ -z "$I" ] && continue
-  K=Task; grep -qx epic <<<"$L" && K=Epic; [ "$K" = Task ] && case "$t" in *"] Story"*) K=Story;; esac
-  setf "$I" "$KAT" "$(oid Katman "$K")"
-  P=$(grep -E '^P[123]$' <<<"$L" | head -1); [ -n "$P" ] && setf "$I" "$PRIO" "$(oid Prio "$P")"
-  echo "#$n → Katman=$K${P:+, Prio=$P}"; sleep 0.5
-done
-READY=$(oid Status "Ready"); for n in 689 678; do setf "$(iid $n)" "$STAT" "$READY"; done
-echo "done."
-SH
-bash ~/board.sh
-```
-Sonra board UI'da **Group by → Katman** (yerleşik boş "Type" yerine). `date -r <reset>`
-ile kota reset saati görülür; `#!/usr/bin/env` içeren script'i **doğrudan** interaktif
-zsh'e yapıştırma (`event not found` — `!` history expansion); `<<'SH'` heredoc'la dosyaya
-yaz. macOS `/bin/bash` 3.2 → `declare -A` YOK.
+**GitHub Project board — GitHub-standardında kal (over-engineering dersi):** Board
+org `21072026` proje `1`. İş üretirken (bkz. `backlog` skill) hiyerarşi **native
+sub-issue** ile kurulur (Epic→Story→Task); board'da **Group by → Parent issue**
+epic/story/task şeritlerini bedavaya verir. Öncelik **P1/P2/P3 label**'dır (board
+etikete göre grupla/sırala); akış **Status** kolonları. **Custom alan yok.**
+> Bu oturumda önce custom `Katman` (Epic/Story/Task) + `Prio` (P1-P3) single-select
+> alanları + toplu `gh` script (`board.sh`) + bir issue-açılışı auto-field workflow'u
+> kurdum — maintainer haklı olarak "gereksiz iş yükü, GitHub-standardında kalalım"
+> dedi ve geri aldık. **Ders:** native sub-issue hiyerarşisi + P-etiketleri zaten
+> tür ve önceliği taşıyor; bunları custom alanla kopyalamak = kalıcı bakım yükü
+> (her issue'da alan doldurma, PAT secret, workflow). Yerlisi neyi ifade ediyorsa
+> onu tekrar üretme. Sub-issue linkleme + etiketleme agent'ın App'iyle çalışır;
+> Projects alan yazımı yazılamaz (gerekmiyor da).
 
 **Transfer yazma yolunu AÇTI (önceki oturum 403 alıyordu):** yeni repoya scoped
 oturumda `git push` + `mcp__github__*` sorunsuz çalıştı. Transfer sonrası ilk iş:


### PR DESCRIPTION
The custom **Katman** (Epic/Story/Task) + **Prio** (P1–P3) board fields, the bulk `gh board.sh` script, and the auto-field workflow duplicated what's **already carried natively**: sub-issue hierarchy (type/parent) and the `P1/P2/P3` labels (priority). Maintainer flagged it as unnecessary maintenance overhead — reverted to GitHub-standard.

- **`backlog` skill:** step 11 + board section now prescribe **native sub-issues** (Group by Parent issue for the epic/story/task swimlanes), **P-labels** for priority, **Status** for the workflow columns — no custom fields, no `gh` script, no token.
- **`agent-experience.md`:** replaced the Katman/Prio/board.sh block with the lesson — don't duplicate what native sub-issues + labels already express.

The auto-field workflow branch (`ci/project-autofield`) was abandoned (never merged), so no runtime change and no token is needed.

Docs/skill only — no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ)_