### PR TITLE
SSO JIT provisioning helper (#545)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,18 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [Unreleased]
 
-## [0.24.2] - 2026-07-22
+## [0.24.3] - 2026-07-22
+
+### Added
+- **SSO just-in-time (JIT) provisioning (part of #545 / story #522).** New
+  `provisionSsoUser()` (`src/lib/ssoProvisioning.ts`) maps a verified IdP identity
+  to a `User` in the tenant org — creating one on first login (default
+  least-privilege `MENTEE`, or an IdP-mapped role), adopting a not-yet-tenanted
+  user into the org, and refusing to relocate an email that already belongs to a
+  different tenant. Idempotent per email; covered by
+  `e2e/sso-provisioning.spec.ts`. This is the tenant-mapping half of #545's
+  criteria; the live SAML/OIDC round-trip that calls it stays deferred until a
+  real tenant IdP is available (see `docs/sso-saml.md`). No runtime auth change.
 
 ### Changed
 - **Tenant isolation rolled out to all authenticated API routes (part of #543 /

--- a/docs/sso-saml.md
+++ b/docs/sso-saml.md
@@ -19,6 +19,13 @@ tenant's own IdP instead of email+password.
     complete.
 - The API never returns the raw certificate; the list only exposes
   `ssoCertificateSet` and `active`.
+- **JIT provisioning** (`src/lib/ssoProvisioning.ts`): `provisionSsoUser()` maps a
+  verified IdP identity to a `User` in the tenant org — creating one on first
+  login (default least-privilege `MENTEE`, or an IdP-mapped role), adopting a
+  not-yet-tenanted user into the org, and refusing to relocate an email that
+  already belongs to a different tenant. Idempotent per email; unit-tested in
+  `e2e/sso-provisioning.spec.ts`. It trusts its inputs, so the callback must only
+  call it AFTER verifying the signed assertion.
 
 ## What's NOT wired yet (and why)
 
@@ -44,9 +51,9 @@ customer's own credentials.
 2. Resolve the tenant from the request (subdomain or work-email lookup).
 3. If `isSsoActive(org)`: build the AuthnRequest from `ssoEntryPoint` /
    `ssoIssuer`, redirect to the IdP.
-4. On callback: verify the signed assertion against `ssoCertificate`, map the
-   IdP subject/email to a `User` in that org (JIT-provision if desired), then
-   issue the NextAuth session.
+4. On callback: verify the signed assertion against `ssoCertificate`, then call
+   `provisionSsoUser({ orgId, email, fullName, role })` (already implemented) to
+   map the IdP subject to a `User` in that org, and issue the NextAuth session.
 5. Fall back to password login whenever SSO is not active for the tenant.
 
 ### Operator notes

--- a/e2e/sso-provisioning.spec.ts
+++ b/e2e/sso-provisioning.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from '@playwright/test';
+import { prisma, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { provisionSsoUser } from '../src/lib/ssoProvisioning';
+
+// JIT provisioning for Enterprise SSO (#545). Proves a verified IdP identity maps
+// to a User in the correct tenant + role — the testable half of #545, exercised
+// against a real DB without a live IdP. Runs with isolation enforcement off so
+// the helper's cross-tenant email lookup is unscoped (as the SSO callback path
+// will arrange).
+test.beforeAll(() => { delete process.env.MT_ENFORCE_ISOLATION; });
+test.afterAll(async () => { await prisma.$disconnect(); });
+
+test('JIT-provisions a new user into the correct tenant with default MENTEE role', async () => {
+  const stamp = uniqueEmail('sso').replace(/[^a-z0-9]/gi, '').toLowerCase();
+  const org = await prisma.organization.create({ data: { name: `SSO Org ${stamp}`, slug: `sso-${stamp}` } });
+  const email = uniqueEmail('sso-new');
+  try {
+    const { user, created } = await provisionSsoUser({ orgId: org.id, email, fullName: 'SSO New' });
+    expect(created).toBe(true);
+    expect(user.orgId).toBe(org.id);
+    expect(user.role).toBe('MENTEE');
+    const row = await prisma.user.findUnique({ where: { email: email.toLowerCase() } });
+    expect(row?.emailVerified).not.toBeNull();
+
+    // Idempotent: a second login returns the same user, does not duplicate.
+    const again = await provisionSsoUser({ orgId: org.id, email, fullName: 'SSO New' });
+    expect(again.created).toBe(false);
+    expect(again.user.id).toBe(user.id);
+  } finally {
+    await cleanupByEmail(email);
+    await prisma.organization.deleteMany({ where: { id: org.id } });
+  }
+});
+
+test('respects an IdP-mapped role', async () => {
+  const stamp = uniqueEmail('sso').replace(/[^a-z0-9]/gi, '').toLowerCase();
+  const org = await prisma.organization.create({ data: { name: `SSO Org ${stamp}`, slug: `ssor-${stamp}` } });
+  const email = uniqueEmail('sso-mentor');
+  try {
+    const { user } = await provisionSsoUser({ orgId: org.id, email, role: 'MENTOR' });
+    expect(user.role).toBe('MENTOR');
+  } finally {
+    await cleanupByEmail(email);
+    await prisma.organization.deleteMany({ where: { id: org.id } });
+  }
+});
+
+test('adopts a not-yet-tenanted user, and refuses cross-tenant reuse', async () => {
+  const stamp = uniqueEmail('sso').replace(/[^a-z0-9]/gi, '').toLowerCase();
+  const orgA = await prisma.organization.create({ data: { name: `SSO A ${stamp}`, slug: `ssoa-${stamp}` } });
+  const orgB = await prisma.organization.create({ data: { name: `SSO B ${stamp}`, slug: `ssob-${stamp}` } });
+  const email = uniqueEmail('sso-adopt');
+  try {
+    // Pre-existing user with no org (single-tenant/default) → adopted into org A.
+    const seeded = await prisma.user.create({
+      data: { email: email.toLowerCase(), password: 'x', role: 'MENTEE', fullName: 'Adopt Me', skills: [] },
+    });
+    expect(seeded.orgId).toBeNull();
+
+    const { user, created } = await provisionSsoUser({ orgId: orgA.id, email });
+    expect(created).toBe(false);
+    expect(user.orgId).toBe(orgA.id);
+
+    // Same email now belongs to org A → an org B IdP must not steal it.
+    await expect(provisionSsoUser({ orgId: orgB.id, email })).rejects.toThrow(/different organization/);
+  } finally {
+    await cleanupByEmail(email);
+    await prisma.organization.deleteMany({ where: { id: { in: [orgA.id, orgB.id] } } });
+  }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "internship-crm",
-  "version": "0.24.2-beta",
+  "version": "0.24.3-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "internship-crm",
-      "version": "0.24.2-beta",
+      "version": "0.24.3-beta",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.24.2-beta",
+  "version": "0.24.3-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/lib/ssoProvisioning.ts
+++ b/src/lib/ssoProvisioning.ts
@@ -1,0 +1,79 @@
+// Just-in-time (JIT) user provisioning for Enterprise SSO (#545).
+//
+// When a tenant's IdP vouches for a user on first login, we create (or adopt) a
+// matching `User` in that tenant's org — so admins don't have to pre-create every
+// account. This is the piece behind #545's "JIT-provisioned user lands in the
+// correct tenant + role" acceptance criterion.
+//
+// SECURITY: this must be called ONLY after a signed SAML assertion / OIDC token
+// has been verified by the (future, gated) SSO callback — it trusts its inputs.
+// It is never a public entry point. The live callback that verifies the IdP
+// round-trip is still deferred (see docs/sso-saml.md); this helper is the
+// tenant-mapping half, isolated so it is unit-testable without a real IdP.
+//
+// Server-only (imports prisma). No client concerns.
+
+import { prisma } from './prisma';
+
+// Roles an IdP attribute mapping may grant. Defaults to the least-privilege
+// MENTEE when the assertion carries no role — an admin can elevate later.
+export type SsoRole = 'MENTEE' | 'MENTOR' | 'ADMIN' | 'COMPANY' | 'SOURCE';
+
+export interface SsoIdentity {
+  orgId: string; // the tenant the IdP config belongs to (resolved by the caller)
+  email: string; // the IdP-verified email (subject / email claim)
+  fullName?: string | null;
+  role?: SsoRole; // from IdP attribute mapping; default MENTEE
+}
+
+export interface ProvisionResult {
+  user: { id: string; email: string; role: string; orgId: string | null };
+  created: boolean;
+}
+
+// Map a verified IdP identity to a User in the tenant org, creating one on first
+// login. Idempotent per email. Throws when the email already belongs to a
+// DIFFERENT org (a misconfiguration we must not paper over by silently moving a
+// user across tenants).
+export async function provisionSsoUser(identity: SsoIdentity): Promise<ProvisionResult> {
+  const email = identity.email.trim().toLowerCase();
+  if (!email) throw new Error('SSO identity has no email');
+  if (!identity.orgId) throw new Error('SSO provisioning requires a resolved orgId');
+
+  const existing = await prisma.user.findUnique({ where: { email } });
+  if (existing) {
+    // Never silently relocate a user to another tenant.
+    if (existing.orgId && existing.orgId !== identity.orgId) {
+      throw new Error('SSO identity email already belongs to a different organization');
+    }
+    // Adopt a not-yet-tenanted user (e.g. from the single-tenant default org)
+    // into this org on first SSO login; otherwise return as-is.
+    if (!existing.orgId) {
+      const user = await prisma.user.update({
+        where: { id: existing.id },
+        data: { orgId: identity.orgId },
+        select: { id: true, email: true, role: true, orgId: true },
+      });
+      return { user, created: false };
+    }
+    return {
+      user: { id: existing.id, email: existing.email, role: existing.role, orgId: existing.orgId },
+      created: false,
+    };
+  }
+
+  const user = await prisma.user.create({
+    data: {
+      email,
+      // SSO users authenticate via the IdP — no local password login.
+      password: '!sso-no-login',
+      role: identity.role ?? 'MENTEE',
+      fullName: identity.fullName?.trim() || email,
+      orgId: identity.orgId,
+      emailVerified: true, // the IdP vouched for this address
+      skills: [],
+    },
+    select: { id: true, email: true, role: true, orgId: true },
+  });
+  return { user, created: true };
+}


### PR DESCRIPTION
Part of #545 (Enterprise SSO) under multi-tenancy story #522.

## What

Adds the **JIT-provisioning** half of #545 — the piece behind its "a JIT-provisioned user lands in the correct tenant + role" acceptance criterion.

`provisionSsoUser({ orgId, email, fullName, role })` (`src/lib/ssoProvisioning.ts`):
- **Creates** a `User` in the tenant org on first login — default least-privilege `MENTEE`, or an IdP-attribute-mapped role; `emailVerified` (the IdP vouched for it); no local password.
- **Adopts** a not-yet-tenanted user (e.g. from the single-tenant default org) into the org.
- **Refuses** to relocate an email that already belongs to a *different* tenant (throws — a misconfiguration we must not paper over).
- Idempotent per email.

Covered by `e2e/sso-provisioning.spec.ts` (new user + default role, idempotency, IdP-mapped role, adopt-and-refuse-cross-tenant), run against a real DB.

## Why this is safe / what's still deferred

- **No runtime auth change.** This helper has no live caller yet — the SAML/OIDC callback that verifies the signed assertion and then calls it is still deferred, because it can't be exercised safely without a real tenant IdP (documented in `docs/sso-saml.md`).
- The helper trusts its inputs by contract; the future callback must only call it *after* verifying the assertion.
- SSO config storage, admin UI, validation and gating already shipped earlier; this fills in the tenant-mapping logic so the eventual callback is a small, well-understood step.

## Verification

- [x] `npm run build`
- [x] `npm run check:i18n`
- [x] `e2e/sso-provisioning.spec.ts` exercises the helper against the DB

Version 0.24.3; CHANGELOG + `docs/sso-saml.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ)_