### PR TITLE
Per-tenant pipeline stages on the mentee journey (#747, Slice B ch.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,19 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [Unreleased]
 
-## [0.25.3] - 2026-07-23
+## [0.25.4] - 2026-07-23
+
+### Changed
+- **Per-tenant pipeline stages on the mentee journey (#747, Slice B — chunk 1).**
+  The portal Journey tracker now renders the viewer tenant's resolved stages
+  (custom labels / order / on-path / terminal) instead of the hardcoded canonical
+  path — via a server-fed client context (`PipelineStagesProvider` +
+  `useResolvedStages`/`useStageLabel`) wrapped in the portal layout. The pure
+  stage helpers (`ResolvedStage`, `defaultPipelineStages`, `onPathKeys`,
+  `stageLabel`) moved to the client-safe `src/lib/pipeline.ts`. Behavior-preserving
+  for the default single-tenant setup (falls back to the canonical, locale-aware
+  defaults). Remaining surfaces (board / candidate filter / analytics) follow in
+  the next chunk.
 
 ### Changed
 - **Pipeline stage storage is now a free String (#747, Slice C).**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "internship-crm",
-  "version": "0.25.3-beta",
+  "version": "0.25.4-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "internship-crm",
-      "version": "0.25.3-beta",
+      "version": "0.25.4-beta",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.25.3-beta",
+  "version": "0.25.4-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/app/portal/layout.tsx
+++ b/src/app/portal/layout.tsx
@@ -10,6 +10,8 @@ import { ResponsiveShell } from '@/components/ResponsiveShell';
 import { BrandWordmark } from '@/components/BrandWordmark';
 import { InstallAppButton } from '@/components/InstallAppButton';
 import { prisma } from '@/lib/prisma';
+import { PipelineStagesProvider } from '@/lib/pipelineStagesClient';
+import { resolveCustomStages } from '@/lib/pipelineStages';
 
 export default async function PortalLayout({ children }: { children: React.ReactNode }) {
   const session = await getServerSession(authOptions);
@@ -32,6 +34,7 @@ export default async function PortalLayout({ children }: { children: React.React
 
   const { locale, t } = await getServerDictionary();
   const me = await prisma.user.findUnique({ where: { id: session.user.id }, select: { avatarUrl: true } });
+  const customStages = await resolveCustomStages(session.user.orgId);
 
   return (
     <ResponsiveShell
@@ -64,7 +67,7 @@ export default async function PortalLayout({ children }: { children: React.React
         </aside>
       }
     >
-      {children}
+      <PipelineStagesProvider stages={customStages}>{children}</PipelineStagesProvider>
     </ResponsiveShell>
   );
 }

--- a/src/components/JourneyTracker.tsx
+++ b/src/components/JourneyTracker.tsx
@@ -2,28 +2,13 @@
 
 import { Check, Compass, Trophy } from 'lucide-react';
 import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
-import { pipelineLabel, pipelineGuidance } from '@/lib/pipeline';
+import { pipelineGuidance, onPathKeys } from '@/lib/pipeline';
+import { useResolvedStages, useStageLabel } from '@/lib/pipelineStagesClient';
 import { useT, useLocale } from '@/i18n/client';
 
-// The happy-path milestones a mentee moves through. Off-path statuses
-// (dropped / found elsewhere) are shown as a standalone note instead.
-const PATH = [
-  'APPLICATION_100',
-  'APPROVAL_PENDING_220',
-  'INTERVIEW_PENDING_250',
-  'INTRODUCTION_PENDING_270',
-  'INTERNSHIP_STARTING_300',
-  'INTERNSHIP_IN_PROGRESS_450',
-  'INTERNSHIP_COMPLETED_490',
-  'JOB_SEEKING_500',
-  'HIREABLE_600',
-  'HIRED_660',
-  'EMPLOYED_700',
-];
-const OFF_PATH = ['INTERNSHIP_DROPPED_460', 'INTERNSHIP_FOUND_ELSEWHERE_800'];
-
 // Key achievement stages that warrant a milestone banner
-// (EPIC: achievements / milestone recognition, roadmap #370).
+// (EPIC: achievements / milestone recognition, roadmap #370). Canonical keys +
+// any tenant stage flagged terminal (handled below).
 const MILESTONE_STAGES = new Set([
   'INTERNSHIP_STARTING_300',
   'INTERNSHIP_IN_PROGRESS_450',
@@ -35,12 +20,18 @@ const MILESTONE_STAGES = new Set([
 export function JourneyTracker({ status }: { status: string }) {
   const t = useT();
   const locale = useLocale();
+  const stages = useResolvedStages();
+  const label = useStageLabel();
+  // The happy-path milestones (excludes off-path); derived from the tenant's
+  // resolved stages so custom pipelines render correctly (defaults unchanged).
+  const PATH = onPathKeys(stages);
+  const offPath = stages.find((s) => s.key === status)?.isOffPath ?? false;
   const idx = PATH.indexOf(status);
-  const offPath = OFF_PATH.includes(status);
   const pct = idx >= 0 ? Math.round(((idx + 1) / PATH.length) * 100) : 0;
   const next = idx >= 0 && idx < PATH.length - 1 ? PATH[idx + 1] : null;
   const guidance = !offPath ? pipelineGuidance(status, locale) : null;
-  const isMilestone = MILESTONE_STAGES.has(status);
+  // Milestone: a canonical milestone key, or any tenant stage marked terminal.
+  const isMilestone = MILESTONE_STAGES.has(status) || (stages.find((s) => s.key === status)?.isTerminal ?? false);
 
   return (
     <Card>
@@ -52,19 +43,19 @@ export function JourneyTracker({ status }: { status: string }) {
           <Trophy className="h-4 w-4 text-yellow-600 dark:text-yellow-400 flex-shrink-0" />
           <div>
             <p className="text-xs font-semibold text-yellow-800 dark:text-yellow-200">{t.portal.journey.milestoneReached}</p>
-            <p className="text-sm text-yellow-900 dark:text-yellow-100 mt-0.5">{pipelineLabel(status, locale)}</p>
+            <p className="text-sm text-yellow-900 dark:text-yellow-100 mt-0.5">{label(status)}</p>
           </div>
         </div>
       )}
 
       {offPath ? (
         <div className="rounded-lg bg-amber-50 dark:bg-amber-950/40 border border-amber-200 dark:border-amber-800 px-3 py-2 text-sm text-amber-800 dark:text-amber-200">
-          {pipelineLabel(status, locale)}
+          {label(status)}
         </div>
       ) : (
         <>
           <div className="flex items-center justify-between text-sm mb-1">
-            <span className="font-semibold text-gray-900 dark:text-gray-100">{pipelineLabel(status, locale)}</span>
+            <span className="font-semibold text-gray-900 dark:text-gray-100">{label(status)}</span>
             <span className="text-gray-400 dark:text-gray-500">{pct}%</span>
           </div>
           <div className="h-2 bg-gray-100 dark:bg-gray-800 rounded-full overflow-hidden mb-4">
@@ -81,7 +72,7 @@ export function JourneyTracker({ status }: { status: string }) {
             </div>
           )}
 
-          {next && <p className="text-xs text-gray-500 dark:text-gray-400 mb-4">{t.portal.journey.next}: {pipelineLabel(next, locale)}</p>}
+          {next && <p className="text-xs text-gray-500 dark:text-gray-400 mb-4">{t.portal.journey.next}: {label(next)}</p>}
 
           <ol className="space-y-1.5">
             {PATH.map((s, i) => {
@@ -95,7 +86,7 @@ export function JourneyTracker({ status }: { status: string }) {
                     {done ? <Check className="h-3 w-3" /> : i + 1}
                   </span>
                   <span className={current ? 'font-medium text-gray-900 dark:text-gray-100' : done ? 'text-gray-500 dark:text-gray-400' : 'text-gray-400 dark:text-gray-600'}>
-                    {pipelineLabel(s, locale)}
+                    {label(s)}
                   </span>
                 </li>
               );

--- a/src/lib/pipeline.ts
+++ b/src/lib/pipeline.ts
@@ -173,3 +173,48 @@ const GUIDANCE: Record<Locale, Partial<Record<PipelineStatus, string>>> = {
 export function pipelineGuidance(status: string, locale: Locale = 'en'): string | null {
   return GUIDANCE[locale]?.[status as PipelineStatus] ?? GUIDANCE.en[status as PipelineStatus] ?? null;
 }
+
+// ── Resolved (possibly per-tenant) stages (#747) ─────────────────────────────
+// Client-safe shape + canonical defaults. The DB-backed resolver
+// (resolvePipelineStages) lives in src/lib/pipelineStages.ts (server-only); these
+// pure helpers are here so client components can share the type + default set
+// without pulling in Prisma.
+export interface ResolvedStage {
+  key: string;
+  label: string;
+  order: number;
+  isTerminal: boolean;
+  isOffPath: boolean;
+  color: string | null;
+}
+
+const DEFAULT_OFF_PATH = new Set<string>(['INTERNSHIP_DROPPED_460', 'INTERNSHIP_FOUND_ELSEWHERE_800']);
+const DEFAULT_TERMINAL = new Set<string>([
+  'EMPLOYED_700',
+  'INTERNSHIP_DROPPED_460',
+  'INTERNSHIP_FOUND_ELSEWHERE_800',
+]);
+
+// The product's canonical stage set, derived from the enum (single source of
+// truth). Used whenever a tenant hasn't customized its pipeline.
+export function defaultPipelineStages(locale: Locale = 'en'): ResolvedStage[] {
+  return PIPELINE_STATUSES.map((key, i) => ({
+    key,
+    label: pipelineLabel(key, locale),
+    order: i,
+    isTerminal: DEFAULT_TERMINAL.has(key),
+    isOffPath: DEFAULT_OFF_PATH.has(key),
+    color: null,
+  }));
+}
+
+// The happy-path key sequence (excludes off-path), sorted by order.
+export function onPathKeys(stages: ResolvedStage[]): string[] {
+  return stages.filter((s) => !s.isOffPath).sort((a, b) => a.order - b.order).map((s) => s.key);
+}
+
+// Label lookup over a resolved set, falling back to the canonical label and then
+// the raw key — so a custom key always renders something sensible.
+export function stageLabel(stages: ResolvedStage[], key: string, locale: Locale = 'en'): string {
+  return stages.find((s) => s.key === key)?.label ?? pipelineLabel(key, locale);
+}

--- a/src/lib/pipelineStages.ts
+++ b/src/lib/pipelineStages.ts
@@ -1,48 +1,16 @@
 // Per-tenant pipeline-stage resolution (#747, part of white-label #546).
-// Server-only (reads the DB).
+// Server-only (reads the DB). The pure shape + defaults live in
+// src/lib/pipeline.ts (client-safe); this module only adds the DB-backed
+// resolver, so client components can share the type/defaults without Prisma.
 //
-// Phase A is additive + behavior-preserving: an org with no PipelineStage rows
-// falls back to the built-in canonical stages (the PipelineStatus enum, mirrored
-// in src/lib/pipeline.ts), so single-tenant production is unchanged. An org that
-// defines rows overrides the label / order / color / on-path grouping for the
-// stages it lists. Relations still store the PipelineStatus enum in this phase;
-// storage moves off the enum (allowing brand-new stage keys) in a later slice.
+// Behavior-preserving: an org with no PipelineStage rows falls back to the
+// canonical stages, so single-tenant production is unchanged.
 
 import { prisma } from './prisma';
-import { PIPELINE_STATUSES, pipelineLabel } from './pipeline';
+import { defaultPipelineStages, onPathKeys, stageLabel, type ResolvedStage } from './pipeline';
 import type { Locale } from '@/i18n/config';
 
-export interface ResolvedStage {
-  key: string;
-  label: string;
-  order: number;
-  isTerminal: boolean;
-  isOffPath: boolean;
-  color: string | null;
-}
-
-// The two off-path terminal states, and the set of terminal states, for the
-// canonical defaults — mirrors JourneyTracker's OFF_PATH and pipeline.ts's
-// nextOnPathStatus (EMPLOYED_700 is the positive terminus).
-const DEFAULT_OFF_PATH = new Set<string>(['INTERNSHIP_DROPPED_460', 'INTERNSHIP_FOUND_ELSEWHERE_800']);
-const DEFAULT_TERMINAL = new Set<string>([
-  'EMPLOYED_700',
-  'INTERNSHIP_DROPPED_460',
-  'INTERNSHIP_FOUND_ELSEWHERE_800',
-]);
-
-// The product's canonical stage set, derived from the enum so it stays the single
-// source of truth. Used whenever a tenant has not customized its pipeline.
-export function defaultPipelineStages(locale: Locale = 'en'): ResolvedStage[] {
-  return PIPELINE_STATUSES.map((key, i) => ({
-    key,
-    label: pipelineLabel(key, locale),
-    order: i,
-    isTerminal: DEFAULT_TERMINAL.has(key),
-    isOffPath: DEFAULT_OFF_PATH.has(key),
-    color: null,
-  }));
-}
+export { defaultPipelineStages, onPathKeys, stageLabel, type ResolvedStage };
 
 // Resolve the stages for a tenant: its custom rows if any, else the canonical
 // defaults. Cheap single indexed query; falls back safely for a null org.
@@ -69,8 +37,21 @@ export async function resolvePipelineStages(
   return defaultPipelineStages(locale);
 }
 
-// The on-path sequence (excludes off-path stages), for "advance one stage"
-// semantics over a resolved stage set. Mirrors nextOnPathStatus for defaults.
-export function onPathKeys(stages: ResolvedStage[]): string[] {
-  return stages.filter((s) => !s.isOffPath).sort((a, b) => a.order - b.order).map((s) => s.key);
+// Resolve a tenant's CUSTOM stages, or null when it uses the built-in defaults.
+// Fed to the client PipelineStagesProvider so default-stage labels can stay
+// localized on the client while custom labels render as the tenant set them.
+export async function resolveCustomStages(
+  orgId: string | null | undefined,
+): Promise<ResolvedStage[] | null> {
+  if (!orgId) return null;
+  const rows = await prisma.pipelineStage.findMany({ where: { orgId }, orderBy: { order: 'asc' } });
+  if (rows.length === 0) return null;
+  return rows.map((r) => ({
+    key: r.key,
+    label: r.label,
+    order: r.order,
+    isTerminal: r.isTerminal,
+    isOffPath: r.isOffPath,
+    color: r.color,
+  }));
 }

--- a/src/lib/pipelineStagesClient.tsx
+++ b/src/lib/pipelineStagesClient.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+import { defaultPipelineStages, stageLabel, onPathKeys, type ResolvedStage } from '@/lib/pipeline';
+import { useLocale } from '@/i18n/client';
+
+// Client access to the viewer's tenant pipeline stages (#747, Slice B). The
+// server layout resolves the org's CUSTOM stages (or null when it uses the
+// built-in defaults) and provides them here; client components read them via the
+// hooks below. When null, we compute the canonical defaults in the *client*
+// locale, so default-stage labels stay localized while custom labels (a single
+// tenant-set string) render as-is.
+
+const Ctx = createContext<ResolvedStage[] | null>(null);
+
+export function PipelineStagesProvider({
+  stages,
+  children,
+}: {
+  stages: ResolvedStage[] | null;
+  children: React.ReactNode;
+}) {
+  return <Ctx.Provider value={stages}>{children}</Ctx.Provider>;
+}
+
+// The viewer's resolved stages (custom if set, else localized defaults).
+export function useResolvedStages(): ResolvedStage[] {
+  const locale = useLocale();
+  const ctx = useContext(Ctx);
+  return ctx && ctx.length > 0 ? ctx : defaultPipelineStages(locale);
+}
+
+// A label(key) resolver bound to the viewer's stages + locale.
+export function useStageLabel(): (key: string) => string {
+  const locale = useLocale();
+  const stages = useResolvedStages();
+  return (key: string) => stageLabel(stages, key, locale);
+}
+
+export { onPathKeys, type ResolvedStage };


### PR DESCRIPTION
Part of #747 (custom pipeline stages) / #546 / #522. **Slice B, chunk 1** — start rendering resolved custom stages on surfaces, beginning with the mentee Journey tracker.

## What
- New server-fed client context: `PipelineStagesProvider` + `useResolvedStages()` / `useStageLabel()` (`src/lib/pipelineStagesClient.tsx`). The portal layout resolves the tenant's **custom** stages (or `null` → defaults) via `resolveCustomStages(orgId)` and provides them.
- **JourneyTracker** now derives its path (`onPathKeys`), labels (`stageLabel`), off-path and milestone/terminal flags from the resolved stages instead of a hardcoded canonical list.
- Pure, client-safe stage helpers (`ResolvedStage`, `defaultPipelineStages`, `onPathKeys`, `stageLabel`) moved into `src/lib/pipeline.ts`; `pipelineStages.ts` re-exports them and keeps the DB resolver server-side (no Prisma in client bundles).

## Safety
- **Behavior-preserving** for the default single-tenant setup: with no custom stages, the hook falls back to the canonical, **locale-aware** defaults (custom labels are a single tenant-set string; defaults stay localized on the client).
- No storage/schema change here (built on Slice C).

## Verification
- [x] `npm run build` · [x] `npm run lint` · [x] `npm run check:i18n`
- Existing `e2e/pipeline-stages.spec.ts` still covers the resolver/defaults.

## Next chunk
Wire the admin/mentor/company layouts + convert the board columns, candidate pipeline filter, and analytics funnels — then #747 → #546 → #522 → #517 close.

Version 0.25.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ)_