### PR TITLE
Per-tenant pipeline stages — foundation (#747)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,19 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [Unreleased]
 
-## [0.25.0] - 2026-07-22
+## [0.25.1] - 2026-07-22
+
+### Added
+- **Per-tenant pipeline stages — foundation (#747, part of white-label #546).**
+  New `PipelineStage` model (per-org: key / label / order / on-path / terminal /
+  color) plus a resolution layer (`src/lib/pipelineStages.ts`,
+  `resolvePipelineStages`) that falls back to the built-in canonical 13 stages
+  when a tenant has none — so single-tenant production is unchanged. Admin-only,
+  premium-gated management API at
+  `/api/admin/organizations/[id]/pipeline-stages` (GET / PUT / DELETE-reset).
+  Relations still store the `PipelineStatus` enum in this phase (no data
+  migration); applying resolved stages to the board/filters/analytics/journey and
+  moving storage off the enum land in later slices. Additive `db push`.
 
 ### Added
 - **Enterprise SSO — live SAML sign-in (closes the wiring for #545 / story #522).**

--- a/docs/pipeline-stages.md
+++ b/docs/pipeline-stages.md
@@ -1,0 +1,39 @@
+# Per-tenant pipeline stages (#747)
+
+Making the mentee pipeline stages tenant-configurable — the heaviest part of the
+white-label track (#546), split out from it. Delivered in safe, gated slices so
+single-tenant production is never at risk.
+
+## Slices
+
+| Slice | What | State |
+|-------|------|-------|
+| A (foundation) | `PipelineStage` model + resolution layer + admin API | **done** |
+| A.2 | Admin UI to edit stages (label / order / color / on-path) | planned |
+| B | Apply resolved stages across board / filters / analytics / journey / bulk-advance | planned |
+| C | Move storage off the enum (`MentorshipRelation.pipelineStatus` enum → String) so tenants can define **new** stage keys, with a data-safe migration | planned |
+
+## How it works (Slice A)
+
+- **`PipelineStage`** (per org): `key`, `label`, `order`, `isTerminal`,
+  `isOffPath`, `color`. `@@unique([orgId, key])`.
+- **`resolvePipelineStages(orgId, locale)`** (`src/lib/pipelineStages.ts`):
+  returns the org's rows if any, else `defaultPipelineStages()` — the canonical
+  13 stages derived from the `PipelineStatus` enum (single source of truth in
+  `src/lib/pipeline.ts`). An org with **no** rows behaves exactly as today.
+- **`onPathKeys(stages)`**: the happy-path sequence (excludes off-path), for
+  "advance one stage" semantics over a resolved set.
+- **Admin API** `/api/admin/organizations/[id]/pipeline-stages`
+  (`GET` / `PUT` / `DELETE`): admin-only; `PUT` is **premium-gated** (a paid
+  plan) and replaces the whole set atomically; `DELETE` resets to the built-in
+  defaults.
+
+## Why relations still use the enum in Slice A
+
+Changing `MentorshipRelation.pipelineStatus` from a Prisma enum to a free string
+(Slice C) is a cross-cutting change (every pipeline surface + a prod migration).
+Doing labels/order/color first (over the canonical keys) delivers most of the
+white-label value with zero storage risk; brand-new tenant-defined keys come in
+Slice C. The MySQL `ENUM → VARCHAR` change preserves existing values (the enum is
+stored as its label string), so Slice C's migration is data-safe, but it is
+sequenced last and verified on preview before prod.

--- a/e2e/pipeline-stages.spec.ts
+++ b/e2e/pipeline-stages.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test';
+import { prisma, uniqueEmail } from './helpers/db';
+import { defaultPipelineStages, resolvePipelineStages, onPathKeys } from '../src/lib/pipelineStages';
+
+// Per-tenant pipeline stages (#747, Phase A). Behavior-preserving: no rows → the
+// canonical enum defaults; rows → the tenant's override. Exercised against a real
+// DB so the fallback + override paths are both proven.
+test.afterAll(async () => { await prisma.$disconnect(); });
+
+test('defaults mirror the canonical 13 stages with correct flags', () => {
+  const d = defaultPipelineStages('en');
+  expect(d).toHaveLength(13);
+  expect(d[0].key).toBe('APPLICATION_100');
+  expect(d.find((s) => s.key === 'EMPLOYED_700')?.isTerminal).toBe(true);
+  expect(d.find((s) => s.key === 'INTERNSHIP_DROPPED_460')?.isOffPath).toBe(true);
+  expect(d.find((s) => s.key === 'INTERNSHIP_FOUND_ELSEWHERE_800')?.isOffPath).toBe(true);
+  // on-path excludes the two off-path stages.
+  expect(onPathKeys(d)).not.toContain('INTERNSHIP_DROPPED_460');
+  expect(onPathKeys(d)).not.toContain('INTERNSHIP_FOUND_ELSEWHERE_800');
+  expect(onPathKeys(d)[0]).toBe('APPLICATION_100');
+});
+
+test('resolves defaults for a null org and for an org with no custom rows', async () => {
+  expect((await resolvePipelineStages(null)).length).toBe(13);
+  const stamp = uniqueEmail('ps').replace(/[^a-z0-9]/gi, '').toLowerCase();
+  const org = await prisma.organization.create({ data: { name: `PS ${stamp}`, slug: `ps-${stamp}` } });
+  try {
+    const resolved = await resolvePipelineStages(org.id);
+    expect(resolved.map((s) => s.key)).toEqual(defaultPipelineStages().map((s) => s.key));
+  } finally {
+    await prisma.organization.deleteMany({ where: { id: org.id } });
+  }
+});
+
+test('an org with custom rows overrides the defaults', async () => {
+  const stamp = uniqueEmail('ps').replace(/[^a-z0-9]/gi, '').toLowerCase();
+  const org = await prisma.organization.create({ data: { name: `PS ${stamp}`, slug: `psc-${stamp}` } });
+  try {
+    await prisma.pipelineStage.createMany({
+      data: [
+        { orgId: org.id, key: 'LEAD', label: 'Lead', order: 0, color: '#2563eb' },
+        { orgId: org.id, key: 'HIRED', label: 'Hired', order: 1, isTerminal: true },
+        { orgId: org.id, key: 'LOST', label: 'Lost', order: 2, isOffPath: true, isTerminal: true },
+      ],
+    });
+    const resolved = await resolvePipelineStages(org.id);
+    expect(resolved.map((s) => s.key)).toEqual(['LEAD', 'HIRED', 'LOST']);
+    expect(resolved[0].color).toBe('#2563eb');
+    expect(onPathKeys(resolved)).toEqual(['LEAD', 'HIRED']); // LOST is off-path
+  } finally {
+    await prisma.pipelineStage.deleteMany({ where: { orgId: org.id } });
+    await prisma.organization.deleteMany({ where: { id: org.id } });
+  }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "internship-crm",
-  "version": "0.25.0-beta",
+  "version": "0.25.1-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "internship-crm",
-      "version": "0.25.0-beta",
+      "version": "0.25.1-beta",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.25.0-beta",
+  "version": "0.25.1-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -90,12 +90,37 @@ model Organization {
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
 
-  users     User[]
-  sources   Source[]
-  cohorts   Cohort[]
-  companies Company[]
-  projects  Project[]
-  relations MentorshipRelation[]
+  users          User[]
+  sources        Source[]
+  cohorts        Cohort[]
+  companies      Company[]
+  projects       Project[]
+  relations      MentorshipRelation[]
+  pipelineStages PipelineStage[]
+}
+
+// Per-tenant customizable pipeline stages (#747, part of white-label #546).
+// Phase A is additive + behavior-preserving: an org with NO rows here uses the
+// built-in canonical stages (the PipelineStatus enum, src/lib/pipeline.ts), so
+// single-tenant production is unchanged. An org that defines rows overrides the
+// label / order / color / on-path grouping for the stages it lists. `key` is the
+// stable identifier (the enum value for the canonical set; a slug for custom
+// stages once storage moves off the enum in a later slice).
+model PipelineStage {
+  id         String       @id @default(cuid())
+  orgId      String
+  org        Organization @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  key        String
+  label      String
+  order      Int
+  isTerminal Boolean      @default(false)
+  isOffPath  Boolean      @default(false)
+  color      String?
+  createdAt  DateTime     @default(now())
+  updatedAt  DateTime     @updatedAt
+
+  @@unique([orgId, key])
+  @@index([orgId, order])
 }
 
 model User {

--- a/src/app/api/admin/organizations/[id]/pipeline-stages/route.ts
+++ b/src/app/api/admin/organizations/[id]/pipeline-stages/route.ts
@@ -1,0 +1,95 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { z } from 'zod';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { isHexColor } from '@/lib/branding';
+import { resolvePipelineStages, defaultPipelineStages } from '@/lib/pipelineStages';
+
+// Per-tenant pipeline-stage management (#747). Admin-only; premium-gated (custom
+// stages require a paid plan). Phase A: label / order / color / on-path grouping
+// over the canonical keys — an org with no rows uses the built-in defaults.
+
+async function requireAdminOrg(id: string) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'ADMIN') return { error: 'Unauthorized' as const, status: 401 };
+  const org = await prisma.organization.findUnique({ where: { id } });
+  if (!org) return { error: 'Organization not found' as const, status: 404 };
+  return { org };
+}
+
+// GET — the org's resolved stages plus whether they are customized.
+export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const gate = await requireAdminOrg(id);
+  if ('error' in gate) return NextResponse.json({ error: gate.error }, { status: gate.status });
+
+  const count = await prisma.pipelineStage.count({ where: { orgId: id } });
+  const stages = await resolvePipelineStages(id);
+  return NextResponse.json({ stages, custom: count > 0, plan: gate.org.plan });
+}
+
+const stageSchema = z.object({
+  key: z.string().min(1).max(60).regex(/^[A-Za-z0-9_]+$/, 'Key must be alphanumeric/underscore'),
+  label: z.string().min(1).max(120),
+  order: z.number().int().min(0).max(1000),
+  isTerminal: z.boolean().optional(),
+  isOffPath: z.boolean().optional(),
+  color: z.string().optional().nullable(),
+});
+const putSchema = z.object({ stages: z.array(stageSchema).min(1).max(50) });
+
+// PUT — replace the org's stage set. Premium-gated (not FREE). Keys must be unique.
+export async function PUT(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const gate = await requireAdminOrg(id);
+  if ('error' in gate) return NextResponse.json({ error: gate.error }, { status: gate.status });
+  if (gate.org.plan === 'FREE') {
+    return NextResponse.json({ error: 'Custom pipeline stages require a paid plan' }, { status: 403 });
+  }
+
+  const parsed = putSchema.safeParse(await req.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 });
+  }
+  const stages = parsed.data.stages;
+
+  const keys = stages.map((s) => s.key);
+  if (new Set(keys).size !== keys.length) {
+    return NextResponse.json({ error: 'Stage keys must be unique' }, { status: 400 });
+  }
+  for (const s of stages) {
+    if (s.color && s.color.trim() && !isHexColor(s.color)) {
+      return NextResponse.json({ error: `Color for "${s.key}" must be a hex value like #2563eb` }, { status: 400 });
+    }
+  }
+
+  // Replace the whole set atomically so order/keys stay consistent.
+  await prisma.$transaction([
+    prisma.pipelineStage.deleteMany({ where: { orgId: id } }),
+    prisma.pipelineStage.createMany({
+      data: stages.map((s) => ({
+        orgId: id,
+        key: s.key,
+        label: s.label.trim(),
+        order: s.order,
+        isTerminal: s.isTerminal ?? false,
+        isOffPath: s.isOffPath ?? false,
+        color: s.color && s.color.trim() ? s.color.trim() : null,
+      })),
+    }),
+  ]);
+
+  const resolved = await resolvePipelineStages(id);
+  return NextResponse.json({ stages: resolved, custom: true });
+}
+
+// DELETE — reset to the built-in canonical stages (drop all custom rows).
+export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const gate = await requireAdminOrg(id);
+  if ('error' in gate) return NextResponse.json({ error: gate.error }, { status: gate.status });
+
+  await prisma.pipelineStage.deleteMany({ where: { orgId: id } });
+  return NextResponse.json({ stages: defaultPipelineStages(), custom: false });
+}

