### PR TITLE
Roll out tenant isolation to all authenticated routes (#543)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,18 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [Unreleased]
 
-## [0.24.1] - 2026-07-22
+## [0.24.2] - 2026-07-22
+
+### Changed
+- **Tenant isolation rolled out to all authenticated API routes (part of #543 /
+  story #522).** Every API route handler that queries a tenant-anchored model now
+  wraps its body in `withTenantScope(session, …)`, so the central enforcement
+  middleware auto-scopes all of its queries to the request's organization once
+  `MT_ENFORCE_ISOLATION` is enabled. Behavior-neutral while the flag is off
+  (`withTenantScope` is a pure passthrough), so single-tenant production is
+  unchanged. Public/token-based routes (register, apply, forgot-password, invite
+  acceptance) are intentionally left unscoped (no session; subject resolved from
+  the token).
 
 ### Added
 - **Tenant-branded transactional emails (part of #546 / story #522).** The

--- a/docs/tenant-isolation.md
+++ b/docs/tenant-isolation.md
@@ -65,10 +65,16 @@ never called `orgScoped()`** is still isolated purely because it ran inside
 ### Per-route rollout status
 
 Handlers adopt the engine by wrapping their body in `withTenantScope(session, …)`.
-Adopted so far: `GET/POST /api/mentorship`, `GET/POST /api/companies`,
-`GET/POST /api/projects`. The remaining tenant-scoped routes are wrapped
-incrementally; because the flag is off, an un-wrapped route simply isn't
-enforced yet and never leaks more than today's single-tenant app.
+**All authenticated API routes that query a tenant-anchored model are now
+wrapped** — every such handler binds the request's org, so with the flag on the
+central middleware scopes all of its queries. Wrapping is behavior-neutral while
+the flag is off (`withTenantScope` is a pure passthrough).
+
+Public / token-based routes (registration, apply, forgot-password, invite
+acceptance) are intentionally not wrapped: they have no session and resolve their
+subject from the invite/reset token, not a tenant context. Routes that only ever
+read the caller's own rows (account, profile, avatar, cv) are wrapped too for
+uniformity, though scoping is redundant there.
 
 ## Turning enforcement on (the guarded rollout)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "internship-crm",
-  "version": "0.24.1-beta",
+  "version": "0.24.2-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "internship-crm",
-      "version": "0.24.1-beta",
+      "version": "0.24.2-beta",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.24.1-beta",
+  "version": "0.24.2-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/app/api/account/2fa/route.ts
+++ b/src/app/api/account/2fa/route.ts
@@ -5,13 +5,16 @@ import { prisma } from '@/lib/prisma';
 import { z } from 'zod';
 import { generateSecret, verifyTotp, otpauthUrl } from '@/lib/totp';
 import { logActivity } from '@/lib/activity';
+import { withTenantScope } from '@/lib/orgContext';
 
 // GET — current 2FA status.
 export async function GET() {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  return await withTenantScope(session, async () => {
   const user = await prisma.user.findUnique({ where: { id: session.user.id }, select: { twoFactorEnabled: true } });
   return NextResponse.json({ enabled: !!user?.twoFactorEnabled });
+  });
 }
 
 const schema = z.object({
@@ -23,6 +26,7 @@ export async function POST(request: Request) {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
+  return await withTenantScope(session, async () => {
   const parsed = schema.safeParse(await request.json());
   if (!parsed.success) return NextResponse.json({ error: 'Validation failed' }, { status: 400 });
   const { action, code } = parsed.data;
@@ -55,4 +59,5 @@ export async function POST(request: Request) {
   await prisma.user.update({ where: { id: session.user.id }, data: { twoFactorEnabled: false, twoFactorSecret: null } });
   await logActivity({ action: '2fa.disable', level: 'warning', actorId: session.user.id, actorEmail: session.user.email ?? null });
   return NextResponse.json({ enabled: false });
+  });
 }

--- a/src/app/api/account/export/route.ts
+++ b/src/app/api/account/export/route.ts
@@ -3,11 +3,13 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { logActivity } from '@/lib/activity';
+import { withTenantScope } from '@/lib/orgContext';
 
 // GET — the current user downloads all of their own data as JSON (GDPR-style).
 export async function GET() {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  return await withTenantScope(session, async () => {
   const id = session.user.id;
 
   const user = await prisma.user.findUnique({
@@ -45,5 +47,6 @@ export async function GET() {
       'Content-Type': 'application/json',
       'Content-Disposition': `attachment; filename="my-data.json"`,
     },
+  });
   });
 }

--- a/src/app/api/account/route.ts
+++ b/src/app/api/account/route.ts
@@ -7,6 +7,7 @@ import { z } from 'zod';
 import { passwordSchema } from '@/lib/password';
 import { logActivity } from '@/lib/activity';
 import { hardDeleteUser } from '@/lib/accountErasure';
+import { withTenantScope } from '@/lib/orgContext';
 
 const schema = z.object({
   email: z.string().email().optional(),
@@ -24,6 +25,7 @@ export async function PUT(request: Request) {
     if (session.user.impersonatorId) {
       return NextResponse.json({ error: 'Cannot change account credentials while impersonating' }, { status: 400 });
     }
+    return await withTenantScope(session, async () => {
     const parsed = schema.safeParse(await request.json());
     if (!parsed.success) {
       return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 });
@@ -70,6 +72,7 @@ export async function PUT(request: Request) {
       await logActivity({ action: 'account.password_change', level: 'warning', actorId: user.id, actorEmail: user.email });
     }
     return NextResponse.json({ message: 'Account updated', emailChanged: !!data.email });
+    });
   } catch (error) {
     console.error('Account update error:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
@@ -87,6 +90,7 @@ export async function DELETE(request: Request) {
       return NextResponse.json({ error: 'Cannot delete an account while impersonating it' }, { status: 400 });
     }
 
+    return await withTenantScope(session, async () => {
     const id = session.user.id;
 
     // Re-authenticate with the current password before destroying the account.
@@ -109,6 +113,7 @@ export async function DELETE(request: Request) {
 
     await logActivity({ action: 'account.delete', level: 'warning', actorId: id, actorEmail: session.user.email ?? null });
     return NextResponse.json({ ok: true });
+    });
   } catch (error) {
     console.error('Account delete error:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });

--- a/src/app/api/account/sign-out-all/route.ts
+++ b/src/app/api/account/sign-out-all/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { logActivity } from '@/lib/activity';
+import { withTenantScope } from '@/lib/orgContext';
 
 // POST — "Sign out of all devices". Stamps sessionsValidFrom = now so every
 // existing JWT (including the caller's own) is rejected on its next request.
@@ -11,6 +12,7 @@ export async function POST() {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
+  return await withTenantScope(session, async () => {
   await prisma.user.update({
     where: { id: session.user.id },
     data: { sessionsValidFrom: new Date() },
@@ -22,4 +24,5 @@ export async function POST() {
     actorEmail: session.user.email ?? null,
   });
   return NextResponse.json({ ok: true });
+  });
 }

--- a/src/app/api/admin/analytics/aging/route.ts
+++ b/src/app/api/admin/analytics/aging/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { withTenantScope } from '@/lib/orgContext';
 
 const DAY = 24 * 60 * 60 * 1000;
 
@@ -18,6 +19,7 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
+  return await withTenantScope(session, async () => {
   // Optional date-range window (?from=YYYY-MM-DD&to=YYYY-MM-DD): only stage
   // transitions that COMPLETED (i.e. the candidate left the stage) within the
   // window feed stageAging. oldestStuck/overdue describe the present, so they
@@ -106,4 +108,5 @@ export async function GET(request: Request) {
   const overdue = items.filter((it) => it.overdue).sort((a, b) => b.daysInStage - a.daysInStage);
 
   return NextResponse.json({ stageAging, oldestStuck, overdue, overdueCount: overdue.length });
+  });
 }

--- a/src/app/api/admin/analytics/benchmark/route.ts
+++ b/src/app/api/admin/analytics/benchmark/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { getSetting } from '@/lib/settings';
 import { resolveOrgId } from '@/lib/orgScope';
+import { withTenantScope } from '@/lib/orgContext';
 
 const HIRED = new Set(['HIRED_660', 'EMPLOYED_700']);
 const DROPPED = new Set(['INTERNSHIP_DROPPED_460', 'INTERNSHIP_FOUND_ELSEWHERE_800']);
@@ -27,6 +28,7 @@ export async function GET() {
     return NextResponse.json({ error: 'feature_locked' }, { status: 403 });
   }
 
+  return await withTenantScope(session, async () => {
   // Aggregate counts per (org, stage) — never fetch raw relation rows.
   const grouped = await prisma.mentorshipRelation.groupBy({
     by: ['orgId', 'pipelineStatus'],
@@ -84,5 +86,6 @@ export async function GET() {
       minRelations: MIN_RELATIONS,
     },
     percentile,
+  });
   });
 }

--- a/src/app/api/admin/analytics/cohorts/route.ts
+++ b/src/app/api/admin/analytics/cohorts/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { getSetting } from '@/lib/settings';
+import { withTenantScope } from '@/lib/orgContext';
 
 const HIRED = new Set(['HIRED_660', 'EMPLOYED_700']);
 const DROPPED = new Set(['INTERNSHIP_DROPPED_460', 'INTERNSHIP_FOUND_ELSEWHERE_800']);
@@ -20,6 +21,7 @@ export async function GET() {
     return NextResponse.json({ error: 'feature_locked' }, { status: 403 });
   }
 
+  return await withTenantScope(session, async () => {
   const cohorts = await prisma.cohort.findMany({
     orderBy: { createdAt: 'desc' },
     select: {
@@ -73,4 +75,5 @@ export async function GET() {
   });
 
   return NextResponse.json({ cohorts: rows });
+  });
 }

--- a/src/app/api/admin/analytics/route.ts
+++ b/src/app/api/admin/analytics/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { withTenantScope } from '@/lib/orgContext';
 
 // GET — aggregate analytics for the admin dashboard:
 // pipeline funnel, mentor workload/outcomes, engagement and RSVP rate.
@@ -16,6 +17,7 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
+  return await withTenantScope(session, async () => {
   const { searchParams } = new URL(request.url);
   const now = new Date();
   const parseDate = (v: string | null): Date | null => {
@@ -110,5 +112,6 @@ export async function GET(request: Request) {
     rsvp: { ...rsvp, responded: rsvpResponded, acceptanceRate: rsvpAcceptanceRate },
     trends,
     range,
+  });
   });
 }

--- a/src/app/api/admin/analytics/sources/route.ts
+++ b/src/app/api/admin/analytics/sources/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { getSetting } from '@/lib/settings';
+import { withTenantScope } from '@/lib/orgContext';
 
 const HIRED = new Set(['HIRED_660', 'EMPLOYED_700']);
 
@@ -18,6 +19,7 @@ export async function GET() {
     return NextResponse.json({ error: 'feature_locked' }, { status: 403 });
   }
 
+  return await withTenantScope(session, async () => {
   const sources = await prisma.source.findMany({
     orderBy: { name: 'asc' },
     select: {
@@ -49,4 +51,5 @@ export async function GET() {
   const unsourced = await prisma.user.count({ where: { role: 'MENTEE', sourceId: null } });
 
   return NextResponse.json({ sources: rows, unsourced });
+  });
 }

--- a/src/app/api/admin/announcements/route.ts
+++ b/src/app/api/admin/announcements/route.ts
@@ -7,6 +7,7 @@ import { logActivity } from '@/lib/activity';
 import { sendEmail } from '@/services/emailService';
 import { logger } from '@/lib/logger';
 import { emailAllowed } from '@/lib/notificationPrefs';
+import { withTenantScope } from '@/lib/orgContext';
 
 const schema = z.object({
   text: z.string().min(1).max(2000),
@@ -19,6 +20,7 @@ export async function GET(request: Request) {
   const session = await getServerSession(authOptions);
   if (!session || session.user.role !== 'ADMIN') return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
+  return await withTenantScope(session, async () => {
   const { searchParams } = new URL(request.url);
   const page = Math.max(1, parseInt(searchParams.get('page') || '1', 10) || 1);
   const pageSize = 20;
@@ -42,6 +44,7 @@ export async function GET(request: Request) {
     page,
     pageSize,
   });
+  });
 }
 
 // POST — broadcast an announcement to every active user as an in-app
@@ -50,6 +53,7 @@ export async function POST(request: Request) {
   const session = await getServerSession(authOptions);
   if (!session || session.user.role !== 'ADMIN') return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
+  return await withTenantScope(session, async () => {
   const parsed = schema.safeParse(await request.json());
   if (!parsed.success) return NextResponse.json({ error: 'Validation failed' }, { status: 400 });
   const { text, link, email } = parsed.data;
@@ -86,4 +90,5 @@ export async function POST(request: Request) {
 
   await logActivity({ action: 'announcement.broadcast', actorId: session.user.id, actorEmail: session.user.email ?? null });
   return NextResponse.json({ recipients: users.length, emailed }, { status: 201 });
+  });
 }

--- a/src/app/api/admin/candidates/bulk/route.ts
+++ b/src/app/api/admin/candidates/bulk/route.ts
@@ -5,6 +5,7 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { logActivity } from '@/lib/activity';
 import { nextOnPathStatus, type PipelineStatus } from '@/lib/pipeline';
+import { withTenantScope } from '@/lib/orgContext';
 
 const bodySchema = z.object({
   candidateIds: z.array(z.string().min(1)).min(1).max(200),
@@ -21,6 +22,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
+  return await withTenantScope(session, async () => {
   const parsed = bodySchema.safeParse(await request.json().catch(() => null));
   if (!parsed.success) return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
   const { candidateIds, action } = parsed.data;
@@ -88,4 +90,5 @@ export async function POST(request: Request) {
   }
 
   return NextResponse.json({ error: 'Unknown action' }, { status: 400 });
+  });
 }

--- a/src/app/api/admin/companies/[id]/entitlements/route.ts
+++ b/src/app/api/admin/companies/[id]/entitlements/route.ts
@@ -5,6 +5,7 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { getCompanyFeatures, setCompanyFeature, isPremiumFeature } from '@/lib/entitlements';
 import { logActivity } from '@/lib/activity';
+import { withTenantScope } from '@/lib/orgContext';
 
 async function requireAdmin() {
   const session = await getServerSession(authOptions);
@@ -16,10 +17,12 @@ async function requireAdmin() {
 export async function GET(_request: Request, { params }: { params: Promise<{ id: string }> }) {
   const session = await requireAdmin();
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  return await withTenantScope(session, async () => {
   const { id } = await params;
   const company = await prisma.company.findUnique({ where: { id }, select: { id: true } });
   if (!company) return NextResponse.json({ error: 'Company not found' }, { status: 404 });
   return NextResponse.json({ features: await getCompanyFeatures(id) });
+  });
 }
 
 const putSchema = z.object({ feature: z.string(), enabled: z.boolean() });
@@ -28,6 +31,7 @@ const putSchema = z.object({ feature: z.string(), enabled: z.boolean() });
 export async function PUT(request: Request, { params }: { params: Promise<{ id: string }> }) {
   const session = await requireAdmin();
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  return await withTenantScope(session, async () => {
   const { id } = await params;
 
   const parsed = putSchema.safeParse(await request.json().catch(() => null));
@@ -48,4 +52,5 @@ export async function PUT(request: Request, { params }: { params: Promise<{ id: 
     detail: parsed.data.feature,
   });
   return NextResponse.json({ features: await getCompanyFeatures(id) });
+  });
 }

--- a/src/app/api/admin/company-users/route.ts
+++ b/src/app/api/admin/company-users/route.ts
@@ -5,6 +5,7 @@ import { prisma } from '@/lib/prisma';
 import { z } from 'zod';
 import { createPasswordResetToken } from '@/lib/passwordReset';
 import { sendPasswordResetEmail } from '@/services/emailService';
+import { withTenantScope } from '@/lib/orgContext';
 
 const schema = z.object({
   companyId: z.string().min(1),
@@ -20,6 +21,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
+  return await withTenantScope(session, async () => {
   const parsed = schema.safeParse(await request.json());
   if (!parsed.success) {
     return NextResponse.json({ error: 'Validation failed' }, { status: 400 });
@@ -45,4 +47,5 @@ export async function POST(request: Request) {
   }
 
   return NextResponse.json({ ok: true, setPasswordUrl: `${appUrl}/auth/reset?token=${token}` });
+  });
 }

--- a/src/app/api/admin/impersonate/route.ts
+++ b/src/app/api/admin/impersonate/route.ts
@@ -6,6 +6,7 @@ import { prisma } from '@/lib/prisma';
 import { createImpersonationGrant } from '@/lib/impersonation';
 import { logActivity } from '@/lib/activity';
 import { notify } from '@/lib/notify';
+import { withTenantScope } from '@/lib/orgContext';
 
 const schema = z.object({ targetUserId: z.string().min(1), reason: z.string().max(300).optional() });
 
@@ -18,6 +19,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
+  return await withTenantScope(session, async () => {
   const parsed = schema.safeParse(await request.json());
   if (!parsed.success) {
     return NextResponse.json({ error: 'targetUserId is required' }, { status: 400 });
@@ -54,4 +56,5 @@ export async function POST(request: Request) {
   await notify(target.id, 'impersonation', `An administrator accessed your account${reason ? ` (${reason})` : ''}.`);
 
   return NextResponse.json({ grant });
+  });
 }

--- a/src/app/api/admin/import/route.ts
+++ b/src/app/api/admin/import/route.ts
@@ -7,6 +7,7 @@ import bcrypt from 'bcryptjs';
 import { randomBytes } from 'crypto';
 import { logActivity } from '@/lib/activity';
 import { resolveOrgId } from '@/lib/orgScope';
+import { withTenantScope } from '@/lib/orgContext';
 
 const schema = z.object({ csv: z.string().min(1).max(200_000), dryRun: z.boolean().optional() });
 
@@ -35,6 +36,7 @@ export async function POST(request: Request) {
   const session = await getServerSession(authOptions);
   if (!session || session.user.role !== 'ADMIN') return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
+  return await withTenantScope(session, async () => {
   const parsed = schema.safeParse(await request.json());
   if (!parsed.success) return NextResponse.json({ error: 'Validation failed' }, { status: 400 });
 
@@ -90,4 +92,5 @@ export async function POST(request: Request) {
   }
   await logActivity({ action: 'users.bulk_import', actorId: session.user.id, actorEmail: session.user.email ?? null, detail: `created ${created}` });
   return NextResponse.json({ created, skipped: skipped.length, errors: errors.length, rows });
+  });
 }

--- a/src/app/api/admin/mentor-suggest/route.ts
+++ b/src/app/api/admin/mentor-suggest/route.ts
@@ -5,6 +5,7 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { runAiGated } from '@/lib/aiGate';
 import { aiRankMentors, type MatchCandidate } from '@/lib/aiMentorMatch';
+import { withTenantScope } from '@/lib/orgContext';
 
 const schema = z.object({ menteeId: z.string().min(1) });
 
@@ -19,6 +20,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
+  return await withTenantScope(session, async () => {
   const parsed = schema.safeParse(await request.json().catch(() => null));
   if (!parsed.success) return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
 
@@ -108,4 +110,5 @@ export async function POST(request: Request) {
   const rest = base.filter((b) => !rankedIds.has(b.mentorId));
 
   return NextResponse.json({ suggestions: [...ranked, ...rest], aiUsed: true });
+  });
 }

--- a/src/app/api/admin/mentorship-requests/route.ts
+++ b/src/app/api/admin/mentorship-requests/route.ts
@@ -5,6 +5,7 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { notify } from '@/lib/notify';
 import { checkActiveRelationLimitForMentee, planLimitError } from '@/lib/planGate';
+import { withTenantScope } from '@/lib/orgContext';
 
 // Admin queue for mentee mentorship requests (#590): list PENDING requests,
 // approve (pick a mentor → MentorshipRelation) or reject. The mentee is
@@ -16,6 +17,7 @@ export async function GET(request: Request) {
   if (!session || session.user.role !== 'ADMIN') {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
+  return await withTenantScope(session, async () => {
   const statusParam = new URL(request.url).searchParams.get('status');
   const status = statusParam === 'APPROVED' || statusParam === 'REJECTED' ? statusParam : 'PENDING';
 
@@ -33,6 +35,7 @@ export async function GET(request: Request) {
     },
   });
   return NextResponse.json({ requests });
+  });
 }
 
 const decideSchema = z.object({
@@ -49,6 +52,7 @@ export async function PUT(request: Request) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
+  return await withTenantScope(session, async () => {
   const parsed = decideSchema.safeParse(await request.json().catch(() => null));
   if (!parsed.success) return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
   const { requestId, action, mentorId } = parsed.data;
@@ -97,4 +101,5 @@ export async function PUT(request: Request) {
   });
   await notify(req.menteeId, 'mentorship_request', 'Your mentorship request was reviewed but could not be approved right now.', '/portal');
   return NextResponse.json({ ok: true });
+  });
 }

--- a/src/app/api/admin/source-users/route.ts
+++ b/src/app/api/admin/source-users/route.ts
@@ -5,6 +5,7 @@ import { prisma } from '@/lib/prisma';
 import { z } from 'zod';
 import { createPasswordResetToken } from '@/lib/passwordReset';
 import { sendPasswordResetEmail } from '@/services/emailService';
+import { withTenantScope } from '@/lib/orgContext';
 
 const schema = z.object({
   sourceId: z.string().min(1),
@@ -21,6 +22,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
+  return await withTenantScope(session, async () => {
   const parsed = schema.safeParse(await request.json());
   if (!parsed.success) return NextResponse.json({ error: 'Validation failed' }, { status: 400 });
   const { sourceId, email, fullName } = parsed.data;
@@ -44,4 +46,5 @@ export async function POST(request: Request) {
   }
 
   return NextResponse.json({ ok: true, setPasswordUrl: `${appUrl}/auth/reset?token=${token}` });
+  });
 }

--- a/src/app/api/admin/sources/[id]/route.ts
+++ b/src/app/api/admin/sources/[id]/route.ts
@@ -2,14 +2,17 @@ import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { withTenantScope } from '@/lib/orgContext';
 
 // DELETE — remove a source (admin). Mentees keep their record; their sourceId is
 // cleared via the optional relation so no mentee is orphaned.
 export async function DELETE(_request: Request, { params }: { params: Promise<{ id: string }> }) {
   const session = await getServerSession(authOptions);
   if (!session || session.user.role !== 'ADMIN') return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  return await withTenantScope(session, async () => {
   const { id } = await params;
   await prisma.user.updateMany({ where: { sourceId: id }, data: { sourceId: null } });
   await prisma.source.delete({ where: { id } }).catch(() => null);
   return NextResponse.json({ ok: true });
+  });
 }

--- a/src/app/api/admin/sources/route.ts
+++ b/src/app/api/admin/sources/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { PipelineStatus } from '@prisma/client';
 import { z } from 'zod';
+import { withTenantScope } from '@/lib/orgContext';
 
 // Pipeline stages that count as a successful outcome for conversion stats.
 const HIRED: PipelineStatus[] = [PipelineStatus.HIRED_660, PipelineStatus.EMPLOYED_700];
@@ -13,6 +14,7 @@ export async function GET() {
   const session = await getServerSession(authOptions);
   if (!session || session.user.role !== 'ADMIN') return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
+  return await withTenantScope(session, async () => {
   const sources = await prisma.source.findMany({
     orderBy: { name: 'asc' },
     include: { _count: { select: { users: true } } },
@@ -46,6 +48,7 @@ export async function GET() {
       };
     }),
   });
+  });
 }
 
 const schema = z.object({
@@ -58,6 +61,7 @@ const schema = z.object({
 export async function POST(request: Request) {
   const session = await getServerSession(authOptions);
   if (!session || session.user.role !== 'ADMIN') return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  return await withTenantScope(session, async () => {
   const parsed = schema.safeParse(await request.json());
   if (!parsed.success) return NextResponse.json({ error: 'Validation failed' }, { status: 400 });
   const { name, contactName, contactEmail } = parsed.data;
@@ -67,4 +71,5 @@ export async function POST(request: Request) {
     data: { name, contactName: contactName || null, contactEmail: contactEmail || null },
   });
   return NextResponse.json({ source }, { status: 201 });
+  });
 }

--- a/src/app/api/admin/users/[id]/erase/route.ts
+++ b/src/app/api/admin/users/[id]/erase/route.ts
@@ -5,6 +5,7 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { logActivity } from '@/lib/activity';
 import { anonymizeUser, hardDeleteUser } from '@/lib/accountErasure';
+import { withTenantScope } from '@/lib/orgContext';
 
 const bodySchema = z.object({
   mode: z.enum(['anonymize', 'delete']),
@@ -23,6 +24,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
+  return await withTenantScope(session, async () => {
   const { id } = await params;
   const parsed = bodySchema.safeParse(await request.json().catch(() => null));
   if (!parsed.success) return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
@@ -52,4 +54,5 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
   });
 
   return NextResponse.json({ ok: true });
+  });
 }

--- a/src/app/api/admin/users/[id]/reset-password/route.ts
+++ b/src/app/api/admin/users/[id]/reset-password/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { createPasswordResetToken } from '@/lib/passwordReset';
 import { sendPasswordResetEmail } from '@/services/emailService';
+import { withTenantScope } from '@/lib/orgContext';
 
 // POST — admin triggers a password reset for any user: issues a single-use
 // reset token, emails the user a link, and returns the link so the admin can
@@ -14,6 +15,7 @@ export async function POST(_request: Request, { params }: { params: Promise<{ id
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
+  return await withTenantScope(session, async () => {
   const { id } = await params;
   const user = await prisma.user.findUnique({ where: { id } });
   if (!user) {
@@ -30,4 +32,5 @@ export async function POST(_request: Request, { params }: { params: Promise<{ id
   }
 
   return NextResponse.json({ ok: true, resetUrl });
+  });
 }

--- a/src/app/api/auth/verify-email/resend/route.ts
+++ b/src/app/api/auth/verify-email/resend/route.ts
@@ -5,6 +5,7 @@ import { prisma } from '@/lib/prisma';
 import { createEmailVerificationToken } from '@/lib/emailVerification';
 import { sendVerificationEmail } from '@/services/emailService';
 import { enforceRateLimit } from '@/lib/rateLimit';
+import { withTenantScope } from '@/lib/orgContext';
 
 // POST — re-send the verification email.
 // - Authenticated: for the current user. The caller already proved who they
@@ -18,6 +19,7 @@ export async function POST(request: Request) {
   const session = await getServerSession(authOptions);
 
   if (session) {
+    return await withTenantScope(session, async () => {
     const user = await prisma.user.findUnique({ where: { id: session.user.id } });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
     if (user.emailVerified) return NextResponse.json({ ok: true, alreadyVerified: true });
@@ -30,6 +32,7 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Could not send the verification email. Please try again shortly.' }, { status: 502 });
     }
     return NextResponse.json({ ok: true });
+    });
   }
 
   const limited = enforceRateLimit(request, 'verify-resend', { limit: 5, windowMs: 15 * 60 * 1000 });

--- a/src/app/api/avatar/[userId]/route.ts
+++ b/src/app/api/avatar/[userId]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { withTenantScope } from '@/lib/orgContext';
 
 // GET — fetch a user's avatar. Any authenticated user may view avatars
 // (they're shown across lists, sidebars and profiles).
@@ -14,6 +15,7 @@ export async function GET(_request: Request, { params }: { params: Promise<{ use
     if (!u?.publicProfile) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
+  return await withTenantScope(session, async () => {
   const avatar = await prisma.avatarFile.findUnique({ where: { userId } });
   if (!avatar) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 
@@ -23,6 +25,7 @@ export async function GET(_request: Request, { params }: { params: Promise<{ use
       'Content-Length': String(avatar.size),
       'Cache-Control': 'private, max-age=300',
     },
+  });
   });
 }
 
@@ -36,7 +39,9 @@ export async function DELETE(_request: Request, { params }: { params: Promise<{ 
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
 
+  return await withTenantScope(session, async () => {
   await prisma.avatarFile.deleteMany({ where: { userId } });
   await prisma.user.update({ where: { id: userId }, data: { avatarUrl: null } });
   return NextResponse.json({ ok: true });
+  });
 }

--- a/src/app/api/avatar/route.ts
+++ b/src/app/api/avatar/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { withTenantScope } from '@/lib/orgContext';
 
 const MAX_BYTES = 2 * 1024 * 1024; // 2 MB
 const ALLOWED = new Set(['image/png', 'image/jpeg', 'image/webp', 'image/gif']);
@@ -11,6 +12,7 @@ export async function POST(request: Request) {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
+  return await withTenantScope(session, async () => {
   const form = await request.formData();
   const file = form.get('file');
   const targetUserId = (form.get('targetUserId') as string) || session.user.id;
@@ -37,4 +39,5 @@ export async function POST(request: Request) {
   await prisma.user.update({ where: { id: targetUserId }, data: { avatarUrl: `/api/avatar/${targetUserId}` } });
 
   return NextResponse.json({ ok: true, avatarUrl: `/api/avatar/${targetUserId}` });
+  });
 }

--- a/src/app/api/calendar-events/route.ts
+++ b/src/app/api/calendar-events/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import type { Prisma } from '@prisma/client';
+import { withTenantScope } from '@/lib/orgContext';
 
 // Stages that are terminal — an overdue deadline on these is not actionable.
 const TERMINAL = ['HIRED_660', 'EMPLOYED_700', 'INTERNSHIP_FOUND_ELSEWHERE_800'];
@@ -13,6 +14,7 @@ export async function GET() {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
+  return await withTenantScope(session, async () => {
   const { id, role } = session.user;
   const relWhere: Prisma.MentorshipRelationWhereInput =
     role === 'ADMIN' ? {} : role === 'MENTOR' ? { mentorId: id } : { menteeId: id };
@@ -72,4 +74,5 @@ export async function GET() {
   ];
 
   return NextResponse.json({ events });
+  });
 }

--- a/src/app/api/candidates/route.ts
+++ b/src/app/api/candidates/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { withTenantScope } from '@/lib/orgContext';
 
 export async function GET(request: Request) {
   try {
@@ -11,6 +12,7 @@ export async function GET(request: Request) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
+    return await withTenantScope(session, async () => {
     const { searchParams } = new URL(request.url);
     const skills = searchParams.get('skills');
     const graduationYear = searchParams.get('graduationYear');
@@ -116,6 +118,7 @@ export async function GET(request: Request) {
     }
 
     return NextResponse.json({ candidates, total, page, pageSize });
+    });
   } catch (error) {
     console.error('Get candidates error:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });

--- a/src/app/api/cohorts/[id]/route.ts
+++ b/src/app/api/cohorts/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { withTenantScope } from '@/lib/orgContext';
 import { z } from 'zod';
 
 const schema = z.object({
@@ -13,6 +14,7 @@ const schema = z.object({
 export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
   const session = await getServerSession(authOptions);
   if (!session || session.user.role !== 'ADMIN') return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  return await withTenantScope(session, async () => {
   const { id } = await params;
 
   const parsed = schema.safeParse(await request.json());
@@ -26,6 +28,7 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
     },
   });
   return NextResponse.json({ cohort });
+  });
 }
 
 // DELETE — remove a cohort (admin). Relations keep their record; their cohortId
@@ -33,9 +36,11 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
 export async function DELETE(_request: Request, { params }: { params: Promise<{ id: string }> }) {
   const session = await getServerSession(authOptions);
   if (!session || session.user.role !== 'ADMIN') return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  return await withTenantScope(session, async () => {
   const { id } = await params;
 
   await prisma.mentorshipRelation.updateMany({ where: { cohortId: id }, data: { cohortId: null } });
   await prisma.cohort.delete({ where: { id } }).catch(() => null);
   return NextResponse.json({ ok: true });
+  });
 }

--- a/src/app/api/cohorts/route.ts
+++ b/src/app/api/cohorts/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { withTenantScope } from '@/lib/orgContext';
 import { z } from 'zod';
 
 // GET — all cohorts with intern counts + per-stage distribution (admin).
@@ -9,6 +10,7 @@ export async function GET() {
   const session = await getServerSession(authOptions);
   if (!session || session.user.role !== 'ADMIN') return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
+  return await withTenantScope(session, async () => {
   const cohorts = await prisma.cohort.findMany({ orderBy: { createdAt: 'desc' }, include: { _count: { select: { relations: true } } } });
   const dist = await prisma.mentorshipRelation.groupBy({
     by: ['cohortId', 'pipelineStatus'],
@@ -21,6 +23,7 @@ export async function GET() {
     (byCohort[d.cohortId] ||= {})[d.pipelineStatus] = d._count._all;
   }
   return NextResponse.json({ cohorts: cohorts.map((c) => ({ id: c.id, name: c.name, term: c.term, interns: c._count.relations, distribution: byCohort[c.id] ?? {} })) });
+  });
 }
 
 const schema = z.object({ name: z.string().min(1).max(120), term: z.string().max(60).optional() });
@@ -29,10 +32,12 @@ const schema = z.object({ name: z.string().min(1).max(120), term: z.string().max
 export async function POST(request: Request) {
   const session = await getServerSession(authOptions);
   if (!session || session.user.role !== 'ADMIN') return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  return await withTenantScope(session, async () => {
   const parsed = schema.safeParse(await request.json());
   if (!parsed.success) return NextResponse.json({ error: 'Validation failed' }, { status: 400 });
   // Trim so a whitespace-only term is stored as null (shows as "—") rather than
   // a blank string. Term is free-text (e.g. "Fall 2026"), so no format check.
   const cohort = await prisma.cohort.create({ data: { name: parsed.data.name.trim(), term: parsed.data.term?.trim() || null } });
   return NextResponse.json({ cohort }, { status: 201 });
+  });
 }

--- a/src/app/api/companies/[id]/route.ts
+++ b/src/app/api/companies/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { withTenantScope } from '@/lib/orgContext';
 import { z } from 'zod';
 
 const updateCompanySchema = z.object({
@@ -34,6 +35,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
+    return await withTenantScope(session, async () => {
     const company = await prisma.company.findUnique({
       where: { id },
       include: {
@@ -52,6 +54,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
     }
 
     return NextResponse.json({ company });
+    });
   } catch (error) {
     console.error('Get company error:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
@@ -67,6 +70,7 @@ export async function PUT(request: Request, { params }: { params: Promise<{ id: 
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
+    return await withTenantScope(session, async () => {
     const body = await request.json();
     const parsed = updateCompanySchema.safeParse(body);
 
@@ -98,6 +102,7 @@ export async function PUT(request: Request, { params }: { params: Promise<{ id: 
     });
 
     return NextResponse.json({ company });
+    });
   } catch (error) {
     console.error('Update company error:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
@@ -113,9 +118,11 @@ export async function DELETE(request: Request, { params }: { params: Promise<{ i
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
+    return await withTenantScope(session, async () => {
     await prisma.company.delete({ where: { id } });
 
     return NextResponse.json({ message: 'Company deleted successfully' });
+    });
   } catch (error) {
     console.error('Delete company error:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });

--- a/src/app/api/company/analytics/route.ts
+++ b/src/app/api/company/analytics/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { withTenantScope } from '@/lib/orgContext';
 
 // GET — company-scoped analytics: stage distribution, interest summary and
 // basic engagement for the company's linked candidates
@@ -19,6 +20,7 @@ export async function GET() {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
 
+  return await withTenantScope(session, async () => {
   const companyId = session.user.role === 'COMPANY' ? session.user.companyId : undefined;
 
   const relations = await prisma.mentorshipRelation.findMany({
@@ -75,5 +77,6 @@ export async function GET() {
     funnel,
     total: relations.length,
     interestCounts,
+  });
   });
 }

--- a/src/app/api/company/candidates/[id]/route.ts
+++ b/src/app/api/company/candidates/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { withTenantScope } from '@/lib/orgContext';
 import { hasFeature } from '@/lib/entitlements';
 
 // GET — read-only candidate detail for a COMPANY user (EPIC: company
@@ -16,6 +17,7 @@ export async function GET(_request: Request, { params }: { params: Promise<{ id:
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
 
+  return await withTenantScope(session, async () => {
   const { id } = await params;
   const relation = await prisma.mentorshipRelation.findFirst({
     where: { companyId: session.user.companyId, menteeId: id },
@@ -114,5 +116,6 @@ export async function GET(_request: Request, { params }: { params: Promise<{ id:
   return NextResponse.json({
     candidate: { ...candidate, pipelineStatus: relation.pipelineStatus, mentorName: relation.mentor.fullName },
     verified,
+  });
   });
 }

--- a/src/app/api/company/interests/route.ts
+++ b/src/app/api/company/interests/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from 'next-auth';
 import { z } from 'zod';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { withTenantScope } from '@/lib/orgContext';
 import { logActivity } from '@/lib/activity';
 
 const bodySchema = z.object({
@@ -18,14 +19,17 @@ export async function GET(request: Request) {
   if (session.user.role !== 'COMPANY' || !session.user.companyId) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
+  const companyId = session.user.companyId;
 
+  return await withTenantScope(session, async () => {
   const menteeId = new URL(request.url).searchParams.get('menteeId');
   if (!menteeId) return NextResponse.json({ error: 'menteeId is required' }, { status: 400 });
 
   const interest = await prisma.companyInterest.findUnique({
-    where: { companyId_menteeId: { companyId: session.user.companyId, menteeId } },
+    where: { companyId_menteeId: { companyId, menteeId } },
   });
   return NextResponse.json({ interest });
+  });
 }
 
 // POST — set (create or update) the requester company's interest on a
@@ -37,30 +41,32 @@ export async function POST(request: Request) {
   if (session.user.role !== 'COMPANY' || !session.user.companyId) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
+  const companyId = session.user.companyId;
 
+  return await withTenantScope(session, async () => {
   const parsed = bodySchema.safeParse(await request.json().catch(() => null));
   if (!parsed.success) return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
   const { menteeId, status, note } = parsed.data;
 
   const relation = await prisma.mentorshipRelation.findFirst({
-    where: { companyId: session.user.companyId, menteeId },
+    where: { companyId, menteeId },
     select: { mentorId: true, mentee: { select: { fullName: true } } },
   });
   if (!relation) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 
-  const company = await prisma.company.findUnique({ where: { id: session.user.companyId }, select: { name: true } });
+  const company = await prisma.company.findUnique({ where: { id: companyId }, select: { name: true } });
 
   // Was there already an interest, and is this a genuine status change? Note-only
   // updates (e.g. the debounced note auto-save) must NOT re-notify the mentor.
   const existing = await prisma.companyInterest.findUnique({
-    where: { companyId_menteeId: { companyId: session.user.companyId, menteeId } },
+    where: { companyId_menteeId: { companyId, menteeId } },
     select: { status: true },
   });
   const statusChanged = !existing || existing.status !== status;
 
   const interest = await prisma.companyInterest.upsert({
-    where: { companyId_menteeId: { companyId: session.user.companyId, menteeId } },
-    create: { companyId: session.user.companyId, menteeId, status, note },
+    where: { companyId_menteeId: { companyId, menteeId } },
+    create: { companyId, menteeId, status, note },
     update: { status, note },
   });
 
@@ -88,4 +94,5 @@ export async function POST(request: Request) {
   });
 
   return NextResponse.json({ interest });
+  });
 }

--- a/src/app/api/company/talent-pool/route.ts
+++ b/src/app/api/company/talent-pool/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { withTenantScope } from '@/lib/orgContext';
 import { hasFeature } from '@/lib/entitlements';
 import { getSetting } from '@/lib/settings';
 
@@ -20,6 +21,7 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: 'feature_locked' }, { status: 403 });
   }
 
+  return await withTenantScope(session, async () => {
   const { searchParams } = new URL(request.url);
   const q = (searchParams.get('q') || '').trim().slice(0, 100);
   const skill = (searchParams.get('skill') || '').trim().slice(0, 60).toLowerCase();
@@ -81,4 +83,5 @@ export async function GET(request: Request) {
   }
 
   return NextResponse.json({ candidates });
+  });
 }

--- a/src/app/api/cv/[userId]/route.ts
+++ b/src/app/api/cv/[userId]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { withTenantScope } from '@/lib/orgContext';
 import { canAccessCv } from '@/lib/cvAccess';
 
 // GET — download a user's CV (access-controlled).
@@ -14,6 +15,7 @@ export async function GET(_request: Request, { params }: { params: Promise<{ use
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
 
+  return await withTenantScope(session, async () => {
   const cv = await prisma.cvFile.findUnique({ where: { userId } });
   if (!cv) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 
@@ -23,6 +25,7 @@ export async function GET(_request: Request, { params }: { params: Promise<{ use
       'Content-Disposition': `inline; filename="${cv.filename.replace(/"/g, '')}"`,
       'Content-Length': String(cv.size),
     },
+  });
   });
 }
 
@@ -36,7 +39,9 @@ export async function DELETE(_request: Request, { params }: { params: Promise<{ 
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
 
+  return await withTenantScope(session, async () => {
   await prisma.cvFile.deleteMany({ where: { userId } });
   await prisma.user.update({ where: { id: userId }, data: { cvUrl: null } });
   return NextResponse.json({ ok: true });
+  });
 }

--- a/src/app/api/cv/route.ts
+++ b/src/app/api/cv/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { withTenantScope } from '@/lib/orgContext';
 import { canAccessCv } from '@/lib/cvAccess';
 
 const MAX_BYTES = 5 * 1024 * 1024; // 5 MB
@@ -16,6 +17,7 @@ export async function POST(request: Request) {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
+  return await withTenantScope(session, async () => {
   const form = await request.formData();
   const file = form.get('file');
   const targetUserId = (form.get('targetUserId') as string) || session.user.id;
@@ -42,4 +44,5 @@ export async function POST(request: Request) {
   await prisma.user.update({ where: { id: targetUserId }, data: { cvUrl: `/api/cv/${targetUserId}` } });
 
   return NextResponse.json({ ok: true, filename: file.name });
+  });
 }

--- a/src/app/api/evaluations/route.ts
+++ b/src/app/api/evaluations/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { withTenantScope } from '@/lib/orgContext';
 import { z } from 'zod';
 import { ALL_CRITERIA, EVALUATION_TYPES } from '@/lib/evaluation';
 import { dispatchWebhook } from '@/lib/webhooks';
@@ -10,6 +11,7 @@ import { dispatchWebhook } from '@/lib/webhooks';
 export async function GET(request: Request) {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  return await withTenantScope(session, async () => {
   const relationId = new URL(request.url).searchParams.get('relationId') || '';
 
   const rel = await prisma.mentorshipRelation.findUnique({ where: { id: relationId } });
@@ -24,6 +26,7 @@ export async function GET(request: Request) {
       ...e,
       direction: e.authorId === rel.menteeId ? 'MENTEE_ON_MENTOR' : 'MENTOR_ON_MENTEE',
     })),
+  });
   });
 }
 
@@ -41,6 +44,7 @@ export async function POST(request: Request) {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
+  return await withTenantScope(session, async () => {
   const parsed = schema.safeParse(await request.json());
   if (!parsed.success) return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 });
 
@@ -62,4 +66,5 @@ export async function POST(request: Request) {
   });
   await dispatchWebhook('evaluation.added', { relationId: rel.id, type: evaluation.type, authorId: session.user.id });
   return NextResponse.json({ evaluation }, { status: 201 });
+  });
 }

--- a/src/app/api/goals/route.ts
+++ b/src/app/api/goals/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { withTenantScope } from '@/lib/orgContext';
 import type { Role } from '@prisma/client';
 import { z } from 'zod';
 
@@ -16,6 +17,7 @@ async function relationIfAllowed(userId: string, role: string, relationId: strin
 export async function GET(request: Request) {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  return await withTenantScope(session, async () => {
   const relationId = new URL(request.url).searchParams.get('relationId') || '';
 
   const rel = await relationIfAllowed(session.user.id, session.user.role, relationId);
@@ -23,6 +25,7 @@ export async function GET(request: Request) {
 
   const goals = await prisma.goal.findMany({ where: { relationId }, orderBy: { createdAt: 'asc' } });
   return NextResponse.json({ goals });
+  });
 }
 
 const schema = z.object({
@@ -37,6 +40,7 @@ export async function POST(request: Request) {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
+  return await withTenantScope(session, async () => {
   const parsed = schema.safeParse(await request.json());
   if (!parsed.success) return NextResponse.json({ error: 'Validation failed' }, { status: 400 });
 
@@ -54,4 +58,5 @@ export async function POST(request: Request) {
     },
   });
   return NextResponse.json({ goal }, { status: 201 });
+  });
 }

--- a/src/app/api/interactions/route.ts
+++ b/src/app/api/interactions/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { withTenantScope } from '@/lib/orgContext';
 import { z } from 'zod';
 import { dispatchWebhook } from '@/lib/webhooks';
 
@@ -21,6 +22,7 @@ export async function GET(request: Request) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
+    return await withTenantScope(session, async () => {
     const { searchParams } = new URL(request.url);
     const relationId = searchParams.get('relationId');
 
@@ -49,6 +51,7 @@ export async function GET(request: Request) {
     });
 
     return NextResponse.json({ interactions });
+    });
   } catch (error) {
     console.error('Get interactions error:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
@@ -63,6 +66,7 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
+    return await withTenantScope(session, async () => {
     const body = await request.json();
     const parsed = createInteractionSchema.safeParse(body);
 
@@ -102,6 +106,7 @@ export async function POST(request: Request) {
 
     await dispatchWebhook('interaction.logged', { relationId, type, date: interaction.date.toISOString() });
     return NextResponse.json({ interaction }, { status: 201 });
+    });
   } catch (error) {
     console.error('Create interaction error:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });

--- a/src/app/api/interview-prep/route.ts
+++ b/src/app/api/interview-prep/route.ts
@@ -6,6 +6,7 @@ import { prisma } from '@/lib/prisma';
 import { isAiConfigured } from '@/lib/cvExtractAi';
 import { aiInterviewPrep } from '@/lib/aiInterviewPrep';
 import { runAiGated } from '@/lib/aiGate';
+import { withTenantScope } from '@/lib/orgContext';
 
 // AI interview-prep assistant (Faz 2, #536) — mentee-facing and FREE for the
 // mentee: cost is metered on the org's AI quota; quota exhaustion surfaces as
@@ -17,7 +18,9 @@ import { runAiGated } from '@/lib/aiGate';
 export async function GET() {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  return NextResponse.json({ configured: isAiConfigured() });
+  return await withTenantScope(session, async () => {
+    return NextResponse.json({ configured: isAiConfigured() });
+  });
 }
 
 const schema = z.object({
@@ -30,28 +33,30 @@ export async function POST(request: Request) {
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   if (session.user.role !== 'MENTEE') return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
 
-  const parsed = schema.safeParse(await request.json().catch(() => ({})));
-  if (!parsed.success) return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+  return await withTenantScope(session, async () => {
+    const parsed = schema.safeParse(await request.json().catch(() => ({})));
+    if (!parsed.success) return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
 
-  const me = await prisma.user.findUnique({
-    where: { id: session.user.id },
-    select: { targetPosition: true, skills: true },
-  });
-  const position = (parsed.data.position || me?.targetPosition || '').trim();
-  if (!position) return NextResponse.json({ error: 'No target position', code: 'no_position' }, { status: 400 });
-  const skills = Array.isArray(me?.skills) ? (me!.skills as string[]) : [];
+    const me = await prisma.user.findUnique({
+      where: { id: session.user.id },
+      select: { targetPosition: true, skills: true },
+    });
+    const position = (parsed.data.position || me?.targetPosition || '').trim();
+    if (!position) return NextResponse.json({ error: 'No target position', code: 'no_position' }, { status: 400 });
+    const skills = Array.isArray(me?.skills) ? (me!.skills as string[]) : [];
 
-  const gated = await runAiGated({
-    scope: 'interview_prep',
-    userId: session.user.id,
-    call: () => aiInterviewPrep(position, skills, parsed.data.focus),
-  });
+    const gated = await runAiGated({
+      scope: 'interview_prep',
+      userId: session.user.id,
+      call: () => aiInterviewPrep(position, skills, parsed.data.focus),
+    });
 
-  if (!gated.ok) {
-    if (gated.reason === 'quota_exceeded') {
-      return NextResponse.json({ error: 'Temporarily unavailable', code: 'quota_exceeded' }, { status: 429 });
+    if (!gated.ok) {
+      if (gated.reason === 'quota_exceeded') {
+        return NextResponse.json({ error: 'Temporarily unavailable', code: 'quota_exceeded' }, { status: 429 });
+      }
+      return NextResponse.json({ error: 'AI is not configured', code: 'not_configured' }, { status: 501 });
     }
-    return NextResponse.json({ error: 'AI is not configured', code: 'not_configured' }, { status: 501 });
-  }
-  return NextResponse.json({ prep: gated.result });
+    return NextResponse.json({ prep: gated.result });
+  });
 }

--- a/src/app/api/invite/route.ts
+++ b/src/app/api/invite/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { sendInvitationEmail } from '@/services/emailService';
 import { resolveOrgId } from '@/lib/orgScope';
+import { withTenantScope } from '@/lib/orgContext';
 import { z } from 'zod';
 import crypto from 'crypto';
 
@@ -20,72 +21,74 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const body = await request.json();
-    const parsed = inviteSchema.safeParse(body);
+    return await withTenantScope(session, async () => {
+      const body = await request.json();
+      const parsed = inviteSchema.safeParse(body);
 
-    if (!parsed.success) {
+      if (!parsed.success) {
+        return NextResponse.json(
+          { error: 'Validation failed', details: parsed.error.flatten() },
+          { status: 400 }
+        );
+      }
+
+      const { email, role } = parsed.data;
+
+      const existingUser = await prisma.user.findUnique({ where: { email } });
+      if (existingUser) {
+        return NextResponse.json(
+          { error: 'A user with this email already exists' },
+          { status: 409 }
+        );
+      }
+
+      const existingToken = await prisma.invitationToken.findFirst({
+        where: { email, used: false, expiresAt: { gt: new Date() } },
+      });
+      if (existingToken) {
+        return NextResponse.json(
+          { error: 'An active invitation has already been sent to this email' },
+          { status: 409 }
+        );
+      }
+
+      const token = crypto.randomBytes(32).toString('hex');
+      const expiresAt = new Date();
+      expiresAt.setDate(expiresAt.getDate() + 7);
+
+      const invitation = await prisma.invitationToken.create({
+        data: {
+          token,
+          email,
+          role,
+          expiresAt,
+        },
+      });
+
+      const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+      const registerUrl = `${appUrl}/auth/register?token=${token}`;
+
+      // The token is already persisted, so a failed/blocked email must not lose the
+      // invitation — the admin can still share registerUrl manually. Report delivery
+      // status instead of 500-ing.
+      let emailSent = false;
+      try {
+        await sendInvitationEmail({ to: email, token, role, orgId: resolveOrgId(session) });
+        emailSent = !!process.env.SMTP_USER;
+      } catch (mailErr) {
+        console.error('Invitation email failed (token still valid):', mailErr);
+      }
+
       return NextResponse.json(
-        { error: 'Validation failed', details: parsed.error.flatten() },
-        { status: 400 }
+        {
+          message: emailSent ? 'Invitation sent' : 'Invitation created (share the link manually)',
+          invitationId: invitation.id,
+          registerUrl,
+          emailSent,
+        },
+        { status: 201 }
       );
-    }
-
-    const { email, role } = parsed.data;
-
-    const existingUser = await prisma.user.findUnique({ where: { email } });
-    if (existingUser) {
-      return NextResponse.json(
-        { error: 'A user with this email already exists' },
-        { status: 409 }
-      );
-    }
-
-    const existingToken = await prisma.invitationToken.findFirst({
-      where: { email, used: false, expiresAt: { gt: new Date() } },
     });
-    if (existingToken) {
-      return NextResponse.json(
-        { error: 'An active invitation has already been sent to this email' },
-        { status: 409 }
-      );
-    }
-
-    const token = crypto.randomBytes(32).toString('hex');
-    const expiresAt = new Date();
-    expiresAt.setDate(expiresAt.getDate() + 7);
-
-    const invitation = await prisma.invitationToken.create({
-      data: {
-        token,
-        email,
-        role,
-        expiresAt,
-      },
-    });
-
-    const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
-    const registerUrl = `${appUrl}/auth/register?token=${token}`;
-
-    // The token is already persisted, so a failed/blocked email must not lose the
-    // invitation — the admin can still share registerUrl manually. Report delivery
-    // status instead of 500-ing.
-    let emailSent = false;
-    try {
-      await sendInvitationEmail({ to: email, token, role, orgId: resolveOrgId(session) });
-      emailSent = !!process.env.SMTP_USER;
-    } catch (mailErr) {
-      console.error('Invitation email failed (token still valid):', mailErr);
-    }
-
-    return NextResponse.json(
-      {
-        message: emailSent ? 'Invitation sent' : 'Invitation created (share the link manually)',
-        invitationId: invitation.id,
-        registerUrl,
-        emailSent,
-      },
-      { status: 201 }
-    );
   } catch (error) {
     console.error('Invite error:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
@@ -100,22 +103,24 @@ export async function GET() {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const invitations = await prisma.invitationToken.findMany({
-      orderBy: { createdAt: 'desc' },
-      select: {
-        id: true,
-        email: true,
-        role: true,
-        used: true,
-        createdAt: true,
-        expiresAt: true,
-        openedAt: true,
-        registeredAt: true,
-        verifiedAt: true,
-      },
-    });
+    return await withTenantScope(session, async () => {
+      const invitations = await prisma.invitationToken.findMany({
+        orderBy: { createdAt: 'desc' },
+        select: {
+          id: true,
+          email: true,
+          role: true,
+          used: true,
+          createdAt: true,
+          expiresAt: true,
+          openedAt: true,
+          registeredAt: true,
+          verifiedAt: true,
+        },
+      });
 
-    return NextResponse.json({ invitations });
+      return NextResponse.json({ invitations });
+    });
   } catch (error) {
     console.error('Get invitations error:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });

--- a/src/app/api/meetings/route.ts
+++ b/src/app/api/meetings/route.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import { randomBytes } from 'crypto';
 import { sendMeetingInviteEmail } from '@/services/emailService';
 import { dispatchWebhook } from '@/lib/webhooks';
+import { withTenantScope } from '@/lib/orgContext';
 
 const schema = z.object({
   relationIds: z.array(z.string().min(1)).min(1),
@@ -20,14 +21,16 @@ export async function GET() {
   if (!session || (session.user.role !== 'MENTOR' && session.user.role !== 'ADMIN')) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
-  const where =
-    session.user.role === 'ADMIN' ? {} : { relation: { mentorId: session.user.id } };
-  const meetings = await prisma.meeting.findMany({
-    where,
-    include: { relation: { include: { mentee: { select: { fullName: true } } } } },
-    orderBy: { scheduledAt: 'desc' },
+  return await withTenantScope(session, async () => {
+    const where =
+      session.user.role === 'ADMIN' ? {} : { relation: { mentorId: session.user.id } };
+    const meetings = await prisma.meeting.findMany({
+      where,
+      include: { relation: { include: { mentee: { select: { fullName: true } } } } },
+      orderBy: { scheduledAt: 'desc' },
+    });
+    return NextResponse.json({ meetings });
   });
-  return NextResponse.json({ meetings });
 }
 
 // POST — schedule a meeting for one or many mentees (bulk). Each gets its own
@@ -38,53 +41,55 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const parsed = schema.safeParse(await request.json());
-  if (!parsed.success) {
-    return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 });
-  }
-  const { relationIds, title, scheduledAt, meetLink } = parsed.data;
-  const when = scheduledAt ? new Date(scheduledAt) : null;
-
-  const where =
-    session.user.role === 'ADMIN'
-      ? { id: { in: relationIds } }
-      : { id: { in: relationIds }, mentorId: session.user.id };
-  const relations = await prisma.mentorshipRelation.findMany({
-    where,
-    include: { mentee: { select: { email: true, fullName: true } } },
-  });
-
-  let created = 0;
-  for (const rel of relations) {
-    const rsvpToken = randomBytes(24).toString('hex');
-    // Auto-generate a ready-to-use video link (Jitsi, no account needed) when
-    // the organizer didn't paste one — each meeting gets its own room.
-    const link = meetLink || `https://meet.jit.si/InternshipCRM-${randomBytes(8).toString('hex')}`;
-    await prisma.meeting.create({
-      data: {
-        relationId: rel.id,
-        title,
-        scheduledAt: when,
-        meetLink: link,
-        rsvpToken,
-        createdById: session.user.id,
-      },
-    });
-    try {
-      await sendMeetingInviteEmail({
-        to: rel.mentee.email,
-        fullName: rel.mentee.fullName,
-        title,
-        scheduledAt: when,
-        meetLink: link,
-        rsvpToken,
-      });
-    } catch (e) {
-      console.error('Meeting invite email failed:', e);
+  return await withTenantScope(session, async () => {
+    const parsed = schema.safeParse(await request.json());
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 });
     }
-    created++;
-  }
+    const { relationIds, title, scheduledAt, meetLink } = parsed.data;
+    const when = scheduledAt ? new Date(scheduledAt) : null;
 
-  if (created > 0) await dispatchWebhook('meeting.scheduled', { title, scheduledAt: when ? when.toISOString() : null, count: created });
-  return NextResponse.json({ created });
+    const where =
+      session.user.role === 'ADMIN'
+        ? { id: { in: relationIds } }
+        : { id: { in: relationIds }, mentorId: session.user.id };
+    const relations = await prisma.mentorshipRelation.findMany({
+      where,
+      include: { mentee: { select: { email: true, fullName: true } } },
+    });
+
+    let created = 0;
+    for (const rel of relations) {
+      const rsvpToken = randomBytes(24).toString('hex');
+      // Auto-generate a ready-to-use video link (Jitsi, no account needed) when
+      // the organizer didn't paste one — each meeting gets its own room.
+      const link = meetLink || `https://meet.jit.si/InternshipCRM-${randomBytes(8).toString('hex')}`;
+      await prisma.meeting.create({
+        data: {
+          relationId: rel.id,
+          title,
+          scheduledAt: when,
+          meetLink: link,
+          rsvpToken,
+          createdById: session.user.id,
+        },
+      });
+      try {
+        await sendMeetingInviteEmail({
+          to: rel.mentee.email,
+          fullName: rel.mentee.fullName,
+          title,
+          scheduledAt: when,
+          meetLink: link,
+          rsvpToken,
+        });
+      } catch (e) {
+        console.error('Meeting invite email failed:', e);
+      }
+      created++;
+    }
+
+    if (created > 0) await dispatchWebhook('meeting.scheduled', { title, scheduledAt: when ? when.toISOString() : null, count: created });
+    return NextResponse.json({ created });
+  });
 }

--- a/src/app/api/mentor/analytics/route.ts
+++ b/src/app/api/mentor/analytics/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { withTenantScope } from '@/lib/orgContext';
 
 // GET — mentor-scoped analytics: their own pipeline funnel, goal summary and
 // engagement stats (EPIC: mentor analytics / pipeline funnel, roadmap #370).
@@ -11,75 +12,77 @@ export async function GET() {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  // A MENTOR sees only their own mentees; an ADMIN sees all (no mentor filter),
-  // mirroring the company analytics route.
-  const relationWhere = session.user.role === 'ADMIN' ? {} : { mentorId: session.user.id };
-  const interactionWhere =
-    session.user.role === 'ADMIN' ? {} : { relation: { mentorId: session.user.id } };
+  return await withTenantScope(session, async () => {
+    // A MENTOR sees only their own mentees; an ADMIN sees all (no mentor filter),
+    // mirroring the company analytics route.
+    const relationWhere = session.user.role === 'ADMIN' ? {} : { mentorId: session.user.id };
+    const interactionWhere =
+      session.user.role === 'ADMIN' ? {} : { relation: { mentorId: session.user.id } };
 
-  const [relations, interactions, goals] = await Promise.all([
-    prisma.mentorshipRelation.findMany({
-      where: relationWhere,
-      select: {
-        id: true,
-        status: true,
-        pipelineStatus: true,
-        startDate: true,
-        mentee: { select: { id: true, fullName: true } },
-        statusChanges: { orderBy: { createdAt: 'asc' }, select: { toStatus: true, createdAt: true } },
-      },
-    }),
-    prisma.interactionLog.count({ where: interactionWhere }),
-    prisma.goal.findMany({
-      where: interactionWhere,
-      select: { status: true, completedAt: true },
-    }),
-  ]);
+    const [relations, interactions, goals] = await Promise.all([
+      prisma.mentorshipRelation.findMany({
+        where: relationWhere,
+        select: {
+          id: true,
+          status: true,
+          pipelineStatus: true,
+          startDate: true,
+          mentee: { select: { id: true, fullName: true } },
+          statusChanges: { orderBy: { createdAt: 'asc' }, select: { toStatus: true, createdAt: true } },
+        },
+      }),
+      prisma.interactionLog.count({ where: interactionWhere }),
+      prisma.goal.findMany({
+        where: interactionWhere,
+        select: { status: true, completedAt: true },
+      }),
+    ]);
 
-  // Pipeline funnel: count mentees per stage (all relations, not just active).
-  const funnel: Record<string, number> = {};
-  for (const r of relations) {
-    funnel[r.pipelineStatus] = (funnel[r.pipelineStatus] ?? 0) + 1;
-  }
-
-  const totalRelations = relations.length;
-  const activeRelations = relations.filter((r) => r.status === 'ACTIVE').length;
-  const hired = relations.filter(
-    (r) => r.pipelineStatus === 'HIRED_660' || r.pipelineStatus === 'EMPLOYED_700'
-  ).length;
-  const conversionToHired = totalRelations > 0 ? Math.round((hired / totalRelations) * 100) : 0;
-
-  // Goal summary across all mentees.
-  const goalsOpen = goals.filter((g) => g.status === 'OPEN').length;
-  const goalsDone = goals.filter((g) => g.status === 'DONE').length;
-  const goalsTotal = goals.length;
-
-  // Average days to hired for completed mentees.
-  let avgDaysToHired: number | null = null;
-  const hiredRelations = relations.filter(
-    (r) => r.pipelineStatus === 'HIRED_660' || r.pipelineStatus === 'EMPLOYED_700'
-  );
-  if (hiredRelations.length > 0) {
-    const durations = hiredRelations
-      .map((r) => {
-        const last = r.statusChanges[r.statusChanges.length - 1];
-        if (!last) return null;
-        return Math.floor((last.createdAt.getTime() - r.startDate.getTime()) / (24 * 60 * 60 * 1000));
-      })
-      .filter((d): d is number => d !== null);
-    if (durations.length > 0) {
-      avgDaysToHired = Math.round(durations.reduce((s, d) => s + d, 0) / durations.length);
+    // Pipeline funnel: count mentees per stage (all relations, not just active).
+    const funnel: Record<string, number> = {};
+    for (const r of relations) {
+      funnel[r.pipelineStatus] = (funnel[r.pipelineStatus] ?? 0) + 1;
     }
-  }
 
-  return NextResponse.json({
-    funnel,
-    totalRelations,
-    activeRelations,
-    hired,
-    conversionToHired,
-    interactions,
-    goals: { open: goalsOpen, done: goalsDone, total: goalsTotal },
-    avgDaysToHired,
+    const totalRelations = relations.length;
+    const activeRelations = relations.filter((r) => r.status === 'ACTIVE').length;
+    const hired = relations.filter(
+      (r) => r.pipelineStatus === 'HIRED_660' || r.pipelineStatus === 'EMPLOYED_700'
+    ).length;
+    const conversionToHired = totalRelations > 0 ? Math.round((hired / totalRelations) * 100) : 0;
+
+    // Goal summary across all mentees.
+    const goalsOpen = goals.filter((g) => g.status === 'OPEN').length;
+    const goalsDone = goals.filter((g) => g.status === 'DONE').length;
+    const goalsTotal = goals.length;
+
+    // Average days to hired for completed mentees.
+    let avgDaysToHired: number | null = null;
+    const hiredRelations = relations.filter(
+      (r) => r.pipelineStatus === 'HIRED_660' || r.pipelineStatus === 'EMPLOYED_700'
+    );
+    if (hiredRelations.length > 0) {
+      const durations = hiredRelations
+        .map((r) => {
+          const last = r.statusChanges[r.statusChanges.length - 1];
+          if (!last) return null;
+          return Math.floor((last.createdAt.getTime() - r.startDate.getTime()) / (24 * 60 * 60 * 1000));
+        })
+        .filter((d): d is number => d !== null);
+      if (durations.length > 0) {
+        avgDaysToHired = Math.round(durations.reduce((s, d) => s + d, 0) / durations.length);
+      }
+    }
+
+    return NextResponse.json({
+      funnel,
+      totalRelations,
+      activeRelations,
+      hired,
+      conversionToHired,
+      interactions,
+      goals: { open: goalsOpen, done: goalsDone, total: goalsTotal },
+      avgDaysToHired,
+    });
   });
 }

--- a/src/app/api/mentor/email/route.ts
+++ b/src/app/api/mentor/email/route.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import { sendEmail } from '@/services/emailService';
 import { notify } from '@/lib/notify';
 import { replyAddress } from '@/lib/replyToken';
+import { withTenantScope } from '@/lib/orgContext';
 
 const schema = z.object({
   relationIds: z.array(z.string().min(1)).min(1),
@@ -23,52 +24,54 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const parsed = schema.safeParse(await request.json());
-  if (!parsed.success) {
-    return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 });
-  }
-  const { relationIds, subject, body } = parsed.data;
-
-  // A mentor may only email their own mentees; admins may email any.
-  const where =
-    session.user.role === 'ADMIN'
-      ? { id: { in: relationIds } }
-      : { id: { in: relationIds }, mentorId: session.user.id };
-  const relations = await prisma.mentorshipRelation.findMany({
-    where,
-    include: { mentee: { select: { email: true, fullName: true } } },
-  });
-
-  // Template placeholders (e.g. "{name}") are filled per recipient with the
-  // mentee's own name — otherwise the literal "{name}" is emailed out. A replacer
-  // function avoids `$`-sequences in a name being interpreted by String.replace.
-  const fill = (s: string, name: string) => s.replace(/\{name\}/g, () => name);
-
-  let sent = 0;
-  for (const rel of relations) {
-    const name = rel.mentee.fullName;
-    const personalSubject = fill(subject, name);
-    const personalBody = fill(body, name);
-    const html = `<div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">${esc(personalBody)
-      .split('\n')
-      .map((l) => `<p>${l || '&nbsp;'}</p>`)
-      .join('')}</div>`;
-    try {
-      // Reply-To routes mentee replies back into this thread (inbound email).
-      await sendEmail({ to: rel.mentee.email, subject: personalSubject, html, replyTo: replyAddress(rel.id) });
-    } catch (e) {
-      console.error('Mentor email failed for', rel.mentee.email, e);
+  return await withTenantScope(session, async () => {
+    const parsed = schema.safeParse(await request.json());
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 });
     }
-    await prisma.interactionLog.create({
-      data: { relationId: rel.id, date: new Date(), type: 'Email', notes: `${personalSubject} — ${personalBody}` },
-    });
-    // Mirror the email into the conversation thread + notify the mentee in-app.
-    await prisma.message.create({
-      data: { relationId: rel.id, senderId: session.user.id, channel: 'EMAIL', body: `${personalSubject}\n\n${personalBody}` },
-    });
-    await notify(rel.menteeId, 'message', `New message from ${session.user.name ?? 'your mentor'}.`, `/messages/${rel.id}`);
-    sent++;
-  }
+    const { relationIds, subject, body } = parsed.data;
 
-  return NextResponse.json({ sent });
+    // A mentor may only email their own mentees; admins may email any.
+    const where =
+      session.user.role === 'ADMIN'
+        ? { id: { in: relationIds } }
+        : { id: { in: relationIds }, mentorId: session.user.id };
+    const relations = await prisma.mentorshipRelation.findMany({
+      where,
+      include: { mentee: { select: { email: true, fullName: true } } },
+    });
+
+    // Template placeholders (e.g. "{name}") are filled per recipient with the
+    // mentee's own name — otherwise the literal "{name}" is emailed out. A replacer
+    // function avoids `$`-sequences in a name being interpreted by String.replace.
+    const fill = (s: string, name: string) => s.replace(/\{name\}/g, () => name);
+
+    let sent = 0;
+    for (const rel of relations) {
+      const name = rel.mentee.fullName;
+      const personalSubject = fill(subject, name);
+      const personalBody = fill(body, name);
+      const html = `<div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">${esc(personalBody)
+        .split('\n')
+        .map((l) => `<p>${l || '&nbsp;'}</p>`)
+        .join('')}</div>`;
+      try {
+        // Reply-To routes mentee replies back into this thread (inbound email).
+        await sendEmail({ to: rel.mentee.email, subject: personalSubject, html, replyTo: replyAddress(rel.id) });
+      } catch (e) {
+        console.error('Mentor email failed for', rel.mentee.email, e);
+      }
+      await prisma.interactionLog.create({
+        data: { relationId: rel.id, date: new Date(), type: 'Email', notes: `${personalSubject} — ${personalBody}` },
+      });
+      // Mirror the email into the conversation thread + notify the mentee in-app.
+      await prisma.message.create({
+        data: { relationId: rel.id, senderId: session.user.id, channel: 'EMAIL', body: `${personalSubject}\n\n${personalBody}` },
+      });
+      await notify(rel.menteeId, 'message', `New message from ${session.user.name ?? 'your mentor'}.`, `/messages/${rel.id}`);
+      sent++;
+    }
+
+    return NextResponse.json({ sent });
+  });
 }

--- a/src/app/api/mentor/mentees/route.ts
+++ b/src/app/api/mentor/mentees/route.ts
@@ -9,6 +9,7 @@ import { sendPasswordResetEmail } from '@/services/emailService';
 import { slugify } from '@/lib/transliterate';
 import { checkActiveRelationLimit, planLimitError } from '@/lib/planGate';
 import { resolveOrgId } from '@/lib/orgScope';
+import { withTenantScope } from '@/lib/orgContext';
 
 const schema = z.object({
   fullName: z.string().min(1),
@@ -28,76 +29,78 @@ export async function POST(request: Request) {
     if (!session || (session.user.role !== 'MENTOR' && session.user.role !== 'ADMIN')) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
-    const parsed = schema.safeParse(await request.json());
-    if (!parsed.success) {
-      return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 });
-    }
-    const { fullName, email, ...rest } = parsed.data;
-
-    // A real email means the mentee can be invited to set a password and log in.
-    // No email → a deterministic placeholder for a tracking-only mentee (no login).
-    const hasRealEmail = !!(email && email.length > 0);
-    const finalEmail = hasRealEmail
-      ? email!
-      : `mentee.${slugify(fullName)}.${crypto.randomBytes(2).toString('hex')}@import.local`;
-
-    const existing = await prisma.user.findUnique({ where: { email: finalEmail } });
-    if (existing) {
-      return NextResponse.json({ error: 'A user with this email already exists' }, { status: 409 });
-    }
-
-    // Plan gate (#547): a new mentee here means a new active relation. Gate on
-    // the creating user's tenant before creating anything. No-op for the
-    // unlimited default org.
-    const orgId = resolveOrgId(session);
-    const gate = await checkActiveRelationLimit(orgId);
-    if (!gate.allowed) {
-      return NextResponse.json(planLimitError(gate), { status: 403 });
-    }
-
-    const mentee = await prisma.user.create({
-      data: {
-        email: finalEmail,
-        password: '!created-no-login',
-        role: 'MENTEE',
-        fullName,
-        orgId,
-        skills: [],
-        phone: rest.phone || null,
-        whatsapp: rest.whatsapp || null,
-        city: rest.city || null,
-        university: rest.university || null,
-        department: rest.department || null,
-        referralSource: rest.referralSource || null,
-      },
-    });
-
-    await prisma.mentorshipRelation.create({
-      data: { mentorId: session.user.id, menteeId: mentee.id, orgId },
-    });
-
-    // If the mentee has a real email, send a "set your password" link so they
-    // can activate their account. The link is also returned so the UI can show
-    // it (and the mentor can share it manually) even if the email fails.
-    let setPasswordUrl: string | null = null;
-    if (hasRealEmail) {
-      const token = await createPasswordResetToken(mentee.id, 'SET_INITIAL');
-      const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
-      setPasswordUrl = `${appUrl}/auth/reset?token=${token}`;
-      try {
-        await sendPasswordResetEmail({
-          to: mentee.email,
-          token,
-          fullName: mentee.fullName,
-          purpose: 'SET_INITIAL',
-          orgId,
-        });
-      } catch (e) {
-        console.error('Mentee set-password email failed:', e);
+    return await withTenantScope(session, async () => {
+      const parsed = schema.safeParse(await request.json());
+      if (!parsed.success) {
+        return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 });
       }
-    }
+      const { fullName, email, ...rest } = parsed.data;
 
-    return NextResponse.json({ menteeId: mentee.id, setPasswordUrl }, { status: 201 });
+      // A real email means the mentee can be invited to set a password and log in.
+      // No email → a deterministic placeholder for a tracking-only mentee (no login).
+      const hasRealEmail = !!(email && email.length > 0);
+      const finalEmail = hasRealEmail
+        ? email!
+        : `mentee.${slugify(fullName)}.${crypto.randomBytes(2).toString('hex')}@import.local`;
+
+      const existing = await prisma.user.findUnique({ where: { email: finalEmail } });
+      if (existing) {
+        return NextResponse.json({ error: 'A user with this email already exists' }, { status: 409 });
+      }
+
+      // Plan gate (#547): a new mentee here means a new active relation. Gate on
+      // the creating user's tenant before creating anything. No-op for the
+      // unlimited default org.
+      const orgId = resolveOrgId(session);
+      const gate = await checkActiveRelationLimit(orgId);
+      if (!gate.allowed) {
+        return NextResponse.json(planLimitError(gate), { status: 403 });
+      }
+
+      const mentee = await prisma.user.create({
+        data: {
+          email: finalEmail,
+          password: '!created-no-login',
+          role: 'MENTEE',
+          fullName,
+          orgId,
+          skills: [],
+          phone: rest.phone || null,
+          whatsapp: rest.whatsapp || null,
+          city: rest.city || null,
+          university: rest.university || null,
+          department: rest.department || null,
+          referralSource: rest.referralSource || null,
+        },
+      });
+
+      await prisma.mentorshipRelation.create({
+        data: { mentorId: session.user.id, menteeId: mentee.id, orgId },
+      });
+
+      // If the mentee has a real email, send a "set your password" link so they
+      // can activate their account. The link is also returned so the UI can show
+      // it (and the mentor can share it manually) even if the email fails.
+      let setPasswordUrl: string | null = null;
+      if (hasRealEmail) {
+        const token = await createPasswordResetToken(mentee.id, 'SET_INITIAL');
+        const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+        setPasswordUrl = `${appUrl}/auth/reset?token=${token}`;
+        try {
+          await sendPasswordResetEmail({
+            to: mentee.email,
+            token,
+            fullName: mentee.fullName,
+            purpose: 'SET_INITIAL',
+            orgId,
+          });
+        } catch (e) {
+          console.error('Mentee set-password email failed:', e);
+        }
+      }
+
+      return NextResponse.json({ menteeId: mentee.id, setPasswordUrl }, { status: 201 });
+    });
   } catch (error) {
     console.error('Create mentee error:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });

--- a/src/app/api/mentorship-requests/route.ts
+++ b/src/app/api/mentorship-requests/route.ts
@@ -5,6 +5,7 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { notify } from '@/lib/notify';
 import { getMenteeRequestGate } from '@/lib/requestGate';
+import { withTenantScope } from '@/lib/orgContext';
 
 // Mentee-side mentorship requests (#590): a mentee asks for a mentor; an admin
 // approves (creating the MentorshipRelation) or rejects via the admin queue.
@@ -20,16 +21,18 @@ export async function GET() {
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   if (session.user.role !== 'MENTEE') return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
 
-  const [requests, gate] = await Promise.all([
-    prisma.mentorshipRequest.findMany({
-      where: { menteeId: session.user.id },
-      orderBy: { createdAt: 'desc' },
-      take: 10,
-      select: { id: true, status: true, message: true, targetPosition: true, createdAt: true, decidedAt: true },
-    }),
-    getMenteeRequestGate(session.user.id),
-  ]);
-  return NextResponse.json({ requests, gate });
+  return await withTenantScope(session, async () => {
+    const [requests, gate] = await Promise.all([
+      prisma.mentorshipRequest.findMany({
+        where: { menteeId: session.user.id },
+        orderBy: { createdAt: 'desc' },
+        take: 10,
+        select: { id: true, status: true, message: true, targetPosition: true, createdAt: true, decidedAt: true },
+      }),
+      getMenteeRequestGate(session.user.id),
+    ]);
+    return NextResponse.json({ requests, gate });
+  });
 }
 
 // POST — create a request. Guards: one PENDING at a time, no request while a
@@ -39,47 +42,49 @@ export async function POST(request: Request) {
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   if (session.user.role !== 'MENTEE') return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
 
-  const parsed = createSchema.safeParse(await request.json().catch(() => ({})));
-  if (!parsed.success) return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+  return await withTenantScope(session, async () => {
+    const parsed = createSchema.safeParse(await request.json().catch(() => ({})));
+    if (!parsed.success) return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
 
-  // Onboarding gate (#591) — server-side, never trust the UI: profile + CV
-  // must be complete before a request is accepted.
-  const gate = await getMenteeRequestGate(session.user.id);
-  if (!gate.complete) {
-    return NextResponse.json(
-      { error: 'Complete your onboarding first', code: 'onboarding_incomplete', missing: gate.missing },
-      { status: 400 }
+    // Onboarding gate (#591) — server-side, never trust the UI: profile + CV
+    // must be complete before a request is accepted.
+    const gate = await getMenteeRequestGate(session.user.id);
+    if (!gate.complete) {
+      return NextResponse.json(
+        { error: 'Complete your onboarding first', code: 'onboarding_incomplete', missing: gate.missing },
+        { status: 400 }
+      );
+    }
+
+    const [activeRelation, pending, latest] = await Promise.all([
+      prisma.mentorshipRelation.findFirst({ where: { menteeId: session.user.id, status: 'ACTIVE' }, select: { id: true } }),
+      prisma.mentorshipRequest.findFirst({ where: { menteeId: session.user.id, status: 'PENDING' }, select: { id: true } }),
+      prisma.mentorshipRequest.findFirst({ where: { menteeId: session.user.id }, orderBy: { createdAt: 'desc' }, select: { createdAt: true } }),
+    ]);
+    if (activeRelation) {
+      return NextResponse.json({ error: 'You already have an active mentorship', code: 'already_mentored' }, { status: 409 });
+    }
+    if (pending) {
+      return NextResponse.json({ error: 'You already have a pending request', code: 'already_pending' }, { status: 409 });
+    }
+    if (latest && Date.now() - latest.createdAt.getTime() < 60 * 60 * 1000) {
+      return NextResponse.json({ error: 'Please wait before submitting another request', code: 'rate_limited' }, { status: 429 });
+    }
+
+    const created = await prisma.mentorshipRequest.create({
+      data: {
+        menteeId: session.user.id,
+        message: parsed.data.message?.trim() || null,
+        targetPosition: parsed.data.targetPosition?.trim() || null,
+      },
+      select: { id: true, status: true, createdAt: true },
+    });
+
+    const admins = await prisma.user.findMany({ where: { role: 'ADMIN', isActive: true }, select: { id: true } });
+    await Promise.all(
+      admins.map((a) => notify(a.id, 'mentorship_request', `New mentorship request from ${session.user.name ?? 'a mentee'}.`, '/admin/mentorship'))
     );
-  }
 
-  const [activeRelation, pending, latest] = await Promise.all([
-    prisma.mentorshipRelation.findFirst({ where: { menteeId: session.user.id, status: 'ACTIVE' }, select: { id: true } }),
-    prisma.mentorshipRequest.findFirst({ where: { menteeId: session.user.id, status: 'PENDING' }, select: { id: true } }),
-    prisma.mentorshipRequest.findFirst({ where: { menteeId: session.user.id }, orderBy: { createdAt: 'desc' }, select: { createdAt: true } }),
-  ]);
-  if (activeRelation) {
-    return NextResponse.json({ error: 'You already have an active mentorship', code: 'already_mentored' }, { status: 409 });
-  }
-  if (pending) {
-    return NextResponse.json({ error: 'You already have a pending request', code: 'already_pending' }, { status: 409 });
-  }
-  if (latest && Date.now() - latest.createdAt.getTime() < 60 * 60 * 1000) {
-    return NextResponse.json({ error: 'Please wait before submitting another request', code: 'rate_limited' }, { status: 429 });
-  }
-
-  const created = await prisma.mentorshipRequest.create({
-    data: {
-      menteeId: session.user.id,
-      message: parsed.data.message?.trim() || null,
-      targetPosition: parsed.data.targetPosition?.trim() || null,
-    },
-    select: { id: true, status: true, createdAt: true },
+    return NextResponse.json({ request: created }, { status: 201 });
   });
-
-  const admins = await prisma.user.findMany({ where: { role: 'ADMIN', isActive: true }, select: { id: true } });
-  await Promise.all(
-    admins.map((a) => notify(a.id, 'mentorship_request', `New mentorship request from ${session.user.name ?? 'a mentee'}.`, '/admin/mentorship'))
-  );
-
-  return NextResponse.json({ request: created }, { status: 201 });
 }

--- a/src/app/api/mentorship/[id]/route.ts
+++ b/src/app/api/mentorship/[id]/route.ts
@@ -8,6 +8,7 @@ import { logActivity } from '@/lib/activity';
 import { notify } from '@/lib/notify';
 import { dispatchWebhook } from '@/lib/webhooks';
 import { PIPELINE_STATUSES } from '@/lib/pipeline';
+import { withTenantScope } from '@/lib/orgContext';
 
 const updateRelationSchema = z.object({
   status: z.enum(['ACTIVE', 'COMPLETED']).optional(),
@@ -27,57 +28,59 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const relation = await prisma.mentorshipRelation.findUnique({
-      where: { id },
-      include: {
-        mentor: { select: { id: true, fullName: true, email: true, department: true } },
-        mentee: {
-          select: {
-            id: true,
-            fullName: true,
-            email: true,
-            university: true,
-            graduationYear: true,
-            skills: true,
-            phone: true,
-            whatsapp: true,
-            city: true,
-            birthDate: true,
-            referralSource: true,
-            cvUrl: true,
+    return await withTenantScope(session, async () => {
+      const relation = await prisma.mentorshipRelation.findUnique({
+        where: { id },
+        include: {
+          mentor: { select: { id: true, fullName: true, email: true, department: true } },
+          mentee: {
+            select: {
+              id: true,
+              fullName: true,
+              email: true,
+              university: true,
+              graduationYear: true,
+              skills: true,
+              phone: true,
+              whatsapp: true,
+              city: true,
+              birthDate: true,
+              referralSource: true,
+              cvUrl: true,
+            },
+          },
+          company: true,
+          interactions: { orderBy: { date: 'desc' } },
+          statusChanges: {
+            orderBy: { createdAt: 'desc' },
+            include: { changedBy: { select: { fullName: true } } },
           },
         },
-        company: true,
-        interactions: { orderBy: { date: 'desc' } },
-        statusChanges: {
-          orderBy: { createdAt: 'desc' },
-          include: { changedBy: { select: { fullName: true } } },
-        },
-      },
+      });
+
+      if (!relation) {
+        return NextResponse.json({ error: 'Relation not found' }, { status: 404 });
+      }
+
+      const isAuthorized =
+        session.user.role === 'ADMIN' ||
+        relation.mentorId === session.user.id ||
+        relation.menteeId === session.user.id;
+
+      if (!isAuthorized) {
+        return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+      }
+
+      // Surface the linked company's shortlist signal (EPIC: company shortlist)
+      // to the mentor/admin viewing this relation.
+      const companyInterest = relation.companyId
+        ? await prisma.companyInterest.findUnique({
+            where: { companyId_menteeId: { companyId: relation.companyId, menteeId: relation.menteeId } },
+          })
+        : null;
+
+      return NextResponse.json({ relation: { ...relation, companyInterest } });
     });
-
-    if (!relation) {
-      return NextResponse.json({ error: 'Relation not found' }, { status: 404 });
-    }
-
-    const isAuthorized =
-      session.user.role === 'ADMIN' ||
-      relation.mentorId === session.user.id ||
-      relation.menteeId === session.user.id;
-
-    if (!isAuthorized) {
-      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-    }
-
-    // Surface the linked company's shortlist signal (EPIC: company shortlist)
-    // to the mentor/admin viewing this relation.
-    const companyInterest = relation.companyId
-      ? await prisma.companyInterest.findUnique({
-          where: { companyId_menteeId: { companyId: relation.companyId, menteeId: relation.menteeId } },
-        })
-      : null;
-
-    return NextResponse.json({ relation: { ...relation, companyInterest } });
   } catch (error) {
     console.error('Get mentorship error:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
@@ -93,72 +96,74 @@ export async function PUT(request: Request, { params }: { params: Promise<{ id: 
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const relation = await prisma.mentorshipRelation.findUnique({
-      where: { id },
-    });
+    return await withTenantScope(session, async () => {
+      const relation = await prisma.mentorshipRelation.findUnique({
+        where: { id },
+      });
 
-    if (!relation) {
-      return NextResponse.json({ error: 'Relation not found' }, { status: 404 });
-    }
+      if (!relation) {
+        return NextResponse.json({ error: 'Relation not found' }, { status: 404 });
+      }
 
-    const isAuthorized =
-      session.user.role === 'ADMIN' || relation.mentorId === session.user.id;
+      const isAuthorized =
+        session.user.role === 'ADMIN' || relation.mentorId === session.user.id;
 
-    if (!isAuthorized) {
-      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-    }
+      if (!isAuthorized) {
+        return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+      }
 
-    const body = await request.json();
-    const parsed = updateRelationSchema.safeParse(body);
+      const body = await request.json();
+      const parsed = updateRelationSchema.safeParse(body);
 
-    if (!parsed.success) {
-      return NextResponse.json(
-        { error: 'Validation failed', details: parsed.error.flatten() },
-        { status: 400 }
-      );
-    }
+      if (!parsed.success) {
+        return NextResponse.json(
+          { error: 'Validation failed', details: parsed.error.flatten() },
+          { status: 400 }
+        );
+      }
 
-    const { stageDeadline, ...rest } = parsed.data;
-    const data: Prisma.MentorshipRelationUncheckedUpdateInput = { ...rest };
-    if (stageDeadline !== undefined) {
-      data.stageDeadline = stageDeadline ? new Date(stageDeadline) : null;
-      // A fresh deadline (or cleared) re-arms the overdue reminder.
-      data.deadlineReminderSentAt = null;
-    }
+      const { stageDeadline, ...rest } = parsed.data;
+      const data: Prisma.MentorshipRelationUncheckedUpdateInput = { ...rest };
+      if (stageDeadline !== undefined) {
+        data.stageDeadline = stageDeadline ? new Date(stageDeadline) : null;
+        // A fresh deadline (or cleared) re-arms the overdue reminder.
+        data.deadlineReminderSentAt = null;
+      }
 
-    const updated = await prisma.mentorshipRelation.update({
-      where: { id },
-      data,
-      include: {
-        mentor: { select: { id: true, fullName: true, email: true } },
-        mentee: { select: { id: true, fullName: true, email: true } },
-        company: { select: { id: true, name: true } },
-      },
-    });
-
-    // Record an audit entry when the pipeline stage actually changes.
-    if (parsed.data.pipelineStatus && parsed.data.pipelineStatus !== relation.pipelineStatus) {
-      await prisma.statusChange.create({
-        data: {
-          relationId: id,
-          fromStatus: relation.pipelineStatus,
-          toStatus: parsed.data.pipelineStatus,
-          changedById: session.user.id,
+      const updated = await prisma.mentorshipRelation.update({
+        where: { id },
+        data,
+        include: {
+          mentor: { select: { id: true, fullName: true, email: true } },
+          mentee: { select: { id: true, fullName: true, email: true } },
+          company: { select: { id: true, name: true } },
         },
       });
-      await logActivity({
-        action: 'pipeline.stage_change',
-        actorId: session.user.id,
-        actorEmail: session.user.email ?? null,
-        targetType: 'relation',
-        targetId: id,
-        detail: `${relation.pipelineStatus} → ${parsed.data.pipelineStatus}`,
-      });
-      await notify(relation.menteeId, 'stage', 'Your pipeline stage was updated.', '/portal');
-      await dispatchWebhook('pipeline.stage_change', { relationId: id, from: relation.pipelineStatus, to: parsed.data.pipelineStatus });
-    }
 
-    return NextResponse.json({ relation: updated });
+      // Record an audit entry when the pipeline stage actually changes.
+      if (parsed.data.pipelineStatus && parsed.data.pipelineStatus !== relation.pipelineStatus) {
+        await prisma.statusChange.create({
+          data: {
+            relationId: id,
+            fromStatus: relation.pipelineStatus,
+            toStatus: parsed.data.pipelineStatus,
+            changedById: session.user.id,
+          },
+        });
+        await logActivity({
+          action: 'pipeline.stage_change',
+          actorId: session.user.id,
+          actorEmail: session.user.email ?? null,
+          targetType: 'relation',
+          targetId: id,
+          detail: `${relation.pipelineStatus} → ${parsed.data.pipelineStatus}`,
+        });
+        await notify(relation.menteeId, 'stage', 'Your pipeline stage was updated.', '/portal');
+        await dispatchWebhook('pipeline.stage_change', { relationId: id, from: relation.pipelineStatus, to: parsed.data.pipelineStatus });
+      }
+
+      return NextResponse.json({ relation: updated });
+    });
   } catch (error) {
     console.error('Update mentorship error:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });

--- a/src/app/api/messages/route.ts
+++ b/src/app/api/messages/route.ts
@@ -10,6 +10,7 @@ import { sendEmail } from '@/services/emailService';
 import { logger } from '@/lib/logger';
 import { emailAllowed } from '@/lib/notificationPrefs';
 import { ALLOWED_DOC_MIME, MAX_DOC_BYTES } from '@/lib/documentAccess';
+import { withTenantScope } from '@/lib/orgContext';
 
 const ATTACHMENT_SELECT = { id: true, filename: true, contentType: true, size: true } as const;
 
@@ -18,70 +19,72 @@ export async function GET(request: Request) {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
-  const relationId = new URL(request.url).searchParams.get('relationId') || '';
-  const rel = await getThreadIfAllowed(session.user, relationId);
-  if (!rel) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  return await withTenantScope(session, async () => {
+    const relationId = new URL(request.url).searchParams.get('relationId') || '';
+    const rel = await getThreadIfAllowed(session.user, relationId);
+    if (!rel) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
 
-  const rows = await prisma.message.findMany({
-    // Exclude messages this viewer deleted "for me".
-    where: { relationId, hiddenFor: { none: { userId: session.user.id } } },
-    orderBy: { createdAt: 'asc' },
-    include: { attachments: { select: ATTACHMENT_SELECT }, reactions: { select: { emoji: true, userId: true } } },
-  });
+    const rows = await prisma.message.findMany({
+      // Exclude messages this viewer deleted "for me".
+      where: { relationId, hiddenFor: { none: { userId: session.user.id } } },
+      orderBy: { createdAt: 'asc' },
+      include: { attachments: { select: ATTACHMENT_SELECT }, reactions: { select: { emoji: true, userId: true } } },
+    });
 
-  // Summarize reactions per message: emoji → { count, mine }.
-  const summarizeReactions = (reactions: { emoji: string; userId: string }[]) => {
-    const map = new Map<string, { emoji: string; count: number; mine: boolean }>();
-    for (const r of reactions) {
-      const cur = map.get(r.emoji) ?? { emoji: r.emoji, count: 0, mine: false };
-      cur.count += 1;
-      if (r.userId === session.user.id) cur.mine = true;
-      map.set(r.emoji, cur);
-    }
-    return Array.from(map.values());
-  };
+    // Summarize reactions per message: emoji → { count, mine }.
+    const summarizeReactions = (reactions: { emoji: string; userId: string }[]) => {
+      const map = new Map<string, { emoji: string; count: number; mine: boolean }>();
+      for (const r of reactions) {
+        const cur = map.get(r.emoji) ?? { emoji: r.emoji, count: 0, mine: false };
+        cur.count += 1;
+        if (r.userId === session.user.id) cur.mine = true;
+        map.set(r.emoji, cur);
+      }
+      return Array.from(map.values());
+    };
 
-  // Mask "deleted for everyone" messages server-side so the original body/
-  // attachments never leak; the client renders a placeholder instead.
-  const messages = rows.map((m) =>
-    m.deletedForEveryoneAt
-      ? {
-          id: m.id,
-          senderId: m.senderId,
-          body: '',
-          channel: m.channel,
-          readAt: m.readAt,
-          createdAt: m.createdAt,
-          editedAt: null,
-          deleted: true,
-          attachments: [],
-          reactions: [],
-        }
-      : {
-          id: m.id,
-          senderId: m.senderId,
-          body: m.body,
-          channel: m.channel,
-          readAt: m.readAt,
-          createdAt: m.createdAt,
-          editedAt: m.editedAt,
-          deleted: false,
-          attachments: m.attachments,
-          reactions: summarizeReactions(m.reactions),
-        },
-  );
+    // Mask "deleted for everyone" messages server-side so the original body/
+    // attachments never leak; the client renders a placeholder instead.
+    const messages = rows.map((m) =>
+      m.deletedForEveryoneAt
+        ? {
+            id: m.id,
+            senderId: m.senderId,
+            body: '',
+            channel: m.channel,
+            readAt: m.readAt,
+            createdAt: m.createdAt,
+            editedAt: null,
+            deleted: true,
+            attachments: [],
+            reactions: [],
+          }
+        : {
+            id: m.id,
+            senderId: m.senderId,
+            body: m.body,
+            channel: m.channel,
+            readAt: m.readAt,
+            createdAt: m.createdAt,
+            editedAt: m.editedAt,
+            deleted: false,
+            attachments: m.attachments,
+            reactions: summarizeReactions(m.reactions),
+          },
+    );
 
-  // Mark the viewer's incoming unread messages as read.
-  await prisma.message.updateMany({
-    where: { relationId, senderId: { not: session.user.id }, readAt: null },
-    data: { readAt: new Date() },
-  });
+    // Mark the viewer's incoming unread messages as read.
+    await prisma.message.updateMany({
+      where: { relationId, senderId: { not: session.user.id }, readAt: null },
+      data: { readAt: new Date() },
+    });
 
-  return NextResponse.json({
-    relationId,
-    mentor: rel.mentor,
-    mentee: rel.mentee,
-    messages,
+    return NextResponse.json({
+      relationId,
+      mentor: rel.mentor,
+      mentee: rel.mentee,
+      messages,
+    });
   });
 }
 
@@ -94,82 +97,84 @@ export async function POST(request: Request) {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
-  const contentType = request.headers.get('content-type') || '';
-  let relationId: string;
-  let body: string;
-  let files: File[] = [];
+  return await withTenantScope(session, async () => {
+    const contentType = request.headers.get('content-type') || '';
+    let relationId: string;
+    let body: string;
+    let files: File[] = [];
 
-  if (contentType.includes('multipart/form-data')) {
-    const form = await request.formData();
-    relationId = String(form.get('relationId') || '');
-    body = String(form.get('body') || '');
-    // Accept multiple files (pasted images + picked files). Cap the count.
-    files = form.getAll('file').filter((f): f is File => f instanceof File && f.size > 0).slice(0, 10);
-    if (!relationId || (!body.trim() && files.length === 0) || body.length > 5000) {
-      return NextResponse.json({ error: 'Validation failed' }, { status: 400 });
-    }
-    for (const file of files) {
-      if (!ALLOWED_DOC_MIME.has(file.type)) {
-        return NextResponse.json({ error: 'File type not allowed' }, { status: 400 });
+    if (contentType.includes('multipart/form-data')) {
+      const form = await request.formData();
+      relationId = String(form.get('relationId') || '');
+      body = String(form.get('body') || '');
+      // Accept multiple files (pasted images + picked files). Cap the count.
+      files = form.getAll('file').filter((f): f is File => f instanceof File && f.size > 0).slice(0, 10);
+      if (!relationId || (!body.trim() && files.length === 0) || body.length > 5000) {
+        return NextResponse.json({ error: 'Validation failed' }, { status: 400 });
       }
-      if (file.size > MAX_DOC_BYTES) {
-        return NextResponse.json({ error: 'File too large (max 10 MB)' }, { status: 400 });
+      for (const file of files) {
+        if (!ALLOWED_DOC_MIME.has(file.type)) {
+          return NextResponse.json({ error: 'File type not allowed' }, { status: 400 });
+        }
+        if (file.size > MAX_DOC_BYTES) {
+          return NextResponse.json({ error: 'File too large (max 10 MB)' }, { status: 400 });
+        }
       }
+    } else {
+      const parsed = schema.safeParse(await request.json().catch(() => null));
+      if (!parsed.success) return NextResponse.json({ error: 'Validation failed' }, { status: 400 });
+      relationId = parsed.data.relationId;
+      body = parsed.data.body;
     }
-  } else {
-    const parsed = schema.safeParse(await request.json().catch(() => null));
-    if (!parsed.success) return NextResponse.json({ error: 'Validation failed' }, { status: 400 });
-    relationId = parsed.data.relationId;
-    body = parsed.data.body;
-  }
 
-  const rel = await getThreadIfAllowed(session.user, relationId);
-  if (!rel) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    const rel = await getThreadIfAllowed(session.user, relationId);
+    if (!rel) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
 
-  // Read each file once into a Buffer, reused for both DB storage and the
-  // recipient's email attachments.
-  const fileBufs = await Promise.all(
-    files.map(async (f) => ({ filename: f.name, contentType: f.type, size: f.size, data: Buffer.from(await f.arrayBuffer()) })),
-  );
+    // Read each file once into a Buffer, reused for both DB storage and the
+    // recipient's email attachments.
+    const fileBufs = await Promise.all(
+      files.map(async (f) => ({ filename: f.name, contentType: f.type, size: f.size, data: Buffer.from(await f.arrayBuffer()) })),
+    );
 
-  const message = await prisma.message.create({
-    data: {
-      relationId: rel.id,
-      senderId: session.user.id,
-      body,
-      channel: 'IN_APP',
-      ...(fileBufs.length
-        ? { attachments: { create: fileBufs.map((fb) => ({ filename: fb.filename, contentType: fb.contentType, size: fb.size, data: fb.data })) } }
-        : {}),
-    },
-    include: { attachments: { select: ATTACHMENT_SELECT } },
-  });
-
-  // Notify the other participant (unless an admin is posting to someone else's thread).
-  const recipient = otherParticipant(rel, session.user.id);
-  if (recipient && recipient !== session.user.id) {
-    await notify(recipient, 'message', `New message from ${session.user.name ?? 'your mentor'}.`, `/messages/${rel.id}`);
-
-    // Mirror the message to the recipient's inbox (unless they opted out). The
-    // Reply-To routes email replies back into this thread via /api/inbound-email.
-    const rcpt = await prisma.user.findUnique({
-      where: { id: recipient },
-      select: { email: true, emailNotifications: true, notificationPrefs: true },
+    const message = await prisma.message.create({
+      data: {
+        relationId: rel.id,
+        senderId: session.user.id,
+        body,
+        channel: 'IN_APP',
+        ...(fileBufs.length
+          ? { attachments: { create: fileBufs.map((fb) => ({ filename: fb.filename, contentType: fb.contentType, size: fb.size, data: fb.data })) } }
+          : {}),
+      },
+      include: { attachments: { select: ATTACHMENT_SELECT } },
     });
-    if (rcpt?.email && emailAllowed(rcpt, 'messages')) {
-      const sender = session.user.name ?? 'Your mentor';
-      const safe = body.replace(/[<>&]/g, (c) => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;' }[c] as string));
-      const attachCount = fileBufs.length;
-      sendEmail({
-        to: rcpt.email,
-        subject: `New message from ${sender}`,
-        html: `<p>${sender} sent you a message:</p>${safe.trim() ? `<blockquote style="border-left:3px solid #ccc;padding-left:12px;color:#444">${safe.replace(/\n/g, '<br>')}</blockquote>` : ''}${attachCount ? `<p>📎 ${attachCount} attachment(s) included.</p>` : ''}<p>Reply to this email or open the conversation in the app.</p>`,
-        replyTo: replyAddress(rel.id),
-        // Mirror the attachments (incl. pasted images) into the email too.
-        attachments: fileBufs.map((fb) => ({ filename: fb.filename, content: fb.data, contentType: fb.contentType })),
-      }).catch((e) => logger.error('Failed to mirror message email', { error: String(e) }));
-    }
-  }
 
-  return NextResponse.json({ message }, { status: 201 });
+    // Notify the other participant (unless an admin is posting to someone else's thread).
+    const recipient = otherParticipant(rel, session.user.id);
+    if (recipient && recipient !== session.user.id) {
+      await notify(recipient, 'message', `New message from ${session.user.name ?? 'your mentor'}.`, `/messages/${rel.id}`);
+
+      // Mirror the message to the recipient's inbox (unless they opted out). The
+      // Reply-To routes email replies back into this thread via /api/inbound-email.
+      const rcpt = await prisma.user.findUnique({
+        where: { id: recipient },
+        select: { email: true, emailNotifications: true, notificationPrefs: true },
+      });
+      if (rcpt?.email && emailAllowed(rcpt, 'messages')) {
+        const sender = session.user.name ?? 'Your mentor';
+        const safe = body.replace(/[<>&]/g, (c) => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;' }[c] as string));
+        const attachCount = fileBufs.length;
+        sendEmail({
+          to: rcpt.email,
+          subject: `New message from ${sender}`,
+          html: `<p>${sender} sent you a message:</p>${safe.trim() ? `<blockquote style="border-left:3px solid #ccc;padding-left:12px;color:#444">${safe.replace(/\n/g, '<br>')}</blockquote>` : ''}${attachCount ? `<p>📎 ${attachCount} attachment(s) included.</p>` : ''}<p>Reply to this email or open the conversation in the app.</p>`,
+          replyTo: replyAddress(rel.id),
+          // Mirror the attachments (incl. pasted images) into the email too.
+          attachments: fileBufs.map((fb) => ({ filename: fb.filename, content: fb.data, contentType: fb.contentType })),
+        }).catch((e) => logger.error('Failed to mirror message email', { error: String(e) }));
+      }
+    }
+
+    return NextResponse.json({ message }, { status: 201 });
+  });
 }

--- a/src/app/api/onboarding/route.ts
+++ b/src/app/api/onboarding/route.ts
@@ -2,61 +2,65 @@ import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { withTenantScope } from '@/lib/orgContext';
 
 // GET — role-aware first-run checklist state for the current user.
 // Returns ordered steps with { key, done, href }.
 export async function GET() {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  const { id, role } = session.user;
 
-  if (role === 'MENTEE') {
-    const user = await prisma.user.findUnique({
-      where: { id },
-      select: { university: true, skills: true, publicProfile: true, cvFile: { select: { id: true } } },
-    });
-    const skills = Array.isArray(user?.skills) ? (user!.skills as unknown[]) : [];
-    return NextResponse.json({
-      role,
-      steps: [
-        { key: 'profile', done: !!(user?.university && skills.length > 0), href: '/portal/profile' },
-        { key: 'cv', done: !!user?.cvFile, href: '/portal/profile' },
-        { key: 'public', done: !!user?.publicProfile, href: '/portal/profile' },
-      ],
-    });
-  }
+  return await withTenantScope(session, async () => {
+    const { id, role } = session.user;
 
-  if (role === 'MENTOR') {
-    const [mentees, interactions, meetings] = await Promise.all([
-      prisma.mentorshipRelation.count({ where: { mentorId: id } }),
-      prisma.interactionLog.count({ where: { relation: { mentorId: id } } }),
-      prisma.meeting.count({ where: { relation: { mentorId: id } } }),
-    ]);
-    return NextResponse.json({
-      role,
-      steps: [
-        { key: 'addMentee', done: mentees > 0, href: '/mentor/mentees/new' },
-        { key: 'logInteraction', done: interactions > 0, href: '/mentor/mentees' },
-        { key: 'scheduleMeeting', done: meetings > 0, href: '/mentor/meetings', optional: true },
-      ].slice(0, mentees > 0 ? 3 : 2),
-    });
-  }
+    if (role === 'MENTEE') {
+      const user = await prisma.user.findUnique({
+        where: { id },
+        select: { university: true, skills: true, publicProfile: true, cvFile: { select: { id: true } } },
+      });
+      const skills = Array.isArray(user?.skills) ? (user!.skills as unknown[]) : [];
+      return NextResponse.json({
+        role,
+        steps: [
+          { key: 'profile', done: !!(user?.university && skills.length > 0), href: '/portal/profile' },
+          { key: 'cv', done: !!user?.cvFile, href: '/portal/profile' },
+          { key: 'public', done: !!user?.publicProfile, href: '/portal/profile' },
+        ],
+      });
+    }
 
-  if (role === 'ADMIN') {
-    const [companies, nonAdmins, relations] = await Promise.all([
-      prisma.company.count(),
-      prisma.user.count({ where: { role: { not: 'ADMIN' } } }),
-      prisma.mentorshipRelation.count(),
-    ]);
-    return NextResponse.json({
-      role,
-      steps: [
-        { key: 'addCompany', done: companies > 0, href: '/admin/companies' },
-        { key: 'inviteUser', done: nonAdmins > 0, href: '/admin/invite' },
-        { key: 'assignMentorship', done: relations > 0, href: '/admin/mentorship' },
-      ],
-    });
-  }
+    if (role === 'MENTOR') {
+      const [mentees, interactions, meetings] = await Promise.all([
+        prisma.mentorshipRelation.count({ where: { mentorId: id } }),
+        prisma.interactionLog.count({ where: { relation: { mentorId: id } } }),
+        prisma.meeting.count({ where: { relation: { mentorId: id } } }),
+      ]);
+      return NextResponse.json({
+        role,
+        steps: [
+          { key: 'addMentee', done: mentees > 0, href: '/mentor/mentees/new' },
+          { key: 'logInteraction', done: interactions > 0, href: '/mentor/mentees' },
+          { key: 'scheduleMeeting', done: meetings > 0, href: '/mentor/meetings', optional: true },
+        ].slice(0, mentees > 0 ? 3 : 2),
+      });
+    }
 
-  return NextResponse.json({ role, steps: [] });
+    if (role === 'ADMIN') {
+      const [companies, nonAdmins, relations] = await Promise.all([
+        prisma.company.count(),
+        prisma.user.count({ where: { role: { not: 'ADMIN' } } }),
+        prisma.mentorshipRelation.count(),
+      ]);
+      return NextResponse.json({
+        role,
+        steps: [
+          { key: 'addCompany', done: companies > 0, href: '/admin/companies' },
+          { key: 'inviteUser', done: nonAdmins > 0, href: '/admin/invite' },
+          { key: 'assignMentorship', done: relations > 0, href: '/admin/mentorship' },
+        ],
+      });
+    }
+
+    return NextResponse.json({ role, steps: [] });
+  });
 }

--- a/src/app/api/profile-view/route.ts
+++ b/src/app/api/profile-view/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { withTenantScope } from '@/lib/orgContext';
 
 const schema = z.object({ userId: z.string().min(1) });
 
@@ -14,19 +15,21 @@ export async function POST(request: Request) {
   const { userId } = parsed.data;
 
   const session = await getServerSession(authOptions);
-  if (session?.user?.id === userId) return NextResponse.json({ ok: true, counted: false });
+  return await withTenantScope(session, async () => {
+    if (session?.user?.id === userId) return NextResponse.json({ ok: true, counted: false });
 
-  const cookieName = `pv_${userId}`;
-  const seen = request.headers.get('cookie')?.includes(`${cookieName}=1`);
-  if (seen) return NextResponse.json({ ok: true, counted: false });
+    const cookieName = `pv_${userId}`;
+    const seen = request.headers.get('cookie')?.includes(`${cookieName}=1`);
+    if (seen) return NextResponse.json({ ok: true, counted: false });
 
-  // Only count if the profile is actually public.
-  const target = await prisma.user.findFirst({ where: { id: userId, publicProfile: true }, select: { id: true } });
-  if (!target) return NextResponse.json({ ok: true, counted: false });
+    // Only count if the profile is actually public.
+    const target = await prisma.user.findFirst({ where: { id: userId, publicProfile: true }, select: { id: true } });
+    if (!target) return NextResponse.json({ ok: true, counted: false });
 
-  await prisma.user.update({ where: { id: userId }, data: { profileViews: { increment: 1 } } });
+    await prisma.user.update({ where: { id: userId }, data: { profileViews: { increment: 1 } } });
 
-  const res = NextResponse.json({ ok: true, counted: true });
-  res.cookies.set(cookieName, '1', { maxAge: 60 * 60, httpOnly: true, sameSite: 'lax', path: '/' });
-  return res;
+    const res = NextResponse.json({ ok: true, counted: true });
+    res.cookies.set(cookieName, '1', { maxAge: 60 * 60, httpOnly: true, sameSite: 'lax', path: '/' });
+    return res;
+  });
 }

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { z } from 'zod';
 import { logActivity } from '@/lib/activity';
+import { withTenantScope } from '@/lib/orgContext';
 
 // Allows only +, digits, spaces, hyphens and parentheses, and requires 7-15 digits.
 function isValidPhone(v: string): boolean {
@@ -112,16 +113,18 @@ export async function GET() {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const user = await prisma.user.findUnique({
-      where: { id: session.user.id },
-      select: PROFILE_SELECT,
+    return await withTenantScope(session, async () => {
+      const user = await prisma.user.findUnique({
+        where: { id: session.user.id },
+        select: PROFILE_SELECT,
+      });
+
+      if (!user) {
+        return NextResponse.json({ error: 'User not found' }, { status: 404 });
+      }
+
+      return NextResponse.json({ user });
     });
-
-    if (!user) {
-      return NextResponse.json({ error: 'User not found' }, { status: 404 });
-    }
-
-    return NextResponse.json({ user });
   } catch (error) {
     console.error('Get profile error:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
@@ -136,32 +139,34 @@ export async function PUT(request: Request) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const body = await request.json();
-    const parsed = updateProfileSchema.safeParse(body);
+    return await withTenantScope(session, async () => {
+      const body = await request.json();
+      const parsed = updateProfileSchema.safeParse(body);
 
-    if (!parsed.success) {
-      return NextResponse.json(
-        { error: 'Validation failed', details: parsed.error.flatten() },
-        { status: 400 }
-      );
-    }
+      if (!parsed.success) {
+        return NextResponse.json(
+          { error: 'Validation failed', details: parsed.error.flatten() },
+          { status: 400 }
+        );
+      }
 
-    const { cvUrl, birthDate, ...rest } = parsed.data;
+      const { cvUrl, birthDate, ...rest } = parsed.data;
 
-    const user = await prisma.user.update({
-      where: { id: session.user.id },
-      data: {
-        ...rest,
-        ...(cvUrl !== undefined ? { cvUrl: cvUrl || null } : {}),
-        ...(birthDate !== undefined
-          ? { birthDate: birthDate ? new Date(birthDate) : null }
-          : {}),
-      },
-      select: PROFILE_SELECT,
+      const user = await prisma.user.update({
+        where: { id: session.user.id },
+        data: {
+          ...rest,
+          ...(cvUrl !== undefined ? { cvUrl: cvUrl || null } : {}),
+          ...(birthDate !== undefined
+            ? { birthDate: birthDate ? new Date(birthDate) : null }
+            : {}),
+        },
+        select: PROFILE_SELECT,
+      });
+
+      await logActivity({ action: 'profile.update', actorId: session.user.id, actorEmail: session.user.email ?? null });
+      return NextResponse.json({ user });
     });
-
-    await logActivity({ action: 'profile.update', actorId: session.user.id, actorEmail: session.user.email ?? null });
-    return NextResponse.json({ user });
   } catch (error) {
     console.error('Update profile error:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });

--- a/src/app/api/projects/[id]/members/route.ts
+++ b/src/app/api/projects/[id]/members/route.ts
@@ -5,6 +5,7 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { logActivity } from '@/lib/activity';
 import { notify } from '@/lib/notify';
+import { withTenantScope } from '@/lib/orgContext';
 
 // Person-level project membership management (#617): add/remove OWNERs and
 // MENTORs. Only an admin or a current OWNER may change the list, and the
@@ -33,99 +34,105 @@ function canManageMembers(user: { id: string; role: string }, project: { members
 export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
   const session = await getServerSession(authOptions);
   if (!session || session.user.role === 'MENTEE') return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  const { id } = await params;
-  const members = await prisma.projectMember.findMany({
-    where: { projectId: id },
-    orderBy: { addedAt: 'asc' },
-    select: { role: true, functionalRole: true, addedAt: true, user: { select: { id: true, fullName: true, role: true } } },
+  return await withTenantScope(session, async () => {
+    const { id } = await params;
+    const members = await prisma.projectMember.findMany({
+      where: { projectId: id },
+      orderBy: { addedAt: 'asc' },
+      select: { role: true, functionalRole: true, addedAt: true, user: { select: { id: true, fullName: true, role: true } } },
+    });
+    return NextResponse.json({ members });
   });
-  return NextResponse.json({ members });
 }
 
 // POST — add (or re-role) a member. Target must be an active MENTOR or ADMIN.
 export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  const { id } = await params;
-  const project = await loadContext(id);
-  if (!project) return NextResponse.json({ error: 'Not found' }, { status: 404 });
-  if (!canManageMembers(session.user, project)) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  return await withTenantScope(session, async () => {
+    const { id } = await params;
+    const project = await loadContext(id);
+    if (!project) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    if (!canManageMembers(session.user, project)) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
 
-  const parsed = addSchema.safeParse(await request.json().catch(() => null));
-  if (!parsed.success) return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
-  const { userId, role } = parsed.data;
-  // Functional role only applies to mentee members; ignore it for owners/mentors.
-  const functionalRole = role === 'MENTEE' ? parsed.data.functionalRole ?? null : null;
+    const parsed = addSchema.safeParse(await request.json().catch(() => null));
+    if (!parsed.success) return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+    const { userId, role } = parsed.data;
+    // Functional role only applies to mentee members; ignore it for owners/mentors.
+    const functionalRole = role === 'MENTEE' ? parsed.data.functionalRole ?? null : null;
 
-  const target = await prisma.user.findUnique({ where: { id: userId }, select: { id: true, role: true, isActive: true } });
-  if (!target || !target.isActive) {
-    return NextResponse.json({ error: 'Member must be an active user' }, { status: 400 });
-  }
-  // Structural role must match who the person is: mentees join as MENTEE
-  // (contributors), mentors/admins as OWNER or MENTOR.
-  if (role === 'MENTEE') {
-    if (target.role !== 'MENTEE') {
-      return NextResponse.json({ error: 'Only a mentee can be added as a mentee member' }, { status: 400 });
+    const target = await prisma.user.findUnique({ where: { id: userId }, select: { id: true, role: true, isActive: true } });
+    if (!target || !target.isActive) {
+      return NextResponse.json({ error: 'Member must be an active user' }, { status: 400 });
     }
-  } else if (target.role !== 'MENTOR' && target.role !== 'ADMIN') {
-    return NextResponse.json({ error: 'An owner or mentor member must be an active mentor or admin' }, { status: 400 });
-  }
+    // Structural role must match who the person is: mentees join as MENTEE
+    // (contributors), mentors/admins as OWNER or MENTOR.
+    if (role === 'MENTEE') {
+      if (target.role !== 'MENTEE') {
+        return NextResponse.json({ error: 'Only a mentee can be added as a mentee member' }, { status: 400 });
+      }
+    } else if (target.role !== 'MENTOR' && target.role !== 'ADMIN') {
+      return NextResponse.json({ error: 'An owner or mentor member must be an active mentor or admin' }, { status: 400 });
+    }
 
-  // Demoting the last OWNER to a non-owner role would leave the project ownerless.
-  const owners = project.members.filter((m) => m.role === 'OWNER');
-  if (role !== 'OWNER' && owners.length === 1 && owners[0].userId === userId) {
-    return NextResponse.json({ error: 'A project must keep at least one owner', code: 'last_owner' }, { status: 409 });
-  }
+    // Demoting the last OWNER to a non-owner role would leave the project ownerless.
+    const owners = project.members.filter((m) => m.role === 'OWNER');
+    if (role !== 'OWNER' && owners.length === 1 && owners[0].userId === userId) {
+      return NextResponse.json({ error: 'A project must keep at least one owner', code: 'last_owner' }, { status: 409 });
+    }
 
-  const member = await prisma.projectMember.upsert({
-    where: { projectId_userId: { projectId: id, userId } },
-    update: { role, functionalRole },
-    create: { projectId: id, userId, role, functionalRole },
-    select: { role: true, functionalRole: true, user: { select: { id: true, fullName: true } } },
+    const member = await prisma.projectMember.upsert({
+      where: { projectId_userId: { projectId: id, userId } },
+      update: { role, functionalRole },
+      create: { projectId: id, userId, role, functionalRole },
+      select: { role: true, functionalRole: true, user: { select: { id: true, fullName: true } } },
+    });
+    if (userId !== session.user.id) {
+      await notify(userId, 'project', `You were added to project "${project.name}".`, '/projects/' + id);
+    }
+    await logActivity({ action: 'project.member_add', actorId: session.user.id, actorEmail: session.user.email ?? null, targetType: 'project', targetId: id, detail: `${userId} as ${role}` });
+    return NextResponse.json({ member }, { status: 201 });
   });
-  if (userId !== session.user.id) {
-    await notify(userId, 'project', `You were added to project "${project.name}".`, '/projects/' + id);
-  }
-  await logActivity({ action: 'project.member_add', actorId: session.user.id, actorEmail: session.user.email ?? null, targetType: 'project', targetId: id, detail: `${userId} as ${role}` });
-  return NextResponse.json({ member }, { status: 201 });
 }
 
 // DELETE — remove a member; the last OWNER is protected.
 export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  const { id } = await params;
-  const project = await loadContext(id);
-  if (!project) return NextResponse.json({ error: 'Not found' }, { status: 404 });
-  if (!canManageMembers(session.user, project)) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  return await withTenantScope(session, async () => {
+    const { id } = await params;
+    const project = await loadContext(id);
+    if (!project) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    if (!canManageMembers(session.user, project)) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
 
-  const parsed = removeSchema.safeParse(await request.json().catch(() => null));
-  if (!parsed.success) return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
-  const { userId } = parsed.data;
+    const parsed = removeSchema.safeParse(await request.json().catch(() => null));
+    if (!parsed.success) return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+    const { userId } = parsed.data;
 
-  const existing = project.members.find((m) => m.userId === userId);
-  if (!existing) return NextResponse.json({ error: 'Not a member' }, { status: 404 });
+    const existing = project.members.find((m) => m.userId === userId);
+    if (!existing) return NextResponse.json({ error: 'Not a member' }, { status: 404 });
 
-  const owners = project.members.filter((m) => m.role === 'OWNER');
-  if (existing.role === 'OWNER' && owners.length === 1) {
-    return NextResponse.json({ error: 'A project must keep at least one owner', code: 'last_owner' }, { status: 409 });
-  }
-
-  await prisma.projectMember.delete({ where: { projectId_userId: { projectId: id, userId } } });
-
-  // Keep the legacy single-owner pointer valid: if the removed user was the
-  // legacy owner, repoint it at a remaining OWNER member.
-  if (project.ownerUserId === userId) {
-    const nextOwner = owners.find((o) => o.userId !== userId);
-    if (nextOwner) {
-      const nextUser = await prisma.user.findUnique({ where: { id: nextOwner.userId }, select: { role: true } });
-      await prisma.project.update({
-        where: { id },
-        data: { ownerUserId: nextOwner.userId, ownerType: nextUser?.role === 'ADMIN' ? 'ADMIN' : 'MENTOR' },
-      });
+    const owners = project.members.filter((m) => m.role === 'OWNER');
+    if (existing.role === 'OWNER' && owners.length === 1) {
+      return NextResponse.json({ error: 'A project must keep at least one owner', code: 'last_owner' }, { status: 409 });
     }
-  }
 
-  await logActivity({ action: 'project.member_remove', actorId: session.user.id, actorEmail: session.user.email ?? null, targetType: 'project', targetId: id, detail: userId });
-  return NextResponse.json({ ok: true });
+    await prisma.projectMember.delete({ where: { projectId_userId: { projectId: id, userId } } });
+
+    // Keep the legacy single-owner pointer valid: if the removed user was the
+    // legacy owner, repoint it at a remaining OWNER member.
+    if (project.ownerUserId === userId) {
+      const nextOwner = owners.find((o) => o.userId !== userId);
+      if (nextOwner) {
+        const nextUser = await prisma.user.findUnique({ where: { id: nextOwner.userId }, select: { role: true } });
+        await prisma.project.update({
+          where: { id },
+          data: { ownerUserId: nextOwner.userId, ownerType: nextUser?.role === 'ADMIN' ? 'ADMIN' : 'MENTOR' },
+        });
+      }
+    }
+
+    await logActivity({ action: 'project.member_remove', actorId: session.user.id, actorEmail: session.user.email ?? null, targetType: 'project', targetId: id, detail: userId });
+    return NextResponse.json({ ok: true });
+  });
 }

--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -5,6 +5,7 @@ import { prisma } from '@/lib/prisma';
 import { z } from 'zod';
 import { canViewProject, resolveOwner, isProjectOwner, isProjectMember } from '@/lib/projectAccess';
 import { logActivity } from '@/lib/activity';
+import { withTenantScope } from '@/lib/orgContext';
 
 const include = {
   ownerUser: { select: { id: true, fullName: true, role: true } },
@@ -22,11 +23,13 @@ const include = {
 export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  const { id } = await params;
-  const project = await prisma.project.findUnique({ where: { id }, include });
-  if (!project) return NextResponse.json({ error: 'Not found' }, { status: 404 });
-  if (!canViewProject(session.user, project)) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-  return NextResponse.json({ project });
+  return await withTenantScope(session, async () => {
+    const { id } = await params;
+    const project = await prisma.project.findUnique({ where: { id }, include });
+    if (!project) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    if (!canViewProject(session.user, project)) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    return NextResponse.json({ project });
+  });
 }
 
 const schema = z.object({
@@ -50,85 +53,89 @@ const schema = z.object({
 export async function PUT(request: Request, { params }: { params: Promise<{ id: string }> }) {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  const { id } = await params;
-  const project = await prisma.project.findUnique({ where: { id } });
-  if (!project) return NextResponse.json({ error: 'Not found' }, { status: 404 });
-  // Owner-only fields (#619): owners (admin / OWNER member / legacy owner)
-  // edit everything; other MENTOR members only the collaborative fields.
-  const owner = await isProjectOwner(session.user, id);
-  const member = owner || (session.user.role === 'MENTOR' && (await isProjectMember(session.user, id)));
-  if (!member) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  return await withTenantScope(session, async () => {
+    const { id } = await params;
+    const project = await prisma.project.findUnique({ where: { id } });
+    if (!project) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    // Owner-only fields (#619): owners (admin / OWNER member / legacy owner)
+    // edit everything; other MENTOR members only the collaborative fields.
+    const owner = await isProjectOwner(session.user, id);
+    const member = owner || (session.user.role === 'MENTOR' && (await isProjectMember(session.user, id)));
+    if (!member) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
 
-  const parsed = schema.safeParse(await request.json());
-  if (!parsed.success) return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 });
-  const d = parsed.data;
+    const parsed = schema.safeParse(await request.json());
+    if (!parsed.success) return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 });
+    const d = parsed.data;
 
-  if (!owner) {
-    const protectedSent = (['name', 'status', 'isPublic', 'startDate', 'endDate', 'ownerType', 'ownerUserId', 'ownerCompanyId'] as const)
-      .filter((k) => d[k] !== undefined);
-    if (protectedSent.length > 0) {
-      return NextResponse.json(
-        { error: 'Only a project owner may change these fields', fields: protectedSent, code: 'owner_only' },
-        { status: 403 }
-      );
+    if (!owner) {
+      const protectedSent = (['name', 'status', 'isPublic', 'startDate', 'endDate', 'ownerType', 'ownerUserId', 'ownerCompanyId'] as const)
+        .filter((k) => d[k] !== undefined);
+      if (protectedSent.length > 0) {
+        return NextResponse.json(
+          { error: 'Only a project owner may change these fields', fields: protectedSent, code: 'owner_only' },
+          { status: 403 }
+        );
+      }
     }
-  }
 
-  const data: Record<string, unknown> = {};
-  if (d.name !== undefined) data.name = d.name;
-  if (d.description !== undefined) data.description = d.description || null;
-  if (d.technologies !== undefined) data.technologies = d.technologies;
-  if (d.repoUrl !== undefined) data.repoUrl = d.repoUrl || null;
-  if (d.demoUrl !== undefined) data.demoUrl = d.demoUrl || null;
-  if (d.boardUrl !== undefined) data.boardUrl = d.boardUrl || null;
-  if (d.status !== undefined) data.status = d.status;
-  if (d.isPublic !== undefined) data.isPublic = d.isPublic;
-  if (d.goals !== undefined) data.goals = d.goals || null;
-  if (d.startDate !== undefined) data.startDate = d.startDate ? new Date(d.startDate) : null;
-  if (d.endDate !== undefined) data.endDate = d.endDate ? new Date(d.endDate) : null;
+    const data: Record<string, unknown> = {};
+    if (d.name !== undefined) data.name = d.name;
+    if (d.description !== undefined) data.description = d.description || null;
+    if (d.technologies !== undefined) data.technologies = d.technologies;
+    if (d.repoUrl !== undefined) data.repoUrl = d.repoUrl || null;
+    if (d.demoUrl !== undefined) data.demoUrl = d.demoUrl || null;
+    if (d.boardUrl !== undefined) data.boardUrl = d.boardUrl || null;
+    if (d.status !== undefined) data.status = d.status;
+    if (d.isPublic !== undefined) data.isPublic = d.isPublic;
+    if (d.goals !== undefined) data.goals = d.goals || null;
+    if (d.startDate !== undefined) data.startDate = d.startDate ? new Date(d.startDate) : null;
+    if (d.endDate !== undefined) data.endDate = d.endDate ? new Date(d.endDate) : null;
 
-  // Transfer (admin only): change the owner, preserving the invariant.
-  let transferred: string | null = null;
-  if (d.ownerType && session.user.role === 'ADMIN') {
-    // For ADMIN ownership default to the acting admin when no specific user is
-    // given (the UI has no admin picker), so a transfer to "Admin (me)" works
-    // even if the client didn't send an id.
-    const ownerUserId = d.ownerType === 'ADMIN' ? d.ownerUserId || session.user.id : d.ownerUserId;
-    const owner = await resolveOwner({ ownerType: d.ownerType, ownerUserId, ownerCompanyId: d.ownerCompanyId });
-    if (!owner) return NextResponse.json({ error: 'Invalid owner' }, { status: 400 });
-    Object.assign(data, owner);
-    transferred = `${project.ownerType} → ${owner.ownerType}`;
-  }
+    // Transfer (admin only): change the owner, preserving the invariant.
+    let transferred: string | null = null;
+    if (d.ownerType && session.user.role === 'ADMIN') {
+      // For ADMIN ownership default to the acting admin when no specific user is
+      // given (the UI has no admin picker), so a transfer to "Admin (me)" works
+      // even if the client didn't send an id.
+      const ownerUserId = d.ownerType === 'ADMIN' ? d.ownerUserId || session.user.id : d.ownerUserId;
+      const owner = await resolveOwner({ ownerType: d.ownerType, ownerUserId, ownerCompanyId: d.ownerCompanyId });
+      if (!owner) return NextResponse.json({ error: 'Invalid owner' }, { status: 400 });
+      Object.assign(data, owner);
+      transferred = `${project.ownerType} → ${owner.ownerType}`;
+    }
 
-  const updated = await prisma.project.update({ where: { id }, data, include });
-  // Keep the members table in step with a legacy transfer (#617): the new
-  // person owner becomes (or stays) an OWNER member. Previous owners keep
-  // their rows — multi-owner is allowed; removal goes through /members.
-  if (transferred && typeof data.ownerUserId === 'string') {
-    await prisma.projectMember.upsert({
-      where: { projectId_userId: { projectId: id, userId: data.ownerUserId } },
-      update: { role: 'OWNER' },
-      create: { projectId: id, userId: data.ownerUserId, role: 'OWNER' },
-    });
-  }
-  if (transferred) {
-    await logActivity({ action: 'project.transfer', level: 'warning', actorId: session.user.id, actorEmail: session.user.email ?? null, targetType: 'project', targetId: id, detail: transferred });
-  }
-  return NextResponse.json({ project: updated });
+    const updated = await prisma.project.update({ where: { id }, data, include });
+    // Keep the members table in step with a legacy transfer (#617): the new
+    // person owner becomes (or stays) an OWNER member. Previous owners keep
+    // their rows — multi-owner is allowed; removal goes through /members.
+    if (transferred && typeof data.ownerUserId === 'string') {
+      await prisma.projectMember.upsert({
+        where: { projectId_userId: { projectId: id, userId: data.ownerUserId } },
+        update: { role: 'OWNER' },
+        create: { projectId: id, userId: data.ownerUserId, role: 'OWNER' },
+      });
+    }
+    if (transferred) {
+      await logActivity({ action: 'project.transfer', level: 'warning', actorId: session.user.id, actorEmail: session.user.email ?? null, targetType: 'project', targetId: id, detail: transferred });
+    }
+    return NextResponse.json({ project: updated });
+  });
 }
 
 export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  const { id } = await params;
-  const project = await prisma.project.findUnique({ where: { id } });
-  if (!project) return NextResponse.json({ error: 'Not found' }, { status: 404 });
-  // Deletion is owner-only (#619).
-  if (!(await isProjectOwner(session.user, id))) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  return await withTenantScope(session, async () => {
+    const { id } = await params;
+    const project = await prisma.project.findUnique({ where: { id } });
+    if (!project) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    // Deletion is owner-only (#619).
+    if (!(await isProjectOwner(session.user, id))) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
 
-  // Detach mentees, then delete.
-  await prisma.mentorshipRelation.updateMany({ where: { projectId: id }, data: { projectId: null } });
-  await prisma.project.delete({ where: { id } });
-  await logActivity({ action: 'project.delete', level: 'warning', actorId: session.user.id, actorEmail: session.user.email ?? null, targetType: 'project', targetId: id });
-  return NextResponse.json({ ok: true });
+    // Detach mentees, then delete.
+    await prisma.mentorshipRelation.updateMany({ where: { projectId: id }, data: { projectId: null } });
+    await prisma.project.delete({ where: { id } });
+    await logActivity({ action: 'project.delete', level: 'warning', actorId: session.user.id, actorEmail: session.user.email ?? null, targetType: 'project', targetId: id });
+    return NextResponse.json({ ok: true });
+  });
 }

--- a/src/app/api/projects/[id]/tasks/route.ts
+++ b/src/app/api/projects/[id]/tasks/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { z } from 'zod';
 import { canManageProject, isProjectMember } from '@/lib/projectAccess';
+import { withTenantScope } from '@/lib/orgContext';
 
 const schema = z.object({ title: z.string().min(1).max(300) });
 
@@ -11,21 +12,23 @@ const schema = z.object({ title: z.string().min(1).max(300) });
 export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  const { id } = await params;
+  return await withTenantScope(session, async () => {
+    const { id } = await params;
 
-  const project = await prisma.project.findUnique({ where: { id } });
-  if (!project) return NextResponse.json({ error: 'Not found' }, { status: 404 });
-  // Tasks are collaborative (#619): owners AND mentor members may edit.
-  if (!canManageProject(session.user, project) && !(await isProjectMember(session.user, id))) {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-  }
+    const project = await prisma.project.findUnique({ where: { id } });
+    if (!project) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    // Tasks are collaborative (#619): owners AND mentor members may edit.
+    if (!canManageProject(session.user, project) && !(await isProjectMember(session.user, id))) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
 
-  const parsed = schema.safeParse(await request.json());
-  if (!parsed.success) return NextResponse.json({ error: 'Validation failed' }, { status: 400 });
+    const parsed = schema.safeParse(await request.json());
+    if (!parsed.success) return NextResponse.json({ error: 'Validation failed' }, { status: 400 });
 
-  const count = await prisma.projectTask.count({ where: { projectId: id } });
-  const task = await prisma.projectTask.create({
-    data: { projectId: id, title: parsed.data.title, order: count },
+    const count = await prisma.projectTask.count({ where: { projectId: id } });
+    const task = await prisma.projectTask.create({
+      data: { projectId: id, title: parsed.data.title, order: count },
+    });
+    return NextResponse.json({ task }, { status: 201 });
   });
-  return NextResponse.json({ task }, { status: 201 });
 }

--- a/src/app/api/relation-notes/route.ts
+++ b/src/app/api/relation-notes/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from 'next-auth';
 import { z } from 'zod';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { withTenantScope } from '@/lib/orgContext';
 
 const bodySchema = z.object({
   relationId: z.string().min(1),
@@ -22,37 +23,39 @@ async function canAccessRelation(userId: string, role: string, relationId: strin
 export async function GET(request: Request) {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  return await withTenantScope(session, async () => {
+    const relationId = new URL(request.url).searchParams.get('relationId');
+    if (!relationId) return NextResponse.json({ error: 'relationId is required' }, { status: 400 });
+    if (!(await canAccessRelation(session.user.id, session.user.role, relationId))) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
 
-  const relationId = new URL(request.url).searchParams.get('relationId');
-  if (!relationId) return NextResponse.json({ error: 'relationId is required' }, { status: 400 });
-  if (!(await canAccessRelation(session.user.id, session.user.role, relationId))) {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-  }
-
-  const notes = await prisma.relationNote.findMany({
-    where: { relationId },
-    orderBy: { createdAt: 'desc' },
-    include: { author: { select: { fullName: true } } },
+    const notes = await prisma.relationNote.findMany({
+      where: { relationId },
+      orderBy: { createdAt: 'desc' },
+      include: { author: { select: { fullName: true } } },
+    });
+    return NextResponse.json({ notes });
   });
-  return NextResponse.json({ notes });
 }
 
 // POST — add a note.
 export async function POST(request: Request) {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  return await withTenantScope(session, async () => {
+    const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+    if (!parsed.success) return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+    const { relationId, body } = parsed.data;
 
-  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
-  if (!parsed.success) return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
-  const { relationId, body } = parsed.data;
+    if (!(await canAccessRelation(session.user.id, session.user.role, relationId))) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
 
-  if (!(await canAccessRelation(session.user.id, session.user.role, relationId))) {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-  }
-
-  const note = await prisma.relationNote.create({
-    data: { relationId, authorId: session.user.id, body },
-    include: { author: { select: { fullName: true } } },
+    const note = await prisma.relationNote.create({
+      data: { relationId, authorId: session.user.id, body },
+      include: { author: { select: { fullName: true } } },
+    });
+    return NextResponse.json({ note }, { status: 201 });
   });
-  return NextResponse.json({ note }, { status: 201 });
 }

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { withTenantScope } from '@/lib/orgContext';
 import type { Prisma } from '@prisma/client';
 
 // GET ?q= — global search over users (by name/email) and companies (by name).
@@ -11,29 +12,30 @@ export async function GET(request: Request) {
   if (!session || (session.user.role !== 'ADMIN' && session.user.role !== 'MENTOR')) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
+  return await withTenantScope(session, async () => {
+    const q = (new URL(request.url).searchParams.get('q') || '').trim();
+    if (q.length < 2) return NextResponse.json({ users: [], companies: [] });
 
-  const q = (new URL(request.url).searchParams.get('q') || '').trim();
-  if (q.length < 2) return NextResponse.json({ users: [], companies: [] });
+    const userWhere: Prisma.UserWhereInput = {
+      OR: [{ fullName: { contains: q } }, { email: { contains: q } }],
+    };
+    if (session.user.role === 'MENTOR') {
+      userWhere.role = 'MENTEE';
+      userWhere.menteeRelations = { some: { mentorId: session.user.id } };
+    }
 
-  const userWhere: Prisma.UserWhereInput = {
-    OR: [{ fullName: { contains: q } }, { email: { contains: q } }],
-  };
-  if (session.user.role === 'MENTOR') {
-    userWhere.role = 'MENTEE';
-    userWhere.menteeRelations = { some: { mentorId: session.user.id } };
-  }
+    const [users, companies] = await Promise.all([
+      prisma.user.findMany({
+        where: userWhere,
+        select: { id: true, fullName: true, email: true, role: true },
+        take: 8,
+        orderBy: { fullName: 'asc' },
+      }),
+      session.user.role === 'ADMIN'
+        ? prisma.company.findMany({ where: { name: { contains: q } }, select: { id: true, name: true }, take: 5 })
+        : Promise.resolve([]),
+    ]);
 
-  const [users, companies] = await Promise.all([
-    prisma.user.findMany({
-      where: userWhere,
-      select: { id: true, fullName: true, email: true, role: true },
-      take: 8,
-      orderBy: { fullName: 'asc' },
-    }),
-    session.user.role === 'ADMIN'
-      ? prisma.company.findMany({ where: { name: { contains: q } }, select: { id: true, name: true }, take: 5 })
-      : Promise.resolve([]),
-  ]);
-
-  return NextResponse.json({ users, companies });
+    return NextResponse.json({ users, companies });
+  });
 }

--- a/src/app/api/source/mentees/route.ts
+++ b/src/app/api/source/mentees/route.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import bcrypt from 'bcryptjs';
 import { randomBytes } from 'crypto';
 import { logActivity } from '@/lib/activity';
+import { withTenantScope } from '@/lib/orgContext';
 
 // The source a SOURCE user represents (their own sourceId).
 async function ownSourceId(userId: string): Promise<string | null> {
@@ -17,31 +18,32 @@ async function ownSourceId(userId: string): Promise<string | null> {
 export async function GET() {
   const session = await getServerSession(authOptions);
   if (!session || session.user.role !== 'SOURCE') return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  return await withTenantScope(session, async () => {
+    const sourceId = await ownSourceId(session.user.id);
+    if (!sourceId) return NextResponse.json({ error: 'No source' }, { status: 403 });
 
-  const sourceId = await ownSourceId(session.user.id);
-  if (!sourceId) return NextResponse.json({ error: 'No source' }, { status: 403 });
-
-  const mentees = await prisma.user.findMany({
-    where: { role: 'MENTEE', sourceId },
-    orderBy: { createdAt: 'desc' },
-    select: {
-      id: true, fullName: true, email: true, university: true, department: true, skills: true, createdAt: true,
-      menteeRelations: {
-        where: { status: 'ACTIVE' },
-        select: { pipelineStatus: true, mentor: { select: { fullName: true } } },
-        take: 1,
+    const mentees = await prisma.user.findMany({
+      where: { role: 'MENTEE', sourceId },
+      orderBy: { createdAt: 'desc' },
+      select: {
+        id: true, fullName: true, email: true, university: true, department: true, skills: true, createdAt: true,
+        menteeRelations: {
+          where: { status: 'ACTIVE' },
+          select: { pipelineStatus: true, mentor: { select: { fullName: true } } },
+          take: 1,
+        },
       },
-    },
-  });
-  return NextResponse.json({
-    mentees: mentees.map((m) => ({
-      id: m.id, fullName: m.fullName, email: m.email, university: m.university, department: m.department,
-      skills: Array.isArray(m.skills) ? m.skills : [],
-      assigned: m.menteeRelations.length > 0,
-      mentor: m.menteeRelations[0]?.mentor.fullName ?? null,
-      pipelineStatus: m.menteeRelations[0]?.pipelineStatus ?? null,
-      createdAt: m.createdAt,
-    })),
+    });
+    return NextResponse.json({
+      mentees: mentees.map((m) => ({
+        id: m.id, fullName: m.fullName, email: m.email, university: m.university, department: m.department,
+        skills: Array.isArray(m.skills) ? m.skills : [],
+        assigned: m.menteeRelations.length > 0,
+        mentor: m.menteeRelations[0]?.mentor.fullName ?? null,
+        pipelineStatus: m.menteeRelations[0]?.pipelineStatus ?? null,
+        createdAt: m.createdAt,
+      })),
+    });
   });
 }
 
@@ -58,31 +60,32 @@ const schema = z.object({
 export async function POST(request: Request) {
   const session = await getServerSession(authOptions);
   if (!session || session.user.role !== 'SOURCE') return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  return await withTenantScope(session, async () => {
+    const sourceId = await ownSourceId(session.user.id);
+    if (!sourceId) return NextResponse.json({ error: 'No source' }, { status: 403 });
 
-  const sourceId = await ownSourceId(session.user.id);
-  if (!sourceId) return NextResponse.json({ error: 'No source' }, { status: 403 });
+    const parsed = schema.safeParse(await request.json());
+    if (!parsed.success) return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 });
+    const { fullName, email, university, department, skills } = parsed.data;
 
-  const parsed = schema.safeParse(await request.json());
-  if (!parsed.success) return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 });
-  const { fullName, email, university, department, skills } = parsed.data;
+    const existing = await prisma.user.findUnique({ where: { email: email.toLowerCase() }, select: { id: true } });
+    if (existing) return NextResponse.json({ error: 'An account with this email already exists' }, { status: 409 });
 
-  const existing = await prisma.user.findUnique({ where: { email: email.toLowerCase() }, select: { id: true } });
-  if (existing) return NextResponse.json({ error: 'An account with this email already exists' }, { status: 409 });
-
-  const password = await bcrypt.hash(randomBytes(18).toString('hex'), 10);
-  const mentee = await prisma.user.create({
-    data: {
-      email: email.toLowerCase(),
-      fullName,
-      role: 'MENTEE',
-      sourceId,
-      university: university || null,
-      department: department || null,
-      skills: skills ? skills.split(',').map((s) => s.trim()).filter(Boolean) : [],
-      password,
-    },
-    select: { id: true, fullName: true, email: true },
+    const password = await bcrypt.hash(randomBytes(18).toString('hex'), 10);
+    const mentee = await prisma.user.create({
+      data: {
+        email: email.toLowerCase(),
+        fullName,
+        role: 'MENTEE',
+        sourceId,
+        university: university || null,
+        department: department || null,
+        skills: skills ? skills.split(',').map((s) => s.trim()).filter(Boolean) : [],
+        password,
+      },
+      select: { id: true, fullName: true, email: true },
+    });
+    await logActivity({ action: 'source.mentee_added', actorId: session.user.id, actorEmail: session.user.email ?? null, targetType: 'user', targetId: mentee.id });
+    return NextResponse.json({ mentee }, { status: 201 });
   });
-  await logActivity({ action: 'source.mentee_added', actorId: session.user.id, actorEmail: session.user.email ?? null, targetType: 'user', targetId: mentee.id });
-  return NextResponse.json({ mentee }, { status: 201 });
 }

--- a/src/app/api/status-changes/route.ts
+++ b/src/app/api/status-changes/route.ts
@@ -5,6 +5,7 @@ import { prisma } from '@/lib/prisma';
 import { z } from 'zod';
 import type { PipelineStatus } from '@prisma/client';
 import { PIPELINE_STATUSES } from '@/lib/pipeline';
+import { withTenantScope } from '@/lib/orgContext';
 
 const stage = z.enum(PIPELINE_STATUSES as unknown as [string, ...string[]]);
 const schema = z.object({
@@ -20,27 +21,28 @@ export async function POST(request: Request) {
   if (!session || session.user.role !== 'ADMIN') {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
+  return await withTenantScope(session, async () => {
+    const parsed = schema.safeParse(await request.json());
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 });
+    }
 
-  const parsed = schema.safeParse(await request.json());
-  if (!parsed.success) {
-    return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 });
-  }
+    const { relationId, fromStatus, toStatus, createdAt } = parsed.data;
+    const relation = await prisma.mentorshipRelation.findUnique({ where: { id: relationId } });
+    if (!relation) {
+      return NextResponse.json({ error: 'Relation not found' }, { status: 404 });
+    }
 
-  const { relationId, fromStatus, toStatus, createdAt } = parsed.data;
-  const relation = await prisma.mentorshipRelation.findUnique({ where: { id: relationId } });
-  if (!relation) {
-    return NextResponse.json({ error: 'Relation not found' }, { status: 404 });
-  }
+    const change = await prisma.statusChange.create({
+      data: {
+        relationId,
+        fromStatus: fromStatus as PipelineStatus,
+        toStatus: toStatus as PipelineStatus,
+        changedById: session.user.id,
+        ...(createdAt ? { createdAt: new Date(createdAt) } : {}),
+      },
+    });
 
-  const change = await prisma.statusChange.create({
-    data: {
-      relationId,
-      fromStatus: fromStatus as PipelineStatus,
-      toStatus: toStatus as PipelineStatus,
-      changedById: session.user.id,
-      ...(createdAt ? { createdAt: new Date(createdAt) } : {}),
-    },
+    return NextResponse.json({ change }, { status: 201 });
   });
-
-  return NextResponse.json({ change }, { status: 201 });
 }

--- a/src/app/api/support/route.ts
+++ b/src/app/api/support/route.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { notify } from '@/lib/notify';
+import { withTenantScope } from '@/lib/orgContext';
 
 // User side of the support channel (#593): every role has a pinned "Support"
 // conversation. The first message opens a SupportTicket; further messages join
@@ -17,67 +18,69 @@ const postSchema = z.object({ body: z.string().min(1).max(5000) });
 export async function GET() {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-
-  const tickets = await prisma.supportTicket.findMany({
-    where: { requesterId: session.user.id },
-    orderBy: { createdAt: 'desc' },
-    take: 20,
-    select: {
-      id: true,
-      status: true,
-      subject: true,
-      createdAt: true,
-      closedAt: true,
-      messages: {
-        orderBy: { createdAt: 'asc' },
-        take: 100,
-        select: { id: true, body: true, createdAt: true, senderId: true, sender: { select: { fullName: true, role: true } } },
+  return await withTenantScope(session, async () => {
+    const tickets = await prisma.supportTicket.findMany({
+      where: { requesterId: session.user.id },
+      orderBy: { createdAt: 'desc' },
+      take: 20,
+      select: {
+        id: true,
+        status: true,
+        subject: true,
+        createdAt: true,
+        closedAt: true,
+        messages: {
+          orderBy: { createdAt: 'asc' },
+          take: 100,
+          select: { id: true, body: true, createdAt: true, senderId: true, sender: { select: { fullName: true, role: true } } },
+        },
       },
-    },
-  });
+    });
 
-  await prisma.supportMessage.updateMany({
-    where: { ticket: { requesterId: session.user.id }, senderId: { not: session.user.id }, readAt: null },
-    data: { readAt: new Date() },
-  });
+    await prisma.supportMessage.updateMany({
+      where: { ticket: { requesterId: session.user.id }, senderId: { not: session.user.id }, readAt: null },
+      data: { readAt: new Date() },
+    });
 
-  return NextResponse.json({ tickets, me: session.user.id });
+    return NextResponse.json({ tickets, me: session.user.id });
+  });
 }
 
 // POST — send a message to support.
 export async function POST(request: Request) {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  return await withTenantScope(session, async () => {
+    const parsed = postSchema.safeParse(await request.json().catch(() => null));
+    if (!parsed.success) return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+    const body = parsed.data.body.trim();
+    if (!body) return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
 
-  const parsed = postSchema.safeParse(await request.json().catch(() => null));
-  if (!parsed.success) return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
-  const body = parsed.data.body.trim();
-  if (!body) return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
-
-  let ticket = await prisma.supportTicket.findFirst({
-    where: { requesterId: session.user.id, status: { in: ['OPEN', 'IN_PROGRESS'] } },
-    orderBy: { createdAt: 'desc' },
-    select: { id: true, status: true },
-  });
-  const isNew = !ticket;
-  if (!ticket) {
-    ticket = await prisma.supportTicket.create({
-      data: { requesterId: session.user.id, subject: body.slice(0, 80) },
+    let ticket = await prisma.supportTicket.findFirst({
+      where: { requesterId: session.user.id, status: { in: ['OPEN', 'IN_PROGRESS'] } },
+      orderBy: { createdAt: 'desc' },
       select: { id: true, status: true },
     });
-  }
+    const isNew = !ticket;
+    if (!ticket) {
+      ticket = await prisma.supportTicket.create({
+        data: { requesterId: session.user.id, subject: body.slice(0, 80) },
+        select: { id: true, status: true },
+      });
+    }
 
-  const message = await prisma.supportMessage.create({
-    data: { ticketId: ticket.id, senderId: session.user.id, body },
-    select: { id: true, createdAt: true },
+    const message = await prisma.supportMessage.create({
+      data: { ticketId: ticket.id, senderId: session.user.id, body },
+      select: { id: true, createdAt: true },
+    });
+    await prisma.supportTicket.update({ where: { id: ticket.id }, data: { updatedAt: new Date() } });
+
+    const admins = await prisma.user.findMany({ where: { role: 'ADMIN', isActive: true }, select: { id: true } });
+    const text = isNew
+      ? `New support ticket from ${session.user.name ?? 'a user'}.`
+      : `New support message from ${session.user.name ?? 'a user'}.`;
+    await Promise.all(admins.map((a) => notify(a.id, 'support', text, '/admin/support')));
+
+    return NextResponse.json({ ticketId: ticket.id, messageId: message.id, isNew }, { status: 201 });
   });
-  await prisma.supportTicket.update({ where: { id: ticket.id }, data: { updatedAt: new Date() } });
-
-  const admins = await prisma.user.findMany({ where: { role: 'ADMIN', isActive: true }, select: { id: true } });
-  const text = isNew
-    ? `New support ticket from ${session.user.name ?? 'a user'}.`
-    : `New support message from ${session.user.name ?? 'a user'}.`;
-  await Promise.all(admins.map((a) => notify(a.id, 'support', text, '/admin/support')));
-
-  return NextResponse.json({ ticketId: ticket.id, messageId: message.id, isNew }, { status: 201 });
 }

--- a/src/app/api/track/pageview/route.ts
+++ b/src/app/api/track/pageview/route.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { hasConsent } from '@/lib/consent';
+import { withTenantScope } from '@/lib/orgContext';
 
 // Cap dwell time per hit so a backgrounded tab / clock skew can't inflate the
 // "time on site" total (30 min is well beyond a single active page view).
@@ -29,27 +30,28 @@ function cleanPath(raw: string): string {
 export async function POST(request: Request) {
   const session = await getServerSession(authOptions);
   if (!session?.user?.id) return new NextResponse(null, { status: 204 });
+  return await withTenantScope(session, async () => {
+    const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+    if (!parsed.success) return new NextResponse(null, { status: 204 });
 
-  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
-  if (!parsed.success) return new NextResponse(null, { status: 204 });
+    // Don't track while impersonating — that activity isn't the user's own.
+    if (session.user.impersonatorId) return new NextResponse(null, { status: 204 });
 
-  // Don't track while impersonating — that activity isn't the user's own.
-  if (session.user.impersonatorId) return new NextResponse(null, { status: 204 });
+    if (!(await hasConsent(session.user.id, 'ACTIVITY_TRACKING'))) {
+      return new NextResponse(null, { status: 204 });
+    }
 
-  if (!(await hasConsent(session.user.id, 'ACTIVITY_TRACKING'))) {
+    const duration = Math.min(parsed.data.durationSec ?? 0, MAX_DURATION_SEC);
+    try {
+      await prisma.$transaction([
+        prisma.pageView.create({
+          data: { userId: session.user.id, path: cleanPath(parsed.data.path), durationSec: duration },
+        }),
+        prisma.user.update({ where: { id: session.user.id }, data: { lastSeenAt: new Date() } }),
+      ]);
+    } catch {
+      // Never let telemetry break navigation.
+    }
     return new NextResponse(null, { status: 204 });
-  }
-
-  const duration = Math.min(parsed.data.durationSec ?? 0, MAX_DURATION_SEC);
-  try {
-    await prisma.$transaction([
-      prisma.pageView.create({
-        data: { userId: session.user.id, path: cleanPath(parsed.data.path), durationSec: duration },
-      }),
-      prisma.user.update({ where: { id: session.user.id }, data: { lastSeenAt: new Date() } }),
-    ]);
-  } catch {
-    // Never let telemetry break navigation.
-  }
-  return new NextResponse(null, { status: 204 });
+  });
 }

--- a/src/app/api/users/[id]/activity/route.ts
+++ b/src/app/api/users/[id]/activity/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { withTenantScope } from '@/lib/orgContext';
 
 // GET — recent activity for a single user (as actor or target). Visible to the
 // user themselves, any admin, or a mentor who mentors that user. Also returns
@@ -9,27 +10,29 @@ import { prisma } from '@/lib/prisma';
 export async function GET(_request: Request, { params }: { params: Promise<{ id: string }> }) {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  const { id } = await params;
+  return await withTenantScope(session, async () => {
+    const { id } = await params;
 
-  let allowed = session.user.id === id || session.user.role === 'ADMIN';
-  if (!allowed && session.user.role === 'MENTOR') {
-    const rel = await prisma.mentorshipRelation.findFirst({ where: { mentorId: session.user.id, menteeId: id }, select: { id: true } });
-    allowed = !!rel;
-  }
-  if (!allowed) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    let allowed = session.user.id === id || session.user.role === 'ADMIN';
+    if (!allowed && session.user.role === 'MENTOR') {
+      const rel = await prisma.mentorshipRelation.findFirst({ where: { mentorId: session.user.id, menteeId: id }, select: { id: true } });
+      allowed = !!rel;
+    }
+    if (!allowed) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
 
-  const [items, lastActive] = await Promise.all([
-    prisma.activityLog.findMany({
-      where: { OR: [{ actorId: id }, { targetId: id }] },
-      orderBy: { createdAt: 'desc' },
-      take: 25,
-    }),
-    prisma.activityLog.findFirst({
-      where: { actorId: id },
-      orderBy: { createdAt: 'desc' },
-      select: { createdAt: true },
-    }),
-  ]);
+    const [items, lastActive] = await Promise.all([
+      prisma.activityLog.findMany({
+        where: { OR: [{ actorId: id }, { targetId: id }] },
+        orderBy: { createdAt: 'desc' },
+        take: 25,
+      }),
+      prisma.activityLog.findFirst({
+        where: { actorId: id },
+        orderBy: { createdAt: 'desc' },
+        select: { createdAt: true },
+      }),
+    ]);
 
-  return NextResponse.json({ items, lastActiveAt: lastActive?.createdAt ?? null });
+    return NextResponse.json({ items, lastActiveAt: lastActive?.createdAt ?? null });
+  });
 }

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { withTenantScope } from '@/lib/orgContext';
 
 export async function GET(_request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
@@ -11,63 +12,65 @@ export async function GET(_request: Request, { params }: { params: Promise<{ id:
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const user = await prisma.user.findUnique({
-      where: { id },
-      select: {
-        id: true,
-        email: true,
-        fullName: true,
-        role: true,
-        phone: true,
-        whatsapp: true,
-        city: true,
-        birthDate: true,
-        referralSource: true,
-        sourceId: true,
-        source: { select: { id: true, name: true } },
-        university: true,
-        department: true,
-        graduationYear: true,
-        skills: true,
-        cvUrl: true,
-        createdAt: true,
-        mentorCapacity: true,
-        // For mentor detail: their active mentees, pipeline stage, and the raw
-        // evaluation scores (averaged on the client for a workload/quality view).
-        mentorRelations: {
-          orderBy: { startDate: 'desc' },
-          select: {
-            id: true,
-            status: true,
-            pipelineStatus: true,
-            startDate: true,
-            mentee: { select: { id: true, fullName: true, email: true } },
-            company: { select: { name: true } },
-            evaluations: { select: { scores: true } },
+    return await withTenantScope(session, async () => {
+      const user = await prisma.user.findUnique({
+        where: { id },
+        select: {
+          id: true,
+          email: true,
+          fullName: true,
+          role: true,
+          phone: true,
+          whatsapp: true,
+          city: true,
+          birthDate: true,
+          referralSource: true,
+          sourceId: true,
+          source: { select: { id: true, name: true } },
+          university: true,
+          department: true,
+          graduationYear: true,
+          skills: true,
+          cvUrl: true,
+          createdAt: true,
+          mentorCapacity: true,
+          // For mentor detail: their active mentees, pipeline stage, and the raw
+          // evaluation scores (averaged on the client for a workload/quality view).
+          mentorRelations: {
+            orderBy: { startDate: 'desc' },
+            select: {
+              id: true,
+              status: true,
+              pipelineStatus: true,
+              startDate: true,
+              mentee: { select: { id: true, fullName: true, email: true } },
+              company: { select: { name: true } },
+              evaluations: { select: { scores: true } },
+            },
           },
-        },
-        menteeRelations: {
-          orderBy: { startDate: 'desc' },
-          include: {
-            mentor: { select: { fullName: true, email: true } },
-            company: { select: { name: true, industry: true } },
-            project: { select: { id: true, name: true } },
-            cohort: { select: { id: true, name: true } },
-            interactions: { orderBy: { date: 'desc' } },
-            statusChanges: {
-              orderBy: { createdAt: 'desc' },
-              include: { changedBy: { select: { fullName: true } } },
+          menteeRelations: {
+            orderBy: { startDate: 'desc' },
+            include: {
+              mentor: { select: { fullName: true, email: true } },
+              company: { select: { name: true, industry: true } },
+              project: { select: { id: true, name: true } },
+              cohort: { select: { id: true, name: true } },
+              interactions: { orderBy: { date: 'desc' } },
+              statusChanges: {
+                orderBy: { createdAt: 'desc' },
+                include: { changedBy: { select: { fullName: true } } },
+              },
             },
           },
         },
-      },
+      });
+
+      if (!user) {
+        return NextResponse.json({ error: 'User not found' }, { status: 404 });
+      }
+
+      return NextResponse.json({ user });
     });
-
-    if (!user) {
-      return NextResponse.json({ error: 'User not found' }, { status: 404 });
-    }
-
-    return NextResponse.json({ user });
   } catch (error) {
     console.error('Get user error:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
@@ -83,55 +86,57 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const body = await request.json();
-    const data: {
-      isActive?: boolean;
-      sourceId?: string | null;
-      skills?: string[];
-      mentorCapacity?: number | null;
-    } = {};
+    return await withTenantScope(session, async () => {
+      const body = await request.json();
+      const data: {
+        isActive?: boolean;
+        sourceId?: string | null;
+        skills?: string[];
+        mentorCapacity?: number | null;
+      } = {};
 
-    if (typeof body.isActive === 'boolean') {
-      // Guard against an admin locking themselves out.
-      if (id === session.user.id && body.isActive === false) {
-        return NextResponse.json({ error: 'You cannot deactivate your own account' }, { status: 400 });
+      if (typeof body.isActive === 'boolean') {
+        // Guard against an admin locking themselves out.
+        if (id === session.user.id && body.isActive === false) {
+          return NextResponse.json({ error: 'You cannot deactivate your own account' }, { status: 400 });
+        }
+        data.isActive = body.isActive;
       }
-      data.isActive = body.isActive;
-    }
 
-    // Assign / clear the mentee's referral source.
-    if ('sourceId' in body && (typeof body.sourceId === 'string' || body.sourceId === null)) {
-      data.sourceId = body.sourceId || null;
-    }
-
-    // Mentor expertise (skills) — admin can populate so skill-match works.
-    if (Array.isArray(body.skills) && body.skills.every((s: unknown) => typeof s === 'string')) {
-      data.skills = [...new Set((body.skills as string[]).map((s) => s.trim()).filter(Boolean))];
-    }
-
-    // Mentor active-mentee capacity (null clears it).
-    if ('mentorCapacity' in body) {
-      const c = body.mentorCapacity;
-      if (c === null || c === '') {
-        data.mentorCapacity = null;
-      } else if (typeof c === 'number' && Number.isInteger(c) && c >= 0 && c <= 999) {
-        data.mentorCapacity = c;
-      } else {
-        return NextResponse.json({ error: 'Invalid mentorCapacity' }, { status: 400 });
+      // Assign / clear the mentee's referral source.
+      if ('sourceId' in body && (typeof body.sourceId === 'string' || body.sourceId === null)) {
+        data.sourceId = body.sourceId || null;
       }
-    }
 
-    if (Object.keys(data).length === 0) {
-      return NextResponse.json({ error: 'No supported fields to update' }, { status: 400 });
-    }
+      // Mentor expertise (skills) — admin can populate so skill-match works.
+      if (Array.isArray(body.skills) && body.skills.every((s: unknown) => typeof s === 'string')) {
+        data.skills = [...new Set((body.skills as string[]).map((s) => s.trim()).filter(Boolean))];
+      }
 
-    const user = await prisma.user.update({
-      where: { id },
-      data,
-      select: { id: true, isActive: true, sourceId: true, skills: true, mentorCapacity: true },
+      // Mentor active-mentee capacity (null clears it).
+      if ('mentorCapacity' in body) {
+        const c = body.mentorCapacity;
+        if (c === null || c === '') {
+          data.mentorCapacity = null;
+        } else if (typeof c === 'number' && Number.isInteger(c) && c >= 0 && c <= 999) {
+          data.mentorCapacity = c;
+        } else {
+          return NextResponse.json({ error: 'Invalid mentorCapacity' }, { status: 400 });
+        }
+      }
+
+      if (Object.keys(data).length === 0) {
+        return NextResponse.json({ error: 'No supported fields to update' }, { status: 400 });
+      }
+
+      const user = await prisma.user.update({
+        where: { id },
+        data,
+        select: { id: true, isActive: true, sourceId: true, skills: true, mentorCapacity: true },
+      });
+
+      return NextResponse.json({ user });
     });
-
-    return NextResponse.json({ user });
   } catch (error) {
     console.error('Update user error:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { withTenantScope } from '@/lib/orgContext';
 
 export async function GET() {
   try {
@@ -11,38 +12,40 @@ export async function GET() {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    // Mentors get a minimal, PII-free directory of active mentors/admins —
-    // just enough for the project owner/member picker (#618).
-    if (session.user.role === 'MENTOR') {
+    return await withTenantScope(session, async () => {
+      // Mentors get a minimal, PII-free directory of active mentors/admins —
+      // just enough for the project owner/member picker (#618).
+      if (session.user.role === 'MENTOR') {
+        const users = await prisma.user.findMany({
+          where: { role: { in: ['MENTOR', 'ADMIN'] }, isActive: true },
+          select: { id: true, fullName: true, role: true },
+          orderBy: { fullName: 'asc' },
+        });
+        return NextResponse.json({ users });
+      }
+
       const users = await prisma.user.findMany({
-        where: { role: { in: ['MENTOR', 'ADMIN'] }, isActive: true },
-        select: { id: true, fullName: true, role: true },
-        orderBy: { fullName: 'asc' },
+        select: {
+          id: true,
+          email: true,
+          fullName: true,
+          role: true,
+          university: true,
+          department: true,
+          graduationYear: true,
+          skills: true,
+          mentorCapacity: true,
+          phone: true,
+          isActive: true,
+          emailVerified: true,
+          createdAt: true,
+          _count: { select: { mentorRelations: true } },
+        },
+        orderBy: { createdAt: 'desc' },
       });
+
       return NextResponse.json({ users });
-    }
-
-    const users = await prisma.user.findMany({
-      select: {
-        id: true,
-        email: true,
-        fullName: true,
-        role: true,
-        university: true,
-        department: true,
-        graduationYear: true,
-        skills: true,
-        mentorCapacity: true,
-        phone: true,
-        isActive: true,
-        emailVerified: true,
-        createdAt: true,
-        _count: { select: { mentorRelations: true } },
-      },
-      orderBy: { createdAt: 'desc' },
     });
-
-    return NextResponse.json({ users });
   } catch (error) {
     console.error('Get users error:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });


### PR DESCRIPTION
Completes the per-route rollout for #543 (multi-tenancy story #522).

## What

Every authenticated API route handler that queries a tenant-anchored model (`User`, `Source`, `Company`, `Project`, `Cohort`, `MentorshipRelation`) now wraps its body in `withTenantScope(session, …)`. With `MT_ENFORCE_ISOLATION` on, the central middleware (shipped in #745) then auto-scopes **all** of that handler's queries to the request's organization — so criterion 1 of #543 ("every tenant-scoped query returns only its tenant's data") holds app-wide, not just for the reference routes.

63 route files wrapped (on top of the 3 reference routes from #745 = 66 total).

## Safety / compatibility

- **Behavior-neutral while the flag is off.** `withTenantScope` is a pure passthrough when `MT_ENFORCE_ISOLATION` is unset/false, so single-tenant production is unchanged.
- The wrapper is placed **after** each handler's existing auth/role guards and, for `try/catch` handlers, **inside** the `try` — logic, returns, and status codes are untouched.
- Public / token-based routes (register, apply, forgot-password, invite acceptance) are intentionally left unscoped: they have no session and resolve their subject from the invite/reset token.
- Routes that only read the caller's own rows (account, profile, avatar, cv) are wrapped too for uniformity (scoping is redundant but harmless there).

## Verification

- [x] `npm run build`
- [x] `npm run lint` (only pre-existing warnings)
- [x] `npm run check:i18n` (unaffected)
- [x] Each batch typechecked (`tsc --noEmit`) clean before integration; full build green

Version 0.24.2; CHANGELOG + `docs/tenant-isolation.md` rollout status updated.

With this merged, #543's enforcement is complete end-to-end (engine + app-wide wiring + isolation test), gated off pending the guarded production rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ)_