### PR TITLE
Pipeline stage storage: enum → String (#747, Slice C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,18 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [Unreleased]
 
-## [0.25.2] - 2026-07-23
+## [0.25.3] - 2026-07-23
+
+### Changed
+- **Pipeline stage storage is now a free String (#747, Slice C).**
+  `MentorshipRelation.pipelineStatus` and `StatusChange.fromStatus/toStatus`
+  changed from the `PipelineStatus` enum to `String`, so a tenant can store its
+  **own** stage keys (not just the canonical 13). **Data-safe:** MySQL
+  `ENUM → VARCHAR` preserves every existing value, and the canonical keys/labels
+  still live in `src/lib/pipeline.ts` (the enum block is retained as the default
+  key registry), so single-tenant behaviour is identical. Covered by
+  `e2e/pipeline-custom-key.spec.ts` (custom keys persist; canonical keys still
+  work). Surfaces rendering resolved custom stages land in Slice B.
 
 ### Added
 - **Per-tenant pipeline stages — admin UI (#747, Slice A.2).** Admin →

--- a/e2e/pipeline-custom-key.spec.ts
+++ b/e2e/pipeline-custom-key.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+// #747 Slice C: MentorshipRelation.pipelineStatus is now a free String (was the
+// PipelineStatus enum), so a tenant can store its OWN stage keys — not just the
+// canonical 13. Proves the storage change end-to-end against a real DB, and that
+// StatusChange (also String now) records a custom key.
+test.afterAll(async () => { await prisma.$disconnect(); });
+
+test('a relation + status change accept a non-canonical (custom) stage key', async () => {
+  const mentor = await seedUser(uniqueEmail('ck-mentor'), 'x', 'MENTOR', 'CK Mentor');
+  const mentee = await seedUser(uniqueEmail('ck-mentee'), 'x', 'MENTEE', 'CK Mentee');
+  let relId: string | null = null;
+  try {
+    const rel = await prisma.mentorshipRelation.create({
+      data: { mentorId: mentor.id, menteeId: mentee.id, pipelineStatus: 'CUSTOM_LEAD_001' },
+    });
+    relId = rel.id;
+    expect(rel.pipelineStatus).toBe('CUSTOM_LEAD_001');
+
+    const change = await prisma.statusChange.create({
+      data: { relationId: rel.id, fromStatus: 'CUSTOM_LEAD_001', toStatus: 'CUSTOM_WON_999', changedById: mentor.id },
+    });
+    expect(change.toStatus).toBe('CUSTOM_WON_999');
+
+    // A canonical key still works exactly as before (regression guard).
+    const updated = await prisma.mentorshipRelation.update({
+      where: { id: rel.id },
+      data: { pipelineStatus: 'APPLICATION_100' },
+    });
+    expect(updated.pipelineStatus).toBe('APPLICATION_100');
+  } finally {
+    if (relId) {
+      await prisma.statusChange.deleteMany({ where: { relationId: relId } });
+      await prisma.mentorshipRelation.deleteMany({ where: { id: relId } });
+    }
+    await cleanupByEmail(mentor.email);
+    await cleanupByEmail(mentee.email);
+  }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "internship-crm",
-  "version": "0.25.2-beta",
+  "version": "0.25.3-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "internship-crm",
-      "version": "0.25.2-beta",
+      "version": "0.25.3-beta",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.25.2-beta",
+  "version": "0.25.3-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -810,7 +810,11 @@ model MentorshipRelation {
   cohortId                String?
   startDate               DateTime         @default(now())
   status                  MentorshipStatus @default(ACTIVE)
-  pipelineStatus          PipelineStatus   @default(APPLICATION_100)
+  // Stage key. Free String (was the PipelineStatus enum) so tenants can define
+  // their own stages (#747). The enum below is kept as the canonical default
+  // key registry; values are unchanged for existing rows (ENUM→VARCHAR keeps
+  // them), so single-tenant behaviour is identical.
+  pipelineStatus          String           @default("APPLICATION_100")
   // Optional deadline for the current pipeline stage; powers overdue flagging
   // and deadline reminders.
   stageDeadline           DateTime?
@@ -998,12 +1002,12 @@ model Meeting {
 
 // Audit trail of pipeline stage changes for a mentorship.
 model StatusChange {
-  id          String         @id @default(cuid())
+  id          String   @id @default(cuid())
   relationId  String
-  fromStatus  PipelineStatus
-  toStatus    PipelineStatus
+  fromStatus  String
+  toStatus    String
   changedById String
-  createdAt   DateTime       @default(now())
+  createdAt   DateTime @default(now())
 
   relation  MentorshipRelation @relation(fields: [relationId], references: [id], onDelete: Cascade)
   changedBy User               @relation("StatusChangedBy", fields: [changedById], references: [id])

--- a/src/app/api/admin/sources/route.ts
+++ b/src/app/api/admin/sources/route.ts
@@ -2,12 +2,11 @@ import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
-import { PipelineStatus } from '@prisma/client';
 import { z } from 'zod';
 import { withTenantScope } from '@/lib/orgContext';
 
 // Pipeline stages that count as a successful outcome for conversion stats.
-const HIRED: PipelineStatus[] = [PipelineStatus.HIRED_660, PipelineStatus.EMPLOYED_700];
+const HIRED: string[] = ['HIRED_660', 'EMPLOYED_700'];
 
 // GET — all sources with mentee counts + conversion (hired) breakdown (admin).
 export async function GET() {

--- a/src/app/api/status-changes/route.ts
+++ b/src/app/api/status-changes/route.ts
@@ -3,7 +3,6 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { z } from 'zod';
-import type { PipelineStatus } from '@prisma/client';
 import { PIPELINE_STATUSES } from '@/lib/pipeline';
 import { withTenantScope } from '@/lib/orgContext';
 
@@ -36,8 +35,8 @@ export async function POST(request: Request) {
     const change = await prisma.statusChange.create({
       data: {
         relationId,
-        fromStatus: fromStatus as PipelineStatus,
-        toStatus: toStatus as PipelineStatus,
+        fromStatus,
+        toStatus,
         changedById: session.user.id,
         ...(createdAt ? { createdAt: new Date(createdAt) } : {}),
       },

--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -8,7 +8,6 @@ import { makeConsentRenewToken } from '@/lib/consentRenew';
 import { getRetentionMonths, RETENTION_GRACE_DAYS } from '@/lib/retention';
 import { getMentorMenteeActivity, getSystemMenteeActivity, formatDuration, type MenteeActivity } from '@/lib/activityReport';
 import { getOrgBranding } from '@/lib/orgBranding';
-import type { PipelineStatus } from '@prisma/client';
 
 // Resolved branding for a transactional email (#546). When no orgId is given
 // (single-tenant, or a caller without tenant context) this returns the product
@@ -410,7 +409,7 @@ export async function checkStageDeadlineReminders() {
       status: 'ACTIVE',
       stageDeadline: { lt: now },
       deadlineReminderSentAt: null,
-      pipelineStatus: { notIn: TERMINAL as unknown as PipelineStatus[] },
+      pipelineStatus: { notIn: [...TERMINAL] },
     },
     include: { mentor: true, mentee: true },
   });


### PR DESCRIPTION
Part of #747 (custom pipeline stages) under white-label #546 / story #522. **Slice C of 4** — the storage change that lets tenants define brand-new stage keys.

## What
- `MentorshipRelation.pipelineStatus` and `StatusChange.fromStatus` / `toStatus` change from the `PipelineStatus` **enum** to **String**.
- The `enum PipelineStatus` block is **retained** as the canonical default-key registry; `src/lib/pipeline.ts` still provides the canonical keys/labels.
- Fixed the 3 call sites that imported the now-unreferenced Prisma enum (`emailService`, `admin/sources`, `status-changes`) to use string literals / the `@/lib/pipeline` union.

## Safety — data-safe migration
- MySQL **`ENUM → VARCHAR` preserves every existing value** (the enum was stored as its label string), so all current relations/history keep their exact stage. `db push` performs the column type change on the topic preview (this PR) and prod (on merge).
- **Behavior-preserving:** the canonical keys still resolve to the same labels/order everywhere; single-tenant production is unchanged. New capability (custom keys) is inert until a tenant defines custom stages.

## Verification
- `e2e/pipeline-custom-key.spec.ts` — a relation + `StatusChange` accept a **non-canonical** key (`CUSTOM_LEAD_001`), and a canonical key still works (regression guard). Runs against a real DB.
- [x] `npm run build` · [x] `npm run lint` · [x] `npm run check:i18n`
- The **topic preview** on this PR runs the real `ENUM → VARCHAR` `db push` — a live check of the migration before prod.

## Next / last slice
Slice B — render resolved custom stages across the board / filters / analytics / journey (+ add/remove in the stage editor). Then #747 → #546 → #522 → #517 close.

Version 0.25.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ)_