### PR TITLE
feat(messages): WhatsApp-style read-receipt ticks (closes #664)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-07-21
+
+### Changed
+- **WhatsApp-style read receipts (closes #664)** — in a conversation thread, your
+  own messages now show tick icons instead of a "Sent/Read" text label: a single
+  tick (✓) when delivered and a blue double tick (✓✓) once the other party has
+  opened the thread. Shown on every message you sent (not just the last), with
+  accessible `Sent`/`Read` labels retained on the icons. Part of the WhatsApp-like
+  messaging story (#663) under the Communication epic (#717).
+
 ## [0.17.1] - 2026-07-21
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.17.1-beta",
+  "version": "0.18.0-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/app/messages/[relationId]/page.tsx
+++ b/src/app/messages/[relationId]/page.tsx
@@ -2,7 +2,7 @@
 
 import { use, useCallback, useEffect, useRef, useState } from 'react';
 import { useSession } from 'next-auth/react';
-import { Paperclip, X, FileText, Download, MoreVertical } from 'lucide-react';
+import { Paperclip, X, FileText, Download, MoreVertical, Check, CheckCheck } from 'lucide-react';
 import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { useT, useLocale } from '@/i18n/client';
@@ -173,10 +173,8 @@ export default function ThreadPage({ params }: { params: Promise<{ relationId: s
           <p className="text-center py-10 text-gray-400 text-sm">{t.messages.empty}</p>
         ) : (
           <div className="space-y-3 max-h-[55vh] overflow-y-auto">
-            {messages.map((m, i) => {
+            {messages.map((m) => {
               const mine = m.senderId === myId;
-              // Show a read receipt on my latest message only.
-              const isMyLast = mine && !messages.slice(i + 1).some((x) => x.senderId === myId);
               return (
                 <div key={m.id} className={`flex ${mine ? 'justify-end' : 'justify-start'}`}>
                   <div className={`max-w-[80%] rounded-2xl px-4 py-2 text-sm ${mine ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-900'}`}>
@@ -223,7 +221,17 @@ export default function ThreadPage({ params }: { params: Promise<{ relationId: s
                     <p className={`text-[10px] mt-1 flex items-center gap-1 ${mine ? 'text-blue-100' : 'text-gray-400'}`}>
                       {m.channel === 'EMAIL' ? '✉ ' : ''}{formatDateTime(m.createdAt, locale)}
                       {m.editedAt && !m.deleted && <span>· {t.messages.edited}</span>}
-                      {isMyLast && !m.deleted && <span>· {m.readAt ? t.messages.read : t.messages.sent}</span>}
+                      {mine && !m.deleted && (
+                        <span
+                          className="inline-flex"
+                          title={m.readAt ? t.messages.read : t.messages.sent}
+                          aria-label={m.readAt ? t.messages.read : t.messages.sent}
+                        >
+                          {m.readAt
+                            ? <CheckCheck className="h-3.5 w-3.5 text-sky-300" aria-hidden />
+                            : <Check className="h-3.5 w-3.5" aria-hidden />}
+                        </span>
+                      )}
                       {!m.deleted && editId !== m.id && (
                         <button
                           type="button"

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,15 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.18.0-beta',
+    date: '2026-07-21',
+    highlights: {
+      en: ['Messages now show WhatsApp-style read receipts — a single tick when delivered and a blue double tick once your message has been read.'],
+      tr: ['Mesajlarda artık WhatsApp tarzı okundu tikleri var — iletildiğinde tek tik, mesajın okunduğunda mavi çift tik.'],
+      de: ['Nachrichten zeigen jetzt WhatsApp-artige Lesebestätigungen — ein Häkchen bei Zustellung und ein blaues Doppelhäkchen, sobald deine Nachricht gelesen wurde.'],
+    },
+  },
+  {
     version: '0.17.1-beta',
     date: '2026-07-21',
     highlights: {


### PR DESCRIPTION
## Amaç
Mesajlaşma thread'inde okundu durumunu WhatsApp tarzı **tiklerle** göster — story #663 (Epic #717 İletişim).

## Ne yapıldı
- `messages/[relationId]/page.tsx`: kendi mesajlarımdaki "Gönderildi/Okundu" **metni** tik ikonlarıyla değiştirildi — iletildi = tek tik (`Check`), okundu (`readAt` set) = mavi çift tik (`CheckCheck`).
- Sadece son mesajda değil, **her kendi mesajımda** gösteriliyor (WhatsApp gibi).
- Erişilebilirlik: ikonlar `aria-hidden`, sarmalayan `<span>`'de `title` + `aria-label` = mevcut `Gönderildi/Okundu` metinleri.

## Kabul kriterleri
- [x] Gönderenin mesajlarında gönderildi/okundu tikleri; okundu `readAt` ile doğru.
- [x] Karşı taraf thread'i açınca mevcut mark-as-read akışıyla tik güncelleniyor.
- [x] `npm run build` geçiyor. (i18n anahtarı eklenmedi; mevcut `read`/`sent` yeniden kullanıldı.)
- [x] Sürüm 0.18.0-beta + CHANGELOG + releaseNotes (EN/TR/DE).

Closes #664

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ)_