### PR TITLE
fix(icon): remove duplicate public/icon.svg colliding with app-router route (closes #689) — 0.14.2-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [Unreleased]
 
+## [0.14.2] - 2026-07-21
+
+### Fixed
+- **`/icon.svg` 500 (closes #689)** — `public/icon.svg` and `src/app/icon.svg`
+  both claimed the `/icon.svg` route (the App Router serves `src/app/icon.svg`
+  as `/icon.svg` automatically, and the `public/` copy collided). Removed the
+  duplicate `public/icon.svg`; the app-router icon still serves the favicon and
+  manifest/layout references.
+
 ## [0.14.1] - 2026-07-20
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.14.1-beta",
+  "version": "0.14.2-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,8 +1,0 @@
-<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Internship CRM">
-  <rect width="64" height="64" rx="14" fill="#1D4ED8"/>
-  <!-- graduation cap -->
-  <path d="M32 16 L52 25 L32 34 L12 25 Z" fill="#ffffff"/>
-  <path d="M22 30 L22 40 C22 43 41 43 41 40 L41 30 L32 34 Z" fill="#bfdbfe"/>
-  <path d="M52 25 L52 37" stroke="#ffffff" stroke-width="2.5" stroke-linecap="round"/>
-  <circle cx="52" cy="39" r="2.5" fill="#ffffff"/>
-</svg>

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,15 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.14.2-beta',
+    date: '2026-07-21',
+    highlights: {
+      en: ['Fixed a broken app icon (the `/icon.svg` address returned an error).'],
+      tr: ['Bozuk uygulama simgesi düzeltildi (`/icon.svg` adresi hata veriyordu).'],
+      de: ['Ein defektes App-Symbol behoben (die Adresse `/icon.svg` gab einen Fehler zurück).'],
+    },
+  },
+  {
     version: '0.14.1-beta',
     date: '2026-07-20',
     highlights: {


### PR DESCRIPTION
## What (closes #689, P1)
`public/icon.svg` and `src/app/icon.svg` (byte-identical) **both claimed the `/icon.svg` route**. Next.js App Router serves `src/app/icon.svg` as `/icon.svg` automatically, so the `public/` copy was a conflicting duplicate → `/icon.svg` 500.

## Fix
Removed `public/icon.svg`. The app-router icon (`src/app/icon.svg`) still serves the favicon and the `/icon.svg` references in `manifest.ts` / `layout.tsx`. Build now emits `/icon.svg` as a single clean static route.

## Verification
`npm run build` green; output shows `○ /icon.svg` (static, no conflict). 0.14.2-beta + CHANGELOG + release notes (EN/TR/DE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ)_