--- a/src/lib/pipelineStages.ts
+++ b/src/lib/pipelineStages.ts
@@ -1,0 +1,76 @@
+// Per-tenant pipeline-stage resolution (#747, part of white-label #546).
+// Server-only (reads the DB).
+//
+// Phase A is additive + behavior-preserving: an org with no PipelineStage rows
+// falls back to the built-in canonical stages (the PipelineStatus enum, mirrored
+// in src/lib/pipeline.ts), so single-tenant production is unchanged. An org that
+// defines rows overrides the label / order / color / on-path grouping for the
+// stages it lists. Relations still store the PipelineStatus enum in this phase;
+// storage moves off the enum (allowing brand-new stage keys) in a later slice.
+
+import { prisma } from './prisma';
+import { PIPELINE_STATUSES, pipelineLabel } from './pipeline';
+import type { Locale } from '@/i18n/config';
+
+export interface ResolvedStage {
+  key: string;
+  label: string;
+  order: number;
+  isTerminal: boolean;
+  isOffPath: boolean;
+  color: string | null;
+}
+
+// The two off-path terminal states, and the set of terminal states, for the
+// canonical defaults — mirrors JourneyTracker's OFF_PATH and pipeline.ts's
+// nextOnPathStatus (EMPLOYED_700 is the positive terminus).
+const DEFAULT_OFF_PATH = new Set<string>(['INTERNSHIP_DROPPED_460', 'INTERNSHIP_FOUND_ELSEWHERE_800']);
+const DEFAULT_TERMINAL = new Set<string>([
+  'EMPLOYED_700',
+  'INTERNSHIP_DROPPED_460',
+  'INTERNSHIP_FOUND_ELSEWHERE_800',
+]);
+
+// The product's canonical stage set, derived from the enum so it stays the single
+// source of truth. Used whenever a tenant has not customized its pipeline.
+export function defaultPipelineStages(locale: Locale = 'en'): ResolvedStage[] {
+  return PIPELINE_STATUSES.map((key, i) => ({
+    key,
+    label: pipelineLabel(key, locale),
+    order: i,
+    isTerminal: DEFAULT_TERMINAL.has(key),
+    isOffPath: DEFAULT_OFF_PATH.has(key),
+    color: null,
+  }));
+}
+
+// Resolve the stages for a tenant: its custom rows if any, else the canonical
+// defaults. Cheap single indexed query; falls back safely for a null org.
+export async function resolvePipelineStages(
+  orgId: string | null | undefined,
+  locale: Locale = 'en',
+): Promise<ResolvedStage[]> {
+  if (orgId) {
+    const rows = await prisma.pipelineStage.findMany({
+      where: { orgId },
+      orderBy: { order: 'asc' },
+    });
+    if (rows.length > 0) {
+      return rows.map((r) => ({
+        key: r.key,
+        label: r.label,
+        order: r.order,
+        isTerminal: r.isTerminal,
+        isOffPath: r.isOffPath,
+        color: r.color,
+      }));
+    }
+  }
+  return defaultPipelineStages(locale);
+}
+
+// The on-path sequence (excludes off-path stages), for "advance one stage"
+// semantics over a resolved stage set. Mirrors nextOnPathStatus for defaults.
+export function onPathKeys(stages: ResolvedStage[]): string[] {
+  return stages.filter((s) => !s.isOffPath).sort((a, b) => a.order - b.order).map((s) => s.key);
+}


