### PR TITLE
feat(ci): zamanlanmış tam e2e koşusundan sonra her seferinde Türkçe özet e-postası

### DIFF
--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -2,7 +2,10 @@ name: E2E Full Suite (scheduled)
 
 # The PR gate (e2e.yml) runs only the @smoke subset; this workflow is the safety
 # net behind it (#621/#624): the FULL Playwright suite, 4× a day, 4-way sharded,
-# with an email alert to the team when a run goes red. Can also be run on demand.
+# with a Turkish summary email after EVERY run — "✅ 238/238 test geçti" as a
+# heartbeat, or the failing tests with error snippets when a run goes red
+# (scripts/e2e-report-email.mjs; E2E_REPORT_MODE=failures repo variable for
+# red-only). Can also be run on demand.
 #
 # Cost note: this repo is PUBLIC since 2026-07, so GitHub-hosted standard runners
 # are free and unmetered. Sharding multiplies billed minutes (each shard repeats
@@ -88,8 +91,12 @@ jobs:
       - name: Install Playwright browser
         run: npx playwright install --with-deps chromium
 
+      # The extra json reporter feeds the summary email below; list+html match
+      # what the config would produce on CI.
       - name: Run full E2E suite (shard ${{ matrix.shard }}/4)
-        run: npx playwright test --shard=${{ matrix.shard }}/4
+        env:
+          PLAYWRIGHT_JSON_OUTPUT_NAME: e2e-results-shard-${{ matrix.shard }}.json
+        run: npx playwright test --shard=${{ matrix.shard }}/4 --reporter=list,html,json
 
       - name: Upload Playwright report
         if: always()
@@ -99,13 +106,28 @@ jobs:
           path: playwright-report/
           retention-days: 7
 
-  # Single alert for the whole run (not one per shard). Reuses the app's SMTP_*
-  # secrets via scripts/send-alert-email.mjs, same as stress.yml.
-  notify:
-    name: Email alert on failure
+      - name: Upload JSON result (for the summary email)
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-json-shard-${{ matrix.shard }}
+          path: e2e-results-shard-${{ matrix.shard }}.json
+          retention-days: 7
+          # A shard that crashed before the tests writes no JSON; the report job
+          # detects the gap via E2E_EXPECTED_REPORTS instead.
+          if-no-files-found: warn
+
+  # Single Turkish summary email for the whole run — after EVERY run, not just
+  # red ones (maintainer request: a "238/238 test geçti" heartbeat doubles as
+  # proof the safety net itself is alive). Aggregates the per-shard JSON
+  # reports; a shard that crashed before writing its report is detected via
+  # E2E_EXPECTED_REPORTS and reported as red. Set the repository variable
+  # E2E_REPORT_MODE=failures to go back to red-only alerts.
+  report:
+    name: Summary email (every run)
     runs-on: ubuntu-latest
     needs: [e2e-full]
-    if: failure()
+    if: always()
     steps:
       - uses: actions/checkout@v7
 
@@ -113,7 +135,14 @@ jobs:
         with:
           node-version: 22
 
-      - name: Send alert email
+      - name: Download per-shard JSON results
+        uses: actions/download-artifact@v7
+        with:
+          pattern: e2e-json-shard-*
+          path: e2e-json-reports
+          merge-multiple: true
+
+      - name: Send summary email
         env:
           SMTP_HOST: ${{ secrets.SMTP_HOST }}
           SMTP_PORT: ${{ secrets.SMTP_PORT }}
@@ -121,14 +150,12 @@ jobs:
           SMTP_PASS: ${{ secrets.SMTP_PASS }}
           SMTP_FROM: ${{ secrets.SMTP_FROM }}
           ALERT_EMAIL_TO: ${{ secrets.ALERT_EMAIL_TO || 'mehmetersahin@gmail.com' }}
-          ALERT_SUBJECT: '⚠️ Internship CRM — scheduled full e2e FAILED'
-          ALERT_BODY: |
-            The scheduled full Playwright suite failed (at least one shard red).
-            Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-            Per-shard reports are attached to the run as artifacts
-            (playwright-report-full-shard-N).
+          PLAYWRIGHT_JSON_REPORT: e2e-json-reports
+          E2E_EXPECTED_REPORTS: '4'
+          E2E_REPORT_MODE: ${{ vars.E2E_REPORT_MODE || 'always' }}
+          E2E_RUN_CONTEXT: 'e2e-full · ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
         run: |
           # Install from the lockfile so nodemailer matches the version the app
           # pins (single source of truth); skip postinstall (prisma generate).
           npm ci --ignore-scripts --no-audit --no-fund
