### PR TITLE
fix(messages): composer toggle overlap + paste hint + ArrowUp edits last message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [Unreleased]
 
+## [0.23.1] - 2026-07-22
+
+### Fixed
+- **"Enter to send" toggle knob overlapped the label** — the switch knob's travel
+  overshot the track and clipped the first letter of the label when on; the knob
+  now stays within the track (`translate-x-3`, `shrink-0`).
+
+### Added
+- **Composer hint + edit-last shortcut** — a small hint under the reply box notes
+  you can paste an image and that **↑ (ArrowUp)** on an empty box edits your last
+  message (WhatsApp/Slack/Telegram style).
+
 ## [0.23.0] - 2026-07-22
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.23.0-beta",
+  "version": "0.23.1-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/app/messages/[relationId]/page.tsx
+++ b/src/app/messages/[relationId]/page.tsx
@@ -73,9 +73,22 @@ export default function ThreadPage({ params }: { params: Promise<{ relationId: s
     });
   };
 
-  // Enter/Shift+Enter behaviour depends on the preference above.
+  // Enter/Shift+Enter behaviour depends on the preference above; ArrowUp on an
+  // empty box edits your last message (WhatsApp/Slack/Telegram style).
   const onComposerKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key !== 'Enter' || e.nativeEvent.isComposing) return;
+    if (e.nativeEvent.isComposing) return;
+    if (e.key === 'ArrowUp' && !body && editId === null) {
+      const lastMine = [...messages].reverse().find((m) => m.senderId === myId && !m.deleted);
+      if (lastMine) {
+        e.preventDefault();
+        setMenuId(null);
+        setReactId(null);
+        setEditId(lastMine.id);
+        setEditBody(lastMine.body);
+      }
+      return;
+    }
+    if (e.key !== 'Enter') return;
     const shouldSend = enterToSend ? !e.shiftKey : e.shiftKey;
     if (shouldSend) {
       e.preventDefault();
@@ -403,17 +416,18 @@ export default function ThreadPage({ params }: { params: Promise<{ relationId: s
         />
         <Button type="submit" loading={sending} disabled={!body.trim() && attachments.length === 0}>{t.messages.send}</Button>
       </form>
-      <div className="mt-1.5 flex justify-end">
+      <div className="mt-1.5 flex items-center justify-between gap-3">
+        <span className="text-xs text-gray-400 truncate">{t.messages.pasteHint}</span>
         <button
           type="button"
           role="switch"
           aria-checked={enterToSend}
           onClick={toggleEnterToSend}
           title={enterToSend ? t.messages.enterToSendOnHint : t.messages.enterToSendOffHint}
-          className="inline-flex items-center gap-1.5 text-xs text-gray-500 hover:text-gray-700"
+          className="inline-flex items-center gap-1.5 text-xs text-gray-500 hover:text-gray-700 shrink-0"
         >
-          <span className={`relative inline-block h-4 w-7 rounded-full transition-colors ${enterToSend ? 'bg-blue-600' : 'bg-gray-300'}`}>
-            <span className={`absolute top-0.5 h-3 w-3 rounded-full bg-white transition-transform ${enterToSend ? 'translate-x-[15px]' : 'translate-x-0.5'}`} />
+          <span className={`relative inline-block h-4 w-7 shrink-0 rounded-full transition-colors ${enterToSend ? 'bg-blue-600' : 'bg-gray-300'}`}>
+            <span className={`absolute top-0.5 left-0.5 h-3 w-3 rounded-full bg-white transition-transform ${enterToSend ? 'translate-x-3' : 'translate-x-0'}`} />
           </span>
           {t.messages.enterToSend}
         </button>

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -957,6 +957,7 @@ const en = {
     enterToSend: 'Enter to send',
     enterToSendOnHint: 'Enter sends · Shift+Enter adds a new line',
     enterToSendOffHint: 'Enter adds a new line · Shift+Enter sends',
+    pasteHint: 'Tip: you can paste an image, and ↑ edits your last message',
   },
   logInteraction: {
     add: 'Log interaction',
@@ -2426,6 +2427,7 @@ const tr: Dict = {
     enterToSend: 'Enter ile gönder',
     enterToSendOnHint: 'Enter gönderir · Shift+Enter alt satıra geçer',
     enterToSendOffHint: 'Enter alt satıra geçer · Shift+Enter gönderir',
+    pasteHint: 'İpucu: resim yapıştırabilirsin, ↑ ile son mesajını düzenlersin',
   },
   logInteraction: {
     add: 'Etkileşim ekle',
@@ -3893,6 +3895,7 @@ const de: Dict = {
     enterToSend: 'Mit Enter senden',
     enterToSendOnHint: 'Enter sendet · Umschalt+Enter fügt eine neue Zeile ein',
     enterToSendOffHint: 'Enter fügt eine neue Zeile ein · Umschalt+Enter sendet',
+    pasteHint: 'Tipp: Du kannst ein Bild einfügen, ↑ bearbeitet deine letzte Nachricht',
   },
   logInteraction: {
     add: 'Interaktion erfassen',

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,15 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.23.1-beta',
+    date: '2026-07-22',
+    highlights: {
+      en: ['Message box polish: fixed the “Enter to send” switch overlapping its label, and pressing ↑ on an empty box now edits your last message.'],
+      tr: ['Mesaj kutusu rötuşu: “Enter ile gönder” anahtarının etiketle çakışması düzeltildi; boş kutuda ↑ tuşuna basınca son mesajını düzenliyorsun.'],
+      de: ['Feinschliff im Nachrichtenfeld: Der Schalter „Mit Enter senden“ überlappt sein Label nicht mehr, und ↑ im leeren Feld bearbeitet jetzt deine letzte Nachricht.'],
+    },
+  },
+  {
     version: '0.23.0-beta',
     date: '2026-07-22',
     highlights: {


### PR DESCRIPTION
Composer polish based on feedback on the new "Enter to send" toggle:

- **Görsel bug düzeltildi:** "Enter ile gönder" switch knob'u track'i aşıp etiketin ilk harfini kırpıyordu → knob artık track içinde (`translate-x-3`, `shrink-0`).
- **İpucu eklendi:** reply kutusunun altında küçük metin — resim yapıştırılabileceği + **↑ ile son mesajı düzenle**.
- **↑ (ArrowUp) kısayolu:** boş reply kutusunda yukarı-ok'a basınca son (silinmemiş, kendi) mesajın edit moduna giriyor (WhatsApp/Slack/Telegram tarzı). IME derlemesinde tetiklenmez.

- [x] `npm run build` + `check:i18n` (1461) geçiyor.
- [x] Sürüm 0.22.1-beta + CHANGELOG + releaseNotes (EN/TR/DE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ)_