### PR TITLE
feat: archive deactivated candidates (hidden from default Adaylar list)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [Unreleased]
 
+## [0.25.14] - 2026-07-24
+
+### Changed
+- **Deactivated candidates are archived by default.** The Adaylar (candidates)
+  list now shows only **active** candidates by default; deactivated ("Devre dışı")
+  candidates move to a separate **Archive** view via an Active | Archived toggle.
+  `GET /api/candidates` defaults to `isActive: true` and accepts `?archived=1` to
+  return the deactivated set (the toggle also drives CSV/Excel export, so exports
+  match the visible view). Bulk activate from the archive restores candidates to
+  the active list.
+
 ## [0.25.11] - 2026-07-24
 
 ### Added

--- a/e2e/admin-bulk-candidates.spec.ts
+++ b/e2e/admin-bulk-candidates.spec.ts
@@ -36,6 +36,11 @@ test('admin can bulk-deactivate and bulk-reactivate selected candidates', async 
       expect(b?.isActive).toBe(false);
     }).toPass({ timeout: 10_000 });
 
+    // Deactivated candidates leave the default (active) view and move to the
+    // Archive tab.
+    await expect(page.getByText('Bulk Candidate A')).toHaveCount(0);
+    await page.getByTestId('candidates-tab-archived').click();
+    await expect(page.getByTestId(`candidate-card-${menteeA.id}`)).toBeVisible({ timeout: 10_000 });
     await expect(page.getByText('Inactive').first()).toBeVisible();
 
     // Reactivate one of them via the API directly (already exercised the UI path above).

