### PR TITLE
fix(onboarding): mentor checklist never dismissed — compute scheduleMeeting.done (closes #690)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [Unreleased]
 
+## [0.14.7] - 2026-07-21
+
+### Fixed
+- **Mentor onboarding checklist never dismissed (closes #690)** — the
+  `scheduleMeeting` step was hard-coded `done: false` and, being counted by the
+  `steps.every(done)` check, kept the checklist on screen forever even after the
+  mentor finished everything. `scheduleMeeting.done` is now computed from the
+  mentor's actual meeting count, and `OnboardingChecklist` decides completion
+  from **required** steps only, so an optional step can no longer pin the
+  checklist open.
+
 ## [0.14.6] - 2026-07-21
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.14.6-beta",
+  "version": "0.14.7-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/app/api/onboarding/route.ts
+++ b/src/app/api/onboarding/route.ts
@@ -27,16 +27,17 @@ export async function GET() {
   }
 
   if (role === 'MENTOR') {
-    const [mentees, interactions] = await Promise.all([
+    const [mentees, interactions, meetings] = await Promise.all([
       prisma.mentorshipRelation.count({ where: { mentorId: id } }),
       prisma.interactionLog.count({ where: { relation: { mentorId: id } } }),
+      prisma.meeting.count({ where: { relation: { mentorId: id } } }),
     ]);
     return NextResponse.json({
       role,
       steps: [
         { key: 'addMentee', done: mentees > 0, href: '/mentor/mentees/new' },
         { key: 'logInteraction', done: interactions > 0, href: '/mentor/mentees' },
-        { key: 'scheduleMeeting', done: false, href: '/mentor/meetings', optional: true },
+        { key: 'scheduleMeeting', done: meetings > 0, href: '/mentor/meetings', optional: true },
       ].slice(0, mentees > 0 ? 3 : 2),
     });
   }

--- a/src/components/OnboardingChecklist.tsx
+++ b/src/components/OnboardingChecklist.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { CheckCircle2, Circle, X, Rocket } from 'lucide-react';
 import { useT } from '@/i18n/client';
 
-interface Step { key: string; done: boolean; href: string }
+interface Step { key: string; done: boolean; href: string; optional?: boolean }
 
 // Role-aware first-run checklist shown on the dashboard. Hides itself when all
 // steps are done or the user dismisses it (remembered per role in localStorage).
@@ -27,7 +27,9 @@ export function OnboardingChecklist() {
   }, []);
 
   if (!steps || steps.length === 0 || dismissed) return null;
-  const allDone = steps.every((s) => s.done);
+  // Only required steps decide completion — an optional step (e.g. the mentor's
+  // "schedule a meeting") must never keep the checklist open forever.
+  const allDone = steps.filter((s) => !s.optional).every((s) => s.done);
   if (allDone) return null;
 
   const labels = t.checklist.steps as Record<string, string>;

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,15 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.14.7-beta',
+    date: '2026-07-21',
+    highlights: {
+      en: ['The mentor getting-started checklist now disappears once you’ve completed the essential steps (scheduling a meeting is correctly optional).'],
+      tr: ['Mentör başlangıç kontrol listesi, temel adımları tamamlayınca artık kayboluyor (toplantı planlamak doğru şekilde isteğe bağlı).'],
+      de: ['Die Mentor-Startcheckliste verschwindet jetzt, sobald du die wesentlichen Schritte erledigt hast (das Planen eines Meetings ist korrekt optional).'],
+    },
+  },
+  {
     version: '0.14.6-beta',
     date: '2026-07-21',
     highlights: {


### PR DESCRIPTION
## Amaç
The mentor onboarding checklist never went away: `scheduleMeeting.done` was hard-coded `false` at `src/app/api/onboarding/route.ts:39`, and `OnboardingChecklist` hides itself only when `steps.every(s => s.done)` — so that permanently-false optional step kept `allDone` from ever becoming true, even after the mentor completed every real step (#690).

## Ne yapıldı
- **`src/app/api/onboarding/route.ts`** — `scheduleMeeting.done` is now computed from `prisma.meeting.count({ where: { relation: { mentorId: id } } })` (matches the dynamic `addMentee` / `logInteraction` steps).
- **`src/components/OnboardingChecklist.tsx`** — `allDone` now considers **required** steps only (`steps.filter(s => !s.optional).every(...)`), and `Step` gains an `optional?: boolean`. Defensive: an optional step can no longer pin the checklist open regardless of its `done`.

## Kabul kriterleri
- [x] Mentor creating a meeting marks `scheduleMeeting` done.
- [x] Checklist disappears once all **required** steps are done.
- [x] `npm run build` — passes.
- [x] Version 0.14.7-beta + CHANGELOG + releaseNotes (EN/TR/DE). (No new i18n keys.)

Closes #690

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ)_