### PR TITLE
feat(messages): emoji reactions on messages (closes #665)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-07-21
+
+### Added
+- **Emoji reactions on messages (closes #665)** — react to a message with 👍 ❤️
+  😂 😮 🎉 (WhatsApp/Slack style). Reaction chips show the emoji + count and
+  highlight the ones you added; tapping a chip or picking from the emoji button
+  toggles your reaction.
+  - Schema: new `MessageReaction` model (`@@unique([messageId, userId, emoji])`),
+    `Message.reactions` (additive `db push`).
+  - API: `POST /api/messages/[id]/reactions` toggles the caller's reaction
+    (thread participants/admin only; emoji restricted to the fixed set);
+    `GET /api/messages` returns a per-message reaction summary (emoji → count +
+    whether you reacted).
+  - Advances the WhatsApp-like messaging story (#663) under the Communication
+    epic (#717).
+
 ## [0.18.0] - 2026-07-21
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.18.0-beta",
+  "version": "0.19.0-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -306,8 +306,26 @@ model Message {
   attachments MessageAttachment[]
   // Per-user "delete for me" — hides the message only from these users' view.
   hiddenFor   MessageHiddenFor[]
+  // Emoji reactions (👍❤️😂…) from thread participants.
+  reactions   MessageReaction[]
 
   @@index([relationId])
+}
+
+// A single emoji reaction on a message by one user (WhatsApp/Slack style).
+// One row per (message, user, emoji) — a user can add several distinct emojis to
+// the same message but not the same emoji twice.
+model MessageReaction {
+  id        String   @id @default(cuid())
+  messageId String
+  userId    String
+  emoji     String
+  createdAt DateTime @default(now())
+
+  message Message @relation(fields: [messageId], references: [id], onDelete: Cascade)
+
+  @@unique([messageId, userId, emoji])
+  @@index([messageId])
 }
 
 // "Delete for me": a message hidden from a single user's view (the message and

--- a/src/app/api/messages/[id]/reactions/route.ts
+++ b/src/app/api/messages/[id]/reactions/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { z } from 'zod';
+import { getThreadIfAllowed } from '@/lib/messaging';
+
+// Fixed reaction set — keeps input bounded (no arbitrary strings stored).
+const REACTION_EMOJIS = ['👍', '❤️', '😂', '😮', '🎉'] as const;
+
+const schema = z.object({ emoji: z.enum(REACTION_EMOJIS) });
+
+// POST — toggle the current user's reaction with the given emoji on a message.
+// Thread participants (and admins) only. Adding the same emoji again removes it.
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const { id } = await params;
+
+  const parsed = schema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) return NextResponse.json({ error: 'Validation failed' }, { status: 400 });
+
+  const message = await prisma.message.findUnique({ where: { id }, select: { relationId: true, deletedForEveryoneAt: true } });
+  if (!message) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  const rel = await getThreadIfAllowed({ id: session.user.id, role: session.user.role }, message.relationId);
+  if (!rel) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  if (message.deletedForEveryoneAt) return NextResponse.json({ error: 'Message deleted' }, { status: 409 });
+
+  const key = { messageId_userId_emoji: { messageId: id, userId: session.user.id, emoji: parsed.data.emoji } };
+  const existing = await prisma.messageReaction.findUnique({ where: key });
+  if (existing) {
+    await prisma.messageReaction.delete({ where: key });
+    return NextResponse.json({ ok: true, active: false });
+  }
+  await prisma.messageReaction.create({ data: { messageId: id, userId: session.user.id, emoji: parsed.data.emoji } });
+  return NextResponse.json({ ok: true, active: true });
+}

--- a/src/app/api/messages/route.ts
+++ b/src/app/api/messages/route.ts
@@ -26,8 +26,20 @@ export async function GET(request: Request) {
     // Exclude messages this viewer deleted "for me".
     where: { relationId, hiddenFor: { none: { userId: session.user.id } } },
     orderBy: { createdAt: 'asc' },
-    include: { attachments: { select: ATTACHMENT_SELECT } },
+    include: { attachments: { select: ATTACHMENT_SELECT }, reactions: { select: { emoji: true, userId: true } } },
   });
+
+  // Summarize reactions per message: emoji → { count, mine }.
+  const summarizeReactions = (reactions: { emoji: string; userId: string }[]) => {
+    const map = new Map<string, { emoji: string; count: number; mine: boolean }>();
+    for (const r of reactions) {
+      const cur = map.get(r.emoji) ?? { emoji: r.emoji, count: 0, mine: false };
+      cur.count += 1;
+      if (r.userId === session.user.id) cur.mine = true;
+      map.set(r.emoji, cur);
+    }
+    return Array.from(map.values());
+  };
 
   // Mask "deleted for everyone" messages server-side so the original body/
   // attachments never leak; the client renders a placeholder instead.
