### PR TITLE
ci: deploy preview and prod automatically on every merge to main

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,24 +1,47 @@
-name: Deploy preview (self-hosted, manual)
+name: Deploy preview (self-hosted, auto on main)
 
-# CI-independent PREVIEW deploy — the sibling of deploy-prod.yml. Runs ON THE
-# SERVER via the self-hosted runner (no GitHub-hosted quota cost), so preview
-# (https://crm-preview.ersah.in, container internship-crm-preview on :3201) can
-# be kept in step with prod even while the hosted deploy.yml is paused.
+# PREVIEW deploy — the sibling of deploy-prod.yml. Runs ON THE SERVER via the
+# self-hosted runner (no GitHub-hosted quota cost), so preview
+# (https://crm-preview.ersah.in, container internship-crm-preview on :3201) is
+# kept in step with main automatically.
+#
+# WHY THIS IS AUTOMATIC (#800): preview used to be dispatch-only. Once per-PR
+# topic previews (topic-preview.yml) took over the per-PR job, nobody remembered
+# to dispatch this one — preview sat 72 commits / 11 minor versions behind prod
+# (0.14.1-beta vs 0.25.14-beta) for a week before anyone noticed. Preview is the
+# first stop for merged code, so it now follows main on its own:
+#
+#   push to main   → deploy (this is the normal path)
+#   every 6 hours  → deploy ONLY if preview drifted from origin/main; the
+#                    self-hosted runner can be offline when a push arrives (see
+#                    runner-watchdog.yml) and that deploy would otherwise be
+#                    lost silently. A no-op when preview is already current.
+#   manual         → deploy any branch/tag/SHA, unconditionally.
 #
 # It reuses infra/deploy-prod.sh unchanged — that script is fully parameterized
-# (CONTAINER / PORT / IMAGE / ENV_FILE), so preview is just the prod deploy with
-# preview overrides.
+# (CONTAINER / PORT / IMAGE / ENV_FILE / NETWORK), so preview is just the prod
+# deploy with preview overrides.
 #
 # SECRETS: read from /etc/internship-crm/preview.env on the server (same shape as
-# prod.env: DATABASE_URL[_PREVIEW], NEXTAUTH_SECRET, NEXTAUTH_URL=the preview URL,
-# SMTP_*). If that file is absent, deploy-prod.sh derives it from the currently
-# running internship-crm-preview container, so no manual setup is needed as long
-# as a preview container already exists.
+# prod.env: DATABASE_URL, NEXTAUTH_SECRET, NEXTAUTH_URL=the preview URL, SMTP_*).
+# If that file is absent, deploy-prod.sh derives it from the currently running
+# internship-crm-preview container, so no manual setup is needed as long as a
+# preview container already exists.
 #
 # ⚠️ The preview DB is SHARED across all previews (see CLAUDE.md) — a schema
 # `db push` here affects every preview. That is unchanged from the old
 # deploy.yml behavior.
 on:
+  # No paths-ignore: the drift gate below already skips redundant builds, and
+  # filtering docs-only merges out here would only delay them until the next
+  # scheduled tick (the gate compares commit shas, so it would rebuild anyway).
+  # Deploying every merge keeps the invariant simple: preview == origin/main.
+  push:
+    branches: [main]
+  schedule:
+    # Drift safety net; offset from deploy-prod.yml's so the two don't contend
+    # for the single self-hosted runner.
+    - cron: '23 */6 * * *'
   workflow_dispatch:
     inputs:
       ref:
@@ -26,37 +49,95 @@ on:
         required: false
         default: 'main'
 
+# Never cancel a deploy mid-container-swap — queue instead. Queued runs are cheap:
+# the drift gate below turns a run whose commit is already live into a no-op.
 concurrency:
   group: deploy-preview-self-hosted
   cancel-in-progress: false
 
 jobs:
   deploy:
-    name: Deploy ${{ inputs.ref }} to preview
+    name: Deploy ${{ inputs.ref || 'main' }} to preview
     runs-on: self-hosted
     steps:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ inputs.ref || 'main' }}