-          node scripts/send-alert-email.mjs
+          node scripts/e2e-report-email.mjs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,8 +45,10 @@ deployed env instead.
 After switching branches, run `npx prisma generate` so the client matches the schema —
 a stale client causes schema-drift 500s (the smoke test will catch these).
 The **full suite** also runs on a schedule, 4× a day at 03/09/15/21 UTC
-(`.github/workflows/e2e-full.yml`, 4-way sharded, GitHub-hosted); a red scheduled run
-emails the team (`ALERT_EMAIL_TO`, stress.yml pattern).
+(`.github/workflows/e2e-full.yml`, 4-way sharded, GitHub-hosted); after **every** scheduled
+run a Turkish summary email goes out (`scripts/e2e-report-email.mjs` → `ALERT_EMAIL_TO`):
+"✅ 238/238 test geçti" heartbeat or the failing tests with error snippets. Set the repo
+variable `E2E_REPORT_MODE=failures` for red-only alerts.
 
 ## Architecture
 

--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -841,3 +841,27 @@ sonuçlarından** doğruladım (`Build and push: success`).
 `git checkout -b <yeni> origin/main` diyerek dallandım — ama merge sonrası `git fetch`
 etmediğim için branch bayat bir `origin/main`'e oturdu ve tüm dosyalar "değişmiş"
 göründü. Merge'den sonra dallanmadan önce `git fetch origin`.
+
+## 2026-07-28 — e2e-full'e her-koşuda Türkçe özet e-postası (+ hızlı-main dersleri)
+
+**Paralel oturum çarpışması (iki kez!):** Aynı gün başka oturumlar (a) smoke gate'i
+çoktan shiplemiş, (b) benim "self-hosted'a taşı" PR'ımın tam tersi yönde #956'yı merge
+etmişti (repo public olunca hosted runner bedava → her şey hosted'a geri). Ders: PR'ı
+yeniden inşa etmeden önce SON main'i tekrar incele ve "bu iş hâlâ gerekli mi, hangi
+parçası kaldı?" sorusunu sor. Ben kapsamı iki kez daralttım: sonunda kalan tek eksik,
+kullanıcının istediği her-koşuda "X/Y test geçti" heartbeat maili idi — onu restore
+edilmiş hosted e2e-full'e ekledim (shard başına JSON raporu + always() report job'ı).
+
+**Conflict'li PR = 0 workflow:** Base'i geride kalmış PR'da `pull_request` check'leri
+HİÇ tetiklenmez (0 check run + `mergeable_state: dirty/unknown`); "CI koşmuyor" diye
+debug etmeden önce buna bak. `merge-tree` ile conflict'i push'lamadan görebilirsin.
+
+**Sharded koşuda özet:** her shard'a `PLAYWRIGHT_JSON_OUTPUT_NAME` + `--reporter=list,html,json`,
+JSON'ları artifact olarak topla, `E2E_EXPECTED_REPORTS` ile "shard çöktü ama rapor yok →
+sahte yeşil" tuzağını kapat. Süre = shard'ların max'ı, toplamı değil.
+
+**Ultracode limiti:** 8 agent'lık workflow hesap limitine takılıp 0 agent'la döndü; ana
+oturum çalışmaya devam edebildi — işi inline bitir, `resumeFromRunId` cebinde dursun.
+
+**Write tool + ESC baytı:** regex'e `\x1b` yazarken dosyaya ham ESC gömülebilir; `cat -A`
+ile kontrol et; ANSI'li fixture'ları heredoc yerine python/json ile üret.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -79,6 +79,18 @@ failure.
 The same alert script can be reused by any other CI job that wants to email on failure
 (e.g. adding an `if: failure()` step to `e2e.yml`).
 
+## Scheduled full E2E summary email
+
+The scheduled full suite (`e2e-full.yml`, 4×/day, 4-way sharded) sends a **Turkish
+summary email after every run** via
+[`scripts/e2e-report-email.mjs`](../scripts/e2e-report-email.mjs): on green a
+`✅ … 238/238 test geçti` heartbeat with the run stats (toplam/geçen/başarısız/flaky/
+atlanan, süre); on red the failing tests with file, title, and error snippet. The
+script aggregates the per-shard Playwright JSON reports and flags a shard that crashed
+before writing its report (`E2E_EXPECTED_REPORTS`). Recipients come from
+`ALERT_EMAIL_TO`; set the repository **variable** `E2E_REPORT_MODE=failures` to switch
+back to red-only alerts.
+
 ## Ideas for further test types
 
 - **Contract / API tests** for `/api/v1/*` against the published OpenAPI spec.

