### PR TITLE
feat: 1:1 direct-message API for project co-members (#769)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,44 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [Unreleased]
 
+## [0.26.2-beta] - 2026-07-28
+
+### Added
+- **1:1 direct-message API for project co-members** (#769), building on the #768
+  authorization layer. No user-visible surface yet — nothing in the UI calls these
+  endpoints; the `/messages` picker (#770) is what will expose them, so no release note
+  accompanies this entry.
+  - `POST /api/conversations` — create-or-get the DIRECT conversation with another user.
+    Idempotent, and 403 when `canMessage()` says no. Authorization lives *inside*
+    `findOrCreateDirectConversation()` rather than in the route, so no future caller can
+    skip it.
+  - `GET`/`POST /api/messages` now accept **`conversationId`** alongside the existing
+    `relationId` (JSON *and* multipart/attachment paths). Exactly one link is queried per
+    request — never an `OR` across both, which would leak the sibling layer's messages
+    into a thread view. Posting notifies **every** other participant
+    (`otherConversationParticipants`) and mirrors to email for those who haven't opted
+    out of `messages`.
+  - The message sub-routes — `PATCH`/`DELETE /api/messages/[id]`,
+    `POST /api/messages/[id]/reactions`, `GET /api/messages/attachments/[id]` — now
+    authorize through a shared `canAccessMessage()` that follows whichever link the
+    message carries. Without this they would have kept failing closed on conversation
+    messages (`relationId` is null there since #768), i.e. a DM could be sent but never
+    edited, deleted, reacted to, or have its attachments downloaded.
+  - `GET /api/messages/unread` counts conversation messages too, so project DMs reach the
+    unread badge instead of being invisible to it.
+  - Reply-by-email stays mentorship-only: the `Reply-To` token is relation-scoped
+    (`replyAddress(relationId)`), so conversation recipients get the notification email
+    without a `Reply-To` rather than one that would bounce into nowhere.
+
+### Schema
+- `Conversation.directKey String? @unique` — the two participant ids sorted and joined,
+  giving a DIRECT conversation one deterministic identity. Create-or-get leans on the
+  constraint (catching `P2002`) instead of a read-then-write race, so two simultaneous
+  "message this person" clicks can't create two conversations for the same pair. Matching
+  on the key also means a GROUP conversation, or one containing both users *plus a third*,
+  can never be returned by mistake. Null for groups — MySQL allows many NULLs in a unique
+  index.
+
 ## [0.26.1-beta] - 2026-07-28
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.26.1-beta",
+  "version": "0.26.2-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -319,6 +319,13 @@ model Conversation {
   // Group conversations can be bound to a project; DIRECT conversations may
   // leave this null.
   projectId String?
+  // Deterministic identity for a DIRECT (1:1) conversation: the two participant
+  // ids sorted and joined with '|'. Unique, so create-or-get can lean on the
+  // constraint instead of a read-then-write race (two simultaneous "message
+  // this person" clicks would otherwise create two conversations for the same
+  // pair). Null for GROUP conversations — MySQL permits many NULLs in a unique
+  // index, so groups are unconstrained.
+  directKey String?          @unique
   createdAt DateTime         @default(now())
   // @default(now()) as well as @updatedAt: without a default, adding this
   // required column to the already-deployed table would fail `db push` on any

--- a/src/app/api/conversations/route.ts
+++ b/src/app/api/conversations/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { z } from 'zod';
+import { findOrCreateDirectConversation } from '@/lib/conversations';
+import { withTenantScope } from '@/lib/orgContext';
+
+const schema = z.object({ userId: z.string().min(1) });
+
+// POST — create-or-get the 1:1 (DIRECT) conversation with another user (#769).
+// Idempotent: calling it repeatedly for the same pair returns the same
+// conversation. 403 when the two aren't allowed to message each other, which
+// today means they share no project and have no mentorship (see canMessage).
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  return await withTenantScope(session, async () => {
+    const parsed = schema.safeParse(await request.json().catch(() => null));
+    if (!parsed.success) return NextResponse.json({ error: 'Validation failed' }, { status: 400 });
+
+    const targetId = parsed.data.userId;
+    if (targetId === session.user.id) {
+      return NextResponse.json({ error: 'Cannot message yourself' }, { status: 400 });
+    }
+
+    // Authorization lives inside findOrCreateDirectConversation, so it can never
+    // be bypassed by a caller that forgets to check first.
+    const conversation = await findOrCreateDirectConversation(session.user.id, targetId);
+    if (!conversation) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+    return NextResponse.json({
+      conversation: {
+        id: conversation.id,
+        type: conversation.type,
+        participants: conversation.participants.map((p) => ({ id: p.user.id, fullName: p.user.fullName })),
+      },
+    });
+  });
+}

--- a/src/app/api/messages/[id]/reactions/route.ts
+++ b/src/app/api/messages/[id]/reactions/route.ts
@@ -3,7 +3,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { z } from 'zod';
-import { getThreadIfAllowed } from '@/lib/messaging';
+import { canAccessMessage } from '@/lib/conversations';
 
 // Fixed reaction set — keeps input bounded (no arbitrary strings stored).
 const REACTION_EMOJIS = ['👍', '❤️', '😂', '😮', '🎉'] as const;
@@ -22,10 +22,13 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
   const parsed = schema.safeParse(await request.json().catch(() => null));
   if (!parsed.success) return NextResponse.json({ error: 'Validation failed' }, { status: 400 });
 
-  const message = await prisma.message.findUnique({ where: { id }, select: { relationId: true, deletedForEveryoneAt: true } });
+  const message = await prisma.message.findUnique({
+    where: { id },
+    select: { relationId: true, conversationId: true, deletedForEveryoneAt: true },
+  });
   if (!message) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-  const rel = await getThreadIfAllowed({ id: session.user.id, role: session.user.role }, message.relationId);
-  if (!rel) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  const allowed = await canAccessMessage({ id: session.user.id, role: session.user.role }, message);
+  if (!allowed) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   if (message.deletedForEveryoneAt) return NextResponse.json({ error: 'Message deleted' }, { status: 409 });
 
   const newEmoji = parsed.data.emoji;

--- a/src/app/api/messages/[id]/route.ts
+++ b/src/app/api/messages/[id]/route.ts
@@ -3,15 +3,15 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { z } from 'zod';
-import { getThreadIfAllowed } from '@/lib/messaging';
+import { canAccessMessage } from '@/lib/conversations';
 
-// Load a message and confirm the caller may see its thread. Returns the message
-// (with relation ids) or null when not found / not allowed.
+// Load a message and confirm the caller may act on it — via its mentorship
+// thread or its conversation (#769), whichever the message is linked to.
+// Returns the message or null when not found / not allowed.
 async function loadAllowed(userId: string, role: string, messageId: string) {
   const message = await prisma.message.findUnique({ where: { id: messageId } });
   if (!message) return null;
-  const rel = await getThreadIfAllowed({ id: userId, role }, message.relationId);
-  if (!rel) return null;
+  if (!(await canAccessMessage({ id: userId, role }, message))) return null;
   return message;
 }
 

--- a/src/app/api/messages/attachments/[id]/route.ts
+++ b/src/app/api/messages/attachments/[id]/route.ts
@@ -2,10 +2,11 @@ import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
-import { getThreadIfAllowed } from '@/lib/messaging';
+import { canAccessMessage } from '@/lib/conversations';
 
-// GET — serve a message attachment's bytes. Only the thread's participants
-// (or an admin) may download it, same rule as reading the thread itself.
+// GET — serve a message attachment's bytes. Only the participants of the
+// message's thread or conversation (or an admin) may download it, same rule as
+// reading the thread itself.
 export async function GET(_request: Request, { params }: { params: Promise<{ id: string }> }) {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -13,12 +14,13 @@ export async function GET(_request: Request, { params }: { params: Promise<{ id:
   const { id } = await params;
   const attachment = await prisma.messageAttachment.findUnique({
     where: { id },
-    include: { message: { select: { relationId: true } } },
+    include: { message: { select: { relationId: true, conversationId: true } } },
   });
   if (!attachment) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 
-  const rel = await getThreadIfAllowed(session.user, attachment.message.relationId);
-  if (!rel) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  if (!(await canAccessMessage(session.user, attachment.message))) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
 
   return new NextResponse(Buffer.from(attachment.data), {
     headers: {

--- a/src/app/api/messages/route.ts
+++ b/src/app/api/messages/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { z } from 'zod';
 import { getThreadIfAllowed, otherParticipant } from '@/lib/messaging';
+import { getConversationIfAllowed, otherConversationParticipants } from '@/lib/conversations';
 import { notify } from '@/lib/notify';
 import { replyAddress } from '@/lib/replyToken';
 import { sendEmail } from '@/services/emailService';
@@ -20,13 +21,26 @@ export async function GET(request: Request) {
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
   return await withTenantScope(session, async () => {
-    const relationId = new URL(request.url).searchParams.get('relationId') || '';
-    const rel = await getThreadIfAllowed(session.user, relationId);
-    if (!rel) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    const params = new URL(request.url).searchParams;
+    const relationId = params.get('relationId') || '';
+    const conversationId = params.get('conversationId') || '';
+    if (!relationId && !conversationId) {
+      return NextResponse.json({ error: 'relationId or conversationId required' }, { status: 400 });
+    }
+
+    // Authorize through whichever layer the caller addressed: a mentorship
+    // thread (legacy relationId) or a conversation (#769). Both fail closed.
+    const rel = relationId ? await getThreadIfAllowed(session.user, relationId) : null;
+    const conversation = conversationId ? await getConversationIfAllowed(session.user, conversationId) : null;
+    if (!rel && !conversation) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+    // Exactly one link is queried — never an OR across both, which would leak
+    // messages from the sibling layer into this thread's view.
+    const scope = rel ? { relationId: rel.id } : { conversationId: conversation!.id };
 
     const rows = await prisma.message.findMany({
       // Exclude messages this viewer deleted "for me".
-      where: { relationId, hiddenFor: { none: { userId: session.user.id } } },
+      where: { ...scope, hiddenFor: { none: { userId: session.user.id } } },
       orderBy: { createdAt: 'asc' },
       include: { attachments: { select: ATTACHMENT_SELECT }, reactions: { select: { emoji: true, userId: true } } },
     });
@@ -75,20 +89,42 @@ export async function GET(request: Request) {
 
     // Mark the viewer's incoming unread messages as read.
     await prisma.message.updateMany({
-      where: { relationId, senderId: { not: session.user.id }, readAt: null },
+      where: { ...scope, senderId: { not: session.user.id }, readAt: null },
       data: { readAt: new Date() },
     });
 
+    // Conversations also carry a per-participant read cursor.
+    if (conversation) {
+      await prisma.conversationParticipant.updateMany({
+        where: { conversationId: conversation.id, userId: session.user.id },
+        data: { lastReadAt: new Date() },
+      });
+    }
+
     return NextResponse.json({
-      relationId,
-      mentor: rel.mentor,
-      mentee: rel.mentee,
+      ...(rel
+        ? { relationId: rel.id, mentor: rel.mentor, mentee: rel.mentee }
+        : {
+            conversationId: conversation!.id,
+            participants: conversation!.participants.map((p) => ({ id: p.user.id, fullName: p.user.fullName })),
+          }),
       messages,
     });
   });
 }
 
-const schema = z.object({ relationId: z.string().min(1), body: z.string().min(1).max(5000) });
+// Either relationId (mentorship thread) or conversationId (#769) identifies the
+// target; `body` may be empty only on the multipart path, where files can stand
+// in for text.
+const schema = z
+  .object({
+    relationId: z.string().min(1).optional(),
+    conversationId: z.string().min(1).optional(),
+    body: z.string().min(1).max(5000),
+  })
+  .refine((d) => Boolean(d.relationId) || Boolean(d.conversationId), {
+    message: 'relationId or conversationId required',
+  });
 
 // POST — post a message to a thread (participants/admin). Notifies the other
 // party. Accepts either JSON (text-only, the original shape) or multipart
@@ -99,17 +135,19 @@ export async function POST(request: Request) {
 
   return await withTenantScope(session, async () => {
     const contentType = request.headers.get('content-type') || '';
-    let relationId: string;
+    let relationId = '';
+    let conversationId = '';
     let body: string;
     let files: File[] = [];
 
     if (contentType.includes('multipart/form-data')) {
       const form = await request.formData();
       relationId = String(form.get('relationId') || '');
+      conversationId = String(form.get('conversationId') || '');
       body = String(form.get('body') || '');
       // Accept multiple files (pasted images + picked files). Cap the count.
       files = form.getAll('file').filter((f): f is File => f instanceof File && f.size > 0).slice(0, 10);
-      if (!relationId || (!body.trim() && files.length === 0) || body.length > 5000) {
+      if ((!relationId && !conversationId) || (!body.trim() && files.length === 0) || body.length > 5000) {
         return NextResponse.json({ error: 'Validation failed' }, { status: 400 });
       }
       for (const file of files) {
@@ -123,12 +161,15 @@ export async function POST(request: Request) {
     } else {
       const parsed = schema.safeParse(await request.json().catch(() => null));
       if (!parsed.success) return NextResponse.json({ error: 'Validation failed' }, { status: 400 });
-      relationId = parsed.data.relationId;
+      relationId = parsed.data.relationId ?? '';
+      conversationId = parsed.data.conversationId ?? '';
       body = parsed.data.body;
     }
 
-    const rel = await getThreadIfAllowed(session.user, relationId);
-    if (!rel) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    // Same two-layer authorization as GET; both paths fail closed.
+    const rel = relationId ? await getThreadIfAllowed(session.user, relationId) : null;
+    const conversation = conversationId ? await getConversationIfAllowed(session.user, conversationId) : null;
+    if (!rel && !conversation) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
 
     // Read each file once into a Buffer, reused for both DB storage and the
     // recipient's email attachments.
@@ -138,7 +179,9 @@ export async function POST(request: Request) {
 
     const message = await prisma.message.create({
       data: {
-        relationId: rel.id,
+        // Exactly one link is set: a conversation message leaves relationId null
+        // (and vice versa), which is what the nullable columns from #768 allow.
+        ...(rel ? { relationId: rel.id } : { conversationId: conversation!.id }),
         senderId: session.user.id,
         body,
         channel: 'IN_APP',
@@ -149,10 +192,16 @@ export async function POST(request: Request) {
       include: { attachments: { select: ATTACHMENT_SELECT } },
     });
 
-    // Notify the other participant (unless an admin is posting to someone else's thread).
-    const recipient = otherParticipant(rel, session.user.id);
-    if (recipient && recipient !== session.user.id) {
-      await notify(recipient, 'message', `New message from ${session.user.name ?? 'your mentor'}.`, `/messages/${rel.id}`);
+    // Notify everyone but the sender — the single other party on a mentorship
+    // thread, or every other participant of a conversation. An admin posting
+    // into someone else's thread isn't a recipient of their own message.
+    const recipients = (
+      rel ? [otherParticipant(rel, session.user.id)] : otherConversationParticipants(conversation!, session.user.id)
+    ).filter((id) => id && id !== session.user.id);
+    const link = rel ? `/messages/${rel.id}` : `/messages/c/${conversation!.id}`;
+
+    for (const recipient of recipients) {
+      await notify(recipient, 'message', `New message from ${session.user.name ?? 'your mentor'}.`, link);
 
       // Mirror the message to the recipient's inbox (unless they opted out). The
       // Reply-To routes email replies back into this thread via /api/inbound-email.
@@ -168,7 +217,10 @@ export async function POST(request: Request) {
           to: rcpt.email,
           subject: `New message from ${sender}`,
           html: `<p>${sender} sent you a message:</p>${safe.trim() ? `<blockquote style="border-left:3px solid #ccc;padding-left:12px;color:#444">${safe.replace(/\n/g, '<br>')}</blockquote>` : ''}${attachCount ? `<p>📎 ${attachCount} attachment(s) included.</p>` : ''}<p>Reply to this email or open the conversation in the app.</p>`,
-          replyTo: replyAddress(rel.id),
+          // Email replies are routed by a relation-scoped token, so only the
+          // mentorship path can offer reply-by-email today; conversation
+          // recipients get the same notification without a Reply-To.
+          ...(rel ? { replyTo: replyAddress(rel.id) } : {}),
           // Mirror the attachments (incl. pasted images) into the email too.
           attachments: fileBufs.map((fb) => ({ filename: fb.filename, content: fb.data, contentType: fb.contentType })),
         }).catch((e) => logger.error('Failed to mirror message email', { error: String(e) }));

--- a/src/app/api/messages/unread/route.ts
+++ b/src/app/api/messages/unread/route.ts
@@ -3,7 +3,9 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 
-// GET — number of unread incoming messages across the viewer's threads.
+// GET — number of unread incoming messages across the viewer's mentorship
+// threads and conversations (#769). Without the conversation arm, project DMs
+// would never reach the unread badge.
 export async function GET() {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -12,7 +14,10 @@ export async function GET() {
     where: {
       readAt: null,
       senderId: { not: session.user.id },
-      relation: { OR: [{ mentorId: session.user.id }, { menteeId: session.user.id }] },
+      OR: [
+        { relation: { OR: [{ mentorId: session.user.id }, { menteeId: session.user.id }] } },
+        { conversation: { participants: { some: { userId: session.user.id } } } },
+      ],
     },
   });
   return NextResponse.json({ count });

--- a/src/lib/conversations.ts
+++ b/src/lib/conversations.ts
@@ -1,4 +1,6 @@
+import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
+import { getThreadIfAllowed } from '@/lib/messaging';
 
 interface SessionUser {
   id: string;
@@ -119,4 +121,68 @@ export function otherConversationParticipants(
   senderId: string,
 ): string[] {
   return [...new Set(conversation.participants.map((p) => p.userId))].filter((id) => id !== senderId);
+}
+
+// The unique identity of a DIRECT conversation between two users: their ids
+// sorted, so the pair maps to one key regardless of who starts the chat.
+export function directKeyFor(userAId: string, userBId: string): string {
+  return [userAId, userBId].sort().join('|');
+}
+
+const CONVERSATION_INCLUDE = {
+  participants: {
+    select: { userId: true, lastReadAt: true, user: { select: { id: true, fullName: true } } },
+  },
+} as const;
+
+// Create-or-get the 1:1 conversation between two users (#769).
+// Returns null when the pair isn't allowed to message each other — the caller
+// turns that into a 403. Authorization is checked HERE so no route can skip it.
+//
+// Concurrency: the pair's identity lives in the unique `directKey` column, so
+// two simultaneous requests can't produce two conversations for the same pair —
+// the loser of the race gets a unique-constraint violation and reads the winner's
+// row instead. Matching on `directKey` (rather than scanning participants) also
+// means a GROUP conversation, or a conversation that happens to include both
+// users plus a third, can never be returned by mistake.
+export async function findOrCreateDirectConversation(userAId: string, userBId: string) {
+  if (!(await canMessage(userAId, userBId))) return null;
+
+  const key = directKeyFor(userAId, userBId);
+  const existing = await prisma.conversation.findUnique({
+    where: { directKey: key },
+    include: CONVERSATION_INCLUDE,
+  });
+  if (existing) return existing;
+
+  try {
+    return await prisma.conversation.create({
+      data: {
+        type: 'DIRECT',
+        directKey: key,
+        participants: { create: [{ userId: userAId }, { userId: userBId }] },
+      },
+      include: CONVERSATION_INCLUDE,
+    });
+  } catch (e) {
+    // Lost the race — the other request created it microseconds earlier.
+    if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002') {
+      return prisma.conversation.findUnique({ where: { directKey: key }, include: CONVERSATION_INCLUDE });
+    }
+    throw e;
+  }
+}
+
+// May this user act on this message? A message belongs to a mentorship thread
+// (legacy `relationId`), a conversation (`conversationId`), or — in principle —
+// both. Authorization follows whichever link it has, so the message/reaction/
+// attachment sub-routes work identically on both paths. A message with neither
+// link is unreachable (fail closed).
+export async function canAccessMessage(
+  user: SessionUser,
+  message: { relationId: string | null; conversationId: string | null },
+): Promise<boolean> {
+  if (message.relationId && (await getThreadIfAllowed(user, message.relationId))) return true;
+  if (message.conversationId && (await getConversationIfAllowed(user, message.conversationId))) return true;
+  return false;
 }


### PR DESCRIPTION
Builds on the `canMessage()` authorization layer from #768 (merged in #943).

**API only — no user-visible surface.** Nothing in the UI calls these endpoints yet, so no user can create a conversation and no conversation message can exist. The `/messages` picker (#770) is what exposes this. That's also why there's no `releaseNotes.ts` entry: there is nothing for a user to notice. Version + `CHANGELOG.md` are bumped as usual.

## Endpoints

**`POST /api/conversations`** — create-or-get the DIRECT conversation with another user. Idempotent; 403 when `canMessage()` says no. Authorization lives **inside** `findOrCreateDirectConversation()` rather than in the route handler, so a future caller can't skip it by forgetting to check first.

**`GET`/`POST /api/messages`** now accept **`conversationId`** alongside the existing `relationId` — on both the JSON and the multipart/attachment paths. The legacy mentorship path is byte-for-byte unchanged in behaviour.

- Exactly **one** link is queried per request (`scope` is either `{ relationId }` or `{ conversationId }`) — never an `OR` across both, which would leak the sibling layer's messages into a thread view.
- Posting notifies **every** other participant via `otherConversationParticipants()` and mirrors to email for those who haven't opted out of `messages`.
- Reading a conversation also advances that participant's `lastReadAt` cursor.

## The part that would have been easy to miss

The message **sub-routes** — `PATCH`/`DELETE /api/messages/[id]`, `POST /api/messages/[id]/reactions`, `GET /api/messages/attachments/[id]` — all authorized via `getThreadIfAllowed(message.relationId)`. Since #768 made `relationId` nullable, a conversation message has `relationId = null`, so every one of them would have **failed closed**: a DM could be sent but never edited, deleted, reacted to, or have its attachments downloaded.

They now share a `canAccessMessage()` helper that follows whichever link the message carries (and fails closed on a message with neither). Same for `GET /api/messages/unread`, which counted only relation-bound messages — project DMs would never have reached the unread badge.

**Reply-by-email stays mentorship-only.** The `Reply-To` token is relation-scoped (`replyAddress(relationId)`), so conversation recipients get the notification email *without* a `Reply-To` rather than one that would bounce into nowhere. Routing inbound email into conversations needs a token-scheme change — out of scope here.

## Schema

`Conversation.directKey String? @unique` — the two participant ids sorted and joined, giving a DIRECT conversation one deterministic identity.

- **Race:** create-or-get leans on the unique constraint (catching `P2002` and re-reading the winner's row) instead of a read-then-write check, so two simultaneous "message this person" clicks can't create two conversations for the same pair.
- **Correctness:** matching on the key means a GROUP conversation, or one containing both users *plus a third*, can never be returned by mistake — a participant-scan match would have needed a careful exact-set check to avoid exactly that.
- Null for groups; MySQL permits many NULLs in a unique index. Nothing has ever created a `Conversation` row, so no backfill is involved.
- **No `@@index` on an FK column** this time — that was the `db push` failure in #943 (`Can't DROP INDEX ..._userId_fkey`).

## Verification

`npx prisma validate`, `npx tsc --noEmit`, `npm run check:i18n` (1519 keys × 3 locales) and `npm run build` all pass; `/api/conversations` shows up in the route manifest. `db push` deliberately not run against the shared DB — CI syncs on deploy, and the topic preview is the real check for the new unique index.

Closes #769

---
_Generated by [Claude Code](https://claude.ai/code/session_01443WW26ffLt4eXUGNEKMiu)_