### PR TITLE
fix: surface swallowed API errors on analytics + candidate pages (closes #679)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [Unreleased]
 
+## [0.14.6] - 2026-07-21
+
+### Fixed
+- **Silent API failures swallowed with `.catch(() => {})` (closes #679)** — the
+  admin analytics page and the candidate-detail dropdowns dropped fetch errors
+  on the floor, so a failed load looked like empty data with no signal. The
+  analytics page now surfaces a load error banner (and logs it); the
+  candidate-detail project/cohort/source dropdown loads log their failures
+  instead of swallowing them; and the evaluation panel shows an inline error
+  when a submission fails instead of silently doing nothing.
+
 ## [0.14.5] - 2026-07-21
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.14.5-beta",
+  "version": "0.14.6-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -71,6 +71,7 @@ export default function AdminAnalyticsPage() {
   const [data, setData] = useState<Analytics | null>(null);
   const [aging, setAging] = useState<Aging | null>(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [range, setRange] = useState<RangePreset>('6m');
   // Premium tier state (#540): drives the full-report export buttons. Detected
   // via the (server-gated) cohorts endpoint — 403 means the tier is off.
@@ -79,18 +80,20 @@ export default function AdminAnalyticsPage() {
   useEffect(() => {
     const qs = rangeQuery(range);
     setLoading(true);
+    setError(null);
     fetch(`/api/admin/analytics${qs}`)
-      .then((r) => r.json())
+      .then((r) => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json(); })
       .then((d) => setData(d))
+      .catch((e) => { console.error('[analytics]', e); setError(t.common.error); })
       .finally(() => setLoading(false));
     fetch(`/api/admin/analytics/aging${qs}`)
       .then((r) => r.json())
       .then((d) => setAging(d))
-      .catch(() => {});
-  }, [range]);
+      .catch((e) => console.error('[analytics/aging]', e));
+  }, [range, t.common.error]);
 
   useEffect(() => {
-    fetch('/api/admin/analytics/cohorts').then((r) => setPremium(r.ok)).catch(() => {});
+    fetch('/api/admin/analytics/cohorts').then((r) => setPremium(r.ok)).catch((e) => console.error('[analytics/cohorts]', e));
   }, []);
 
   const maxFunnel = data ? Math.max(1, ...PIPELINE_STATUSES.map((s) => data.funnel[s] || 0)) : 1;
@@ -161,6 +164,13 @@ export default function AdminAnalyticsPage() {
           )}
         </div>
       </div>
+
+      {error && (
+        <div className="mb-4 flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" role="alert">
+          <AlertTriangle className="h-4 w-4 shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
 
       {loading ? (
         <div className="text-center py-12 text-gray-400">{t.common.loading}</div>

--- a/src/app/admin/candidates/[id]/page.tsx
+++ b/src/app/admin/candidates/[id]/page.tsx
@@ -187,15 +187,15 @@ export default function AdminMenteeDetailPage() {
     fetch('/api/projects')
       .then((r) => (r.ok ? r.json() : { projects: [] }))
       .then((d) => setProjects(d.projects ?? []))
-      .catch(() => {});
+      .catch((e) => console.error('[candidate] projects load failed', e));
     fetch('/api/cohorts')
       .then((r) => (r.ok ? r.json() : { cohorts: [] }))
       .then((d) => setCohorts(d.cohorts ?? []))
-      .catch(() => {});
+      .catch((e) => console.error('[candidate] cohorts load failed', e));
     fetch('/api/admin/sources')
       .then((r) => (r.ok ? r.json() : { sources: [] }))
       .then((d) => setSources(d.sources ?? []))
-      .catch(() => {});
+      .catch((e) => console.error('[candidate] sources load failed', e));
   }, [id]);
 
   const changeSource = useCallback(

--- a/src/components/EvaluationPanel.tsx
+++ b/src/components/EvaluationPanel.tsx
@@ -36,6 +36,7 @@ export function EvaluationPanel({
   const [comment, setComment] = useState('');
   const [type, setType] = useState<'INTERIM' | 'FINAL'>('INTERIM');
   const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const formCriteria = audience === 'MENTOR' ? MENTOR_CRITERIA : EVAL_CRITERIA;
 
@@ -48,6 +49,7 @@ export function EvaluationPanel({
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
     setSaving(true);
+    setError(null);
     try {
       const res = await fetch('/api/evaluations', {
         method: 'POST',
@@ -55,6 +57,10 @@ export function EvaluationPanel({
         body: JSON.stringify({ relationId, scores, comment, type }),
       });
       if (res.ok) { setScores({}); setComment(''); setType('INTERIM'); await load(); }
+      else setError(t.common.error);
+    } catch (err) {
+      console.error('[evaluations] submit failed', err);
+      setError(t.common.error);
     } finally {
       setSaving(false);
     }
@@ -102,6 +108,7 @@ export function EvaluationPanel({
             placeholder={t.evaluation.comment}
             className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
           />
+          {error && <p className="text-sm text-red-600" role="alert">{error}</p>}
           <Button type="submit" size="sm" loading={saving} disabled={Object.keys(scores).length === 0}>
             {t.evaluation.add}
           </Button>

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,15 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.14.6-beta',
+    date: '2026-07-21',
+    highlights: {
+      en: ['When a page fails to load its data, you now see a clear error instead of a blank screen, and saving an evaluation shows an error if it doesn’t go through.'],
+      tr: ['Bir sayfa verisini yükleyemediğinde artık boş ekran yerine net bir hata görüyorsun; bir değerlendirme kaydedilmezse hata gösteriliyor.'],
+      de: ['Wenn eine Seite ihre Daten nicht laden kann, siehst du jetzt einen klaren Fehler statt eines leeren Bildschirms, und beim Speichern einer Bewertung wird ein Fehler angezeigt, falls es nicht klappt.'],
+    },
+  },
+  {
     version: '0.14.5-beta',
     date: '2026-07-21',
     highlights: {


### PR DESCRIPTION
## Amaç
`.catch(() => {})` on several client fetches swallowed API failures, so a failed load looked identical to genuinely-empty data — no banner, no console signal, nothing for a user or dev to act on (#679).

## Ne yapıldı
- **`src/app/admin/analytics/page.tsx`** — the main analytics fetch now throws on non-OK, sets an `error` state, and renders a red error banner (with `AlertTriangle`); the aging + cohorts fetches `console.error` instead of silently discarding.
- **`src/app/admin/candidates/[id]/page.tsx`** — the projects / cohorts / sources dropdown loads now `console.error` their failures instead of `.catch(() => {})`.
- **`src/components/EvaluationPanel.tsx`** — submit now shows an inline error message when the request fails (`!res.ok` or throws) instead of silently doing nothing.

Reuses the existing `t.common.error` i18n string — no new keys.

## Kabul kriterleri
- [x] `npm run build` — passes
- [x] `npm run check:i18n` — 1438 keys × 3 locales OK
- [x] Version bump 0.14.5 → 0.14.6-beta + CHANGELOG + releaseNotes (EN/TR/DE)

Closes #679

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ)_