### PR TITLE
fix: allow long admin announcements (raise cap + widen text columns)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [Unreleased]
 
+## [0.25.8] - 2026-07-23
+
+### Fixed
+- **Admins can now publish long announcements.** `POST /api/admin/announcements`
+  capped `text` at 2 000 chars and returned a bare `400 Validation failed`, so
+  long-form broadcasts (release notes, articles) were rejected. The cap is raised
+  to 20 000 chars, and `Announcement.text` / `Notification.text` are widened from
+  the Prisma default `VARCHAR(191)` to `@db.Text` so the longer text is actually
+  stored (otherwise raising the cap would just move the failure to a DB 500). The
+  400 response now also includes the zod `details` for easier debugging.
+
 ## [0.25.7] - 2026-07-23
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.25.7-beta",
+  "version": "0.25.8-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -391,7 +391,9 @@ model Notification {
   id        String   @id @default(cuid())
   userId    String
   type      String
-  text      String
+  // Long-form text (e.g. a broadcast announcement fanned out to every user) —
+  // TEXT, not the default VARCHAR(191), so long messages aren't truncated/rejected.
+  text      String   @db.Text
   link      String?
   read      Boolean  @default(false)
   createdAt DateTime @default(now())
@@ -406,7 +408,9 @@ model Notification {
 // what was sent, by whom, and to how many people.
 model Announcement {
   id             String   @id @default(cuid())
-  text           String
+  // Broadcast body — TEXT, not the default VARCHAR(191), so admins can publish
+  // long-form announcements (release notes, articles) without hitting a limit.
+  text           String   @db.Text
   link           String?
   sentById       String
   recipientCount Int

--- a/src/app/api/admin/announcements/route.ts
+++ b/src/app/api/admin/announcements/route.ts
@@ -10,7 +10,10 @@ import { emailAllowed } from '@/lib/notificationPrefs';
 import { withTenantScope } from '@/lib/orgContext';
 
 const schema = z.object({
-  text: z.string().min(1).max(2000),
+  // Long-form announcements (release notes, articles) are allowed; the previous
+  // 2 000-char cap rejected them with a bare 400. Kept bounded to protect the
+  // per-user notification fan-out.
+  text: z.string().min(1).max(20000),
   link: z.string().max(500).optional(),
   email: z.boolean().optional(),
 });
@@ -55,7 +58,7 @@ export async function POST(request: Request) {
 
   return await withTenantScope(session, async () => {
   const parsed = schema.safeParse(await request.json());
-  if (!parsed.success) return NextResponse.json({ error: 'Validation failed' }, { status: 400 });
+  if (!parsed.success) return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 });
   const { text, link, email } = parsed.data;
 
   const users = await prisma.user.findMany({

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,15 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.25.8-beta',
+    date: '2026-07-23',
+    highlights: {
+      en: ['Fixed: admins can now publish long announcements (release notes, articles). Longer messages were previously rejected with a "Validation failed" error.'],
+      tr: ['Düzeltildi: yöneticiler artık uzun duyurular (sürüm notları, makaleler) yayınlayabiliyor. Daha uzun mesajlar önceden "Validation failed" hatasıyla reddediliyordu.'],
+      de: ['Behoben: Admins können jetzt lange Ankündigungen (Release Notes, Artikel) veröffentlichen. Längere Nachrichten wurden zuvor mit einem „Validation failed“-Fehler abgelehnt.'],
+    },
+  },
+  {
     version: '0.25.7-beta',
     date: '2026-07-23',
     highlights: {


### PR DESCRIPTION
## Summary

Publishing a long announcement from **Admin → Duyurular** returned `400 Validation failed`. Two layers were too tight:

1. `POST /api/admin/announcements` validated `text` with `z.string().max(2000)` — long-form broadcasts (release notes, articles) exceeded it and were rejected.
2. `Announcement.text` and `Notification.text` were plain Prisma `String`, which maps to `VARCHAR(191)` on MySQL — so even after raising the zod cap, any text over 191 chars would fail at the DB with a 500. (Announcements fan out into one `Notification` row per user, so both columns matter.)

## Changes

- `src/app/api/admin/announcements/route.ts`: raise `text` cap `2000 → 20000` (still bounded to protect the per-user notification fan-out); the `400` now also returns the zod `details` for easier debugging.
- `prisma/schema.prisma`: `Announcement.text` and `Notification.text` → `@db.Text` (was default `VARCHAR(191)`). Non-destructive widening; CI runs `prisma db push` on deploy.
- Version bump `0.25.8-beta` + `CHANGELOG.md` + `src/lib/releaseNotes.ts` (EN/TR/DE).

## Verification

- [x] `npm run lint` clean (only pre-existing warnings)
- [x] `npx prisma format && validate && generate` clean
- [x] `npm run check:i18n` OK (1496 keys × 3 locales)
- [ ] CI green (Lint · Typecheck · Build + Playwright smoke + topic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ)_