### PR TITLE
Per-tenant pipeline stages: admin board + candidate filter (#747, Slice B ch.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,17 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [Unreleased]
 
-## [0.25.4] - 2026-07-23
+## [0.25.5] - 2026-07-23
+
+### Changed
+- **Per-tenant pipeline stages on the admin board + candidate filter (#747,
+  Slice B — chunk 2).** The admin Kanban board (stage labels + the per-card
+  "move to" stage picker) and the candidates page (pipeline-stage filter dropdown
+  + stage labels + CSV/Excel export) now render the viewer tenant's resolved
+  stages via the shared context (`PipelineStagesProvider` now wired into the admin
+  layout too). Behavior-preserving for the default single-tenant setup; the board's
+  three-phase grouping remains the canonical model (custom relabels/colors show
+  through). Remaining: analytics funnels + mentor/company mirror surfaces.
 
 ### Changed
 - **Per-tenant pipeline stages on the mentee journey (#747, Slice B — chunk 1).**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "internship-crm",
-  "version": "0.25.4-beta",
+  "version": "0.25.5-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "internship-crm",
-      "version": "0.25.4-beta",
+      "version": "0.25.5-beta",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.25.4-beta",
+  "version": "0.25.5-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/app/admin/board/page.tsx
+++ b/src/app/admin/board/page.tsx
@@ -3,8 +3,9 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { GraduationCap, User, ChevronDown, ChevronRight, AlertTriangle } from 'lucide-react';
-import { PIPELINE_STATUSES, PIPELINE_GROUPS, pipelineLabel, type PipelineGroupKey } from '@/lib/pipeline';
-import { useT, useLocale } from '@/i18n/client';
+import { PIPELINE_GROUPS, type PipelineGroupKey } from '@/lib/pipeline';
+import { useResolvedStages, useStageLabel } from '@/lib/pipelineStagesClient';
+import { useT } from '@/i18n/client';
 
 interface Relation {
   id: string;
@@ -23,7 +24,8 @@ const WIP_LIMIT = 8;
 // Stages are grouped into three collapsible phases so 13 columns don't sprawl.
 export default function AdminBoardPage() {
   const t = useT();
-  const locale = useLocale();
+  const stages = useResolvedStages();
+  const label = useStageLabel();
   const router = useRouter();
   const [relations, setRelations] = useState<Relation[]>([]);
   const [loading, setLoading] = useState(true);
@@ -94,7 +96,7 @@ export default function AdminBoardPage() {
         }`}
       >
         <div className="flex items-center justify-between mb-3 px-1">
-          <span className="text-xs font-semibold text-gray-700">{pipelineLabel(status, locale)}</span>
+          <span className="text-xs font-semibold text-gray-700">{label(status)}</span>
           <span
             title={overLimit ? t.adminBoard.wipWarning : undefined}
             className={`text-xs rounded-full px-2 py-0.5 border ${
@@ -148,8 +150,8 @@ export default function AdminBoardPage() {
                   onChange={(e) => { e.stopPropagation(); moveTo(r.id, e.target.value); }}
                   className="mt-2 w-full rounded border border-gray-200 px-1.5 py-1 text-xs text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-100"
                 >
-                  {PIPELINE_STATUSES.map((sv) => (
-                    <option key={sv} value={sv}>{pipelineLabel(sv, locale)}</option>
+                  {stages.map((sv) => (
+                    <option key={sv.key} value={sv.key}>{sv.label}</option>
                   ))}
                 </select>
               </div>

--- a/src/app/admin/candidates/page.tsx
+++ b/src/app/admin/candidates/page.tsx
@@ -6,8 +6,8 @@ import { SavedViews } from '@/components/SavedViews';
 import { AssignMentorInline } from '@/components/admin/AssignMentorInline';
 import { EmptyState } from '@/components/EmptyState';
 import Link from "next/link";
-import { useT, useLocale } from "@/i18n/client";
-import { pipelineLabel, pipelineOptions } from '@/lib/pipeline';
+import { useT } from "@/i18n/client";
+import { useResolvedStages, useStageLabel } from '@/lib/pipelineStagesClient';
 import { Card } from '@/components/ui/Card';
 import { SkeletonRows } from '@/components/ui/Skeleton';
 import { Badge } from '@/components/ui/Badge';
@@ -46,7 +46,8 @@ const gradYears = Array.from({ length: MAX_GRAD_YEAR - MIN_GRAD_YEAR + 1 }, (_, 
 
 export default function CandidatesPage() {
   const t = useT();
-  const locale = useLocale();
+  const stages = useResolvedStages();
+  const label = useStageLabel();
   const { data: session } = useSession();
   const [mentors, setMentors] = useState<{ id: string; fullName: string }[]>([]);
   const [candidates, setCandidates] = useState<Candidate[]>([]);
@@ -72,7 +73,7 @@ export default function CandidatesPage() {
     return [
       c.fullName, c.email, c.phone, c.whatsapp, c.city, c.university, c.department,
       c.graduationYear, c.skills.join('; '),
-      rel?.pipelineStatus ? pipelineLabel(rel.pipelineStatus, locale) : '',
+      rel?.pipelineStatus ? label(rel.pipelineStatus) : '',
       rel?.company?.name ?? '', rel?.mentor?.fullName ?? '',
     ];
   };
@@ -214,7 +215,7 @@ export default function CandidatesPage() {
         <p className="text-gray-500 mt-1">{t.candidates.subtitle}</p>
         {statusFilter && (
           <div className="mt-3 inline-flex items-center gap-2 bg-blue-50 border border-blue-200 rounded-full px-3 py-1 text-sm text-blue-700">
-            {pipelineLabel(statusFilter, locale)}
+            {label(statusFilter)}
             <button
               type="button"
               onClick={() => {
@@ -292,7 +293,7 @@ export default function CandidatesPage() {
           />
           <Select
             aria-label={t.candidates.allStages}
-            options={[{ value: '', label: t.candidates.allStages }, ...pipelineOptions(locale)]}
+            options={[{ value: '', label: t.candidates.allStages }, ...stages.map((s) => ({ value: s.key, label: s.label }))]}
             value={statusFilter}
             onChange={(e) => setStatusFilter(e.target.value)}
           />

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -11,6 +11,8 @@ import { AdminNav } from '@/components/AdminNav';
 import { GlobalSearch } from '@/components/GlobalSearch';
 import { prisma } from '@/lib/prisma';
 import { is2faRequiredFor } from '@/lib/twoFactorPolicy';
+import { PipelineStagesProvider } from '@/lib/pipelineStagesClient';
+import { resolveCustomStages } from '@/lib/pipelineStages';
 
 export default async function AdminLayout({ children }: { children: React.ReactNode }) {
   const session = await getServerSession(authOptions);
@@ -25,6 +27,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
 
   const { locale, t } = await getServerDictionary();
   const me = await prisma.user.findUnique({ where: { id: session.user.id }, select: { avatarUrl: true, twoFactorEnabled: true } });
+  const customStages = await resolveCustomStages(session.user.orgId);
 
   // Auth hardening: when the org requires 2FA for this role, hold the user at a
   // setup gate until they enable it. Skipped while impersonating (the admin is
@@ -62,7 +65,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
         </aside>
       }
     >
-      {children}
+      <PipelineStagesProvider stages={customStages}>{children}</PipelineStagesProvider>
     </ResponsiveShell>
   );
 }


### PR DESCRIPTION
Part of #747 / #546 / #522. **Slice B, chunk 2** — render resolved custom stages on the admin board and candidate filter.

## What
- Admin layout now provides the tenant stage context (`PipelineStagesProvider` + `resolveCustomStages`).
- **Admin Kanban board**: stage column labels + the per-card "move to" stage picker use the resolved stages (`useStageLabel` / `useResolvedStages`).
- **Candidates page**: pipeline-stage filter dropdown + the active-filter label + CSV/Excel export "Stage" column use resolved stages.

## Safety
- **Behavior-preserving** for the default single-tenant setup (falls back to the canonical, locale-aware defaults).
- The board's three-phase grouping (`PIPELINE_GROUPS`) remains the canonical model — relabels/reorder/colors show through; fully arbitrary custom keys still group under the canonical phases (documented in `docs/pipeline-stages.md`).

## Verification
- [x] `npm run build` · [x] `npm run lint` · [x] `npm run check:i18n`

## Remaining for #747
Analytics funnels + mentor/company mirror surfaces, then #747 → #546 → #522 → #517 close.

Version 0.25.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ)_