### PR TITLE
fix: ProjectsManager loading counter + page-level search data-testids (#682, #702)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,24 @@ version is shown in the sidebar footer of every page (links to the
   the one already live (recorded per-container; `FORCE=1` overrides for a deliberate
   rollback). Preview/topic deploys are unaffected. Infra-only; no app change.
 
+## [0.25.15] - 2026-07-28
+
+### Fixed
+- **`ProjectsManager` no longer shows a misleading `(0)` while loading** (#682). The
+  "All projects" heading rendered `({projects.length})` from the initial empty array
+  at the same time as the loading indicator, so users could not tell "no projects"
+  from "still loading". The counter is now suppressed until `loading` is false.
+
+### Changed
+- **Page-level search inputs carry a unique `data-testid`** (#702). `AdminNav`
+  renders its own sidebar `input[type="search"]` on every admin page, so an
+  unscoped `input[type="search"]` locator in an e2e spec silently matched the
+  sidebar filter instead of the page's own search box (the pitfall documented in
+  `CLAUDE.md`). Added `mentorship-search`, `users-search`, `board-search`,
+  `mentors-search`, `interactions-search` and `company-search` (cohorts,
+  organizations and sources already had one). Attribute-only; no behaviour change.
+- Synced the stale `version` field in `package-lock.json` with `package.json`.
+
 ## [0.25.14] - 2026-07-24
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "internship-crm",
-  "version": "0.25.10-beta",
+  "version": "0.25.14-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "internship-crm",
-      "version": "0.25.10-beta",
+      "version": "0.25.14-beta",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {
@@ -3855,6 +3855,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -5683,6 +5684,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.25.14-beta",
+  "version": "0.25.15-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/app/admin/board/page.tsx
+++ b/src/app/admin/board/page.tsx
@@ -172,6 +172,7 @@ export default function AdminBoardPage() {
       <div className="flex flex-wrap items-center gap-3 mb-4">
         <input
           type="search"
+          data-testid="board-search"
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           placeholder={t.adminBoard.searchPlaceholder}

--- a/src/app/admin/mentors/page.tsx
+++ b/src/app/admin/mentors/page.tsx
@@ -110,6 +110,7 @@ export default function MentorsPage() {
 
       <input
         type="search"
+        data-testid="mentors-search"
         value={search}
         onChange={(e) => setSearch(e.target.value)}
         placeholder={t.mentors.searchPlaceholder}

--- a/src/app/admin/mentorship/page.tsx
+++ b/src/app/admin/mentorship/page.tsx
@@ -234,6 +234,7 @@ export default function MentorshipPage() {
         ))}
         <input
           type="search"
+          data-testid="mentorship-search"
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           placeholder={t.mentorships.searchPlaceholder}

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -139,6 +139,7 @@ export default function AdminUsersPage() {
         ))}
         <input
           type="search"
+          data-testid="users-search"
           value={search}
           onChange={(e) => { setSearch(e.target.value); setPage(1); }}
           placeholder={t.usersAdmin.searchPlaceholder}

--- a/src/app/company/page.tsx
+++ b/src/app/company/page.tsx
@@ -52,6 +52,7 @@ export default function CompanyOverviewPage() {
         <div className="flex flex-wrap items-center gap-2 mb-4">
           <input
             type="search"
+            data-testid="company-search"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder={t.company.searchPlaceholder}

--- a/src/app/mentor/interactions/page.tsx
+++ b/src/app/mentor/interactions/page.tsx
@@ -73,6 +73,7 @@ export default function MentorInteractionsPage() {
           ))}
           <input
             type="search"
+            data-testid="interactions-search"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder={t.mentor.interactionSearchPlaceholder}

--- a/src/components/ProjectsManager.tsx
+++ b/src/components/ProjectsManager.tsx
@@ -312,7 +312,7 @@ export function ProjectsManager({ isAdmin }: { isAdmin: boolean }) {
       </Card>
       )}
 
-      <h2 className="text-sm font-medium text-gray-500 mb-3">{t.projects.allProjects} ({projects.length})</h2>
+      <h2 className="text-sm font-medium text-gray-500 mb-3">{t.projects.allProjects} {loading ? '' : `(${projects.length})`}</h2>
       {loading ? (
         <p className="text-center py-10 text-gray-400">{t.common.loading}</p>
       ) : projects.length === 0 ? (

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,21 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.25.15-beta',
+    date: '2026-07-28',
+    highlights: {
+      en: [
+        'The projects list no longer flashes "(0)" while it is still loading — the project count now appears only once the data has arrived, so an empty list is never mistaken for a slow one.',
+      ],
+      tr: [
+        'Projeler listesi yüklenirken artık "(0)" göstermiyor — proje sayısı yalnızca veriler geldikten sonra çıkıyor, böylece boş liste ile yavaş yüklenen liste karışmıyor.',
+      ],
+      de: [
+        'Die Projektliste zeigt beim Laden nicht mehr "(0)" — die Projektanzahl erscheint erst, wenn die Daten geladen sind, sodass eine leere Liste nicht mit einer langsam ladenden verwechselt wird.',
+      ],
+    },
+  },
+  {
     version: '0.25.14-beta',
     date: '2026-07-24',
     highlights: {


### PR DESCRIPTION
Backlog sweep — two small independent items from the stajyer backlog (#478).

## #682 — `ProjectsManager` showed a misleading `(0)` while loading

`src/components/ProjectsManager.tsx` rendered the "All projects" heading with
`({projects.length})` derived from the initial empty array, at the same time as
the loading indicator — so users could not tell "there are no projects" from
"still loading". The counter is now suppressed until `loading` is false.

```diff
-{t.projects.allProjects} ({projects.length})
+{t.projects.allProjects} {loading ? '' : `(${projects.length})`}
```

## #702 — page-level search inputs now carry a unique `data-testid`

`AdminNav` renders its own sidebar `input[type="search"]` on every admin page, so
an unscoped `input[type="search"]` locator in an e2e spec silently matches the
sidebar filter instead of the page's own search box — the pitfall documented in
`CLAUDE.md`. Added stable test ids:

| Page | `data-testid` |
|---|---|
| `admin/mentorship` | `mentorship-search` |
| `admin/users` | `users-search` |
| `admin/board` | `board-search` |
| `admin/mentors` | `mentors-search` |
| `mentor/interactions` | `interactions-search` |
| `company` | `company-search` |

`admin/cohorts`, `admin/organizations` and `admin/sources` already had one
(`cohort-search`, `org-search`, `source-search`), so they were left as-is.
Attribute-only — no behaviour or visual change.

## Also

- Synced the stale `version` field in `package-lock.json` with `package.json`
  (it was left at `0.25.10-beta`).

## Versioning

- `package.json` → `0.25.15-beta`
- `CHANGELOG.md` → `## [0.25.15] - 2026-07-28`
- `src/lib/releaseNotes.ts` → user-facing EN/TR/DE entry for the #682 fix
  (#702 is test-infrastructure only, so it is not in the user-facing notes)

## Verification

- `npm run build` passes.

Closes #682
Closes #702

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01443WW26ffLt4eXUGNEKMiu

---
_Generated by [Claude Code](https://claude.ai/code/session_01443WW26ffLt4eXUGNEKMiu)_