### PR TITLE
Tenant-branded transactional emails (#546)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,19 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [Unreleased]
 
-## [0.24.0] - 2026-07-22
+## [0.24.1] - 2026-07-22
+
+### Added
+- **Tenant-branded transactional emails (part of #546 / story #522).** The
+  account-lifecycle emails (invitation, password reset / set-initial, email
+  verification) now render the recipient organization's white-label brand — brand
+  name in the subject + From display name + heading, the org logo when set, and
+  the org accent color on the heading/button — resolved via `getOrgBranding`.
+  Callers that have the recipient's `orgId` (invite, forgot-password, admin
+  reset/company-user/source-user creation, apply, mentee creation, verification
+  resend) pass it through; when no org resolves it falls back to the product
+  defaults, so single-tenant emails are unchanged. `sendEmail` gained an optional
+  `fromName` override.
 
 ### Added
 - **Tenant isolation enforcement engine (part of #543 / story #522).** A single

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "internship-crm",
-  "version": "0.24.0-beta",
+  "version": "0.24.1-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "internship-crm",
-      "version": "0.24.0-beta",
+      "version": "0.24.1-beta",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.24.0-beta",
+  "version": "0.24.1-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/app/api/admin/company-users/route.ts
+++ b/src/app/api/admin/company-users/route.ts
@@ -39,7 +39,7 @@ export async function POST(request: Request) {
   const token = await createPasswordResetToken(user.id, 'SET_INITIAL');
   const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
   try {
-    await sendPasswordResetEmail({ to: user.email, token, fullName: user.fullName, purpose: 'SET_INITIAL' });
+    await sendPasswordResetEmail({ to: user.email, token, fullName: user.fullName, purpose: 'SET_INITIAL', orgId: user.orgId });
   } catch (e) {
     console.error('Company-user set-password email failed:', e);
   }

--- a/src/app/api/admin/source-users/route.ts
+++ b/src/app/api/admin/source-users/route.ts
@@ -38,7 +38,7 @@ export async function POST(request: Request) {
   const token = await createPasswordResetToken(user.id, 'SET_INITIAL');
   const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
   try {
-    await sendPasswordResetEmail({ to: user.email, token, fullName: user.fullName, purpose: 'SET_INITIAL' });
+    await sendPasswordResetEmail({ to: user.email, token, fullName: user.fullName, purpose: 'SET_INITIAL', orgId: user.orgId });
   } catch (e) {
     console.error('Source-user set-password email failed:', e);
   }

--- a/src/app/api/admin/users/[id]/reset-password/route.ts
+++ b/src/app/api/admin/users/[id]/reset-password/route.ts
@@ -24,7 +24,7 @@ export async function POST(_request: Request, { params }: { params: Promise<{ id
   const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
   const resetUrl = `${appUrl}/auth/reset?token=${token}`;
   try {
-    await sendPasswordResetEmail({ to: user.email, token, fullName: user.fullName });
+    await sendPasswordResetEmail({ to: user.email, token, fullName: user.fullName, orgId: user.orgId });
   } catch (e) {
     console.error('Admin reset email failed:', e);
   }

--- a/src/app/api/apply/route.ts
+++ b/src/app/api/apply/route.ts
@@ -84,7 +84,7 @@ export async function POST(request: Request) {
   // Let the applicant set a password so they can sign in to the portal.
   const token = await createPasswordResetToken(mentee.id, 'SET_INITIAL');
   try {
-    await sendPasswordResetEmail({ to: mentee.email, token, fullName: mentee.fullName, purpose: 'SET_INITIAL' });
+    await sendPasswordResetEmail({ to: mentee.email, token, fullName: mentee.fullName, purpose: 'SET_INITIAL', orgId: mentee.orgId });
   } catch (e) {
     console.error('Applicant set-password email failed:', e);
   }

--- a/src/app/api/auth/forgot/route.ts
+++ b/src/app/api/auth/forgot/route.ts
@@ -27,7 +27,7 @@ export async function POST(request: Request) {
     if (user) {
       const token = await createPasswordResetToken(user.id, 'RESET');
       try {
-        await sendPasswordResetEmail({ to: user.email, token, fullName: user.fullName });
+        await sendPasswordResetEmail({ to: user.email, token, fullName: user.fullName, orgId: user.orgId });
       } catch (e) {
         console.error('Password reset email failed:', e);
       }

--- a/src/app/api/auth/verify-email/resend/route.ts
+++ b/src/app/api/auth/verify-email/resend/route.ts
@@ -24,7 +24,7 @@ export async function POST(request: Request) {
 
     const token = await createEmailVerificationToken(user.id);
     try {
-      await sendVerificationEmail({ to: user.email, token, fullName: user.fullName });
+      await sendVerificationEmail({ to: user.email, token, fullName: user.fullName, orgId: user.orgId });
     } catch (e) {
       console.error('Resend verification email failed:', e);
       return NextResponse.json({ error: 'Could not send the verification email. Please try again shortly.' }, { status: 502 });
@@ -41,7 +41,7 @@ export async function POST(request: Request) {
   if (user && !user.emailVerified) {
     const token = await createEmailVerificationToken(user.id);
     try {
-      await sendVerificationEmail({ to: user.email, token, fullName: user.fullName });
+      await sendVerificationEmail({ to: user.email, token, fullName: user.fullName, orgId: user.orgId });
     } catch (e) {
       console.error('Resend verification email failed (public path):', e);
     }

--- a/src/app/api/invite/[id]/route.ts
+++ b/src/app/api/invite/[id]/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { sendInvitationEmail } from '@/services/emailService';
+import { resolveOrgId } from '@/lib/orgScope';
 
 // POST — resend an invitation. Re-emails the link; if the token has expired it
 // is extended by 7 days. Used (accepted) invitations cannot be resent.
@@ -24,7 +25,7 @@ export async function POST(_request: Request, { params }: { params: Promise<{ id
   const registerUrl = `${appUrl}/auth/register?token=${invite.token}`;
   let emailSent = false;
   try {
-    await sendInvitationEmail({ to: invite.email, token: invite.token, role: invite.role });
+    await sendInvitationEmail({ to: invite.email, token: invite.token, role: invite.role, orgId: resolveOrgId(session) });
     emailSent = !!process.env.SMTP_USER;
   } catch (e) {
     console.error('Resend invitation email failed (token still valid):', e);

--- a/src/app/api/invite/route.ts
+++ b/src/app/api/invite/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { sendInvitationEmail } from '@/services/emailService';
+import { resolveOrgId } from '@/lib/orgScope';
 import { z } from 'zod';
 import crypto from 'crypto';
 
@@ -70,7 +71,7 @@ export async function POST(request: Request) {
     // status instead of 500-ing.
     let emailSent = false;
     try {
-      await sendInvitationEmail({ to: email, token, role });
+      await sendInvitationEmail({ to: email, token, role, orgId: resolveOrgId(session) });
       emailSent = !!process.env.SMTP_USER;
     } catch (mailErr) {
       console.error('Invitation email failed (token still valid):', mailErr);

--- a/src/app/api/mentor/mentees/route.ts
+++ b/src/app/api/mentor/mentees/route.ts
@@ -90,6 +90,7 @@ export async function POST(request: Request) {
           token,
           fullName: mentee.fullName,
           purpose: 'SET_INITIAL',
+          orgId,
         });
       } catch (e) {
         console.error('Mentee set-password email failed:', e);

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,15 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.24.1-beta',
+    date: '2026-07-22',
+    highlights: {
+      en: ['Invitation, password-reset and email-verification messages now carry your organization’s brand — its name, logo and accent color — when one is configured (unchanged for the default single-tenant setup).'],
+      tr: ['Davet, parola sıfırlama ve e-posta doğrulama mesajları artık—yapılandırıldıysa—organizasyonunuzun markasını (adı, logosu ve vurgu rengi) taşıyor (varsayılan tek kiracılı kurulumda değişiklik yok).'],
+      de: ['Einladungs-, Passwort-Reset- und E-Mail-Bestätigungsnachrichten tragen jetzt — sofern konfiguriert — die Marke deiner Organisation (Name, Logo und Akzentfarbe) (bei der standardmäßigen Einzelmandanten-Einrichtung unverändert).'],
+    },
+  },
+  {
     version: '0.24.0-beta',
     date: '2026-07-22',
     highlights: {

--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -7,7 +7,30 @@ import { emailAllowed } from '@/lib/notificationPrefs';
 import { makeConsentRenewToken } from '@/lib/consentRenew';
 import { getRetentionMonths, RETENTION_GRACE_DAYS } from '@/lib/retention';
 import { getMentorMenteeActivity, getSystemMenteeActivity, formatDuration, type MenteeActivity } from '@/lib/activityReport';
+import { getOrgBranding } from '@/lib/orgBranding';
 import type { PipelineStatus } from '@prisma/client';
+
+// Resolved branding for a transactional email (#546). When no orgId is given
+// (single-tenant, or a caller without tenant context) this returns the product
+// defaults, so behavior is unchanged. The accent falls back to the product blue.
+const DEFAULT_ACCENT = '#2563eb';
+async function emailBrand(orgId?: string | null) {
+  const b = await getOrgBranding(orgId ?? null);
+  return {
+    name: b.name,
+    accent: b.color || DEFAULT_ACCENT,
+    logoUrl: b.logoUrl,
+    supportEmail: b.supportEmail,
+  };
+}
+
+// A small brand header (logo if the tenant set one, otherwise the heading text).
+function brandHeader(brand: { name: string; accent: string; logoUrl: string | null }, heading: string): string {
+  const logo = brand.logoUrl
+    ? `<img src="${brand.logoUrl}" alt="${brand.name}" style="max-height:40px;margin-bottom:12px;" />`
+    : '';
+  return `${logo}<h2 style="color: ${brand.accent};">${heading}</h2>`;
+}
 
 const smtpPort = Number(process.env.SMTP_PORT) || 587;
 const transporter = nodemailer.createTransport({
@@ -40,10 +63,10 @@ function htmlToText(html: string): string {
 // A From header with a display name ("Internship CRM <noreply@…>") looks less
 // like bulk/spam than a bare address. Honor an address that already includes a
 // name; otherwise wrap the configured address.
-function fromHeader(): string {
+function fromHeader(brandName?: string | null): string {
   const addr = process.env.SMTP_FROM || process.env.SMTP_USER || '';
   if (addr.includes('<') || !addr) return addr;
-  const name = process.env.MAIL_FROM_NAME || 'Internship CRM';
+  const name = brandName || process.env.MAIL_FROM_NAME || 'Internship CRM';
   return `${name} <${addr}>`;
 }
 
@@ -53,12 +76,16 @@ export async function sendEmail({
   html,
   replyTo,
   attachments,
+  fromName,
 }: {
   to: string;
   subject: string;
   html: string;
   replyTo?: string;
   attachments?: { filename: string; content: Buffer; contentType?: string }[];
+  // Overrides the From display name (e.g. a tenant's brand name, #546). Falls
+  // back to MAIL_FROM_NAME / "Internship CRM" when omitted.
+  fromName?: string | null;
 }) {
   if (!process.env.SMTP_USER) {
     console.log(`[Email skipped - no SMTP config] To: ${to}, Subject: ${subject}`);
@@ -66,7 +93,7 @@ export async function sendEmail({
   }
 
   await transporter.sendMail({
-    from: fromHeader(),
+    from: fromHeader(fromName),
     to,
     subject,
     html,
@@ -93,25 +120,29 @@ export async function sendInvitationEmail({
   to,
   token,
   role,
+  orgId,
 }: {
   to: string;
   token: string;
   role: string;
+  orgId?: string | null;
 }) {
   const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
   const registerUrl = `${appUrl}/auth/register?token=${token}`;
+  const brand = await emailBrand(orgId);
 
   await sendEmail({
     to,
-    subject: 'You have been invited to Internship CRM',
+    fromName: brand.name,
+    subject: `You have been invited to ${brand.name}`,
     html: `
       <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
-        <h2 style="color: #2563eb;">Welcome to Internship CRM</h2>
+        ${brandHeader(brand, `Welcome to ${brand.name}`)}
         <p>You have been invited to join as a <strong>${role}</strong>.</p>
         <p>Click the button below to complete your registration:</p>
         <a href="${registerUrl}" style="
           display: inline-block;
-          background-color: #2563eb;
+          background-color: ${brand.accent};
           color: white;
           padding: 12px 24px;
           text-decoration: none;
@@ -136,33 +167,37 @@ export async function sendPasswordResetEmail({
   token,
   fullName,
   purpose = 'RESET',
+  orgId,
 }: {
   to: string;
   token: string;
   fullName?: string | null;
   purpose?: 'RESET' | 'SET_INITIAL';
+  orgId?: string | null;
 }) {
   const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
   const resetUrl = `${appUrl}/auth/reset?token=${token}`;
   const isInitial = purpose === 'SET_INITIAL';
+  const brand = await emailBrand(orgId);
 
   const heading = isInitial ? 'Set your password' : 'Reset your password';
   const intro = isInitial
-    ? 'An account has been created for you on Internship CRM. Set a password to activate it and sign in.'
+    ? `An account has been created for you on ${brand.name}. Set a password to activate it and sign in.`
     : 'We received a request to reset your password. Click the button below to choose a new one.';
   const cta = isInitial ? 'Set password' : 'Reset password';
 
   await sendEmail({
     to,
-    subject: isInitial ? 'Activate your Internship CRM account' : 'Reset your Internship CRM password',
+    fromName: brand.name,
+    subject: isInitial ? `Activate your ${brand.name} account` : `Reset your ${brand.name} password`,
     html: `
       <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
-        <h2 style="color: #2563eb;">${heading}</h2>
+        ${brandHeader(brand, heading)}
         ${fullName ? `<p>Hi ${fullName},</p>` : ''}
         <p>${intro}</p>
         <a href="${resetUrl}" style="
           display: inline-block;
-          background-color: #2563eb;
+          background-color: ${brand.accent};
           color: white;
           padding: 12px 24px;
           text-decoration: none;
@@ -186,25 +221,29 @@ export async function sendVerificationEmail({
   to,
   token,
   fullName,
+  orgId,
 }: {
   to: string;
   token: string;
   fullName?: string | null;
+  orgId?: string | null;
 }) {
   const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
   const verifyUrl = `${appUrl}/auth/verify?token=${token}`;
+  const brand = await emailBrand(orgId);
 
   await sendEmail({
     to,
-    subject: 'Verify your Internship CRM email',
+    fromName: brand.name,
+    subject: `Verify your ${brand.name} email`,
     html: `
       <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
-        <h2 style="color: #2563eb;">Confirm your email</h2>
+        ${brandHeader(brand, 'Confirm your email')}
         ${fullName ? `<p>Hi ${fullName},</p>` : ''}
         <p>Please confirm your email address to activate full access to your account.</p>
         <a href="${verifyUrl}" style="
           display: inline-block;
-          background-color: #2563eb;
+          background-color: ${brand.accent};
           color: white;
           padding: 12px 24px;
           text-decoration: none;


### PR DESCRIPTION
Part of #546 (white-label) under multi-tenancy story #522.

## What

The account-lifecycle emails now carry the **recipient organization's white-label brand**:

- **Invitation**, **password reset / set-initial**, and **email verification** emails render the org's brand **name** (subject + From display name + heading), **logo** (when set), and **accent color** (heading + button), resolved via `getOrgBranding(orgId)`.
- `sendEmail` gained an optional `fromName` override; a shared `emailBrand()` + `brandHeader()` helper centralizes resolution.
- Callers thread the recipient's `orgId` where they have it: invite + resend (inviter's org), forgot-password, admin reset-password, company-user / source-user creation, apply, mentee creation, verification resend.

## Safety / compatibility

- **Fully backward-compatible.** When no `orgId` resolves (single-tenant, or a caller without tenant context), `emailBrand()` returns the product defaults — so today's single-tenant emails are **byte-for-byte unchanged** (name "Internship CRM", the existing blue accent, no logo).
- Self-registration verification stays on product branding (a self-registered user has no org yet).

## Verification

- [x] `npm run build`
- [x] `npm run check:i18n`

Version 0.24.1; CHANGELOG + release notes updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ)_