### PR TITLE
feat(messages): per-user "Enter to send" toggle in the composer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-07-21
+
+### Added
+- **"Enter to send" toggle in the message composer** — a small per-user switch
+  under the reply box lets you choose how Enter behaves. When on, **Enter sends**
+  and **Shift+Enter** inserts a new line; when off (the default), **Enter** inserts
+  a new line and **Shift+Enter** sends. The choice is remembered per device
+  (`localStorage`). Handles IME composition (won't send mid-composition).
+
 ## [0.20.0] - 2026-07-21
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.20.0-beta",
+  "version": "0.21.0-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/app/messages/[relationId]/page.tsx
+++ b/src/app/messages/[relationId]/page.tsx
@@ -54,8 +54,35 @@ export default function ThreadPage({ params }: { params: Promise<{ relationId: s
   const [editId, setEditId] = useState<string | null>(null);
   const [editBody, setEditBody] = useState('');
   const [rowBusy, setRowBusy] = useState(false);
+  // Per-user (per-device) composer preference: when on, Enter sends and
+  // Shift+Enter inserts a newline; when off (default), Enter is a newline and
+  // Shift+Enter sends. Persisted in localStorage so it sticks for this user.
+  const [enterToSend, setEnterToSend] = useState(false);
   const endRef = useRef<HTMLDivElement>(null);
   const fileRef = useRef<HTMLInputElement>(null);
+
+  // Load the saved Enter-to-send preference once on mount.
+  useEffect(() => {
+    setEnterToSend(localStorage.getItem('messages-enter-to-send') === '1');
+  }, []);
+  const toggleEnterToSend = () => {
+    setEnterToSend((prev) => {
+      const next = !prev;
+      try { localStorage.setItem('messages-enter-to-send', next ? '1' : '0'); } catch { /* ignore */ }
+      return next;
+    });
+  };
+
+  // Enter/Shift+Enter behaviour depends on the preference above.
+  const onComposerKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key !== 'Enter' || e.nativeEvent.isComposing) return;
+    const shouldSend = enterToSend ? !e.shiftKey : e.shiftKey;
+    if (shouldSend) {
+      e.preventDefault();
+      if (!sending) void send();
+    }
+    // otherwise let the textarea insert a newline (default behaviour)
+  };
 
   const load = useCallback(async () => {
     const res = await fetch(`/api/messages?relationId=${relationId}`);
@@ -96,8 +123,8 @@ export default function ThreadPage({ params }: { params: Promise<{ relationId: s
     if (imgs.length) { e.preventDefault(); addFiles(imgs); }
   };
 
-  const send = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const send = async (e?: React.FormEvent) => {
+    e?.preventDefault();
     if (!body.trim() && attachments.length === 0) return;
     setSending(true);
     setAttachError('');
@@ -369,12 +396,28 @@ export default function ThreadPage({ params }: { params: Promise<{ relationId: s
           value={body}
           onChange={(e) => setBody(e.target.value)}
           onPaste={onPaste}
+          onKeyDown={onComposerKeyDown}
           rows={2}
           placeholder={t.messages.replyPlaceholder}
           className="flex-1 rounded-lg border border-gray-300 px-3.5 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-100 focus:border-blue-400 resize-none"
         />
         <Button type="submit" loading={sending} disabled={!body.trim() && attachments.length === 0}>{t.messages.send}</Button>
       </form>
+      <div className="mt-1.5 flex justify-end">
+        <button
+          type="button"
+          role="switch"
+          aria-checked={enterToSend}
+          onClick={toggleEnterToSend}
+          title={enterToSend ? t.messages.enterToSendOnHint : t.messages.enterToSendOffHint}
+          className="inline-flex items-center gap-1.5 text-xs text-gray-500 hover:text-gray-700"
+        >
+          <span className={`relative inline-block h-4 w-7 rounded-full transition-colors ${enterToSend ? 'bg-blue-600' : 'bg-gray-300'}`}>
+            <span className={`absolute top-0.5 h-3 w-3 rounded-full bg-white transition-transform ${enterToSend ? 'translate-x-[15px]' : 'translate-x-0.5'}`} />
+          </span>
+          {t.messages.enterToSend}
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -954,6 +954,9 @@ const en = {
     deleteFailed: 'Could not delete the message. Please try again.',
     messageActions: 'Message actions',
     react: 'React',
+    enterToSend: 'Enter to send',
+    enterToSendOnHint: 'Enter sends · Shift+Enter adds a new line',
+    enterToSendOffHint: 'Enter adds a new line · Shift+Enter sends',
   },
   logInteraction: {
     add: 'Log interaction',
@@ -2420,6 +2423,9 @@ const tr: Dict = {
     deleteFailed: 'Mesaj silinemedi. Lütfen tekrar deneyin.',
     messageActions: 'Mesaj işlemleri',
     react: 'Tepki ver',
+    enterToSend: 'Enter ile gönder',
+    enterToSendOnHint: 'Enter gönderir · Shift+Enter alt satıra geçer',
+    enterToSendOffHint: 'Enter alt satıra geçer · Shift+Enter gönderir',
   },
   logInteraction: {
     add: 'Etkileşim ekle',
@@ -3884,6 +3890,9 @@ const de: Dict = {
     deleteFailed: 'Nachricht konnte nicht gelöscht werden. Bitte versuche es erneut.',
     messageActions: 'Nachrichtenaktionen',
     react: 'Reagieren',
+    enterToSend: 'Mit Enter senden',
+    enterToSendOnHint: 'Enter sendet · Umschalt+Enter fügt eine neue Zeile ein',
+    enterToSendOffHint: 'Enter fügt eine neue Zeile ein · Umschalt+Enter sendet',
   },
   logInteraction: {
     add: 'Interaktion erfassen',

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,15 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.21.0-beta',
+    date: '2026-07-21',
+    highlights: {
+      en: ['New “Enter to send” toggle in the message box — turn it on to send with Enter (Shift+Enter for a new line), or leave it off to send with Shift+Enter. Your choice is remembered.'],
+      tr: ['Mesaj kutusunda yeni “Enter ile gönder” anahtarı — açarsan Enter ile gönderirsin (Shift+Enter alt satır), kapalı bırakırsan Shift+Enter ile gönderirsin. Tercihin hatırlanır.'],
+      de: ['Neuer Schalter „Mit Enter senden“ im Nachrichtenfeld — aktiviert sendest du mit Enter (Umschalt+Enter für neue Zeile), deaktiviert sendest du mit Umschalt+Enter. Deine Wahl wird gemerkt.'],
+    },
+  },
+  {
     version: '0.20.0-beta',
     date: '2026-07-21',
     highlights: {


### PR DESCRIPTION
## Amaç
Mesaj kutusuna, Enter davranışını seçtiren küçük bir **kullanıcıya özel aç/kapa** anahtarı.

## Davranış
- **Açık:** Enter **gönderir**, Shift+Enter alt satıra geçer.
- **Kapalı (varsayılan):** Enter alt satıra geçer, Shift+Enter **gönderir**.
- Tercih cihaz bazında `localStorage`'da saklanır (`messages-enter-to-send`), o kullanıcı için kalıcı.
- IME/derleme (isComposing) sırasında Enter göndermez (Türkçe/CJK klavye güvenliği).

## Ne yapıldı (`messages/[relationId]/page.tsx`)
- `enterToSend` state + localStorage yükle/kaydet; `send()` opsiyonel event alacak şekilde uyarlandı.
- Textarea'ya `onKeyDown` — tercihe göre Enter/Shift+Enter gönder/satır.
- Reply kutusunun altında küçük switch (role="switch", `aria-checked`, ipucu title'ı). i18n EN/TR/DE.

## Kabul
- [x] Enter/Shift+Enter tercihe göre çalışıyor; varsayılan = Enter satır, Shift+Enter gönder.
- [x] Tercih kalıcı (localStorage).
- [x] `npm run build` + `check:i18n` (1460) geçiyor.
- [x] Sürüm 0.21.0-beta + CHANGELOG + releaseNotes (EN/TR/DE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ)_