### PR TITLE
feat(white-label): apply tenant brand name + logo to app chrome (#546 / #522)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-07-21
+
+### Added
+- **White-label chrome — tenant brand applied to the live app (part of #546 /
+  story #522).** The app wordmark (sidebar header + mobile top bar across the
+  admin/mentor/portal/company/source shells) now renders the signed-in user's
+  **organization brand name and logo** instead of the hardcoded "Internship CRM".
+  A new self-resolving `BrandWordmark` server component reads the org branding
+  (`getOrgBranding`) and falls back to the product default when the org has no
+  branding or there's no org, so single-tenant chrome is unchanged. Branding is
+  managed at `/admin/organizations` (already shipped). Follow-ups tracked
+  separately: applying `brandColor` to the accent palette, per-recipient email
+  branding, and custom pipeline stages (#546 remainder).
+
 ## [0.21.0] - 2026-07-21
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.21.0-beta",
+  "version": "0.22.0-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -3,10 +3,10 @@ import { authOptions } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import { BetaBadge } from '@/components/BetaBadge';
 import { AccountMenu } from '@/components/AccountMenu';
-import { GraduationCap } from 'lucide-react';
 import { getServerDictionary } from '@/i18n/server';
 import { APP_VERSION } from '@/lib/version';
 import { ResponsiveShell } from '@/components/ResponsiveShell';
+import { BrandWordmark } from '@/components/BrandWordmark';
 import { AdminNav } from '@/components/AdminNav';
 import { GlobalSearch } from '@/components/GlobalSearch';
 import { prisma } from '@/lib/prisma';
@@ -35,13 +35,13 @@ export default async function AdminLayout({ children }: { children: React.ReactN
 
   return (
     <ResponsiveShell
+      brand={<BrandWordmark />}
       headerExtra={<GlobalSearch />}
       sidebar={
         <aside className="w-64 h-full bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-800 flex flex-col">
         <div className="p-6 border-b border-gray-200">
           <div className="flex items-center gap-2">
-            <GraduationCap className="h-7 w-7 text-blue-600" />
-            <span className="font-bold text-gray-900">InternshipCRM</span>
+            <BrandWordmark />
             <BetaBadge />
           </div>
           <p className="text-xs text-gray-500 mt-1">{t.panel.admin}</p>

--- a/src/app/company/layout.tsx
+++ b/src/app/company/layout.tsx
@@ -4,10 +4,11 @@ import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import { BetaBadge } from '@/components/BetaBadge';
 import { AccountMenu } from '@/components/AccountMenu';
-import { GraduationCap, LayoutDashboard, Sparkles } from 'lucide-react';
+import { LayoutDashboard, Sparkles } from 'lucide-react';
 import { getServerDictionary } from '@/i18n/server';
 import { APP_VERSION } from '@/lib/version';
 import { ResponsiveShell } from '@/components/ResponsiveShell';
+import { BrandWordmark } from '@/components/BrandWordmark';
 import { InstallAppButton } from '@/components/InstallAppButton';
 import { prisma } from '@/lib/prisma';
 import { hasFeature } from '@/lib/entitlements';
@@ -26,12 +27,12 @@ export default async function CompanyLayout({ children }: { children: React.Reac
 
   return (
     <ResponsiveShell
+      brand={<BrandWordmark />}
       sidebar={
         <aside className="w-64 h-full bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-800 flex flex-col">
           <div className="p-6 border-b border-gray-200">
             <div className="flex items-center gap-2">
-              <GraduationCap className="h-7 w-7 text-blue-600" />
-              <span className="font-bold text-gray-900">InternshipCRM</span>
+              <BrandWordmark />
               <BetaBadge />
             </div>
             <p className="text-xs text-gray-500 mt-1">{t.panel.company}</p>

--- a/src/app/mentor/layout.tsx
+++ b/src/app/mentor/layout.tsx
@@ -4,10 +4,11 @@ import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import { BetaBadge } from '@/components/BetaBadge';
 import { AccountMenu } from '@/components/AccountMenu';
-import { GraduationCap, LayoutDashboard, Columns3, Users, BookOpen, Mail, CalendarClock, CalendarRange, CalendarDays, FolderGit2, Activity } from 'lucide-react';
+import { LayoutDashboard, Columns3, Users, BookOpen, Mail, CalendarClock, CalendarRange, CalendarDays, FolderGit2, Activity } from 'lucide-react';
 import { getServerDictionary } from '@/i18n/server';
 import { APP_VERSION } from '@/lib/version';
 import { ResponsiveShell } from '@/components/ResponsiveShell';
+import { BrandWordmark } from '@/components/BrandWordmark';
 import { InstallAppButton } from '@/components/InstallAppButton';
 import { prisma } from '@/lib/prisma';
 import { is2faRequiredFor } from '@/lib/twoFactorPolicy';
@@ -34,12 +35,12 @@ export default async function MentorLayout({ children }: { children: React.React
 
   return (
     <ResponsiveShell
+      brand={<BrandWordmark />}
       sidebar={
         <aside className="w-64 h-full bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-800 flex flex-col">
         <div className="p-6 border-b border-gray-200">
           <div className="flex items-center gap-2">
-            <GraduationCap className="h-7 w-7 text-blue-600" />
-            <span className="font-bold text-gray-900">InternshipCRM</span>
+            <BrandWordmark />
             <BetaBadge />
           </div>
           <p className="text-xs text-gray-500 mt-1">{t.panel.mentor}</p>

--- a/src/app/portal/layout.tsx
+++ b/src/app/portal/layout.tsx
@@ -3,11 +3,11 @@ import { authOptions } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import { BetaBadge } from '@/components/BetaBadge';
 import { AccountMenu } from '@/components/AccountMenu';
-import { GraduationCap } from 'lucide-react';
 import { getServerDictionary } from '@/i18n/server';
 import { PortalNav } from '@/components/PortalNav';
 import { APP_VERSION } from '@/lib/version';
 import { ResponsiveShell } from '@/components/ResponsiveShell';
+import { BrandWordmark } from '@/components/BrandWordmark';
 import { InstallAppButton } from '@/components/InstallAppButton';
 import { prisma } from '@/lib/prisma';
 
@@ -35,12 +35,12 @@ export default async function PortalLayout({ children }: { children: React.React
 
   return (
     <ResponsiveShell
+      brand={<BrandWordmark />}
       sidebar={
         <aside className="w-64 h-full bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-800 flex flex-col">
         <div className="p-6 border-b border-gray-200">
           <div className="flex items-center gap-2">
-            <GraduationCap className="h-7 w-7 text-blue-600" />
-            <span className="font-bold text-gray-900">InternshipCRM</span>
+            <BrandWordmark />
             <BetaBadge />
           </div>
           <p className="text-xs text-gray-500 mt-1">{t.panel.mentee}</p>

--- a/src/app/source/layout.tsx
+++ b/src/app/source/layout.tsx
@@ -4,10 +4,11 @@ import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import { BetaBadge } from '@/components/BetaBadge';
 import { AccountMenu } from '@/components/AccountMenu';
-import { GraduationCap, LayoutDashboard } from 'lucide-react';
+import { LayoutDashboard } from 'lucide-react';
 import { getServerDictionary } from '@/i18n/server';
 import { APP_VERSION } from '@/lib/version';
 import { ResponsiveShell } from '@/components/ResponsiveShell';
+import { BrandWordmark } from '@/components/BrandWordmark';
 import { InstallAppButton } from '@/components/InstallAppButton';
 import { prisma } from '@/lib/prisma';
 
@@ -22,12 +23,12 @@ export default async function SourceLayout({ children }: { children: React.React
 
   return (
     <ResponsiveShell
+      brand={<BrandWordmark />}
       sidebar={
         <aside className="w-64 h-full bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-800 flex flex-col">
           <div className="p-6 border-b border-gray-200">
             <div className="flex items-center gap-2">
-              <GraduationCap className="h-7 w-7 text-blue-600" />
-              <span className="font-bold text-gray-900">InternshipCRM</span>
+              <BrandWordmark />
               <BetaBadge />
             </div>
             <p className="text-xs text-gray-500 mt-1">{t.panel.source}</p>

--- a/src/components/BrandWordmark.tsx
+++ b/src/components/BrandWordmark.tsx
@@ -1,0 +1,25 @@
+import { getServerSession } from 'next-auth';
+import { GraduationCap } from 'lucide-react';
+import { authOptions } from '@/lib/auth';
+import { getOrgBranding } from '@/lib/orgBranding';
+
+// White-label app wordmark (#546): shows the signed-in user's tenant brand — its
+// logo (if set) or the default graduation-cap icon, plus the brand name. Falls
+// back to the product default ("Internship CRM") when the org has no branding or
+// there's no org, so single-tenant chrome is unchanged. Self-resolving server
+// component so layouts can drop it in with no prop threading.
+export async function BrandWordmark({ className }: { className?: string }) {
+  const session = await getServerSession(authOptions);
+  const brand = await getOrgBranding(session?.user?.orgId);
+  return (
+    <span className={`flex items-center gap-2 ${className ?? ''}`}>
+      {brand.logoUrl ? (
+        // eslint-disable-next-line @next/next/no-img-element -- tenant logo is an arbitrary external/stored URL
+        <img src={brand.logoUrl} alt={brand.name} className="h-7 w-auto max-w-[150px] object-contain" />
+      ) : (
+        <GraduationCap className="h-7 w-7 text-blue-600" />
+      )}
+      <span className="font-bold text-gray-900 dark:text-gray-100">{brand.name}</span>
+    </span>
+  );
+}

--- a/src/components/ResponsiveShell.tsx
+++ b/src/components/ResponsiveShell.tsx
@@ -14,10 +14,14 @@ export function ResponsiveShell({
   sidebar,
   children,
   headerExtra,
+  brand,
 }: {
   sidebar: React.ReactNode;
   children: React.ReactNode;
   headerExtra?: React.ReactNode;
+  // White-label wordmark for the mobile top bar (#546); falls back to the
+  // product name when not provided.
+  brand?: React.ReactNode;
 }) {
   const [open, setOpen] = useState(false);
 
@@ -25,7 +29,7 @@ export function ResponsiveShell({
     <div className="min-h-screen bg-gray-50 dark:bg-gray-950 lg:flex">
       {/* Mobile top bar */}
       <div className="lg:hidden sticky top-0 z-30 flex items-center justify-between bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-800 h-14 px-4">
-        <span className="font-bold text-gray-900 dark:text-gray-100">InternshipCRM</span>
+        {brand ?? <span className="font-bold text-gray-900 dark:text-gray-100">InternshipCRM</span>}
         <BetaBadge className="ml-2" />
         <div className="flex items-center gap-1">
           <MessagesButton />

--- a/src/lib/orgBranding.ts
+++ b/src/lib/orgBranding.ts
@@ -1,0 +1,14 @@
+import { prisma } from '@/lib/prisma';
+import { resolveBranding, type ResolvedBranding } from '@/lib/branding';
+
+// Server-side: resolve a tenant's white-label branding (#546) for the given org,
+// falling back to the product defaults when the org has no overrides (or no org
+// — single-tenant / not signed in). Cheap single-row lookup.
+export async function getOrgBranding(orgId: string | null | undefined): Promise<ResolvedBranding> {
+  if (!orgId) return resolveBranding(null);
+  const org = await prisma.organization.findUnique({
+    where: { id: orgId },
+    select: { brandName: true, brandLogoUrl: true, brandColor: true, supportEmail: true },
+  });
+  return resolveBranding(org);
+}

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,15 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.22.0-beta',
+    date: '2026-07-21',
+    highlights: {
+      en: ['White-label: an organization’s own brand name and logo now appear in the app’s sidebar and top bar (set them under Admin → Organizations).'],
+      tr: ['White-label: bir organizasyonun kendi marka adı ve logosu artık uygulamanın kenar çubuğunda ve üst barında görünüyor (Admin → Organizasyonlar’dan ayarla).'],
+      de: ['White-Label: Der eigene Markenname und das Logo einer Organisation erscheinen jetzt in der Seitenleiste und der obersten Leiste der App (unter Admin → Organisationen einstellbar).'],
+    },
+  },
+  {
     version: '0.21.0-beta',
     date: '2026-07-21',
     highlights: {


### PR DESCRIPTION
## Amaç
Story #522 (Faz-3 MT) → #546 white-label'ın **canlı uygulaması**: tenant'ın marka adı + logosu artık uygulama chrome'unda görünüyor (bugüne kadar yönetiliyordu ama uygulanmıyordu).

## Ne yapıldı
- **`src/components/BrandWordmark.tsx`** (yeni, self-resolving server component): oturumdaki kullanıcının org branding'ini (`getOrgBranding`) çözer; logo varsa logoyu, yoksa varsayılan `GraduationCap` ikonunu + marka adını render eder.
- **`src/lib/orgBranding.ts`** (yeni): `getOrgBranding(orgId)` → org yoksa/branding null'sa `resolveBranding(null)` (ürün varsayılanı).
- **5 rol layout'u** (admin/mentor/portal/company/source): sidebar header'daki sabit `GraduationCap + "InternshipCRM"` → `<BrandWordmark />`.
- **`ResponsiveShell`**: mobil üst bara `brand` prop'u; her layout `brand={<BrandWordmark />}` geçiyor.

**Prod-güvenli:** default org branding null → `resolveBranding` varsayılana düşer → tek-kiracı chrome hiç değişmez. Branding zaten `/admin/organizations`'tan yönetiliyor.

## Kapsam dışı (ayrı follow-up)
- `brandColor` → accent paleti eşlemesi (arbitrary hex → palet üretimi).
- Per-recipient e-posta branding'i (e-postalar hâlâ `MAIL_FROM_NAME` env ile brandlenebiliyor).
- Özel pipeline aşamaları (#546'nın en ağır parçası — audit "ayrı alt-issue" öneriyor).

## Kabul
- [x] Org marka adı/logosu chrome'da görünüyor; null'da varsayılan.
- [x] `npm run build` geçiyor.
- [x] Sürüm 0.22.0-beta + CHANGELOG + releaseNotes (EN/TR/DE).

Refs #546, #522

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ)_