### PR TITLE
ci: make production deploys forward-only and deterministic (fix deploy oscillation)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -41,7 +41,10 @@ jobs:
       - name: Deploy
         run: |
           chmod +x infra/deploy-prod.sh
-          # deploy-prod.sh syncs to origin/<ref>, builds from source, migrates,
-          # seeds, swaps the container and health-checks. Secrets come from the
-          # server-side env file, never from the repo or workflow.
-          BRANCH="${{ inputs.ref }}" ENV_FILE="${ENV_FILE:-/etc/internship-crm/prod.env}" ./infra/deploy-prod.sh --no-pull
+          # deploy-prod.sh syncs to origin/<ref> (hard reset — NOT --no-pull, so
+          # the build reflects origin/main at deploy time rather than whatever the
+          # shared self-hosted workspace happened to be left at), builds from
+          # source, migrates, seeds, swaps the container and health-checks.
+          # FORWARD_ONLY=1 makes prod refuse to regress to an older commit.
+          # Secrets come from the server-side env file, never from the repo/workflow.
+          BRANCH="${{ inputs.ref }}" FORWARD_ONLY=1 ENV_FILE="${ENV_FILE:-/etc/internship-crm/prod.env}" ./infra/deploy-prod.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [Unreleased]
 
+### Fixed
+- **Production deploys are now forward-only and deterministic (deploy oscillation).**
+  Prod could regress to an older version after some merges ("one step forward, one
+  step back"): the `deploy-prod.yml` / `deploy-preview.yml` jobs share one
+  self-hosted runner workspace and called `deploy-prod.sh --no-pull`, which builds
+  whatever commit the shared workspace was left at rather than `origin/main`; and
+  two uncoordinated deployers (the cron `autodeploy.sh` poller + the workflow) write
+  the prod container with no guard against out-of-order builds. Prod deploy now
+  hard-resets to `origin/main` at deploy time (dropped `--no-pull`) and a
+  `FORWARD_ONLY=1` guard in `deploy-prod.sh` refuses to deploy a commit older than
+  the one already live (recorded per-container; `FORCE=1` overrides for a deliberate
+  rollback). Preview/topic deploys are unaffected. Infra-only; no app change.
+
 ## [0.25.11] - 2026-07-24
 
 ### Added

--- a/infra/autodeploy.sh
+++ b/infra/autodeploy.sh
@@ -33,7 +33,8 @@ deploy_if_changed() {
   fi
   echo "$(date -u +%FT%TZ) main moved ${local_sha:0:7} → ${remote_sha:0:7}; deploying"
   # deploy-prod.sh does its own git reset --hard to origin/main.
-  ./infra/deploy-prod.sh
+  # FORWARD_ONLY=1: never regress prod to an older commit (see deploy-prod.sh).
+  FORWARD_ONLY=1 ./infra/deploy-prod.sh
 }
 
 # Prevent overlapping runs (cron every 5 min while a build takes longer).

--- a/infra/deploy-prod.sh
+++ b/infra/deploy-prod.sh
@@ -96,6 +96,26 @@ fi
 GIT_SHA="$(git rev-parse HEAD)"
 log "Deploying $(git rev-parse --short HEAD) — $(node -p "require('./package.json').version" 2>/dev/null || echo '?')"
 
+# ── 1b. Forward-only guard (prod) ────────────────────────────────────────────
+# Production must only ever move FORWARD. Two uncoordinated deployers write the
+# prod container (the cron autodeploy poller + the deploy-prod workflow), and a
+# stale/out-of-order build could otherwise overwrite a newer release with an
+# older commit (the "one step forward, one step back" regressions). When
+# FORWARD_ONLY=1, refuse to deploy a commit that is an ancestor of (i.e. older
+# than) the last one this container successfully deployed. Preview/topic deploys
+# leave FORWARD_ONLY unset so they can still deploy arbitrary/older PR refs.
+# Set FORCE=1 for a deliberate rollback.
+STATE_FILE="${DEPLOY_STATE_FILE:-$(dirname "$ENV_FILE")/.${CONTAINER}.deployed-sha}"
+if [ "${FORWARD_ONLY:-0}" = "1" ] && [ "${FORCE:-0}" != "1" ] && [ -f "$STATE_FILE" ]; then
+  LAST_SHA="$(cat "$STATE_FILE" 2>/dev/null || true)"
+  if [ -n "$LAST_SHA" ] && [ "$LAST_SHA" != "$GIT_SHA" ] \
+     && git cat-file -e "${LAST_SHA}^{commit}" 2>/dev/null \
+     && git merge-base --is-ancestor "$GIT_SHA" "$LAST_SHA" 2>/dev/null; then
+    log "SKIP: $(git rev-parse --short "$GIT_SHA") is older than the live commit ${LAST_SHA:0:7} — refusing to regress $CONTAINER (set FORCE=1 to roll back deliberately)."
+    exit 0
+  fi
+fi
+
 # ── 2. Build image from source ───────────────────────────────────────────────
 if [ "$SKIP_BUILD" -eq 0 ]; then
   log "Building $IMAGE (GIT_SHA=$GIT_SHA)"
@@ -164,6 +184,11 @@ if [ "$ok" -ne 1 ]; then
   docker logs --tail 40 "$CONTAINER" >&2 || true
   exit 1
 fi
+
+# Record the commit now live in this container so the next deploy can enforce
+# forward-only progress (see the guard above).
+mkdir -p "$(dirname "$STATE_FILE")" 2>/dev/null || true
+printf '%s\n' "$GIT_SHA" > "$STATE_FILE" 2>/dev/null || true
 
 docker image prune -af >/dev/null 2>&1 || true
 docker builder prune -af --filter until=72h >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary

Production (crm.ersah.in) sometimes **regressed to an older version after merges** — "one step forward, one step back" instead of always advancing. Found two root causes:

1. **Non-deterministic build source.** `deploy-prod.yml` and `deploy-preview.yml` run on the **same single self-hosted runner, sharing one git workspace**, and called `deploy-prod.sh --no-pull` — which builds **whatever commit the shared workspace was left at** (e.g. by a `topic-preview` job that checked out some PR's merge ref) rather than `origin/main`.
2. **Two uncoordinated deployers, no ordering guard.** Both the cron `autodeploy.sh` poller and the `deploy-prod.yml` workflow write the prod container, with nothing preventing a stale/out-of-order build from overwriting a newer release with an older commit.

## Fix

- **`deploy-prod.yml`**: dropped `--no-pull` so `deploy-prod.sh` hard-resets to `origin/main` at deploy time (build always reflects latest main, not stale workspace state); sets `FORWARD_ONLY=1`.
- **`deploy-prod.sh`**: a **forward-only guard** — when `FORWARD_ONLY=1`, refuse to deploy a commit that is an *ancestor of* (older than) the last commit this container deployed (recorded per-container in a state file). `FORCE=1` overrides for a deliberate rollback. Preview/topic deploys don't set the flag, so they can still deploy arbitrary/older PR refs.
- **`autodeploy.sh`**: cron poller now also passes `FORWARD_ONLY=1`.

Net effect: every prod deploy builds `origin/main`, and prod can never move backward.

## Notes

- Infra/CI only — no app or version change (CHANGELOG `[Unreleased]` note added).
- Live prod was separately re-deployed to the current `main` (**0.25.14**) via a manual `deploy-prod` dispatch.
- `bash -n` clean on both scripts; workflow YAML validated.

## Verification

- [ ] CI green (CI · E2E · Topic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWmERdivABmoZwifwMKfsZ)_