### PR TITLE
🐛 Bulk-scheduled meetings share one link (#759)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [Unreleased]
 
+## [0.25.7] - 2026-07-23
+
+### Fixed
+- **Bulk meeting scheduling now creates one shared link (#759).** When
+  scheduling a meeting for several mentees at once ("select all") without pasting
+  a link, the auto-generated Jitsi room was created *inside* the per-relation loop
+  — so each participant got a different room instead of joining the same meeting.
+  The link is now generated once and shared across all selected participants; the
+  per-person RSVP token stays unique. `src/app/api/meetings/route.ts`; regression
+  test in `e2e/auto-meet-link.spec.ts`.
+
 ## [0.25.6] - 2026-07-23
 
 ### Changed
@@ -24,6 +35,8 @@ version is shown in the sidebar footer of every page (links to the
   stages (Admin → Organizations → Edit stages) and see them everywhere. Known
   canonical-model limitations (board 3-phase grouping, bulk advance) documented in
   `docs/pipeline-stages.md`.
+
+## [0.25.5] - 2026-07-23
 
 ### Changed
 - **Per-tenant pipeline stages on the admin board + candidate filter (#747,

--- a/e2e/auto-meet-link.spec.ts
+++ b/e2e/auto-meet-link.spec.ts
@@ -33,3 +33,51 @@ test('scheduling a meeting without a link auto-generates a video room link', asy
     await cleanupByEmail(mentorEmail);
   }
 });
+
+// #759 — a bulk-scheduled meeting is ONE shared meeting: every selected mentee
+// must get the SAME auto-generated link (not a separate room each), while the
+// per-person RSVP token stays unique.
+test('bulk scheduling without a link shares one meeting link across all selected mentees', async ({ page }) => {
+  const mentorEmail = uniqueEmail('bulk-mentor');
+  const mentor = await seedUser(mentorEmail, 'MentorPass123', 'MENTOR', 'Bulk Mentor');
+  const mentees = await Promise.all([
+    seedUser(uniqueEmail('bulk-m1'), 'x', 'MENTEE', 'Bulk M1'),
+    seedUser(uniqueEmail('bulk-m2'), 'x', 'MENTEE', 'Bulk M2'),
+    seedUser(uniqueEmail('bulk-m3'), 'x', 'MENTEE', 'Bulk M3'),
+  ]);
+  const rels = await Promise.all(
+    mentees.map((m) => prisma.mentorshipRelation.create({ data: { mentorId: mentor.id, menteeId: m.id } })),
+  );
+  const relIds = rels.map((r) => r.id);
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', mentorEmail);
+    await page.fill('input[type="password"]', 'MentorPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/mentor'), { timeout: 20_000 });
+
+    const res = await page.request.post('/api/meetings', {
+      data: { relationIds: relIds, title: 'Weekly', scheduledAt: '2026-09-01T10:00:00.000Z', meetLink: '' },
+    });
+    expect(res.ok()).toBeTruthy();
+    expect((await res.json()).created).toBe(relIds.length);
+
+    const meetings = await prisma.meeting.findMany({ where: { relationId: { in: relIds } } });
+    expect(meetings).toHaveLength(relIds.length);
+
+    // All share exactly one auto-generated link…
+    const links = new Set(meetings.map((m) => m.meetLink));
+    expect(links.size).toBe(1);
+    expect([...links][0]).toContain('meet.jit.si');
+
+    // …but each participant's RSVP token is unique.
+    const tokens = new Set(meetings.map((m) => m.rsvpToken));
+    expect(tokens.size).toBe(relIds.length);
+  } finally {
+    await prisma.meeting.deleteMany({ where: { relationId: { in: relIds } } });
+    await prisma.mentorshipRelation.deleteMany({ where: { id: { in: relIds } } });
+    await Promise.all(mentees.map((m) => cleanupByEmail(m.email)));
+    await cleanupByEmail(mentorEmail);
+  }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "internship-crm",
-  "version": "0.25.6-beta",
+  "version": "0.25.7-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "internship-crm",
-      "version": "0.25.6-beta",
+      "version": "0.25.7-beta",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.25.6-beta",
+  "version": "0.25.7-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/app/api/meetings/route.ts
+++ b/src/app/api/meetings/route.ts
@@ -58,12 +58,15 @@ export async function POST(request: Request) {
       include: { mentee: { select: { email: true, fullName: true } } },
     });
 
+    // Bulk scheduling creates ONE shared meeting: everyone selected joins the
+    // same room, so the video link is generated once (Jitsi, no account needed)
+    // when the organizer didn't paste one. The per-person RSVP token stays
+    // unique — each participant confirms attendance individually.
+    const link = meetLink || `https://meet.jit.si/InternshipCRM-${randomBytes(8).toString('hex')}`;
+
     let created = 0;
     for (const rel of relations) {
       const rsvpToken = randomBytes(24).toString('hex');
-      // Auto-generate a ready-to-use video link (Jitsi, no account needed) when
-      // the organizer didn't paste one — each meeting gets its own room.
-      const link = meetLink || `https://meet.jit.si/InternshipCRM-${randomBytes(8).toString('hex')}`;
       await prisma.meeting.create({
         data: {
           relationId: rel.id,

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,15 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.25.7-beta',
+    date: '2026-07-23',
+    highlights: {
+      en: ['Fixed: when you schedule a meeting for several mentees at once, everyone now gets the same meeting link and joins one shared call — instead of each person getting a separate room.'],
+      tr: ['Düzeltildi: birden çok menteeye aynı anda toplantı planladığınızda artık herkese aynı toplantı linki gidiyor ve tek bir ortak görüşmede buluşuluyor — önceki gibi herkese ayrı oda oluşturulmuyor.'],
+      de: ['Behoben: Wenn du ein Meeting für mehrere Mentees gleichzeitig planst, erhalten jetzt alle denselben Meeting-Link und treffen sich in einem gemeinsamen Call — statt dass jede Person einen eigenen Raum bekommt.'],
+    },
+  },
+  {
     version: '0.25.6-beta',
     date: '2026-07-23',
     highlights: {


### PR DESCRIPTION
## Sorun
Toplu seçim ("Tümünü seç") ile bir toplantı planlandığında, organizatör link alanını boş bıraktığında her katılımcıya **ayrı** bir Jitsi odası üretiliyordu. Oysa bu tek bir ortak toplantı — herkesin **aynı** linke katılması gerekir.

## Kök neden
`src/app/api/meetings/route.ts` — link, katılımcı döngüsünün **içinde** üretiliyordu; `meetLink` boşken her tur yeni bir `randomBytes` odası oluşturuyordu.

## Çözüm
- Link üretimi döngüden **önce bir kez** yapılıyor → seçili herkes aynı odayı paylaşıyor.
- Kişiye özel `rsvpToken` benzersiz kalmaya devam ediyor.
- Organizatör kendi linkini yapıştırdıysa davranış değişmiyor.
- Yanıltıcı yorum güncellendi.

## Test
`e2e/auto-meet-link.spec.ts` içine regresyon testi: birden çok relation seçilip link boş bırakıldığında tüm `Meeting` kayıtları **aynı** `meetLink`'e sahip, `rsvpToken`'lar **farklı**.

## Sürüm
`0.25.6-beta` + CHANGELOG + releaseNotes (EN/TR/DE).

Closes #759

🤖 Generated with [Claude Code](https://claude.com/claude-code)