### PR TITLE
fix(i18n): account language selector reflects effective locale (closes #653) — 0.14.5-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [Unreleased]
 
+## [0.14.5] - 2026-07-21
+
+### Fixed
+- **Account language selector out of sync with the UI (closes #653)** — the
+  selector read the DB `preferredLanguage` while `getLocale()` lets the `locale`
+  cookie win, so a `tr` cookie + `en`/null preference showed "English" over a
+  Turkish UI. The selector now reflects the effective (cookie-first) locale and
+  converges `preferredLanguage` to it so they can't diverge again; the locale
+  cookie is written with `samesite=lax` (matching theme/accent).
+
 ## [0.14.4] - 2026-07-21
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.14.4-beta",
+  "version": "0.14.5-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/components/AccountSettings.tsx
+++ b/src/components/AccountSettings.tsx
@@ -61,7 +61,21 @@ export function AccountSettings() {
         setEmail(user.email);
         setEmailNotifications(user.emailNotifications !== false);
         setNotifPrefs((user.notificationPrefs && typeof user.notificationPrefs === 'object') ? user.notificationPrefs : {});
-        setLanguage(user.preferredLanguage ?? 'en');
+        // The language selector must reflect the EFFECTIVE locale, not just the
+        // DB preference: getLocale() lets the `locale` cookie win, so a cookie of
+        // `tr` with a `preferredLanguage` of `en`/null renders a Turkish UI while
+        // the selector said "English" (#653). Prefer the cookie, and converge the
+        // DB preference to it so the two never diverge again.
+        const m = document.cookie.match(new RegExp('(?:^|; )' + LOCALE_COOKIE + '=([^;]*)'));
+        const cookieLocale = m ? decodeURIComponent(m[1]) : null;
+        const validCookie = cookieLocale && (locales as readonly string[]).includes(cookieLocale) ? cookieLocale : null;
+        setLanguage(validCookie ?? user.preferredLanguage ?? 'en');
+        if (validCookie && validCookie !== user.preferredLanguage) {
+          fetch('/api/profile', {
+            method: 'PUT', headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ preferredLanguage: validCookie }),
+          }).catch(() => {});
+        }
         setTheme(user.theme ?? 'system');
         setAccent(resolveAccent(user.accentColor));
         setRole(user.role ?? '');
@@ -156,7 +170,7 @@ export function AccountSettings() {
 
   const changeLanguage = async (next: string) => {
     setLanguage(next);
-    document.cookie = `${LOCALE_COOKIE}=${next}; path=/; max-age=${60 * 60 * 24 * 365}`;
+    document.cookie = `${LOCALE_COOKIE}=${next}; path=/; max-age=${60 * 60 * 24 * 365}; samesite=lax`;
     try {
       await fetch('/api/profile', {
         method: 'PUT', headers: { 'Content-Type': 'application/json' },

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,15 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.14.5-beta',
+    date: '2026-07-21',
+    highlights: {
+      en: ['The language shown in Account settings now always matches the actual interface language.'],
+      tr: ['Hesap ayarlarında görünen dil artık her zaman arayüzün gerçek diliyle aynı.'],
+      de: ['Die in den Kontoeinstellungen angezeigte Sprache stimmt jetzt immer mit der tatsächlichen Oberflächensprache überein.'],
+    },
+  },
+  {
     version: '0.14.4-beta',
     date: '2026-07-21',
     highlights: {


### PR DESCRIPTION
## What (closes #653, P2)
On `/account` the language selector read the DB `preferredLanguage`, but `getLocale()` (`src/i18n/server.ts`) lets the **`locale` cookie win**. So a `tr` cookie with an `en`/null preference rendered a Turkish UI while the selector said "English" — the two sources of truth diverged.

## Fix (`AccountSettings.tsx`)
- The selector now reads the **effective** locale (cookie-first, matching `getLocale`), so the shown value always equals the rendered UI.
- **Converges** the DB `preferredLanguage` to the cookie when they differ, so they can't drift apart again.
- Writes the locale cookie with **`samesite=lax`** (matching the theme/accent cookies).

## Verification
`npm run build` + `npm run check:i18n` (1438 × 3) green. 0.14.5-beta + CHANGELOG + release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ)_