### PR TITLE
Per-tenant pipeline stages across all remaining surfaces — completes #747

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,20 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [Unreleased]
 
-## [0.25.5] - 2026-07-23
+## [0.25.6] - 2026-07-23
+
+### Changed
+- **Per-tenant pipeline stages across all remaining surfaces (#747, Slice B —
+  final).** The mentor & company shells now provide the stage context; the
+  mentor/company/admin **analytics funnels** + dashboards, the mentor **kanban
+  board**, and the candidate/mentor/company **detail** views all render the
+  viewer tenant's resolved stage labels/order/colors. The write path
+  (`PUT /api/mentorship/[id]`, `POST /api/status-changes`) now accepts free-string
+  stage keys so custom stages can be assigned. Behavior-preserving for the default
+  single-tenant setup. **Completes #747** — a tenant can define its own pipeline
+  stages (Admin → Organizations → Edit stages) and see them everywhere. Known
+  canonical-model limitations (board 3-phase grouping, bulk advance) documented in
+  `docs/pipeline-stages.md`.
 
 ### Changed
 - **Per-tenant pipeline stages on the admin board + candidate filter (#747,

--- a/docs/pipeline-stages.md
+++ b/docs/pipeline-stages.md
@@ -9,9 +9,27 @@ single-tenant production is never at risk.
 | Slice | What | State |
 |-------|------|-------|
 | A (foundation) | `PipelineStage` model + resolution layer + admin API | **done** |
-| A.2 | Admin UI to edit stages (label / order / color / on-path) | planned |
-| B | Apply resolved stages across board / filters / analytics / journey / bulk-advance | planned |
-| C | Move storage off the enum (`MentorshipRelation.pipelineStatus` enum → String) so tenants can define **new** stage keys, with a data-safe migration | planned |
+| A.2 | Admin UI to edit stages (label / order / color / on-path) | **done** |
+| C | Move storage off the enum (`MentorshipRelation.pipelineStatus` enum → String) so tenants can define **new** stage keys, with a data-safe migration | **done** |
+| B | Apply resolved stages across journey / board / filters / analytics + accept dynamic keys on the write path | **done** |
+
+### Slice B — what renders resolved stages
+Every stage-rendering surface now reads the viewer tenant's resolved stages via a
+server-fed client context (`PipelineStagesProvider` in the admin/mentor/company/
+portal layouts) + `useResolvedStages()`/`useStageLabel()`, or server-side
+`resolvePipelineStages()` on server pages: the mentee **journey**, admin & mentor
+**kanban boards**, the candidate **filter** + list + export, and the admin/mentor/
+company **analytics funnels** + dashboards. The write path (`PUT /api/mentorship/[id]`,
+`POST /api/status-changes`) accepts free-string stage keys so custom stages can be
+assigned.
+
+### Known limitations (canonical-model, acceptable for now)
+- The kanban board's **three-phase grouping** (`PIPELINE_GROUPS`: pre / internship /
+  result) is the canonical model. Relabels/reorder/colors show through; a tenant's
+  brand-new keys that aren't among the canonical set won't appear under a phase
+  group (they still work everywhere else). Per-tenant grouping is a future refinement.
+- **Bulk "advance stage"** advances along the canonical on-path order
+  (`nextOnPathStatus`); for a fully custom key set it no-ops rather than guessing.
 
 ## How it works (Slice A)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "internship-crm",
-  "version": "0.25.5-beta",
+  "version": "0.25.6-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "internship-crm",
-      "version": "0.25.5-beta",
+      "version": "0.25.6-beta",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.25.5-beta",
+  "version": "0.25.6-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -7,11 +7,11 @@ import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { Badge } from '@/components/ui/Badge';
 import { Select } from '@/components/ui/Select';
-import { PIPELINE_STATUSES, pipelineLabel } from '@/lib/pipeline';
+import { useResolvedStages, useStageLabel } from '@/lib/pipelineStagesClient';
 import { CohortComparison } from '@/components/admin/CohortComparison';
 import { ProgramBenchmark } from '@/components/admin/ProgramBenchmark';
 import { SourceConversion } from '@/components/admin/SourceConversion';