--- a/e2e/candidates-archive.spec.ts
+++ b/e2e/candidates-archive.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// Deactivated ("Devre dışı") candidates are hidden from the default Adaylar list
+// and live in a separate Archive view.
+test('deactivated candidates are archived and hidden from the default list', async ({ page }) => {
+  const adminEmail = uniqueEmail('arch-admin');
+  const activeEmail = uniqueEmail('arch-active');
+  const archivedEmail = uniqueEmail('arch-inactive');
+  await seedUser(adminEmail, 'AdminPass123', 'ADMIN', 'Arch Admin');
+  const activeMentee = await seedUser(activeEmail, 'x', 'MENTEE', 'Zeynep ActiveOne');
+  const archivedMentee = await seedUser(archivedEmail, 'x', 'MENTEE', 'Kerem ArchivedOne');
+  // Deactivate one candidate directly.
+  await prisma.user.update({ where: { id: archivedMentee.id }, data: { isActive: false } });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', 'AdminPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    // Default (Active) view: the active candidate shows, the deactivated one does not.
+    await page.goto('/admin/candidates');
+    await expect(page.getByTestId(`candidate-card-${activeMentee.id}`)).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId(`candidate-card-${archivedMentee.id}`)).toHaveCount(0);
+
+    // Archive view: the deactivated candidate shows (with its Inactive badge), the active one does not.
+    await page.getByTestId('candidates-tab-archived').click();
+    await expect(page.getByTestId(`candidate-card-${archivedMentee.id}`)).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId(`candidate-card-${archivedMentee.id}`).getByText('Inactive')).toBeVisible();
+    await expect(page.getByTestId(`candidate-card-${activeMentee.id}`)).toHaveCount(0);
+
+    // Back to Active.
+    await page.getByTestId('candidates-tab-active').click();
+    await expect(page.getByTestId(`candidate-card-${activeMentee.id}`)).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId(`candidate-card-${archivedMentee.id}`)).toHaveCount(0);
+  } finally {
+    await cleanupByEmail(activeEmail);
+    await cleanupByEmail(archivedEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.25.11-beta",
+  "version": "0.25.14-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/app/admin/candidates/page.tsx
+++ b/src/app/admin/candidates/page.tsx
@@ -66,6 +66,8 @@ export default function CandidatesPage() {
   const [error, setError] = useState('');
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [bulkBusy, setBulkBusy] = useState(false);
+  // Deactivated candidates are hidden by default and live in the archive view.
+  const [archived, setArchived] = useState(false);
 
   const COLS = ['Name', 'Email', 'Phone', 'WhatsApp', 'City', 'University', 'Department', 'Graduation', 'Skills', 'Stage', 'Project', 'Mentor'];
   const toRow = (c: Candidate) => {
@@ -122,8 +124,9 @@ export default function CandidatesPage() {
     if (cityFilter) params.set('city', cityFilter);
     if (projectFilter) params.set('project', projectFilter);
     if (sourceFilter) params.set('source', sourceFilter);
+    if (archived) params.set('archived', '1');
     return params;
-  }, [skillFilter, yearFilter, search, statusFilter, cityFilter, projectFilter, sourceFilter]);
+  }, [skillFilter, yearFilter, search, statusFilter, cityFilter, projectFilter, sourceFilter, archived]);
 
   const fetchCandidates = useCallback(async () => {
     setLoading(true);
@@ -165,10 +168,10 @@ export default function CandidatesPage() {
     return () => clearTimeout(timeout);
   }, [fetchCandidates]);
 
-  // Any filter change returns to the first page.
+  // Any filter change (including switching to/from the archive) returns to page 1.
   useEffect(() => {
     setPage(1);
-  }, [search, skillFilter, yearFilter, statusFilter, cityFilter, projectFilter, sourceFilter]);
+  }, [search, skillFilter, yearFilter, statusFilter, cityFilter, projectFilter, sourceFilter, archived]);
 
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
@@ -332,6 +335,31 @@ export default function CandidatesPage() {
         </div>
       </div>
 
+      {/* Active vs. archive (deactivated) view */}
+      <div className="mb-4 inline-flex rounded-lg border border-gray-300 dark:border-gray-700 overflow-hidden text-sm" role="tablist" aria-label={t.candidates.viewLabel}>
+        {([false, true] as const).map((isArchive) => (
+          <button
+            key={String(isArchive)}
+            type="button"
+            role="tab"
+            aria-selected={archived === isArchive}
+            data-testid={isArchive ? 'candidates-tab-archived' : 'candidates-tab-active'}
+            onClick={() => {
+              if (archived === isArchive) return;
+              setArchived(isArchive);
+              setSelected(new Set());
+            }}
+            className={`px-4 py-1.5 ${
+              archived === isArchive
+                ? 'bg-blue-600 text-white'
+                : 'bg-white dark:bg-gray-900 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800'
+            }`}
+          >
+            {isArchive ? t.candidates.archivedTab : t.candidates.activeTab}
+          </button>
+        ))}
+      </div>
+
       {/* Results count + bulk selection */}
       <div className="flex flex-wrap items-center justify-between gap-2 mb-4">
         <div className="flex items-center gap-3">
@@ -369,13 +397,17 @@ export default function CandidatesPage() {
         <Card><SkeletonRows rows={6} /></Card>
       ) : candidates.length === 0 ? (
         <Card>
-          <EmptyState
-            icon={Users}
-            title={t.candidates.none}
-            description={t.emptyState.candidates}
-            actionLabel={t.emptyState.inviteCta}
-            actionHref="/admin/invite"
-          />
+          {archived ? (
+            <EmptyState icon={Users} title={t.candidates.noneArchived} />
+          ) : (
+            <EmptyState
+              icon={Users}
+              title={t.candidates.none}
+              description={t.emptyState.candidates}
+              actionLabel={t.emptyState.inviteCta}
+              actionHref="/admin/invite"
+            />
+          )}
         </Card>
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">

--- a/src/app/api/candidates/route.ts
+++ b/src/app/api/candidates/route.ts
@@ -23,6 +23,9 @@ export async function GET(request: Request) {
     const project = searchParams.get('project');
     const cohortId = searchParams.get('cohort');
     const sourceId = searchParams.get('source');
+    // Deactivated ("archived") candidates are hidden by default and only shown
+    // when the archive view is requested (?archived=1).
+    const archived = searchParams.get('archived') === '1';
     // Pagination. `all=1` returns everything (used by CSV/Excel export so the
     // download isn't limited to the current page).
     const all = searchParams.get('all') === '1';
@@ -31,6 +34,8 @@ export async function GET(request: Request) {
 
     const where: Record<string, unknown> = {
       role: 'MENTEE',
+      // Active candidates by default; the archive view flips this to inactive.
+      isActive: !archived,
     };
     if (sourceId) where.sourceId = sourceId;
 

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -220,6 +220,10 @@ const en = {
     allGradYears: 'All graduation years',
     clearFilters: 'Clear filters',
     found: 'candidates found',
+    viewLabel: 'View',
+    activeTab: 'Active',
+    archivedTab: 'Archived',
+    noneArchived: 'No archived candidates',
   },
   candidateDetail: {
     companyInterest: { interested: 'Company is interested', shortlisted: 'Shortlisted by company', pass: 'Company passed' },
@@ -1737,6 +1741,10 @@ const tr: Dict = {
     allGradYears: 'Tüm mezuniyet yılları',
     clearFilters: 'Filtreleri temizle',
     found: 'aday bulundu',
+    viewLabel: 'Görünüm',
+    activeTab: 'Aktif',
+    archivedTab: 'Arşiv',
+    noneArchived: 'Arşivlenmiş aday yok',
   },
   candidateDetail: {
     companyInterest: { interested: 'Şirket ilgileniyor', shortlisted: 'Şirket kısa listeye aldı', pass: 'Şirket geçti' },
@@ -3252,6 +3260,10 @@ const de: Dict = {
     allGradYears: 'Alle Abschlussjahre',
     clearFilters: 'Filter zurücksetzen',
     found: 'Kandidaten gefunden',
+    viewLabel: 'Ansicht',
+    activeTab: 'Aktiv',
+    archivedTab: 'Archiviert',
+    noneArchived: 'Keine archivierten Kandidaten',
   },
   candidateDetail: {
     companyInterest: { interested: 'Unternehmen interessiert', shortlisted: 'Vom Unternehmen auf die Shortlist gesetzt', pass: 'Unternehmen hat abgesagt' },

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,21 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.25.14-beta',
+    date: '2026-07-24',
+    highlights: {
+      en: [
+        'The Candidates list now hides deactivated candidates by default and keeps them in a separate Archive view — switch between Active and Archived with one click. Exports follow whichever view you\'re in, and you can bulk-reactivate archived candidates to move them back.',
+      ],
+      tr: [
+        'Adaylar listesi artık devre dışı bırakılmış adayları varsayılan olarak gizliyor ve onları ayrı bir Arşiv görünümünde tutuyor — Aktif ve Arşiv arasında tek tıkla geçin. Dışa aktarma bulunduğunuz görünümü izler ve arşivdeki adayları toplu olarak yeniden etkinleştirip geri taşıyabilirsiniz.',
+      ],
+      de: [
+        'Die Kandidatenliste blendet deaktivierte Kandidaten jetzt standardmäßig aus und hält sie in einer separaten Archiv-Ansicht — mit einem Klick zwischen Aktiv und Archiviert wechseln. Exporte folgen der aktuellen Ansicht, und du kannst archivierte Kandidaten per Sammelaktion wieder aktivieren.',
+      ],
+    },
+  },
+  {
     version: '0.25.11-beta',
     date: '2026-07-24',
     highlights: {


### PR DESCRIPTION
## Summary

On the **Adaylar** (candidates) page, deactivated ("Devre dışı") candidates were mixed into the main list. They should sit in an archive by default. Now the list shows **only active** candidates, and deactivated ones live in a separate **Archive** view.

## Changes

- `GET /api/candidates`: defaults to `isActive: true`; accepts `?archived=1` to return the deactivated set. (Only the admin candidates page consumes this endpoint — fetch + export share the same params.)
- `src/app/admin/candidates/page.tsx`: an **Active | Archived** segmented toggle. Switching resets the page and clears selection; the toggle also drives CSV/Excel export so exports match the visible view. Archive-specific empty state.
- Bulk **activate** from the Archive restores candidates to the active list (existing bulk endpoint, unchanged).
- i18n EN/TR/DE (`viewLabel`, `activeTab` = Aktif, `archivedTab` = Arşiv, `noneArchived`).
- Tests: new `e2e/candidates-archive.spec.ts` (default hides deactivated; Archive tab shows them; toggle back); updated `e2e/admin-bulk-candidates.spec.ts` for the new behavior (deactivated cards leave the active view and appear under Archive).
- Version **0.25.14** + CHANGELOG + release notes (EN/TR/DE).

## Verification

- [x] `npm run lint` clean · `npm run check:i18n` OK (1509 keys × 3)
- [ ] CI green (CI · E2E · Topic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ)_