### PR TITLE
fix(portal): remove dead mailto button, make mentor email a link (closes #654) — 0.14.4-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [Unreleased]
 
+## [0.14.4] - 2026-07-21
+
+### Fixed
+- **Portal "email mentor" dead button (closes #654)** — the mentee portal had a
+  bare `mailto:` button that did nothing when no mail client was configured.
+  Removed it; the reliable **in-app "Message mentor"** button (already primary)
+  stays, and the mentor's email address is now a `mailto:` link itself (visible +
+  copyable + best-effort), so contact works in every environment.
+
 ## [0.14.3] - 2026-07-21
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.14.3-beta",
+  "version": "0.14.4-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/app/portal/page.tsx
+++ b/src/app/portal/page.tsx
@@ -15,7 +15,7 @@ import { prisma } from '@/lib/prisma';
 import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Badge, StatusBadge } from '@/components/ui/Badge';
 import { InteractionTypeBadge } from '@/components/InteractionTypeBadge';
-import { User, Building2, BookOpen, ExternalLink, MessageCircle, Mail, Github, Linkedin } from 'lucide-react';
+import { User, Building2, BookOpen, ExternalLink, MessageCircle, Github, Linkedin } from 'lucide-react';
 import Link from 'next/link';
 import { formatDate } from '@/lib/relativeTime';
 
@@ -247,7 +247,7 @@ export default async function PortalDashboard() {
                   {t.portal.yourMentor}
                 </p>
                 <p className="font-semibold text-gray-900">{activeRelation.mentor.fullName}</p>
-                <p className="text-sm text-gray-600">{activeRelation.mentor.email}</p>
+                <a href={`mailto:${activeRelation.mentor.email}`} className="text-sm text-gray-600 hover:text-blue-600 hover:underline break-all">{activeRelation.mentor.email}</a>
                 {activeRelation.mentor.phone && (
                   <p className="text-sm text-gray-600">{activeRelation.mentor.phone}</p>
                 )}
@@ -259,10 +259,6 @@ export default async function PortalDashboard() {
                     <MessageCircle className="h-4 w-4" />
                     {t.portal.messageMentor}
                   </Link>
-                  <a href={`mailto:${activeRelation.mentor.email}`} className="inline-flex items-center gap-1.5 border border-gray-300 text-gray-700 text-sm px-3 py-1.5 rounded-lg hover:bg-gray-50 transition-colors">
-                    <Mail className="h-4 w-4" />
-                    {t.portal.emailMentor}
-                  </a>
                 </div>
               </div>
 

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,15 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.14.4-beta',
+    date: '2026-07-21',
+    highlights: {
+      en: ['Contacting your mentor from the portal is more reliable — use the in-app “Message mentor” button; the email address is now a clickable link.'],
+      tr: ['Portaldan mentörünle iletişim daha güvenilir — uygulama-içi “Mentöre mesaj” butonunu kullan; e-posta adresi artık tıklanabilir bir bağlantı.'],
+      de: ['Die Kontaktaufnahme mit deinem Mentor über das Portal ist zuverlässiger — nutze die In-App-Schaltfläche „Mentor benachrichtigen“; die E-Mail-Adresse ist jetzt ein anklickbarer Link.'],
+    },
+  },
+  {
     version: '0.14.2-beta',
     date: '2026-07-21',
     highlights: {


### PR DESCRIPTION
## What (closes #654, P2)
The mentee portal had a bare `mailto:` "email mentor" button (`portal/page.tsx:262`) that silently did nothing on browsers without a configured mail client.

## Fix
- Removed the dead secondary button (and the now-unused `Mail` import).
- The reliable **in-app "Message mentor"** button (`/messages/[relationId]`) was already the primary action and stays — works in every environment (AC1).
- The mentor's **email address** (already shown) is now a `mailto:` link itself — visible, copyable, and best-effort openable — so there's no mystery "dead" button (AC2).

## Verification
`npm run build` + `npm run check:i18n` (1438 × 3) green. 0.14.4-beta + CHANGELOG + release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ)_