+
+      - name: Decide whether a deploy is needed
+        id: gate
+        env:
+          EVENT: ${{ github.event_name }}
+          REF: ${{ inputs.ref || 'main' }}
+          HEALTH_URL: http://127.0.0.1:3201/api/health
+        run: |
+          # A manual dispatch is the explicit override: always deploy, even the
+          # commit that is already live (that's how you force a rebuild).
+          if [ "$EVENT" = workflow_dispatch ]; then
+            echo "deploy=true" >> "$GITHUB_OUTPUT"
+            echo "### Preview: deploying \`$REF\` (manual dispatch)" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          # Ask the remote directly rather than trusting a local ref: this job's
+          # workspace is shared and shallow, so refs/remotes/origin/main can be
+          # stale or absent here.
+          TARGET="$(git ls-remote origin refs/heads/main | cut -c1-7)"
+          [ -n "$TARGET" ] || { echo "could not resolve origin/main" >&2; exit 1; }
+          # Ground truth for what is actually live: the container reports the
+          # GIT_SHA baked into its image at /api/health. An unreachable endpoint
+          # (container down or wedged) counts as drift, so the deploy repairs it.
+          LIVE="$(curl -fsS --max-time 10 "$HEALTH_URL" \
+                  | sed -n 's/.*"sha"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' || true)"
+          if [ "$LIVE" = "$TARGET" ]; then
+            echo "deploy=false" >> "$GITHUB_OUTPUT"
+            echo "### Preview already current at \`$TARGET\` — nothing to deploy" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "deploy=true" >> "$GITHUB_OUTPUT"
+            echo "### Preview drifted: live \`${LIVE:-unreachable}\` → deploying \`$TARGET\`" >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Deploy
+        if: steps.gate.outputs.deploy == 'true'
+        env:
+          EVENT: ${{ github.event_name }}
+          REF: ${{ inputs.ref || 'main' }}
         run: |
           chmod +x infra/deploy-prod.sh
           ENV_FILE="${ENV_FILE:-/etc/internship-crm/preview.env}"
-          # Preview has no hand-written secrets file; deploy-prod.sh derives one
-          # from the running preview container. Remove any previously-derived
-          # file first so the derivation always regenerates cleanly (self-healing
-          # if an older run wrote a malformed one).
-          rm -f "$ENV_FILE" || true
+
+          # Preview has no hand-written secrets file — deploy-prod.sh derives one
+          # from the running preview container when it is absent. Keep a good file
+          # (re-deriving on every run would destroy the only copy the moment the
+          # container is gone), but drop an unreadable/incomplete one so the
+          # derivation regenerates it. Self-healing without being destructive.
+          if [ -f "$ENV_FILE" ] && \
+             ! ( set -a; . "$ENV_FILE" >/dev/null 2>&1; [ -n "${DATABASE_URL:-}" ] ); then
+            echo "preview env file is malformed or incomplete — removing so it is re-derived"
+            rm -f "$ENV_FILE" || true
+          fi
+
+          # Automatic runs track the TIP of origin/main: let deploy-prod.sh
+          # hard-reset to it (no --no-pull) instead of deploying the commit this
+          # job checked out. That way a run that queued behind a newer one can
+          # never land an older commit on top of it — the regression #794 fixed
+          # for prod. A manual dispatch of a NON-main ref keeps --no-pull so an
+          # arbitrary tag/SHA (or an older PR ref) deploys exactly as checked out.
+          PULL_ARGS=()
+          if [ "$EVENT" = workflow_dispatch ] && [ "$REF" != main ]; then
+            PULL_ARGS=(--no-pull)
+          fi
+
           # Same script as prod, with preview container/port/image/env overrides.
           # NETWORK=bridge: the preview DB user is granted from the docker
           # gateway (host.docker.internal), not localhost, so preview uses bridge
           # networking + a published port instead of host networking.
-          BRANCH="${{ inputs.ref }}" \
+          # FORWARD_ONLY is deliberately unset — preview must stay able to deploy
+          # arbitrary/older refs on demand.
+          BRANCH="$REF" \
           CONTAINER=internship-crm-preview \
           PORT=3201 \
           IMAGE=internship-crm-preview:local \
           NETWORK=bridge \
           ENV_FILE="$ENV_FILE" \
-          ./infra/deploy-prod.sh --no-pull
+          ./infra/deploy-prod.sh "${PULL_ARGS[@]}"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,10 +1,29 @@
-name: Deploy prod (self-hosted, manual)
+name: Deploy prod (self-hosted, auto on main)
 
 # CI-independent production deploy that RUNS ON THE SERVER via a self-hosted
 # runner (#636). Because self-hosted minutes don't count against the
 # GitHub-hosted quota, this works even while that quota is exhausted — and it
 # can be triggered remotely (e.g. by an agent over the GitHub API) so a deploy
 # no longer needs a human at an SSH prompt.
