### PR TITLE
docs: official org Priority field IS agent-writable via issue_write (corrects #710)

### DIFF
--- a/.claude/skills/backlog/SKILL.md
+++ b/.claude/skills/backlog/SKILL.md
@@ -87,11 +87,12 @@ not a coder. Author issues; do not implement unless explicitly told to.
     findings from step 2 (especially "already partly exists"), the dependency
     order, and a recommended next item. Do not paste full issue bodies back.
 
-11. **Link it into the hierarchy — that's all the board needs.** After creating an
-    issue, link it as a sub-issue of its parent Story/Epic with
-    `mcp__github__sub_issue_write`. Do **not** add custom board fields — the
-    board stays **GitHub-standard** (see below). Sub-issue linking + labels both
-    work with the agent's App; that's everything the board needs.
+11. **Link it in + set the official Priority.** After creating an issue: (a) link
+    it as a sub-issue of its parent Story/Epic with `mcp__github__sub_issue_write`;
+    (b) set the board's native **Priority** field via `mcp__github__issue_write`
+    (`issue_fields`, mapped from the P-label — see the board section). Do **not**
+    add *custom* board fields — the board stays **GitHub-standard**. Sub-issue
+    linking, labels, and the org Priority field all work with the agent's App.
 
 ## GitHub Project board — conventions (org `21072026`, project `1`)
 
@@ -109,14 +110,23 @@ they encoded is already carried natively. Reverted. Don't reintroduce them.)
   theme, create a small umbrella **Story** and nest them. Never a mega-parent —
   "No Parent" always holds the top-level epics/stories, and that's correct
   (a tree always has roots).
-- **Priority = the `P1`/`P2`/`P3` label.** Don't create a priority field — the
-  label already carries it and the board can group/sort/filter by label.
+- **Priority** — set the `P0`–`P3` **label** (for filtering/at-a-glance) AND the
+  board's **official org "Priority" field** (options **Urgent/High/Medium/Low**).
+  The Priority field is an **org-level issue field** (`list_issue_fields` shows it),
+  so — unlike a project custom field — the agent's App **CAN write it** via
+  `mcp__github__issue_write` (method `update`, `issue_fields:
+  [{field_name:"Priority", field_option_name:"High"}]`). Set it on every issue,
+  mapping the label: **P0→Urgent, P1→High, P2→Medium, P3→Low**. This is a native
+  GitHub field (not the custom `Prio` we removed), so it's fine — it drives the
+  board's Priority view/sort. (`Effort`, `Start date`, `Target date` org fields
+  also exist and are settable the same way if ever needed.)
 - **Status** = the built-in workflow column (Backlog → Ready → In progress →
-  In review → Done). Move a P1 bug to Ready so it surfaces.
-- **Env note:** the agent's App can't write GitHub Projects fields and this sandbox
-  has no `gh` — but with the standard approach nothing needs writing: labels +
-  sub-issues go through the normal issue API, and grouping is a one-time board
-  setting the maintainer makes in the UI.
+  In review → Done). Move a P0/P1 bug to Ready so it surfaces.
+- **What the agent CAN vs CAN'T write:** CAN — labels, sub-issue links, and the
+  **org-level issue fields** (Priority/Effort/dates) via `issue_write`. CANNOT —
+  project-scoped custom fields / board item placement (needs `gh` + Projects
+  scope). So set Priority via `issue_write`; leave board grouping to the one-time
+  UI setting. (`list_issue_fields` needs BOTH owner+repo; owner-only 403s.)
 
 ## Repo facts to reuse (verify, don't assume they're still true)
 

--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -27,7 +27,16 @@ etikete göre grupla/sırala); akış **Status** kolonları. **Custom alan yok.*
 > tür ve önceliği taşıyor; bunları custom alanla kopyalamak = kalıcı bakım yükü
 > (her issue'da alan doldurma, PAT secret, workflow). Yerlisi neyi ifade ediyorsa
 > onu tekrar üretme. Sub-issue linkleme + etiketleme agent'ın App'iyle çalışır;
-> Projects alan yazımı yazılamaz (gerekmiyor da).
+> *proje-scope'lu* custom alan/board yerleşimi yazılamaz.
+
+**AMA resmî org "Priority" alanı YAZILABİLİR (önemli düzeltme):** Board'daki resmî
+Priority, proje custom alanı değil bir **org-seviyesi issue alanı** (Urgent/High/
+Medium/Low; `Effort`, `Start date`, `Target date` de öyle). `mcp__github__list_issue_fields`
+(owner+repo ile; owner-only 403) görür, ve agent bunu **`mcp__github__issue_write`**
+(`method:update`, `issue_fields:[{field_name:"Priority",field_option_name:"High"}]`)
+ile **set edebilir**. Bu yüzden custom "Prio" gereksizdi — resmî alanı P-etiketinden
+doldur: **P0→Urgent, P1→High, P2→Medium, P3→Low**. (Bu oturumda 33 açık issue'ya
+tek tek uygulandı, `list_issues` field_filter=Priority ile doğrulandı.)
 
 **Transfer yazma yolunu AÇTI (önceki oturum 403 alıyordu):** yeni repoya scoped
 oturumda `git push` + `mcp__github__*` sorunsuz çalıştı. Transfer sonrası ilk iş:


### PR DESCRIPTION
Follow-up to #710. The board's **real** Priority is an **org-level issue field** (Urgent/High/Medium/Low) — not a project custom field. `mcp__github__list_issue_fields` (owner+**repo**) shows it, and the agent's App **CAN set it** via `mcp__github__issue_write` (`issue_fields: [{field_name:"Priority", field_option_name:"High"}]`). So #710's "just use labels, agent can't write board fields" was incomplete.

- **`backlog` skill:** step 11 + board section now say to set **both** the `P0`–`P3` label **and** the official Priority field (map P0→Urgent, P1→High, P2→Medium, P3→Low) via `issue_write`. Clarifies CAN-write (labels, sub-issues, org issue fields) vs CAN'T-write (project custom fields / board placement).
- **`agent-experience.md`:** records the discovery + the mapping.

Already applied to all 33 open issues this session (21 Medium, 12 Low, plus the P1s → High), verified via `list_issues` Priority filter (21 Medium). The maintainer can now delete the leftover custom `Prio` field — the official Priority column is populated.

Docs/skill only — no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ)_