### PR TITLE
#681 Fix admin dashboard quick actions i18n

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -253,7 +253,7 @@ export default async function AdminDashboard() {
           <Card className="hover:border-blue-200 hover:shadow-md transition-all cursor-pointer">
             <div className="flex items-center gap-3">
               <Building2 className="h-5 w-5 text-blue-600" />
-              <span className="font-medium text-gray-700">Manage Companies</span>
+              <span className="font-medium text-gray-700">{t.dashboard.quickActions.manageCompanies}</span>
             </div>
           </Card>
         </Link>
@@ -261,7 +261,7 @@ export default async function AdminDashboard() {
           <Card className="hover:border-blue-200 hover:shadow-md transition-all cursor-pointer">
             <div className="flex items-center gap-3">
               <Users className="h-5 w-5 text-blue-600" />
-              <span className="font-medium text-gray-700">Browse Candidates</span>
+              <span className="font-medium text-gray-700">{t.dashboard.quickActions.browseCandidates}</span>
             </div>
           </Card>
         </Link>
@@ -269,7 +269,7 @@ export default async function AdminDashboard() {
           <Card className="hover:border-blue-200 hover:shadow-md transition-all cursor-pointer">
             <div className="flex items-center gap-3">
               <Bell className="h-5 w-5 text-blue-600" />
-              <span className="font-medium text-gray-700">Send Invitations</span>
+              <span className="font-medium text-gray-700">{t.dashboard.quickActions.sendInvitations}</span>
             </div>
           </Card>
         </Link>

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -171,6 +171,11 @@ const en = {
     newCandidates: 'New Candidates',
     recentlyRegistered: 'Recently registered mentees',
     noCandidates: 'No candidates yet',
+    quickActions: {
+      manageCompanies: 'Manage Companies',
+      browseCandidates: 'Browse Candidates',
+      sendInvitations: 'Send Invitations',
+    },
   },
   candidates: {
     selectAll: 'Select all',
@@ -1640,6 +1645,11 @@ const tr: Dict = {
     newCandidates: 'Yeni Adaylar',
     recentlyRegistered: 'Yeni kaydolan mentee’ler',
     noCandidates: 'Henüz aday yok',
+    quickActions: {
+      manageCompanies: 'Şirketleri Yönet',
+      browseCandidates: 'Adayları Görüntüle',
+      sendInvitations: 'Davet Gönder',
+    },
   },
   candidates: {
     selectAll: 'Tümünü seç',
@@ -3107,6 +3117,11 @@ const de: Dict = {
     newCandidates: 'Neue Kandidaten',
     recentlyRegistered: 'Kürzlich registrierte Mentees',
     noCandidates: 'Noch keine Kandidaten',
+    quickActions: {
+      manageCompanies: 'Unternehmen verwalten',
+      browseCandidates: 'Bewerber anzeigen',
+      sendInvitations: 'Einladungen senden',
+    },
   },
   candidates: {
     selectAll: 'Alle auswählen',


### PR DESCRIPTION
## Summary

Replace the three hardcoded English quick-action labels on the admin dashboard with i18n translations.

Closes #681

## Changes

- Added English, Turkish, and German translation keys.
- Replaced hardcoded quick-action labels with i18n keys.
- Followed the existing project i18n implementation.

## Verification

- [x] `npm run check:i18n`
- [x] `npm run build`
- [x] Verified manually in English, Turkish, and German.