### PR TITLE
feat(messages): hourly unread-message email digest (closes #667)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-07-21
+
+### Added
+- **Unread-message email digest (closes #667)** — an hourly cron
+  (`sendUnreadMessageDigests`) gathers messages left unread for over an hour,
+  groups them per recipient, and sends **one** summary email (sender + preview +
+  "Open" link) instead of nagging per message. Idempotent via a new
+  `Message.digestedAt` flag (a message is never digested twice), and it respects
+  each recipient's email opt-out (`emailAllowed(user, 'messages')`). The instant
+  in-app notification is unchanged; this is an additive "still unread" reminder.
+  Completes the WhatsApp-like messaging story (#663) under the Communication
+  epic (#717).
+
 ## [0.19.0] - 2026-07-21
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.19.0-beta",
+  "version": "0.20.0-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -296,6 +296,9 @@ model Message {
   channel              MessageChannel @default(IN_APP)
   readAt               DateTime?
   createdAt            DateTime       @default(now())
+  // Set once this message has been included in an unread-digest email so the
+  // hourly digest cron never re-sends the same message (#667).
+  digestedAt           DateTime?
   // Set when the sender edits the message (shows an "(edited)" label).
   editedAt             DateTime?
   // Set when the sender (or an admin) deletes the message for everyone; the body

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,15 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.20.0-beta',
+    date: '2026-07-21',
+    highlights: {
+      en: ['If you miss messages, you now get a single hourly “unread messages” email summary instead of one email per message — and only if you haven’t opted out.'],
+      tr: ['Mesajları kaçırırsan, artık her mesaj için ayrı e-posta yerine saatte bir tek “okunmamış mesajlar” özeti alıyorsun — ve yalnızca kapatmadıysan.'],
+      de: ['Wenn du Nachrichten verpasst, erhältst du jetzt eine einzige stündliche „ungelesene Nachrichten“-Zusammenfassung statt einer E-Mail pro Nachricht — und nur, wenn du es nicht deaktiviert hast.'],
+    },
+  },
+  {
     version: '0.19.0-beta',
     date: '2026-07-21',
     highlights: {

--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -785,6 +785,75 @@ export async function sendWeeklyAnalyticsReport() {
   return { locked: false, sent };
 }
 
+// Unread-message digest (#667): once an hour, gather messages that have been
+// unread for over UNREAD_DIGEST_AFTER_MIN minutes and not yet digested, group by
+// recipient, and send ONE summary email (opt-in). Complements the instant in-app
+// notification without spamming per message. Idempotent via Message.digestedAt,
+// so a message is never included in more than one digest.
+const UNREAD_DIGEST_AFTER_MIN = 60;
+
+export async function sendUnreadMessageDigests() {
+  const now = new Date();
+  const cutoff = new Date(now.getTime() - UNREAD_DIGEST_AFTER_MIN * 60 * 1000);
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+
+  const userSelect = { id: true, fullName: true, email: true, emailNotifications: true, notificationPrefs: true } as const;
+  const msgs = await prisma.message.findMany({
+    where: { readAt: null, digestedAt: null, deletedForEveryoneAt: null, createdAt: { lt: cutoff } },
+    orderBy: { createdAt: 'asc' },
+    include: {
+      relation: { include: { mentor: { select: userSelect }, mentee: { select: userSelect } } },
+    },
+  });
+
+  // Group unread messages by recipient (the participant who is NOT the sender).
+  type Recipient = (typeof msgs)[number]['relation']['mentor'];
+  const byRecipient = new Map<string, { recipient: Recipient; items: { relationId: string; from: string; preview: string }[] }>();
+  const allIds: string[] = [];
+  for (const m of msgs) {
+    allIds.push(m.id);
+    const rel = m.relation;
+    const recipient = m.senderId === rel.mentorId ? rel.mentee : rel.mentor;
+    const sender = m.senderId === rel.mentorId ? rel.mentor : rel.mentee;
+    if (!recipient?.email) continue;
+    const entry = byRecipient.get(recipient.id) ?? { recipient, items: [] };
+    entry.items.push({ relationId: rel.id, from: sender?.fullName ?? 'Someone', preview: m.body.slice(0, 120) });
+    byRecipient.set(recipient.id, entry);
+  }
+
+  let sent = 0;
+  for (const { recipient, items } of byRecipient.values()) {
+    if (!emailAllowed(recipient, 'messages')) continue;
+    const rows = items
+      .map((it) => {
+        const safe = it.preview.replace(/[<>&]/g, (c) => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;' }[c] as string));
+        return `<li style="margin-bottom:8px;"><strong>${it.from}:</strong> ${safe || '(attachment)'} — <a href="${appUrl}/messages/${it.relationId}">Open</a></li>`;
+      })
+      .join('');
+    try {
+      await sendEmail({
+        to: recipient.email!,
+        subject: `You have ${items.length} unread message${items.length === 1 ? '' : 's'}`,
+        html: `<div style="font-family: Arial, sans-serif; max-width: 680px; margin: 0 auto;">
+          <h2 style="color:#2563eb;">Unread messages</h2>
+          <p>Hi ${recipient.fullName}, you have ${items.length} unread message${items.length === 1 ? '' : 's'} waiting:</p>
+          <ul style="padding-left:18px;">${rows}</ul>
+        </div>`,
+      });
+      sent++;
+    } catch (e) {
+      console.error('Unread message digest failed:', e);
+    }
+  }
+
+  // Mark every considered message as digested (even for opted-out recipients) so
+  // the cron never reprocesses them.
+  if (allIds.length) {
+    await prisma.message.updateMany({ where: { id: { in: allIds } }, data: { digestedAt: now } });
+  }
+  return { sent, considered: allIds.length };
+}
+
 const scheduledTasks = new Map<string, ReturnType<typeof cron.schedule>>();
 
 export function initCronJobs() {
@@ -853,6 +922,17 @@ export function initCronJobs() {
     }
   });
   scheduledTasks.set('activity-digest', activityTask);
+
+  // Unread-message digest — hourly at :20 (offset from the other hourly jobs).
+  const unreadDigestTask = cron.schedule('20 * * * *', async () => {
+    try {
+      const r = await sendUnreadMessageDigests();
+      if (r.sent) console.log(`[Cron] Unread message digests sent: ${r.sent}`);
+    } catch (e) {
+      console.error('[Cron] Unread message digest error:', e);
+    }
+  });
+  scheduledTasks.set('unread-message-digest', unreadDigestTask);
 
   console.log('[Cron] Scheduled jobs initialized');
 }


### PR DESCRIPTION
## Amaç
Okunmayan mesajları biriktirip **tek toplu e-posta** ile iletmek (per-mesaj spam yerine) — story #663'ün son task'ı, Epic #717 İletişim.

## Ne yapıldı
- **`sendUnreadMessageDigests()`** (emailService): `readAt=null`, `digestedAt=null`, `createdAt` 1 saatten eski mesajları alıcı-bazlı gruplar, opt-in olanlara **tek** özet e-posta gönderir (gönderen + önizleme + "Open" linki).
- **İdempotent:** yeni `Message.digestedAt` flag'i — bir mesaj birden fazla digest'e girmez (opt-out edenlerinki de "considered" olarak işaretlenir, tekrar işlenmez). Additive `db push`; `prisma validate` ✅.
- **Cron:** `initCronJobs`'a saatlik (:20) iş eklendi (diğer saatlik işlerden offset'li).
- **Opt-out'a saygı:** `emailAllowed(user, 'messages')`. Anlık in-app bildirim değişmedi — bu ek bir "hâlâ okunmadı" hatırlatması (davranış değişikliği/e2e riski yok).

## Kabul kriterleri
- [x] X süre okunmayan mesajlar tek toplu e-postayla iletiliyor.
- [x] Aynı mesaj tekrar gönderilmiyor (`digestedAt`).
- [x] Opt-out edene gönderilmiyor.
- [x] `prisma validate` + `npm run build` geçiyor.
- [x] Sürüm 0.20.0-beta + CHANGELOG + releaseNotes (EN/TR/DE).

Closes #667

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ)_