+#
+# WHY THIS IS AUTOMATIC (#800): this workflow was dispatch-only, so "merging to
+# main deploys to production" (CLAUDE.md) held only as long as somebody
+# remembered to click Run workflow — 44 consecutive manual dispatches. It now
+# follows main by itself:
+#
+#   push to main   → deploy (the normal path; PRs already passed the smoke gate
+#                    in e2e.yml before they could merge)
+#   every 6 hours  → deploy ONLY if prod drifted from origin/main; the
+#                    self-hosted runner can be offline when a push arrives (see
+#                    runner-watchdog.yml) and that deploy would otherwise be lost
+#                    silently. A no-op when prod is already current.
+#   manual         → deploy any branch/tag/SHA, unconditionally.
+#
+# ── FUTURE: weekly release train ────────────────────────────────────────────
+# The plan is for main to flow continuously to preview and reach production on a
+# weekly cadence instead. To switch, delete the `push:` block below and uncomment
+# the weekly `schedule` entry — nothing else changes, and deploy-preview.yml keeps
+# tracking main so preview stays the always-current staging environment.
 #
 # PREREQUISITES (one-time, on the Plesk server):
 #   1. Register a self-hosted runner for this repo (Settings → Actions →
@@ -14,9 +33,19 @@ name: Deploy prod (self-hosted, manual)
 #   2. Create /etc/internship-crm/prod.env (chmod 600) with the production
 #      secrets — see infra/README.md. The runner's user must be able to read it
 #      and run docker.
-#
-# After that, dispatch this workflow (UI "Run workflow", or the API) any time.
 on:
+  # No paths-ignore: the drift gate below already skips redundant builds, and
+  # filtering docs-only merges out here would only delay them until the next
+  # scheduled tick (the gate compares commit shas, so it would rebuild anyway).
+  # Deploying every merge keeps the invariant simple: prod == origin/main.
+  push:
+    branches: [main]
+  schedule:
+    # Drift safety net; offset from deploy-preview.yml's so the two don't
+    # contend for the single self-hosted runner.
+    - cron: '53 */6 * * *'
+    # Weekly release train — see "FUTURE" above. Mondays 06:00 UTC.
+    # - cron: '0 6 * * 1'
   workflow_dispatch:
     inputs:
       ref:
@@ -24,27 +53,73 @@ on:
         required: false
         default: 'main'
 
+# Never cancel a deploy mid-container-swap — queue instead. Queued runs are cheap:
+# the drift gate below turns a run whose commit is already live into a no-op.
 concurrency:
   group: deploy-prod-self-hosted
   cancel-in-progress: false
 
 jobs:
   deploy:
-    name: Deploy ${{ inputs.ref }} to production
+    name: Deploy ${{ inputs.ref || 'main' }} to production
     runs-on: self-hosted
     steps:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ inputs.ref || 'main' }}
+
+      - name: Decide whether a deploy is needed
+        id: gate
+        env:
+          EVENT: ${{ github.event_name }}
+          REF: ${{ inputs.ref || 'main' }}
+          HEALTH_URL: http://127.0.0.1:3200/api/health
+        run: |
+          # A manual dispatch is the explicit override: always deploy, even the
+          # commit that is already live (that's how you force a rebuild).
+          if [ "$EVENT" = workflow_dispatch ]; then
+            echo "deploy=true" >> "$GITHUB_OUTPUT"
+            echo "### Production: deploying \`$REF\` (manual dispatch)" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          # Ask the remote directly rather than trusting a local ref: this job's
+          # workspace is shared and shallow, so refs/remotes/origin/main can be
+          # stale or absent here.
+          TARGET="$(git ls-remote origin refs/heads/main | cut -c1-7)"
+          [ -n "$TARGET" ] || { echo "could not resolve origin/main" >&2; exit 1; }
+          # Ground truth for what is actually live: the container reports the
+          # GIT_SHA baked into its image at /api/health. An unreachable endpoint
+          # (container down or wedged) counts as drift, so the deploy repairs it.
+          LIVE="$(curl -fsS --max-time 10 "$HEALTH_URL" \
+                  | sed -n 's/.*"sha"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' || true)"
+          if [ "$LIVE" = "$TARGET" ]; then
+            echo "deploy=false" >> "$GITHUB_OUTPUT"
+            echo "### Production already current at \`$TARGET\` — nothing to deploy" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "deploy=true" >> "$GITHUB_OUTPUT"
+            echo "### Production drifted: live \`${LIVE:-unreachable}\` → deploying \`$TARGET\`" >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Deploy
+        if: steps.gate.outputs.deploy == 'true'
+        env:
+          EVENT: ${{ github.event_name }}
+          REF: ${{ inputs.ref || 'main' }}
         run: |
           chmod +x infra/deploy-prod.sh