--- a/scripts/e2e-report-email.mjs
+++ b/scripts/e2e-report-email.mjs
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+/**
+ * Emails a summary of a Playwright run from its JSON reporter output, using the
+ * same SMTP_* env vars as the app's emailService. Invoked by the `report` job of
+ * e2e-full.yml after EVERY scheduled full run, so the maintainer gets a
+ * "238/238 test geçti" heartbeat — or the failure list — without watching logs.
+ *
+ * Env:
+ *   PLAYWRIGHT_JSON_REPORT  JSON report path; may be a single file, a directory
+ *                           (all *.json inside — the sharded-run case), or a
+ *                           comma-separated list (default: e2e-report.json)
+ *   E2E_EXPECTED_REPORTS    if set (e.g. 4 shards), fewer parsed reports than
+ *                           this is reported as a crashed shard (red)
+ *   SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS, SMTP_FROM   (SMTP transport)
+ *   ALERT_EMAIL_TO          recipient(s), comma-separated   (required)
+ *   E2E_REPORT_MODE         'always' (default) | 'failures' (only email on red)
+ *   E2E_RUN_CONTEXT         free text shown in the email (host, image, date)
+ *   E2E_REPORT_DRY_RUN      '1' → print the email to stdout, never touch SMTP
+ *
+ * Exits 0 when the email was sent or gracefully skipped (missing SMTP config,
+ * mode=failures on a green run); exits non-zero only if a send was attempted
+ * and failed — so cron surfaces broken alerting without masking test results.
+ */
+import nodemailer from 'nodemailer';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+function skip(reason) {
+  console.log(`::warning title=E2E report email not sent::${reason}`);
+  process.exit(0);
+}
+
+const stripAnsi = (s) => String(s).replace(/\x1b\[[0-9;]*m/g, '');
+
+// ── Locate + parse the Playwright JSON report(s) (defensively — a missing or
+//    corrupt report is itself a failure signal, not a reason to crash). A
+//    sharded run produces one JSON per shard; point this at the directory. ───
+const reportSpec = process.env.PLAYWRIGHT_JSON_REPORT || 'e2e-report.json';
+let reportPaths = [];
+try {
+  if (statSync(reportSpec).isDirectory()) {
+    reportPaths = readdirSync(reportSpec)
+      .filter((f) => f.endsWith('.json'))
+      .sort()
+      .map((f) => path.join(reportSpec, f));
+  } else {
+    reportPaths = [reportSpec];
+  }
+} catch {
+  reportPaths = reportSpec.split(',').map((s) => s.trim()).filter(Boolean);
+}
+
+const reports = [];
+const parseErrors = [];
+for (const p of reportPaths) {
+  try {
+    reports.push(JSON.parse(readFileSync(p, 'utf8')));
+  } catch (err) {
+    parseErrors.push(`Rapor okunamadı (${p}): ${err.message}`);
+  }
+}
+const reportError = reports.length === 0
+  ? (parseErrors[0] ?? `Hiç JSON raporu bulunamadı (${reportSpec})`)
+  : null;
+
+// Fewer reports than expected shards = a shard crashed before writing its
+// report; totals below would silently look green without this check.
+const expectedReports = Number(process.env.E2E_EXPECTED_REPORTS) || 0;
+const missingReports = expectedReports > 0 && reports.length < expectedReports;
+
+const sum = (k) => reports.reduce((acc, r) => acc + (r?.stats?.[k] ?? 0), 0);
+const passed = sum('expected');
+const failed = sum('unexpected');
+const flaky = sum('flaky');
+const skipped = sum('skipped');
+const total = passed + failed + flaky + skipped;
+// Shards run in parallel — wall clock is the slowest shard, not the sum.
+const maxDuration = reports.reduce((acc, r) => Math.max(acc, r?.stats?.duration ?? 0), 0);
+const durationMin = maxDuration ? (maxDuration / 60000).toFixed(1) : '?';
+
+// Walk nested suites for failing specs: file, title chain, first error snippet.
+const failures = [];
+function walkSuites(suites, chain) {
+  for (const suite of suites ?? []) {
+    const nextChain = suite.title ? [...chain, suite.title] : chain;
+    for (const spec of suite.specs ?? []) {
+      if (spec.ok === false) {
+        let error = '';
+        for (const t of spec.tests ?? []) {
+          const bad = (t.results ?? []).find((r) => r.error?.message);
+          if (bad) {
+            error = stripAnsi(bad.error.message).slice(0, 500);
+            break;
+          }
+        }
+        failures.push({
+          file: spec.file || suite.file || '?',
+          title: [...nextChain, spec.title].filter(Boolean).join(' › '),
+          error,
+        });
+      }
+    }
+    walkSuites(suite.suites, nextChain);
+  }
+}
+for (const r of reports) walkSuites(r?.suites, []);
+
+const isRed =
+  reportError !== null || failed > 0 || failures.length > 0 || missingReports || parseErrors.length > 0;
+const mode = process.env.E2E_REPORT_MODE || 'always';
+if (mode === 'failures' && !isRed) {
+  skip(`Koşu yeşil ve E2E_REPORT_MODE=failures — özet e-postası atlandı (${passed}/${total} geçti).`);
+}
+
+// ── Compose (Turkish) ────────────────────────────────────────────────────────
+const subject = reportError
+  ? '❌ Internship CRM — e2e: rapor üretilemedi (koşu muhtemelen çöktü)'
+  : failed > 0 || failures.length > 0
+    ? `❌ Internship CRM — e2e: ${failed} test BAŞARISIZ (${passed}/${total})`
+    : missingReports || parseErrors.length > 0
+      ? `❌ Internship CRM — e2e: eksik rapor (${reports.length}/${expectedReports} shard) — bir shard çökmüş olabilir`
+      : `✅ Internship CRM — e2e: ${passed}/${total} test geçti`;
+
+const lines = [];
+if (process.env.E2E_RUN_CONTEXT) lines.push(`Koşu: ${process.env.E2E_RUN_CONTEXT}`);
+if (reportError) {
+  lines.push('', reportError, '', 'Playwright JSON raporu bulunamadı veya bozuk — koşu büyük ihtimalle testlere gelemeden çöktü. Workflow koşusunun loglarına bakın.');
+} else {
+  lines.push(
+    '',
+    `Toplam:     ${total}`,
+    `Geçen:      ${passed}`,
+    `Başarısız:  ${failed}`,
+    `Flaky:      ${flaky}`,
+    `Atlanan:    ${skipped}`,
+    `Süre:       ${durationMin} dk${reports.length > 1 ? ` (${reports.length} paralel shard, en yavaşı)` : ''}`
+  );
+  if (missingReports) {
+    lines.push('', `⚠️ ${expectedReports} shard'dan yalnızca ${reports.length} rapor üretti — eksik shard'lar testlere gelemeden çökmüş olabilir; workflow koşusundaki loglara bakın.`);
+  }
+  for (const e of parseErrors) lines.push('', `⚠️ ${e}`);
+  if (failures.length > 0) {
+    lines.push('', '--- Başarısız testler ---');
+    for (const f of failures) {
+      lines.push('', `✗ ${f.file} › ${f.title}`);
+      if (f.error) lines.push(f.error.split('\n').map((l) => `    ${l}`).join('\n'));
+    }
+  } else if (!isRed) {
+    lines.push('', 'Her şey yolunda — başarısız test yok. 🎉');
+  }
+}
+const detail = lines.join('\n');
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, (c) =>
+    ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c])
+  );
+}
+
+const heading = isRed ? 'E2E koşusunda sorun var' : 'E2E koşusu temiz';
+const color = isRed ? '#b91c1c' : '#15803d';
+const html = `<div style="font-family:system-ui,Arial,sans-serif;line-height:1.5">
+  <h2 style="color:${color};margin:0 0 8px">${heading}</h2>
+  <p><strong>Internship CRM</strong> zamanlanmış tam e2e koşusunun özeti:</p>
+  <pre style="background:#f3f4f6;padding:12px;border-radius:8px;white-space:pre-wrap;font-size:13px">${escapeHtml(detail)}</pre>
+  <p style="color:#6b7280;font-size:12px">Zamanlanmış tam e2e koşusu (e2e-full workflow'u) tarafından gönderildi. Yanıtlar izlenmiyor.</p>
+</div>`;
+
+if (process.env.E2E_REPORT_DRY_RUN === '1') {
+  console.log(`[dry-run] Subject: ${subject}`);
+  console.log(`[dry-run] Body:\n${detail}`);
+  process.exit(0);
+}
+
+const to = process.env.ALERT_EMAIL_TO;
+if (!to) skip('ALERT_EMAIL_TO is not set — no e2e report was delivered.');
+if (!process.env.SMTP_HOST || !process.env.SMTP_USER) {
+  skip(`SMTP is not configured (SMTP_HOST/SMTP_USER) — no e2e report delivered to ${to}.`);
+}
+
+const port = Number(process.env.SMTP_PORT) || 587;
+const transporter = nodemailer.createTransport({
+  host: process.env.SMTP_HOST,
+  port,
+  secure: port === 465,
+  auth: { user: process.env.SMTP_USER, pass: process.env.SMTP_PASS },
+});
+
+try {
+  const info = await transporter.sendMail({
+    from: process.env.SMTP_FROM || process.env.SMTP_USER,
+    to,
+    subject,
+    text: detail,
+    html,
+  });
+  console.log(`E2E report email sent to ${to} (messageId=${info.messageId})`);
+} catch (err) {
+  console.error('Failed to send e2e report email:', err);
+  process.exit(1);
+}


