### PR TITLE
ci: self-hosted runner watchdog (auto-restart the Plesk runner)

### DIFF
--- a/.github/workflows/runner-watchdog.yml
+++ b/.github/workflows/runner-watchdog.yml
@@ -1,0 +1,108 @@
+name: Runner Watchdog (self-hosted health)
+
+# Keeps the self-hosted runner (Plesk server) alive.
+#
+# Runs on a GitHub-HOSTED runner ON PURPOSE: if the self-hosted runner is down
+# (e.g. after a server reboot its `svc.sh` service didn't come back up), a
+# self-hosted watchdog could never run — it would just queue behind the dead
+# runner. This one SSHes in from a hosted runner, checks the runner service, and
+# (re)starts + enables it, unblocking every queued `topic-preview` job.
+#
+# Requires the same SSH_* secrets the deploy workflow uses:
+#   SSH_PRIVATE_KEY, SSH_HOST, SSH_USER, SSH_PORT
+# The SSH user must be root, or have (passwordless) sudo for systemctl.
+
+on:
+  schedule:
+    - cron: '*/15 * * * *' # every 15 minutes
+  workflow_dispatch: {}
+
+concurrency:
+  group: runner-watchdog
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  watchdog:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Setup SSH key
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          SSH_PORT: ${{ secrets.SSH_PORT }}
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          # Write via env var (not inline interpolation) to preserve exact OpenSSH format.
+          echo "$SSH_PRIVATE_KEY" | tr -d '\r' > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H -p "${SSH_PORT:-22}" "$SSH_HOST" >> ~/.ssh/known_hosts 2>/dev/null || \
+          ssh-keyscan -H "$SSH_HOST" >> ~/.ssh/known_hosts 2>/dev/null || true
+
+      - name: Check & (re)start the self-hosted runner service
+        env:
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_PORT: ${{ secrets.SSH_PORT }}
+        run: |
+          ssh -i ~/.ssh/deploy_key -p "${SSH_PORT:-22}" -o StrictHostKeyChecking=no \
+            "${SSH_USER}@${SSH_HOST}" 'bash -s' <<'REMOTE'
+          set -uo pipefail
+
+          # Use sudo only when we're not already root and it's available non-interactively.
+          SUDO=""
+          if [ "$(id -u)" -ne 0 ]; then
+            if sudo -n true 2>/dev/null; then SUDO="sudo -n"; fi
+          fi
+
+          # 1) Preferred path: the systemd unit created by `svc.sh install`
+          #    (named actions.runner.<org>-<repo>.<name>.service).
+          UNIT="$($SUDO systemctl list-unit-files --type=service --no-legend 'actions.runner.*' 2>/dev/null | awk '{print $1}' | head -1)"
+          if [ -z "$UNIT" ]; then
+            UNIT="$($SUDO systemctl list-units --type=service --all --no-legend 'actions.runner.*' 2>/dev/null | awk '{print $1}' | head -1)"
+          fi
+
+          if [ -n "$UNIT" ]; then
+            echo "Runner service: $UNIT"
+            if $SUDO systemctl is-active --quiet "$UNIT"; then
+              echo "OK: runner service already active."
+              exit 0
+            fi
+            echo "Runner service NOT active — starting..."
+            $SUDO systemctl start "$UNIT" || { echo "ERROR: failed to start $UNIT"; $SUDO systemctl status "$UNIT" --no-pager -l 2>/dev/null | tail -20; exit 1; }
+            # Enable so a future server reboot brings it back automatically (root cause fix).
+            $SUDO systemctl enable "$UNIT" 2>/dev/null || true
+            sleep 3
+            if $SUDO systemctl is-active --quiet "$UNIT"; then
+              echo "RECOVERED: runner service is now active (and enabled on boot)."
+              exit 0
+            fi
+            echo "ERROR: runner still not active after start."
+            $SUDO systemctl status "$UNIT" --no-pager -l 2>/dev/null | tail -20
+            exit 1
+          fi
+
+          # 2) Fallback: no systemd unit — drive svc.sh directly from the runner dir.
+          echo "No systemd unit found; locating svc.sh..."
+          SVC="$(find /root /home /opt -maxdepth 5 -name svc.sh -path '*actions-runner*' 2>/dev/null | head -1)"
+          if [ -z "$SVC" ]; then
+            echo "ERROR: could not locate the runner (no actions.runner.* unit, no svc.sh)."
+            exit 1
+          fi
+          RUNNER_DIR="$(dirname "$SVC")"
+          echo "Runner dir: $RUNNER_DIR"
+          cd "$RUNNER_DIR"
+          if $SUDO ./svc.sh status 2>/dev/null | grep -qiE 'active \(running\)|is running'; then
+            echo "OK: runner is running (svc.sh)."
+            exit 0
+          fi
+          echo "Runner not running — starting via svc.sh..."
+          $SUDO ./svc.sh start || { echo "ERROR: svc.sh start failed"; exit 1; }
+          sleep 3
+          $SUDO ./svc.sh status 2>/dev/null | tail -5 || true
+          echo "svc.sh start issued."
+          REMOTE


### PR DESCRIPTION
## Summary

The self-hosted runner on the Plesk server didn't come back up after a server reboot, so every **Topic Preview (self-hosted, auto per-PR)** job sat in `queued` and PRs (e.g. #786) got stuck — even though hosted **CI** and **E2E** were green. This adds a watchdog that keeps the runner alive.

## Changes

- New `.github/workflows/runner-watchdog.yml`:
  - Runs on **`ubuntu-latest` (GitHub-hosted)** on purpose — a self-hosted watchdog couldn't run when the runner is the thing that's down (it would just queue behind it).
  - SSHes into the server (reusing the deploy `SSH_PRIVATE_KEY` / `SSH_HOST` / `SSH_USER` / `SSH_PORT` secrets), finds the `actions.runner.*` systemd unit, and **starts it if it's not active**, then **`enable`s it** so a future reboot self-heals (the actual root cause). Falls back to `svc.sh` in the runner dir if no systemd unit exists.
  - Triggers: `schedule` every 15 min + `workflow_dispatch`.

## Why hosted, not self-hosted

If the runner is offline, only a hosted job can reach the box to revive it. This is the standard "external watchdog" pattern.

## Verification

- [x] YAML block-scalar + heredoc indentation verified (closing `REMOTE` at base indent → column 0 after YAML strips common indent).
- [ ] After merge: dispatch once to revive the currently-down runner and drain the queued topic jobs.

Note: CI-config only — no app/version change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ)_