@@ -43,6 +55,7 @@ export async function GET(request: Request) {
           editedAt: null,
           deleted: true,
           attachments: [],
+          reactions: [],
         }
       : {
           id: m.id,
@@ -54,6 +67,7 @@ export async function GET(request: Request) {
           editedAt: m.editedAt,
           deleted: false,
           attachments: m.attachments,
+          reactions: summarizeReactions(m.reactions),
         },
   );
 

--- a/src/app/messages/[relationId]/page.tsx
+++ b/src/app/messages/[relationId]/page.tsx
@@ -2,7 +2,7 @@
 
 import { use, useCallback, useEffect, useRef, useState } from 'react';
 import { useSession } from 'next-auth/react';
-import { Paperclip, X, FileText, Download, MoreVertical, Check, CheckCheck } from 'lucide-react';
+import { Paperclip, X, FileText, Download, MoreVertical, Check, CheckCheck, SmilePlus } from 'lucide-react';
 import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { useT, useLocale } from '@/i18n/client';
@@ -24,7 +24,11 @@ interface Msg {
   editedAt: string | null;
   deleted: boolean;
   attachments: Attachment[];
+  reactions: { emoji: string; count: number; mine: boolean }[];
 }
+
+// Fixed reaction set (mirrors the server's REACTION_EMOJIS).
+const REACTIONS = ['👍', '❤️', '😂', '😮', '🎉'] as const;
 interface Party { id: string; fullName: string }
 
 export default function ThreadPage({ params }: { params: Promise<{ relationId: string }> }) {
@@ -46,6 +50,7 @@ export default function ThreadPage({ params }: { params: Promise<{ relationId: s
   const [forbidden, setForbidden] = useState(false);
   // Per-message edit/delete state.
   const [menuId, setMenuId] = useState<string | null>(null);
+  const [reactId, setReactId] = useState<string | null>(null);
   const [editId, setEditId] = useState<string | null>(null);
   const [editBody, setEditBody] = useState('');
   const [rowBusy, setRowBusy] = useState(false);
@@ -124,6 +129,18 @@ export default function ThreadPage({ params }: { params: Promise<{ relationId: s
     } finally {
       setSending(false);
     }
+  };
+
+  const react = async (id: string, emoji: string) => {
+    setReactId(null);
+    try {
+      const res = await fetch(`/api/messages/${id}/reactions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ emoji }),
+      });
+      if (res.ok) await load();
+    } catch { /* non-critical; ignore */ }
   };
 
   const startEdit = (m: Msg) => { setMenuId(null); setEditId(m.id); setEditBody(m.body); };
@@ -233,16 +250,55 @@ export default function ThreadPage({ params }: { params: Promise<{ relationId: s
                         </span>
                       )}
                       {!m.deleted && editId !== m.id && (
-                        <button
-                          type="button"
-                          onClick={() => setMenuId(menuId === m.id ? null : m.id)}
-                          aria-label={t.messages.messageActions}
-                          className={`ml-auto rounded p-0.5 ${mine ? 'hover:bg-blue-700' : 'hover:bg-gray-200'}`}
-                        >
-                          <MoreVertical className="h-3.5 w-3.5" />
-                        </button>
+                        <span className="ml-auto flex items-center gap-0.5">
+                          <button
+                            type="button"
+                            onClick={() => { setReactId(reactId === m.id ? null : m.id); setMenuId(null); }}
+                            aria-label={t.messages.react}
+                            className={`rounded p-0.5 ${mine ? 'hover:bg-blue-700' : 'hover:bg-gray-200'}`}
+                          >
+                            <SmilePlus className="h-3.5 w-3.5" />
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => { setMenuId(menuId === m.id ? null : m.id); setReactId(null); }}
+                            aria-label={t.messages.messageActions}
+                            className={`rounded p-0.5 ${mine ? 'hover:bg-blue-700' : 'hover:bg-gray-200'}`}
+                          >
+                            <MoreVertical className="h-3.5 w-3.5" />
+                          </button>
+                        </span>
                       )}
                     </p>
+
+                    {/* Emoji picker */}
+                    {reactId === m.id && !m.deleted && (
+                      <div className="mt-1.5 flex gap-1 rounded-lg bg-white/90 border border-black/5 px-1.5 py-1 w-fit">
+                        {REACTIONS.map((emoji) => (
+                          <button key={emoji} type="button" onClick={() => react(m.id, emoji)} className="text-base leading-none hover:scale-125 transition-transform" aria-label={emoji}>
+                            {emoji}
+                          </button>
+                        ))}
+                      </div>
+                    )}
+
+                    {/* Reaction chips */}
+                    {!m.deleted && m.reactions.length > 0 && (
+                      <div className="mt-1.5 flex flex-wrap gap-1">
+                        {m.reactions.map((r) => (
+                          <button
+                            key={r.emoji}
+                            type="button"
+                            onClick={() => react(m.id, r.emoji)}
+                            aria-pressed={r.mine}
+                            className={`inline-flex items-center gap-0.5 rounded-full px-1.5 py-0.5 text-xs border ${r.mine ? 'bg-blue-100 border-blue-300 text-blue-800' : 'bg-white/90 border-black/5 text-gray-700'}`}
+                          >
+                            <span>{r.emoji}</span>
+                            <span>{r.count}</span>
+                          </button>
+                        ))}
+                      </div>
+                    )}
                     {menuId === m.id && !m.deleted && editId !== m.id && (
                       <div className="mt-1.5 flex flex-wrap gap-1.5">
                         {mine && (

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -953,6 +953,7 @@ const en = {
     editFailed: 'Could not edit the message. Please try again.',
     deleteFailed: 'Could not delete the message. Please try again.',
     messageActions: 'Message actions',
+    react: 'React',
   },
   logInteraction: {
     add: 'Log interaction',
@@ -2418,6 +2419,7 @@ const tr: Dict = {
     editFailed: 'Mesaj düzenlenemedi. Lütfen tekrar deneyin.',
     deleteFailed: 'Mesaj silinemedi. Lütfen tekrar deneyin.',
     messageActions: 'Mesaj işlemleri',
+    react: 'Tepki ver',
   },
   logInteraction: {
     add: 'Etkileşim ekle',
@@ -3881,6 +3883,7 @@ const de: Dict = {
     editFailed: 'Nachricht konnte nicht bearbeitet werden. Bitte versuche es erneut.',
     deleteFailed: 'Nachricht konnte nicht gelöscht werden. Bitte versuche es erneut.',
     messageActions: 'Nachrichtenaktionen',
+    react: 'Reagieren',
   },
   logInteraction: {
     add: 'Interaktion erfassen',

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,15 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.19.0-beta',
+    date: '2026-07-21',
+    highlights: {
+      en: ['React to messages with emoji (👍 ❤️ 😂 😮 🎉) — tap the reaction button on any message and see reaction counts, just like WhatsApp or Slack.'],
+      tr: ['Mesajlara emoji ile tepki ver (👍 ❤️ 😂 😮 🎉) — herhangi bir mesajdaki tepki butonuna dokun, tepki sayılarını gör; tıpkı WhatsApp veya Slack gibi.'],
+      de: ['Reagiere auf Nachrichten mit Emojis (👍 ❤️ 😂 😮 🎉) — tippe bei einer Nachricht auf die Reaktionsschaltfläche und sieh die Reaktionszahlen, wie bei WhatsApp oder Slack.'],
+    },
+  },
+  {
     version: '0.18.0-beta',
     date: '2026-07-21',
     highlights: {


### PR DESCRIPTION
## Amaç
Mesajlara emoji ile hızlı tepki (👍 ❤️ 😂 😮 🎉) — story #663 (Epic #717 İletişim).

## Ne yapıldı
- **Şema:** yeni `MessageReaction { id, messageId, userId, emoji, createdAt }`, `@@unique([messageId, userId, emoji])` + `Message.reactions`. Additive `db push`; `prisma validate` ✅.
- **API:** `POST /api/messages/[id]/reactions` toggle (ekle/kaldır) — yalnızca thread katılımcıları (+admin), emoji sabit sete kısıtlı (zod enum); silinen mesaja tepki 409. `GET /api/messages` her mesaj için reaksiyon özeti döner (emoji → sayı + `mine`).
- **UI** (`messages/[relationId]/page.tsx`): mesaj başına reaksiyon çipleri (emoji + sayı, kendi tepkin vurgulu) + `SmilePlus` emoji seçici; çipe/emojiye tıklayınca toggle. i18n EN/TR/DE (`messages.react`).

## Kabul kriterleri
- [x] Reaksiyon eklenip kaldırılabiliyor; herkes özet sayıları görüyor.
- [x] Yalnızca katılımcılar (+admin) tepki verebiliyor (sunucu doğrulaması).
- [x] `prisma validate` + `npm run build` + `check:i18n` (1457) geçiyor.
- [x] Sürüm 0.19.0-beta + CHANGELOG + releaseNotes (EN/TR/DE).

Closes #665

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ)_