-          # deploy-prod.sh syncs to origin/<ref> (hard reset — NOT --no-pull, so
-          # the build reflects origin/main at deploy time rather than whatever the
-          # shared self-hosted workspace happened to be left at), builds from
-          # source, migrates, seeds, swaps the container and health-checks.
+          # Automatic runs deploy the TIP of origin/main: deploy-prod.sh syncs to
+          # it (hard reset — NOT --no-pull, so the build reflects origin/main at
+          # deploy time rather than whatever the shared self-hosted workspace
+          # happened to be left at). A manual dispatch of a NON-main ref keeps
+          # --no-pull so an arbitrary tag/SHA deploys exactly as checked out.
+          PULL_ARGS=()
+          if [ "$EVENT" = workflow_dispatch ] && [ "$REF" != main ]; then
+            PULL_ARGS=(--no-pull)
+          fi
           # FORWARD_ONLY=1 makes prod refuse to regress to an older commit.
           # Secrets come from the server-side env file, never from the repo/workflow.
-          BRANCH="${{ inputs.ref }}" FORWARD_ONLY=1 ENV_FILE="${ENV_FILE:-/etc/internship-crm/prod.env}" ./infra/deploy-prod.sh
+          BRANCH="$REF" \
+          FORWARD_ONLY=1 \
+          ENV_FILE="${ENV_FILE:-/etc/internship-crm/prod.env}" \
+          ./infra/deploy-prod.sh "${PULL_ARGS[@]}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,36 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [Unreleased]
 