### PR DESCRIPTION
Part of #747 (custom pipeline stages) under white-label #546 / story #522. **Slice A of 4** (see `docs/pipeline-stages.md`) — the behavior-preserving foundation.

## What

- **`PipelineStage`** model (per org: `key`, `label`, `order`, `isTerminal`, `isOffPath`, `color`; `@@unique([orgId, key])`).
- **`src/lib/pipelineStages.ts`** — `resolvePipelineStages(orgId, locale)` returns the org's rows if any, else `defaultPipelineStages()` (the canonical 13 stages derived from the `PipelineStatus` enum — single source of truth). `onPathKeys()` gives the happy-path sequence.
- **Admin API** `/api/admin/organizations/[id]/pipeline-stages` — admin-only; `GET` (resolved stages + `custom` flag), `PUT` (**premium-gated**, replaces the set atomically), `DELETE` (reset to defaults).

## Safety

- **Behavior-preserving.** An org with **no** `PipelineStage` rows uses the built-in defaults, so single-tenant production is byte-for-byte unchanged. Relations still store the `PipelineStatus` enum in this slice — **no data migration**.
- `PUT` is gated to paid plans; admin-only throughout.

## Tests / verification

- `e2e/pipeline-stages.spec.ts` — defaults mirror the 13 canonical stages with correct on-path/terminal flags; null-org and no-rows fall back to defaults; custom rows override; `onPathKeys` excludes off-path. Run against a real DB.
- [x] `npm run build` · [x] `npm run lint` · [x] `npm run check:i18n`

## Next slices (tracked in `docs/pipeline-stages.md`)
A.2 admin UI · B apply resolved stages across board/filters/analytics/journey/bulk · C move storage off the enum (data-safe `ENUM → VARCHAR`) so tenants can define brand-new keys.

Additive `db push` (`PipelineStage`). Version 0.25.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ)_