### PR TITLE
fix(import): set orgId on CSV-imported users (closes #678) — 0.14.3-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [Unreleased]
 
+## [0.14.3] - 2026-07-21
+
+### Fixed
+- **CSV bulk import now sets `orgId` (closes #678)** — imported MENTEE users
+  inherited no org, so they fell outside the tenant's plan-limit counts and
+  (with `MT_ENFORCE_ISOLATION`) isolation. `POST /api/admin/import` now sets
+  `orgId: resolveOrgId(session)` on create, matching every other create path
+  (mentor add-mentee, apply). Null-org admins are unaffected (single-tenant).
+
 ## [0.14.2] - 2026-07-21
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.14.2-beta",
+  "version": "0.14.3-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/app/api/admin/import/route.ts
+++ b/src/app/api/admin/import/route.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import bcrypt from 'bcryptjs';
 import { randomBytes } from 'crypto';
 import { logActivity } from '@/lib/activity';
+import { resolveOrgId } from '@/lib/orgScope';
 
 const schema = z.object({ csv: z.string().min(1).max(200_000), dryRun: z.boolean().optional() });
 
@@ -72,6 +73,9 @@ export async function POST(request: Request) {
         fullName: fullName || email.split('@')[0],
         password,
         role: 'MENTEE',
+        // Inherit the importing admin's org so CSV-imported users stay inside
+        // the tenant's counts/isolation, like every other create path (#678).
+        orgId: resolveOrgId(session),
         phone: phone || null,
         university: university || null,
         department: department || null,


### PR DESCRIPTION
## What (closes #678, P1)
`POST /api/admin/import` created MENTEE users **without `orgId`**, so CSV-imported users fell outside the tenant's plan-limit counts and (with `MT_ENFORCE_ISOLATION`) isolation.

## Fix
Set `orgId: resolveOrgId(session)` on the `user.create`, matching every other create path (mentor add-mentee, apply). Null-org admins are unaffected (single-tenant fails open). One-line + import.

## Verification
`npm run build` green. 0.14.3-beta + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ)_