### PR DESCRIPTION
## Ne değişti

> **Kapsam notu:** Bu PR iki kez main'e göre daraltıldı. İstenen yapının çoğu bugün başka oturumlarca shiplendi: smoke-only PR gate + `@smoke` seti zaten main'de; #956 repo public olduğu için (hosted runner'lar ücretsiz) tam suite'i **4×/gün, 4 shard, hosted** olarak geri açtı. Geriye kalan tek eksik, maintainer'ın istediği **her koşuda "X test çalıştı, her şey yolunda" özeti** idi — mevcut `notify` job'ı yalnızca hata durumunda, sayısız/İngilizce bir alert atıyordu. Bu PR onu ekler.

### Her koşuda Türkçe özet e-postası
- `scripts/e2e-report-email.mjs` (yeni): Playwright JSON raporlarından Türkçe özet üretir.
  - Yeşil: `✅ Internship CRM — e2e: 238/238 test geçti` + toplam/geçen/başarısız/flaky/atlanan/süre + "her şey yolunda" — heartbeat aynı zamanda güvenlik ağının çalıştığının kanıtı.
  - Kırmızı: `❌ … N test BAŞARISIZ (X/Y)` + başarısız testlerin dosya/başlık/hata özeti (ANSI temizlenmiş).
  - Dosya, klasör (shard raporları) veya virgüllü liste kabul eder; shard'ları toplar (süre = en yavaş shard). `E2E_EXPECTED_REPORTS` ile raporunu yazamadan çöken shard **sahte yeşile dönüşemez** — eksik rapor kırmızı olarak bildirilir. Rapor hiç yoksa "koşu çöktü" maili.
  - `E2E_REPORT_DRY_RUN=1` test modu; SMTP yoksa zarif skip (exit 0); yalnızca gerçek gönderim hatasında exit ≠ 0.
- `e2e-full.yml`: her shard artık JSON raporu da üretir (`--reporter=list,html,json` + artifact); hata-durumunda `notify` job'ı, her koşuda çalışan (`if: always()`) `report` job'ına dönüştü — shard JSON'larını indirir, tek özet maili atar. Repo variable `E2E_REPORT_MODE=failures` ile yalnızca-kırmızıda moduna dönülebilir. Alıcı: `ALERT_EMAIL_TO` (varsayılan maintainer).

## Doğrulama
- Fixture senaryoları dry-run ile: tek dosya, 2-shard klasörü (geçen+kalan karışık), beklenen 4/gelen 2 shard (eksik-rapor uyarısı ❌), boş klasör ("rapor üretilemedi" ❌), `failures` modu yeşilde mail atmıyor, SMTP'siz zarif skip. Hepsi doğru konu/sayaç/çıkış koduyla.
- `node --check` + workflow YAML parse.
- Merge sonrası `workflow_dispatch` ile uçtan uca gerçek koşu tetiklenecek (ilk gerçek özet maili).

Docs: `CLAUDE.md` e2e bölümü, `docs/testing.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqU3Ks9YVsiSWsjmdUuTwc