+### Changed
+- **Preview and production now deploy automatically on every merge to `main`.** Both
+  `deploy-preview.yml` and `deploy-prod.yml` were `workflow_dispatch`-only, so
+  "merging to `main` deploys" held only while someone remembered to click *Run
+  workflow*. Prod survived on 44 consecutive manual dispatches; the shared preview
+  did not — once per-PR topic previews (#583) took over the per-PR job, nobody
+  dispatched the shared one and https://crm-preview.ersah.in sat **72 commits / 11
+  minor versions behind** prod (0.14.1-beta vs 0.25.14-beta) for a week. Both
+  workflows now trigger on `push` to `main` (plus a 6-hourly safety net and manual
+  dispatch), keeping preview as the always-current staging environment ahead of the
+  planned weekly production release train — the switch to which is documented in
+  `deploy-prod.yml`'s header.
+  - **Drift gate:** automatic runs compare the live container's `/api/health` `sha`
+    with `origin/main` and exit without building when they match, so the scheduled
+    run is a no-op unless a push was genuinely missed (the self-hosted runner can be
+    offline) — and an unreachable container counts as drift, so the deploy also
+    repairs a down environment. `workflow_dispatch` bypasses the gate and still takes
+    any branch/tag/SHA.
+  - Automatic runs deploy the **tip of `origin/main`** rather than the commit they
+    checked out, so a run queued behind a newer one can never land an older commit on
+    top of it (the regression class fixed for prod in #794, now closed for preview too).
+  - `deploy-preview.yml` no longer deletes `/etc/internship-crm/preview.env` on every
+    run. It validates the file and removes it only when it fails to `source` or lacks
+    `DATABASE_URL` — a workflow that now runs unattended must not be able to destroy
+    the only copy of secrets derived from a container that may since have gone away.
+  - A manual dispatch of a **tag or SHA** now deploys it correctly (previously
+    `git reset --hard origin/<tag>` would have failed; non-branch refs deploy as
+    checked out).
+  - Infra/CI only; no application change, so no version bump. Closes #800.
+
 ### Fixed
 - **Production deploys are now forward-only and deterministic (deploy oscillation).**
   Prod could regress to an older version after some merges ("one step forward, one

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,17 +110,30 @@ SMTP_* for email. Seeder: `SEED_ADMIN_EMAIL` / `SEED_ADMIN_PASSWORD` / `SEED_ADM
 
 ## Deployment
 
-`.github/workflows/deploy.yml` runs on push to `main` (production) and on PRs (preview):
-1. Build Docker image, push to `ghcr.io`.
-2. SSH to the Plesk server, `docker run` the image, `prisma db push --accept-data-loss`.
+All three environments deploy **on the self-hosted runner** (the Plesk server itself), so
+they cost no GitHub-hosted Actions minutes. Each builds the image locally from source,
+runs `prisma db push --accept-data-loss`, swaps its container and health-checks it.
 
-| Env | Container | Port | URL |
-|-----|-----------|------|-----|
-| Production | `internship-crm` | 3200 | https://crm.ersah.in |
-| Preview (PRs) | `internship-crm-preview` | 3201 | https://crm-preview.ersah.in |
+| Env | Container | Port | URL | Trigger |
+|-----|-----------|------|-----|---------|
+| Production | `internship-crm` | 3200 | https://crm.ersah.in | push to `main` (+6h drift check, manual) |
+| Preview | `internship-crm-preview` | 3201 | https://crm-preview.ersah.in | push to `main` (+6h drift check, manual) |
+| Topic (per PR) | `internship-crm-pr<N>` | 33xx | `https://crm-pr<N>.ersah.in` | every push to the PR |
 
-⚠️ **All open PRs share one preview container** (tracked in issue #39).
-⚠️ The preview DB is **shared** — `prisma db push` there affects everyone's preview.
+- `deploy-prod.yml` / `deploy-preview.yml` — **both follow `main` automatically**. Every merge
+  lands on preview and prod. Each has a *drift gate*: it reads the live container's
+  `/api/health` `sha` and skips the build when it already matches `origin/main`, so the
+  6-hourly scheduled run is a no-op unless a push was missed (the runner can be offline —
+  see `runner-watchdog.yml`). A manual `workflow_dispatch` always deploys, and takes any
+  branch/tag/SHA. Prod additionally runs with `FORWARD_ONLY=1` so it can never regress to
+  an older commit (`FORCE=1` for a deliberate rollback).
+- **Planned:** prod moves to a weekly release train while preview keeps tracking `main`.
+  The switch is documented in the header of `deploy-prod.yml` (drop `push:`, uncomment the
+  weekly `schedule:`).
+- `topic-preview.yml` — per-PR isolated environment, torn down when the PR closes (#583).
+- `deploy.yml` is the **legacy hosted** pipeline (ghcr.io + SSH), **paused** — don't extend it.
+- ⚠️ The preview DB is **shared** by the shared preview *and* every topic env —
+  `prisma db push` there affects everyone.
 
 ## Conventions & gotchas for agents
 

--- a/README.md
+++ b/README.md
@@ -130,16 +130,25 @@ the stress test nightly and **emails the team on failure**.
 
 ## Deployment
 
-CI/CD via GitHub Actions ([`.github/workflows/deploy.yml`](.github/workflows/deploy.yml)):
-push to `main` deploys **production**; every PR deploys a **preview**.
+CI/CD via GitHub Actions, running on a **self-hosted runner** (the Plesk host itself, so
+deploys cost no hosted Actions minutes). Every merge to `main` goes to **both** the shared
+preview and production; every PR additionally gets its own throwaway environment.
 
-| Environment | URL | Trigger |
-|-------------|-----|---------|
-| Production | https://crm.ersah.in | push to `main` |
-| Preview | https://crm-preview.ersah.in | pull requests |
+| Environment | URL | Trigger | Workflow |
+|-------------|-----|---------|----------|
+| Production | https://crm.ersah.in | push to `main` | [`deploy-prod.yml`](.github/workflows/deploy-prod.yml) |
+| Preview | https://crm-preview.ersah.in | push to `main` | [`deploy-preview.yml`](.github/workflows/deploy-preview.yml) |
+| Topic (per PR) | `https://crm-pr<N>.ersah.in` | every push to the PR | [`topic-preview.yml`](.github/workflows/topic-preview.yml) |
 
-The pipeline builds a Docker image, pushes it to GitHub Container Registry, then SSHes to the
-Plesk host to run the container and apply the schema with `prisma db push`.
+Each deploy builds the Docker image from source on the server, applies the schema with
+`prisma db push`, swaps the container and health-checks it. Prod and preview also run
+every 6 hours as a safety net: they compare the live container's `/api/health` `sha`
+against `origin/main` and only rebuild if the environment has actually drifted (e.g. a push
+arrived while the runner was offline). Both can be dispatched manually against any
+branch/tag/SHA.
+
+> Production is moving to a **weekly release train** while preview keeps tracking `main`;
+> see the header of `deploy-prod.yml` for the one-line switch.
 
 ## Project structure
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -187,6 +187,41 @@ Add a cron entry on the server — every 5 min it deploys only if `main` moved:
 ```
 No inbound port, no listener — just `git fetch` + the deploy script, lock-guarded.
 
+> Redundant now that `deploy-prod.yml` follows `main` on the self-hosted runner (see
+> below) — keep it only as a belt-and-braces poller. It is safe to run alongside the
+> workflow: `deploy-prod.sh`'s `FORWARD_ONLY=1` guard stops the two from deploying
+> out of order.
+
+### Automatic deploys on the self-hosted runner
+Once the runner is registered (see *Permanent fix* below), `main` reaches both
+long-lived environments by itself — no dispatch, no SSH:
+
+| Workflow | Env | Container | Port | Triggers |
+|----------|-----|-----------|------|----------|
+| `deploy-preview.yml` | https://crm-preview.ersah.in | `internship-crm-preview` | 3201 | push to `main`, every 6h (`:23`), manual |
+| `deploy-prod.yml` | https://crm.ersah.in | `internship-crm` | 3200 | push to `main`, every 6h (`:53`), manual |
+
+Both wrap this same `deploy-prod.sh`; preview just overrides
+`CONTAINER`/`PORT`/`IMAGE`/`ENV_FILE` and sets `NETWORK=bridge` (its DB user is
+granted from the docker gateway, not localhost).
+
+**Drift gate.** Automatic runs first read the live container's `/api/health` `sha` and
+compare it to `origin/main`. Equal → the run exits without building, so the 6-hourly
+schedule is free unless something was actually missed (a push that arrived while the
+runner was offline — see `runner-watchdog.yml`) or the container is unreachable, which
+counts as drift so the deploy also repairs it. A manual `workflow_dispatch` skips the
+gate entirely: it always rebuilds, and accepts any branch/tag/SHA.
+
+**Preview secrets** live in `/etc/internship-crm/preview.env`, same shape as `prod.env`
+but with `NEXTAUTH_URL=https://crm-preview.ersah.in`. There is no need to write it by
+hand: when absent, `deploy-prod.sh` derives it from the running preview container. The
+workflow keeps a valid file and only deletes one that fails to `source` or has no
+`DATABASE_URL`, so an automatic run can never destroy the only copy of those values.
+
+> **Future:** prod moves to a weekly release train while preview keeps tracking `main`.
+> The switch is one edit in `deploy-prod.yml` — drop the `push:` block, uncomment the
+> weekly `schedule:` entry.
+
 ### Topic-preview foundations without Actions
 ```bash
 # DNS (from anywhere): wildcard *.ersah.in A record


### PR DESCRIPTION
## Summary

Neither long-lived environment followed `main` on its own. `deploy-prod.yml` and
`deploy-preview.yml` were both `workflow_dispatch`-only, so "merging to `main` deploys to
production" (CLAUDE.md) held only while a human remembered to click **Run workflow**.

- **Production** got by on manual dispatches — **44 consecutive** `workflow_dispatch` runs,
  no other event has ever triggered it.
- **The shared preview did not.** Once per-PR topic previews (#583) took over the per-PR job,
  nobody dispatched the shared one: `deploy-preview.yml` has run **3 times ever, all manual,
  last on 2026-07-21**.

Measured from `/api/health` while writing this:

| Env | version | sha | |
|-----|---------|-----|---|
| https://crm.ersah.in | `0.25.14-beta` | `7fa3135` | already behind `main` (`380a47b`) again |
| https://crm-preview.ersah.in | `0.14.1-beta` | `763ce3f` | **72 commits / 11 minor versions behind** |

Both workflows now follow `main` by themselves, making preview the always-current staging
environment ahead of the planned **weekly production release train** (whose one-edit switch
is documented in `deploy-prod.yml`'s header).

Closes #800

## Changes

- **`push: [main]` on both `deploy-prod.yml` and `deploy-preview.yml`** — every merge lands
  on preview and prod. `workflow_dispatch` is kept as the manual override.
- **6-hourly drift safety net** (`:23` preview / `:53` prod, offset so they don't contend for
  the single self-hosted runner). A push that arrives while the runner is offline
  (`runner-watchdog.yml`) is otherwise lost silently — that is how preview went stale for a
  week without anyone noticing.
- **Drift gate** so the schedule costs nothing when there's nothing to do: automatic runs read
  the live container's `/api/health` `sha` and exit *before* building when it already matches
  `origin/main`. Notable details:
  - the target sha comes from `git ls-remote origin refs/heads/main`, not a local ref — the
    shared runner workspace is shallow and its `refs/remotes/origin/main` can be stale
    (verified: in this session local `origin/main` read `d9894f6` while the real tip was
    `380a47b`);
  - an **unreachable** container counts as drift, so a scheduled run also repairs a down
    environment rather than skipping it;
  - `workflow_dispatch` bypasses the gate entirely — a manual run always rebuilds.
- **Automatic runs deploy the tip of `origin/main`**, not the commit the job checked out, so a
  run queued behind a newer one can never land an older commit on top of it. This closes for
  preview the same regression class #794 fixed for prod (preview still passed `--no-pull`).
  Prod keeps `FORWARD_ONLY=1`.
- **`deploy-preview.yml` no longer `rm`s `/etc/internship-crm/preview.env` on every run.** That
  was acceptable for a hand-dispatched workflow; for one that now runs unattended it can
  destroy the only copy of secrets derived from a container that may since have gone away. It
  now validates the file and removes it only when it fails to `source` or has no
  `DATABASE_URL` — still self-healing after the malformed-file bug (#696), no longer
  destructive.
- **Manual dispatch of a tag or SHA now works** — previously `git reset --hard origin/<tag>`
  would have failed; non-branch refs deploy as checked out.
- No `paths-ignore`: the gate already suppresses redundant builds, and filtering docs-only
  merges here would merely delay them to the next tick (the gate compares shas, so it would
  rebuild anyway). Deploying every merge keeps the invariant simple: **live == `origin/main`**.
- Refreshed the deployment sections of `README.md`, `CLAUDE.md` and `infra/README.md`, which
  all still described the paused hosted `deploy.yml` and "every PR deploys a preview".

Infra/CI only — no application code changed, so no version bump (same as #794).

## Verification

- [x] Both workflows parse as valid YAML (as do the other 8, unchanged).
- [x] **Drift gate exercised against local stub health endpoints across the full matrix** —
      already-current (compact *and* whitespaced JSON), stale sha, container down, and manual
      dispatch — for `push`, `schedule` and `workflow_dispatch`:

  | event | scenario | result |
  |---|---|---|
  | push / schedule | current | `deploy=false` — "already current" |
  | push / schedule | stale sha | `deploy=true` |
  | push / schedule | container down | `deploy=true` — "unreachable", repairs it |
  | workflow_dispatch | current | `deploy=true` — override |

  Testing this is what surfaced the `sha` parse being intolerant of `"sha": "…"` with
  whitespace; the regex is now `"sha"[[:space:]]*:[[:space:]]*"…"`. Verified the real
  endpoints parse correctly (`7fa3135`, `763ce3f`).
- [x] `--no-pull` selection verified for every event/ref combination (dispatch of a non-`main`
      ref → `--no-pull`; everything else → sync to `origin/main`).
- [x] Env-file guard unit-checked: a well-formed file with shell-special characters in
      `DATABASE_URL` is **kept**; a file that is syntactically broken or missing
      `DATABASE_URL` is **removed** for re-derivation; an absent file is left to the script.
- [x] `infra/deploy-prod.sh` is unchanged — the deploy path itself carries no new risk.
- [ ] `npm run lint` / `tsc` / `test:e2e` — not run: no application code in this diff.

## ⚠️ One thing to know before merging

Merging triggers the first automatic preview deploy, which jumps preview **72 commits** and
runs `prisma db push --accept-data-loss` against the **shared preview DB**. That schema is
already proven on prod (`0.25.x`), and the preview DB holds only synthetic data, but per
CLAUDE.md a `db push` there wants explicit confirmation — flagging it rather than assuming.
Production is unaffected beyond going to `origin/main`, which is where it is meant to be.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QVShP5vdAZT7CSRs1aEsbm)_