-import { useT, useLocale } from '@/i18n/client';
+import { useT } from '@/i18n/client';
 
 interface Analytics {
   funnel: Record<string, number>;
@@ -67,7 +67,8 @@ function Stat({ label, value }: { label: string; value: string | number }) {
 
 export default function AdminAnalyticsPage() {
   const t = useT();
-  const locale = useLocale();
+  const label = useStageLabel();
+  const stages = useResolvedStages();
   const [data, setData] = useState<Analytics | null>(null);
   const [aging, setAging] = useState<Aging | null>(null);
   const [loading, setLoading] = useState(true);
@@ -96,12 +97,12 @@ export default function AdminAnalyticsPage() {
     fetch('/api/admin/analytics/cohorts').then((r) => setPremium(r.ok)).catch((e) => console.error('[analytics/cohorts]', e));
   }, []);
 
-  const maxFunnel = data ? Math.max(1, ...PIPELINE_STATUSES.map((s) => data.funnel[s] || 0)) : 1;
+  const maxFunnel = data ? Math.max(1, ...stages.map((s) => data.funnel[s.key] || 0)) : 1;
 
   const exportExcel = async () => {
     if (!data) return;
     const { exportXlsx } = await import('@/lib/excel');
-    const rows = PIPELINE_STATUSES.map((s) => [pipelineLabel(s, locale), data.funnel[s] || 0]);
+    const rows = stages.map((s) => [label(s.key), data.funnel[s.key] || 0]);
     await exportXlsx(`analytics-${new Date().toISOString().slice(0, 10)}`, ['Stage', 'Count'], rows, 'Funnel');
   };
 
@@ -119,7 +120,7 @@ export default function AdminAnalyticsPage() {
     const { exportXlsxSheets } = await import('@/lib/excel');
     const a = t.analytics;
     await exportXlsxSheets(`analytics-full-${new Date().toISOString().slice(0, 10)}`, [
-      { name: 'Funnel', columns: ['Stage', 'Count'], rows: PIPELINE_STATUSES.map((s) => [pipelineLabel(s, locale), data.funnel[s] || 0]) },
+      { name: 'Funnel', columns: ['Stage', 'Count'], rows: stages.map((s) => [label(s.key), data.funnel[s.key] || 0]) },
       ...(data.trends ? [{
         name: 'Trends',
         columns: [a.fullReportMonth, a.trendNewRelations, a.trendInteractions],
@@ -189,11 +190,11 @@ export default function AdminAnalyticsPage() {
         <Card>
           <CardHeader><CardTitle>{t.analytics.funnel}</CardTitle></CardHeader>
           <div className="space-y-1.5">
-            {PIPELINE_STATUSES.map((s) => {
-              const n = data.funnel[s] || 0;
+            {stages.map((s) => {
+              const n = data.funnel[s.key] || 0;
               return (
-                <div key={s} className="flex items-center gap-2 text-sm">
-                  <span className="w-48 truncate text-gray-600 flex-shrink-0">{pipelineLabel(s, locale)}</span>
+                <div key={s.key} className="flex items-center gap-2 text-sm">
+                  <span className="w-48 truncate text-gray-600 flex-shrink-0">{s.label}</span>
                   <div className="flex-1 bg-gray-100 rounded h-4 overflow-hidden">
                     <div className="bg-blue-500 h-full" style={{ width: `${(n / maxFunnel) * 100}%` }} />
                   </div>
@@ -288,7 +289,7 @@ export default function AdminAnalyticsPage() {
               <div className="divide-y divide-gray-50 dark:divide-gray-800">
                 {aging.stageAging.map((s) => (
                   <div key={s.pipelineStatus} className="flex items-center justify-between py-2 text-sm">
-                    <span className="truncate">{pipelineLabel(s.pipelineStatus, locale)}</span>
+                    <span className="truncate">{label(s.pipelineStatus)}</span>
                     <span className="text-gray-500 flex-shrink-0">
                       {t.analytics.aging.avg} {s.avgDays}{t.analytics.aging.days} · {t.analytics.aging.median} {s.medianDays}{t.analytics.aging.days} · {s.count} {t.analytics.aging.candidates}
                     </span>
@@ -312,7 +313,7 @@ export default function AdminAnalyticsPage() {
                   >
                     <div className="min-w-0">
                       <p className="truncate">{it.menteeName}</p>
-                      <p className="text-xs text-gray-400 truncate">{pipelineLabel(it.pipelineStatus, locale)}</p>
+                      <p className="text-xs text-gray-400 truncate">{label(it.pipelineStatus)}</p>
                     </div>
                     <span className="flex items-center gap-1.5 flex-shrink-0">
                       {it.overdue && <AlertTriangle className="h-3.5 w-3.5 text-red-500" />}

--- a/src/app/admin/analytics/report/page.tsx
+++ b/src/app/admin/analytics/report/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { ArrowLeft, Lock, Printer } from 'lucide-react';
 import { Button } from '@/components/ui/Button';
-import { PIPELINE_STATUSES, pipelineLabel } from '@/lib/pipeline';
+import { useResolvedStages, useStageLabel } from '@/lib/pipelineStagesClient';
 import { useT, useLocale } from '@/i18n/client';
 
 interface Analytics {
@@ -37,6 +37,8 @@ const td = 'py-1.5 pr-4 text-sm border-b border-gray-100';
 export default function AnalyticsReportPage() {
   const t = useT();
   const locale = useLocale();
+  const label = useStageLabel();
+  const stages = useResolvedStages();
   const c = t.analytics;
   const [data, setData] = useState<Analytics | null>(null);
   const [cohorts, setCohorts] = useState<CohortRow[] | null>(null);
@@ -101,8 +103,8 @@ export default function AnalyticsReportPage() {
         <table className="w-full"><thead><tr>
           <th className={th}>{c.funnel}</th><th className={th}>#</th>
         </tr></thead><tbody>
-          {PIPELINE_STATUSES.map((s) => (
-            <tr key={s}><td className={td}>{pipelineLabel(s, locale)}</td><td className={td}>{data.funnel[s] || 0}</td></tr>
+          {stages.map((s) => (
+            <tr key={s.key}><td className={td}>{label(s.key)}</td><td className={td}>{data.funnel[s.key] || 0}</td></tr>
           ))}
         </tbody></table>
       </Section>

--- a/src/app/admin/candidates/[id]/page.tsx
+++ b/src/app/admin/candidates/[id]/page.tsx
@@ -9,7 +9,7 @@ import { InteractionTypeBadge } from '@/components/InteractionTypeBadge';
 import { Select } from '@/components/ui/Select';
 import { Button } from '@/components/ui/Button';
 import { ArrowLeft, KeyRound, Trash2, Plus } from 'lucide-react';
-import { pipelineLabel, pipelineOptions, PIPELINE_STATUSES } from '@/lib/pipeline';
+import { useResolvedStages, useStageLabel } from '@/lib/pipelineStagesClient';
 import { CvManager } from '@/components/CvManager';
 import { nextAction } from '@/lib/matching';
 import { EvaluationPanel } from '@/components/EvaluationPanel';
@@ -71,6 +71,8 @@ export default function AdminMenteeDetailPage() {
   const id = useParams().id as string;
   const t = useT();
   const locale = useLocale();
+  const label = useStageLabel();
+  const stages = useResolvedStages();
   const toast = useToast();
   const [user, setUser] = useState<MenteeDetail | null>(null);
   const [loading, setLoading] = useState(true);
@@ -144,8 +146,8 @@ export default function AdminMenteeDetailPage() {
   }, [id]);
 
   // Manual stage-history corrections (S9.4): add or remove audit entries.
-  const [histFrom, setHistFrom] = useState(PIPELINE_STATUSES[0] as string);
-  const [histTo, setHistTo] = useState(PIPELINE_STATUSES[0] as string);
+  const [histFrom, setHistFrom] = useState(stages[0]?.key ?? '');
+  const [histTo, setHistTo] = useState(stages[0]?.key ?? '');
   const [histDate, setHistDate] = useState('');
   const [histBusy, setHistBusy] = useState(false);
 
@@ -255,7 +257,7 @@ export default function AdminMenteeDetailPage() {
             <p className="text-gray-500">{user.email}</p>
           </div>
           <div className="flex items-center gap-3">
-            {rel && <Badge variant="info">{pipelineLabel(rel.pipelineStatus, locale)}</Badge>}
+            {rel && <Badge variant="info">{label(rel.pipelineStatus)}</Badge>}
             <Button variant="outline" size="sm" loading={resetting} onClick={resetPassword}>
               <KeyRound className="h-4 w-4 mr-1" />
               {t.candidateDetail.resetPassword}
@@ -322,7 +324,7 @@ export default function AdminMenteeDetailPage() {
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 max-w-lg">
                 <Select
                   label={t.candidateDetail.stage}
-                  options={pipelineOptions(locale)}
+                  options={stages.map((s) => ({ value: s.key, label: s.label }))}
                   value={rel.pipelineStatus}
                   disabled={saving}
                   onChange={(e) => changeStage(rel.id, e.target.value)}
@@ -382,9 +384,9 @@ export default function AdminMenteeDetailPage() {
                     {rel.statusChanges.map((sc) => (
                       <li key={sc.id} className="group flex items-center gap-2 text-sm border-l-2 border-blue-100 pl-3">
                         <span className="flex-1 min-w-0">
-                          <span className="text-gray-400">{pipelineLabel(sc.fromStatus, locale)}</span>
+                          <span className="text-gray-400">{label(sc.fromStatus)}</span>
                           {' → '}
-                          <span className="font-medium">{pipelineLabel(sc.toStatus, locale)}</span>
+                          <span className="font-medium">{label(sc.toStatus)}</span>
                           <span className="text-xs text-gray-400"> · {sc.changedBy.fullName} · {formatDate(sc.createdAt, locale)}</span>
                         </span>
                         <button
@@ -402,10 +404,10 @@ export default function AdminMenteeDetailPage() {
                 {/* Manually add a correcting history entry */}
                 <div className="mt-3 flex flex-wrap items-end gap-2 rounded-lg border border-gray-100 bg-gray-50 p-3">
                   <div className="w-40">
-                    <Select label={t.candidateDetail.from} options={pipelineOptions(locale)} value={histFrom} onChange={(e) => setHistFrom(e.target.value)} />
+                    <Select label={t.candidateDetail.from} options={stages.map((s) => ({ value: s.key, label: s.label }))} value={histFrom} onChange={(e) => setHistFrom(e.target.value)} />
                   </div>
                   <div className="w-40">
-                    <Select label={t.candidateDetail.to} options={pipelineOptions(locale)} value={histTo} onChange={(e) => setHistTo(e.target.value)} />
+                    <Select label={t.candidateDetail.to} options={stages.map((s) => ({ value: s.key, label: s.label }))} value={histTo} onChange={(e) => setHistTo(e.target.value)} />
                   </div>
                   <div>
                     <label className="block text-xs text-gray-500 mb-1">{t.candidateDetail.date}</label>

--- a/src/app/admin/mentors/[id]/page.tsx
+++ b/src/app/admin/mentors/[id]/page.tsx
@@ -6,8 +6,8 @@ import Link from 'next/link';
 import { ArrowLeft, Users, Star } from 'lucide-react';
 import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Badge } from '@/components/ui/Badge';
-import { pipelineLabel } from '@/lib/pipeline';
-import { useT, useLocale } from '@/i18n/client';
+import { useStageLabel } from '@/lib/pipelineStagesClient';
+import { useT } from '@/i18n/client';
 
 interface MentorRelation {
   id: string;
@@ -30,7 +30,7 @@ interface MentorDetail {
 export default function AdminMentorDetailPage() {
   const id = useParams().id as string;
   const t = useT();
-  const locale = useLocale();
+  const label = useStageLabel();
   const [user, setUser] = useState<MentorDetail | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -117,7 +117,7 @@ export default function AdminMentorDetailPage() {
                       {r.mentee.email}{r.company ? ` · ${r.company.name}` : ''}
                     </p>
                   </div>
-                  <Badge variant="default" className="flex-shrink-0">{pipelineLabel(r.pipelineStatus, locale)}</Badge>
+                  <Badge variant="default" className="flex-shrink-0">{label(r.pipelineStatus)}</Badge>
                 </div>
               ))}
             </div>

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -6,7 +6,7 @@ import { Card, CardHeader, CardTitle, CardDescription } from '@/components/ui/Ca
 import { Badge, StatusBadge } from '@/components/ui/Badge';
 import { Users, Building2, BookOpen, Bell } from 'lucide-react';
 import Link from 'next/link';
-import { PIPELINE_STATUSES, pipelineLabel } from '@/lib/pipeline';
+import { resolvePipelineStages } from '@/lib/pipelineStages';
 import { getServerDictionary } from '@/i18n/server';
 
 async function getStats() {
@@ -61,9 +61,10 @@ async function getStats() {
 }
 
 export default async function AdminDashboard() {
-  await getServerSession(authOptions);
+  const session = await getServerSession(authOptions);
   const stats = await getStats();
   const { locale, t } = await getServerDictionary();
+  const stages = await resolvePipelineStages(session?.user.orgId, locale);
 
   return (
     <div>
@@ -139,18 +140,18 @@ export default async function AdminDashboard() {
           <CardDescription>{t.dashboard.perStage}</CardDescription>
         </CardHeader>
         {(() => {
-          const max = Math.max(1, ...PIPELINE_STATUSES.map((s) => stats.pipelineCounts[s] ?? 0));
+          const max = Math.max(1, ...stages.map((s) => stats.pipelineCounts[s.key] ?? 0));
           return (
             <div className="space-y-2">
-              {PIPELINE_STATUSES.map((s) => {
-                const count = stats.pipelineCounts[s] ?? 0;
+              {stages.map((s) => {
+                const count = stats.pipelineCounts[s.key] ?? 0;
                 return (
                   <Link
-                    key={s}
-                    href={`/admin/candidates?status=${s}`}
+                    key={s.key}
+                    href={`/admin/candidates?status=${s.key}`}
                     className="flex items-center gap-3 rounded-lg px-1 py-0.5 hover:bg-blue-50 transition-colors"
                   >
-                    <span className="text-xs text-gray-600 w-56 flex-shrink-0 truncate">{pipelineLabel(s, locale)}</span>
+                    <span className="text-xs text-gray-600 w-56 flex-shrink-0 truncate">{s.label}</span>
                     <div className="flex-1 bg-gray-100 rounded-full h-2.5 overflow-hidden">
                       <div
                         className="bg-blue-500 h-full rounded-full"

--- a/src/app/api/mentorship/[id]/route.ts
+++ b/src/app/api/mentorship/[id]/route.ts
@@ -7,12 +7,14 @@ import { z } from 'zod';
 import { logActivity } from '@/lib/activity';
 import { notify } from '@/lib/notify';
 import { dispatchWebhook } from '@/lib/webhooks';
-import { PIPELINE_STATUSES } from '@/lib/pipeline';
 import { withTenantScope } from '@/lib/orgContext';
 
 const updateRelationSchema = z.object({
   status: z.enum(['ACTIVE', 'COMPLETED']).optional(),
-  pipelineStatus: z.enum(PIPELINE_STATUSES).optional(),
+  // Stage key is a free string now (#747) so tenants can use their own stages;
+  // the UI only offers the tenant's resolved stages. Bounded to the PipelineStage
+  // key constraint.
+  pipelineStatus: z.string().min(1).max(60).optional(),
   companyId: z.string().nullable().optional(),
   projectId: z.string().nullable().optional(),
   cohortId: z.string().nullable().optional(),

--- a/src/app/api/status-changes/route.ts
+++ b/src/app/api/status-changes/route.ts
@@ -3,10 +3,10 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { z } from 'zod';
-import { PIPELINE_STATUSES } from '@/lib/pipeline';
 import { withTenantScope } from '@/lib/orgContext';
 
-const stage = z.enum(PIPELINE_STATUSES as unknown as [string, ...string[]]);
+// Stage key is a free string now (#747) so tenant-defined stages are accepted.
+const stage = z.string().min(1).max(60);
 const schema = z.object({
   relationId: z.string().min(1),
   fromStatus: stage,

--- a/src/app/company/analytics/page.tsx
+++ b/src/app/company/analytics/page.tsx
@@ -5,8 +5,8 @@ import Link from 'next/link';
 import { BarChart3, Users, Star, BookmarkCheck, X } from 'lucide-react';
 import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { SkeletonRows } from '@/components/ui/Skeleton';
-import { PIPELINE_STATUSES, pipelineLabel } from '@/lib/pipeline';
-import { useT, useLocale } from '@/i18n/client';
+import { useResolvedStages, useStageLabel } from '@/lib/pipelineStagesClient';
+import { useT } from '@/i18n/client';
 
 interface CompanyAnalytics {
   funnel: Record<string, number>;
@@ -23,7 +23,8 @@ interface CompanyAnalytics {
 // summary (EPIC: company pipeline analytics, roadmap #370).
 export default function CompanyAnalyticsPage() {
   const t = useT();
-  const locale = useLocale();
+  const label = useStageLabel();
+  const stages = useResolvedStages();
   const [data, setData] = useState<CompanyAnalytics | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -37,7 +38,7 @@ export default function CompanyAnalyticsPage() {
   }, [t.common.error]);
 
   const ca = t.companyAnalytics;
-  const maxFunnel = data ? Math.max(1, ...PIPELINE_STATUSES.map((s) => data.funnel[s] || 0)) : 1;
+  const maxFunnel = data ? Math.max(1, ...stages.map((s) => data.funnel[s.key] || 0)) : 1;
 
   return (
     <div>
@@ -80,13 +81,13 @@ export default function CompanyAnalyticsPage() {
                 <p className="text-sm text-gray-400 dark:text-gray-500 py-4 text-center">{ca.noData}</p>
               ) : (
                 <div className="space-y-2">
-                  {PIPELINE_STATUSES.filter((s) => (data.funnel[s] ?? 0) > 0).map((s) => {
-                    const count = data.funnel[s] ?? 0;
+                  {stages.filter((s) => (data.funnel[s.key] ?? 0) > 0).map((s) => {
+                    const count = data.funnel[s.key] ?? 0;
                     const pct = Math.round((count / maxFunnel) * 100);
                     return (
-                      <div key={s}>
+                      <div key={s.key}>
                         <div className="flex items-center justify-between text-sm mb-1">
-                          <span className="text-gray-700 dark:text-gray-300 truncate">{pipelineLabel(s, locale)}</span>
+                          <span className="text-gray-700 dark:text-gray-300 truncate">{label(s.key)}</span>
                           <span className="font-semibold text-gray-900 dark:text-gray-100 ml-2 flex-shrink-0">{count}</span>
                         </div>
                         <div className="h-2 bg-gray-100 dark:bg-gray-700 rounded-full overflow-hidden">

--- a/src/app/company/candidates/[id]/page.tsx
+++ b/src/app/company/candidates/[id]/page.tsx
@@ -7,8 +7,8 @@ import { ArrowLeft, FileText, ExternalLink, Star, Bookmark, ThumbsDown, Check, S
 import { Card } from '@/components/ui/Card';
 import { Badge } from '@/components/ui/Badge';
 import { Button } from '@/components/ui/Button';
-import { pipelineLabel } from '@/lib/pipeline';
-import { useT, useLocale } from '@/i18n/client';
+import { useStageLabel } from '@/lib/pipelineStagesClient';
+import { useT } from '@/i18n/client';
 
 type InterestStatus = 'INTERESTED' | 'SHORTLISTED' | 'PASS';
 interface Interest { status: InterestStatus; note?: string | null }
@@ -61,7 +61,7 @@ interface Verified {
 // detail). Authorized server-side by a mentorship relation to this company.
 export default function CompanyCandidateDetailPage() {
   const t = useT();
-  const locale = useLocale();
+  const label = useStageLabel();
   const { id } = useParams<{ id: string }>();
   const [candidate, setCandidate] = useState<Candidate | null>(null);
   const [verified, setVerified] = useState<Verified | null>(null);
@@ -169,7 +169,7 @@ export default function CompanyCandidateDetailPage() {
           <div className="min-w-0 flex-1">
             <div className="flex flex-wrap items-center gap-2">
               <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100">{candidate.fullName}</h1>
-              <Badge variant="info">{pipelineLabel(candidate.pipelineStatus, locale)}</Badge>
+              <Badge variant="info">{label(candidate.pipelineStatus)}</Badge>
             </div>
             {candidate.targetPosition && <p className="text-blue-600 dark:text-blue-400 text-sm font-medium mt-0.5">{candidate.targetPosition}</p>}
             <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{t.company.mentor}: {candidate.mentorName}</p>

--- a/src/app/company/layout.tsx
+++ b/src/app/company/layout.tsx
@@ -12,6 +12,8 @@ import { BrandWordmark } from '@/components/BrandWordmark';
 import { InstallAppButton } from '@/components/InstallAppButton';
 import { prisma } from '@/lib/prisma';
 import { hasFeature } from '@/lib/entitlements';
+import { PipelineStagesProvider } from '@/lib/pipelineStagesClient';
+import { resolveCustomStages } from '@/lib/pipelineStages';
 
 export default async function CompanyLayout({ children }: { children: React.ReactNode }) {
   const session = await getServerSession(authOptions);
@@ -24,6 +26,7 @@ export default async function CompanyLayout({ children }: { children: React.Reac
   // Show the premium talent-pool link only when the company is entitled (admins
   // always see it for support).
   const showTalentPool = session.user.role === 'ADMIN' || (await hasFeature(session.user.companyId, 'TALENT_POOL_SEARCH'));
+  const customStages = await resolveCustomStages(session.user.orgId);
 
   return (
     <ResponsiveShell
@@ -78,7 +81,7 @@ export default async function CompanyLayout({ children }: { children: React.Reac
         </aside>
       }
     >
-      {children}
+      <PipelineStagesProvider stages={customStages}>{children}</PipelineStagesProvider>
     </ResponsiveShell>
   );
 }

--- a/src/app/company/page.tsx
+++ b/src/app/company/page.tsx
@@ -7,8 +7,8 @@ import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Badge } from '@/components/ui/Badge';
 import { Select } from '@/components/ui/Select';
 import { SkeletonRows } from '@/components/ui/Skeleton';
-import { pipelineLabel, pipelineOptions } from '@/lib/pipeline';
-import { useT, useLocale } from '@/i18n/client';
+import { useResolvedStages, useStageLabel } from '@/lib/pipelineStagesClient';
+import { useT } from '@/i18n/client';
 
 interface Relation {
   id: string;
@@ -20,7 +20,8 @@ interface Relation {
 // Read-only company overview: the mentees linked to this company.
 export default function CompanyOverviewPage() {
   const t = useT();
-  const locale = useLocale();
+  const label = useStageLabel();
+  const stages = useResolvedStages();
   const [relations, setRelations] = useState<Relation[]>([]);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
@@ -58,7 +59,7 @@ export default function CompanyOverviewPage() {
           />
           <div className="w-56">
             <Select value={stage} onChange={(e) => setStage(e.target.value)}
-              options={[{ value: '', label: t.company.allStages }, ...pipelineOptions(locale)]} />
+              options={[{ value: '', label: t.company.allStages }, ...stages.map((s) => ({ value: s.key, label: s.label }))]} />
           </div>
         </div>
       )}
@@ -87,7 +88,7 @@ export default function CompanyOverviewPage() {
                   </p>
                 </div>
                 <div className="flex items-center gap-2 flex-shrink-0">
-                  <Badge variant="info">{pipelineLabel(r.pipelineStatus, locale)}</Badge>
+                  <Badge variant="info">{label(r.pipelineStatus)}</Badge>
                   <ChevronRight className="h-4 w-4 text-gray-300 dark:text-gray-600" />
                 </div>
               </Link>

--- a/src/app/mentor/analytics/page.tsx
+++ b/src/app/mentor/analytics/page.tsx
@@ -5,8 +5,8 @@ import Link from 'next/link';
 import { BarChart3, Users, BookOpen, Target, TrendingUp, Award } from 'lucide-react';
 import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { SkeletonRows } from '@/components/ui/Skeleton';
-import { PIPELINE_STATUSES, pipelineLabel } from '@/lib/pipeline';
-import { useT, useLocale } from '@/i18n/client';
+import { useResolvedStages } from '@/lib/pipelineStagesClient';
+import { useT } from '@/i18n/client';
 
 interface MentorAnalytics {
   funnel: Record<string, number>;
@@ -39,7 +39,7 @@ function StatCard({ icon: Icon, value, label, color }: { icon: React.ElementType
 // stats for the signed-in mentor (EPIC: mentor analytics, roadmap #370).
 export default function MentorAnalyticsPage() {
   const t = useT();
-  const locale = useLocale();
+  const stages = useResolvedStages();
   const [data, setData] = useState<MentorAnalytics | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -54,7 +54,7 @@ export default function MentorAnalyticsPage() {
 
   const ma = t.mentorAnalytics;
 
-  const maxFunnel = data ? Math.max(1, ...PIPELINE_STATUSES.map((s) => data.funnel[s] || 0)) : 1;
+  const maxFunnel = data ? Math.max(1, ...stages.map((s) => data.funnel[s.key] || 0)) : 1;
 
   return (
     <div>
@@ -93,13 +93,13 @@ export default function MentorAnalyticsPage() {
                 <p className="text-sm text-gray-400 dark:text-gray-500 py-4 text-center">{ma.noData}</p>
               ) : (
                 <div className="space-y-2">
-                  {PIPELINE_STATUSES.filter((s) => (data.funnel[s] ?? 0) > 0).map((s) => {
-                    const count = data.funnel[s] ?? 0;
+                  {stages.filter((s) => (data.funnel[s.key] ?? 0) > 0).map((s) => {
+                    const count = data.funnel[s.key] ?? 0;
                     const pct = Math.round((count / maxFunnel) * 100);
                     return (
-                      <div key={s}>
+                      <div key={s.key}>
                         <div className="flex items-center justify-between text-sm mb-1">
-                          <span className="text-gray-700 dark:text-gray-300 truncate">{pipelineLabel(s, locale)}</span>
+                          <span className="text-gray-700 dark:text-gray-300 truncate">{s.label}</span>
                           <span className="font-semibold text-gray-900 dark:text-gray-100 ml-2 flex-shrink-0">{count}</span>
                         </div>
                         <div className="h-2 bg-gray-100 dark:bg-gray-700 rounded-full overflow-hidden">
@@ -111,7 +111,7 @@ export default function MentorAnalyticsPage() {
                       </div>
                     );
                   })}
-                  {PIPELINE_STATUSES.every((s) => !data.funnel[s]) && (
+                  {stages.every((s) => !data.funnel[s.key]) && (
                     <p className="text-sm text-gray-400 dark:text-gray-500 py-4 text-center">{ma.noData}</p>
                   )}
                 </div>

--- a/src/app/mentor/board/page.tsx
+++ b/src/app/mentor/board/page.tsx
@@ -3,8 +3,8 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { GraduationCap } from 'lucide-react';
-import { PIPELINE_STATUSES, pipelineLabel } from '@/lib/pipeline';
-import { useT, useLocale } from '@/i18n/client';
+import { useResolvedStages, useStageLabel } from '@/lib/pipelineStagesClient';
+import { useT } from '@/i18n/client';
 
 interface Mentee {
   id: string;
@@ -21,7 +21,8 @@ interface Relation {
 
 export default function MentorBoardPage() {
   const t = useT();
-  const locale = useLocale();
+  const label = useStageLabel();
+  const stages = useResolvedStages();
   const router = useRouter();
   const [relations, setRelations] = useState<Relation[]>([]);
   const [loading, setLoading] = useState(true);
@@ -66,7 +67,8 @@ export default function MentorBoardPage() {
       </div>
 
       <div className="flex gap-4 overflow-x-auto pb-4">
-        {PIPELINE_STATUSES.map((status) => {
+        {stages.map((s) => {
+          const status = s.key;
           const items = relations.filter((r) => r.pipelineStatus === status);
           return (
             <div
@@ -75,7 +77,7 @@ export default function MentorBoardPage() {
                 e.preventDefault();
                 setDragOver(status);
               }}
-              onDragLeave={() => setDragOver((s) => (s === status ? null : s))}
+              onDragLeave={() => setDragOver((prev) => (prev === status ? null : prev))}
               onDrop={(e) => {
                 e.preventDefault();
                 setDragOver(null);
@@ -87,7 +89,7 @@ export default function MentorBoardPage() {
               }`}
             >
               <div className="flex items-center justify-between mb-3 px-1">
-                <span className="text-xs font-semibold text-gray-700">{pipelineLabel(status, locale)}</span>
+                <span className="text-xs font-semibold text-gray-700">{label(status)}</span>
                 <span className="text-xs text-gray-400 bg-white border border-gray-200 rounded-full px-2 py-0.5">
                   {items.length}
                 </span>

--- a/src/app/mentor/layout.tsx
+++ b/src/app/mentor/layout.tsx
@@ -12,6 +12,8 @@ import { BrandWordmark } from '@/components/BrandWordmark';
 import { InstallAppButton } from '@/components/InstallAppButton';
 import { prisma } from '@/lib/prisma';
 import { is2faRequiredFor } from '@/lib/twoFactorPolicy';
+import { PipelineStagesProvider } from '@/lib/pipelineStagesClient';
+import { resolveCustomStages } from '@/lib/pipelineStages';
 
 export default async function MentorLayout({ children }: { children: React.ReactNode }) {
   const session = await getServerSession(authOptions);
@@ -26,6 +28,7 @@ export default async function MentorLayout({ children }: { children: React.React
 
   const { locale, t } = await getServerDictionary();
   const me = await prisma.user.findUnique({ where: { id: session.user.id }, select: { avatarUrl: true, twoFactorEnabled: true } });
+  const customStages = await resolveCustomStages(session.user.orgId);
 
   // Auth hardening: hold in-scope roles at the 2FA setup gate until enabled.
   // Skipped while impersonating (the admin behind it is already authenticated).
@@ -140,7 +143,7 @@ export default async function MentorLayout({ children }: { children: React.React
         </aside>
       }
     >
-      {children}
+      <PipelineStagesProvider stages={customStages}>{children}</PipelineStagesProvider>
     </ResponsiveShell>
   );
 }

--- a/src/app/mentor/mentees/[id]/page.tsx
+++ b/src/app/mentor/mentees/[id]/page.tsx
@@ -11,7 +11,7 @@ import { Input } from '@/components/ui/Input';
 import { Select } from '@/components/ui/Select';
 import { ArrowLeft, Plus, Trash2, ExternalLink } from 'lucide-react';
 import Link from 'next/link';
-import { pipelineOptions, pipelineLabel } from '@/lib/pipeline';
+import { useResolvedStages, useStageLabel } from '@/lib/pipelineStagesClient';
 import { useT, useLocale } from '@/i18n/client';
 import { EvaluationPanel } from '@/components/EvaluationPanel';
 import { GoalsPanel } from '@/components/GoalsPanel';
@@ -75,6 +75,8 @@ export default function MenteeDetailPage() {
   const id = params.id as string;
   const t = useT();
   const locale = useLocale();
+  const label = useStageLabel();
+  const stages = useResolvedStages();
   const toast = useToast();
 
   const [relation, setRelation] = useState<RelationDetail | null>(null);
@@ -174,7 +176,7 @@ export default function MenteeDetailPage() {
             <div className="w-full">
               <Select
                 label={t.mentor.pipelineStage}
-                options={pipelineOptions(locale)}
+                options={stages.map((s) => ({ value: s.key, label: s.label }))}
                 value={relation.pipelineStatus}
                 disabled={savingStage}
                 onChange={(e) => handlePipelineChange(e.target.value)}
@@ -304,9 +306,9 @@ export default function MenteeDetailPage() {
               {relation.statusChanges.map((sc) => (
                 <li key={sc.id} className="text-sm border-l-2 border-blue-100 pl-3">
                   <p className="text-gray-700">
-                    <span className="text-gray-400">{pipelineLabel(sc.fromStatus, locale)}</span>
+                    <span className="text-gray-400">{label(sc.fromStatus)}</span>
                     {' → '}
-                    <span className="font-medium text-gray-900">{pipelineLabel(sc.toStatus, locale)}</span>
+                    <span className="font-medium text-gray-900">{label(sc.toStatus)}</span>
                   </p>
                   <p className="text-xs text-gray-400 mt-0.5">
                     {sc.changedBy.fullName} · {formatDateTime(sc.createdAt, locale)}

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,15 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.25.6-beta',
+    date: '2026-07-23',
+    highlights: {
+      en: ['Customizable pipeline stages: an organization can now rename, reorder, recolor and define its own pipeline stages (Admin → Organizations → Edit stages), and they appear across the board, candidate filters, analytics and the mentee journey. Off by default — the standard stages are unchanged until a tenant customizes them.'],
+      tr: ['Özelleştirilebilir pipeline aşamaları: bir organizasyon artık kendi aşamalarını yeniden adlandırabilir, sıralayabilir, renklendirebilir ve tanımlayabilir (Admin → Organizasyonlar → Aşamaları düzenle); bunlar board, aday filtreleri, analitik ve mentee sürecinde görünür. Varsayılan kapalı — bir kiracı özelleştirene kadar standart aşamalar değişmez.'],
+      de: ['Anpassbare Pipeline-Phasen: Eine Organisation kann ihre Phasen jetzt umbenennen, neu anordnen, umfärben und eigene definieren (Admin → Organisationen → Phasen bearbeiten); sie erscheinen im Board, in Kandidatenfiltern, in der Analyse und im Mentee-Verlauf. Standardmäßig aus — die Standardphasen bleiben unverändert, bis ein Mandant sie anpasst.'],
+    },
+  },
+  {
     version: '0.25.0-beta',
     date: '2026-07-22',
     highlights: {


### PR DESCRIPTION
Part of #747 / #546 / #522 / #517. **Slice B, final chunk — completes #747.**

## What
- **Mentor & company layouts** now provide the tenant stage context (`PipelineStagesProvider`).
- Converted the remaining stage-rendering surfaces to the tenant's resolved stages:
  - mentor & company & admin **analytics funnels** + the admin **dashboard** funnel
  - mentor **kanban board** (labels + move-to picker)
  - candidate / mentor / company **detail** views (stage badges, history, selects)
- **Write path accepts dynamic keys:** `PUT /api/mentorship/[id]` and `POST /api/status-changes` now validate `pipelineStatus` / stage as a bounded free string (not the old enum), so a custom stage can actually be assigned/moved-to.

Together with the earlier slices (A model, A.2 admin editor, C enum→String migration, B ch.1 journey, B ch.2 admin board+filter), **a tenant can now define its own pipeline stages and see them across the whole app.**

## Safety
- **Behavior-preserving** for the default single-tenant setup: with no custom stages, every surface falls back to the canonical, locale-aware defaults.
- Known canonical-model limitations documented in `docs/pipeline-stages.md`: the board's 3-phase grouping stays canonical (relabels/colors show through), and bulk "advance stage" follows the canonical on-path order.

## Verification
- [x] `npm run build` · [x] `npm run lint` · [x] `npm run check:i18n`
- 13 surface files + 2 API validators converted; each batch typechecked clean before integration.

Version 0.25.6. On merge I'll close #747 → and with #546's other parts done, evaluate #546/#522/#517 closure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ)_