### PR TITLE
fix(dark-mode): colored-box contrast net covers 500/800/900 shades (closes #658, #659)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [Unreleased]
 
+## [0.17.1] - 2026-07-21
+
+### Fixed
+- **Dark-mode contrast on colored info boxes (closes #658, #659)** — the compound
+  dark-mode override "safety net" in `globals.css` now also remaps the darker
+  `text-*-800/900` and lighter `text-*-500` shades (not just 600/700) on
+  `bg-*-50` boxes, for blue/green/red/amber/indigo/yellow/**purple**. This fixes
+  the dark-on-dark text on the portal's amber "complete your profile" heading
+  (`text-yellow-800`) and blue/green labels (`text-blue-500`, `text-green-500`)
+  without per-element `dark:` utilities, and covers the same class of boxes
+  app-wide. Completes the dark-mode contrast story (#657) under the UX epic (#718).
+
 ## [0.17.0] - 2026-07-21
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.17.0-beta",
+  "version": "0.17.1-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -96,30 +96,77 @@ html.dark .text-amber-900 { color: #fde68a; }
 html.dark .bg-blue-50.text-blue-700,
 html.dark .bg-blue-50 .text-blue-700,
 html.dark .bg-blue-50 .text-blue-600,
+html.dark .bg-blue-50.text-blue-800,
+html.dark .bg-blue-50 .text-blue-800,
+html.dark .bg-blue-50.text-blue-900,
+html.dark .bg-blue-50 .text-blue-900,
+html.dark .bg-blue-50.text-blue-500,
+html.dark .bg-blue-50 .text-blue-500,
 html.dark .hover\:text-blue-700:hover,
 html.dark .group:hover .group-hover\:text-blue-600 { color: #93c5fd; } /* blue-300 */
 
 /*
- * Same dark-on-dark fix for the other accent colors (#503): mid-tone
- * text-*-600/700 on a retinted bg-*-50 box → the color's -300 shade. Only the
- * combinations that actually occur in the app are covered (green, red, amber,
- * indigo, yellow); *-600/700 on chips that stay light (bg-*-100) is untouched.
+ * Same dark-on-dark fix for the other accent colors (#503, extended in #658):
+ * mid-tone / strong text-*-500/600/700/800/900 on a retinted bg-*-50 box →
+ * the color's -300 shade. Covering the darker 800/900 and the lighter 500 too
+ * makes this a durable safety net (e.g. the portal's text-yellow-800 heading and
+ * text-blue-500 label), so most boxes need no per-element dark: utilities.
+ * *-* on chips that stay light (bg-*-100) is untouched.
  */
 html.dark .bg-green-50.text-green-700,
 html.dark .bg-green-50 .text-green-700,
-html.dark .bg-green-50 .text-green-600 { color: #86efac; } /* green-300 */
+html.dark .bg-green-50 .text-green-600,
+html.dark .bg-green-50.text-green-800,
+html.dark .bg-green-50 .text-green-800,
+html.dark .bg-green-50.text-green-900,
+html.dark .bg-green-50 .text-green-900,
+html.dark .bg-green-50.text-green-500,
+html.dark .bg-green-50 .text-green-500 { color: #86efac; } /* green-300 */
 html.dark .bg-red-50.text-red-700,
 html.dark .bg-red-50 .text-red-700,
-html.dark .bg-red-50 .text-red-600 { color: #fca5a5; } /* red-300 */
+html.dark .bg-red-50 .text-red-600,
+html.dark .bg-red-50.text-red-800,
+html.dark .bg-red-50 .text-red-800,
+html.dark .bg-red-50.text-red-900,
+html.dark .bg-red-50 .text-red-900,
+html.dark .bg-red-50.text-red-500,
+html.dark .bg-red-50 .text-red-500 { color: #fca5a5; } /* red-300 */
 html.dark .bg-amber-50.text-amber-700,
 html.dark .bg-amber-50 .text-amber-700,
-html.dark .bg-amber-50 .text-amber-600 { color: #fcd34d; } /* amber-300 */
+html.dark .bg-amber-50 .text-amber-600,
+html.dark .bg-amber-50.text-amber-800,
+html.dark .bg-amber-50 .text-amber-800,
+html.dark .bg-amber-50.text-amber-900,
+html.dark .bg-amber-50 .text-amber-900,
+html.dark .bg-amber-50.text-amber-500,
+html.dark .bg-amber-50 .text-amber-500 { color: #fcd34d; } /* amber-300 */
 html.dark .bg-indigo-50.text-indigo-700,
 html.dark .bg-indigo-50 .text-indigo-700,
-html.dark .bg-indigo-50 .text-indigo-600 { color: #a5b4fc; } /* indigo-300 */
+html.dark .bg-indigo-50 .text-indigo-600,
+html.dark .bg-indigo-50.text-indigo-800,
+html.dark .bg-indigo-50 .text-indigo-800,
+html.dark .bg-indigo-50.text-indigo-900,
+html.dark .bg-indigo-50 .text-indigo-900,
+html.dark .bg-indigo-50.text-indigo-500,
+html.dark .bg-indigo-50 .text-indigo-500 { color: #a5b4fc; } /* indigo-300 */
 html.dark .bg-yellow-50.text-yellow-700,
 html.dark .bg-yellow-50 .text-yellow-700,
-html.dark .bg-yellow-50 .text-yellow-600 { color: #fde047; } /* yellow-300 */
+html.dark .bg-yellow-50 .text-yellow-600,
+html.dark .bg-yellow-50.text-yellow-800,
+html.dark .bg-yellow-50 .text-yellow-800,
+html.dark .bg-yellow-50.text-yellow-900,
+html.dark .bg-yellow-50 .text-yellow-900,
+html.dark .bg-yellow-50.text-yellow-500,
+html.dark .bg-yellow-50 .text-yellow-500 { color: #fde047; } /* yellow-300 */
+html.dark .bg-purple-50.text-purple-700,
+html.dark .bg-purple-50 .text-purple-700,
+html.dark .bg-purple-50 .text-purple-600,
+html.dark .bg-purple-50.text-purple-800,
+html.dark .bg-purple-50 .text-purple-800,
+html.dark .bg-purple-50.text-purple-900,
+html.dark .bg-purple-50 .text-purple-900,
+html.dark .bg-purple-50.text-purple-500,
+html.dark .bg-purple-50 .text-purple-500 { color: #d8b4fe; } /* purple-300 */
 
 /*
  * Accent color system.

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,15 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.17.1-beta',
+    date: '2026-07-21',
+    highlights: {
+      en: ['Dark mode: text inside colored info boxes (like the portal’s “complete your profile” note) is now readable instead of dark-on-dark.'],
+      tr: ['Koyu tema: renkli bilgi kutularındaki yazılar (ör. portaldaki “profilini tamamla” notu) artık koyu-üstüne-koyu yerine okunaklı.'],
+      de: ['Dunkelmodus: Text in farbigen Infoboxen (z. B. der Hinweis „Profil vervollständigen“ im Portal) ist jetzt lesbar statt dunkel auf dunkel.'],
+    },
+  },
+  {
     version: '0.17.0-beta',
     date: '2026-07-21',
     highlights: {


### PR DESCRIPTION
## Amaç
Koyu temada renkli bilgi kutularındaki (`bg-*-50`) düşük kontrastlı metni düzelt — story #657 (Epic #718 / UX'in son story'si).

## Ne yapıldı
- **#658 — Override ağını genişlet:** `globals.css`'deki compound koyu-tema "güvenlik ağı" artık yalnızca `text-*-600/700` değil, **daha koyu `text-*-800/900` ve daha açık `text-*-500`** tonlarını da `-300` shade'e remap ediyor; renkler: blue/green/red/amber/indigo/yellow + **purple** (yeni). Hem `.bg .text` (iç içe) hem `.bg.text` varyantları.
- **#659 — Tarama + tekil düzeltmeler:** Genişletilen ağ, dokümante edilen portal yüzeylerini otomatik kapsıyor — amber "profilini tamamla" başlığı (`text-yellow-800`), mavi/yeşil etiketler (`text-blue-500`, `text-green-500`, `text-blue-800`). Uygulama geneli tarama ağ dışında renkli-kutu yüzeyi bulmadı (`bg-orange-500` bir nokta göstergesi, kutu değil).

## Kabul kriterleri
- [x] `bg-*-50` kutusundaki `text-*-500/800/900` metinler koyu temada açık renge remap oluyor.
- [x] Açık tema değişmedi; `dark:` ile sabitlenen elemanlar etkilenmedi (compound selector yalnızca ilgili kombinasyonu hedefler).
- [x] `npm run build` geçiyor. (dark-mode e2e computed-style kontrolü CI'da doğrular.)
- [x] Sürüm 0.17.1-beta + CHANGELOG + releaseNotes (EN/TR/DE).

Closes #658
Closes #659

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ)_