### PR TITLE
docs: security-audit playbook + session retrospective (backlog #951)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,11 @@ runs `prisma db push --accept-data-loss`, swaps its container and health-checks 
   with the concrete, reusable lessons you learned (environment quirks, tooling limits, process
   gotchas). Read it at the start of a session too — it captures fast-changing tactical tips that
   complement these durable rules.
+- **Security work** starts from [`docs/security-audit-playbook.md`](docs/security-audit-playbook.md):
+  how to stand up a local DB in this container (no Docker daemon — apt MariaDB), the Playwright
+  `executablePath` workaround, the role × endpoint matrix method, **which areas already tested
+  clean** (don't re-litigate them; breaking one is a regression), and what was never examined.
+  Root tracking issue for the 2026-07 audit: **#951**.
 - **Landing page copy** lives in the three `landing:` blocks of `src/i18n/dictionaries.ts`
   (EN/TR/DE — key parity is enforced by `npm run check:i18n` and CI). Several e2e specs
   assert exact landing strings (e.g. "Connect Talent with", "Everything you need",

--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -23,6 +23,7 @@ optional body schema alone is insufficient: trim the body, then reject only when
 the trimmed body and parsed file list are both empty. For attachment-only ticket
 creation, derive the ticket subject from the first filename while leaving
 attachment validation and transactional storage untouched.
+
 ## 2026-07-23 — Meeting series auto-generation API (#774, 0.25.10-beta)
 
 **Playwright in this sandbox needs two env prerequisites before tests even boot:**
@@ -735,3 +736,44 @@ haftalık rapor/devam takibi, sertifika üretimi (enum değeri var, üretici yok
 **Ayrım önemli:** "grep sıfır sonuç verdi" ile "ben görmedim" farklı iddialardır.
 Her "Mevcut durum" maddesini `dosya:satır` ile bağla; iddiayı doğrulanabilir yap.
 
+## 2026-07-28 — Güvenlik denetimi (Playwright + hacker gözü) → backlog #814–#903
+
+**Bu container'da Docker daemon YOK; lokal DB için `apt-get install mariadb-server`.**
+`docker compose -f docker-compose.dev.yml up -d` çalışmıyor (`/var/run/docker.sock`
+yok, `service docker start` ulimit hatası veriyor). Çalışan yol: `apt-get update`
+(bu şart — bayat apt listesi 404 veriyor) `&& apt-get install -y mariadb-server`,
+sonra `service mariadb start`. Prisma `mysql` provider'ı MariaDB 10.11 ile
+sorunsuz `db push` yaptı. Root socket-auth kullanıyor, o yüzden Prisma için
+parolalı kullanıcı gerekiyor:
+`CREATE USER 'crm'@'%' IDENTIFIED BY 'crm'; GRANT ALL PRIVILEGES ON *.* TO 'crm'@'%';`
+
+**Playwright: `chromium_headless_shell` symlink'i işe yaramaz, `executablePath` kullan.**
+CLAUDE.md "eksik sürümü symlink'le" diyor ama 1194 build'inin dizin yapısı farklı
+(`chrome-linux/headless_shell`), Playwright 1.61 ise
+`chrome-headless-shell-linux64/chrome-headless-shell` arıyor. Çalışan çözüm:
+`chromium.launch({ executablePath: '/opt/pw-browsers/chromium', args: ['--no-sandbox'] })`.
+Ayrıca scratchpad'den çalıştırırken `import ... from '@playwright/test'` çözülmüyor —
+mutlak yol ver: `/home/user/Internship/node_modules/@playwright/test/index.mjs`.
+
+**Login otomasyonunda hidrasyonu bekle — yoksa parola URL'e düşer.**
+`goto` + hemen `click('button[type=submit]')` React hydrate olmadan native GET
+submit tetikliyor ve URL `?email=...&password=...` oluyor. `waitUntil:'networkidle'`
++ ~4 sn bekleyince düzeldi. Bu bir test tuzağı değil, **gerçek bir bulgu** çıktı:
+formlarda `method="post"` yok (#873).
+
+**Yetki testinde status kodu tek başına yeterli DEĞİL.** En kritik bulgu (#847:
+COMPANY/SOURCE tüm görüşme kayıtlarını okuyor) `200` dönüyordu — sızıntı dönen
+satırların içeriğindeydi. Rol matrisi testi her satırın sahipliğini doğrulamalı.
+Ayrıca `405` yanıtları yanlış pozitif üretiyor (route o metodu desteklemiyor),
+bulgu sayarken filtrele.
+
+**`seed:demo` SOURCE kullanıcısı üretmiyor.** Rolü test etmek için elle oluşturmak
+gerekti (`prisma` + `bcrypt.hash`). Kapsamlama boşluğu tam bu rolde çıktı — seed'e
+eklenmesi #899'un kabul kriterlerinde.
+
+**`sub_issue_write` yanıtları ebeveynin TÜM gövdesini geri döndürüyor.** 37 bağlantı
+için bu çok büyük context tüketimi demek. Öğrenilen sıra: önce tüm issue'ları
+oluştur (yanıtlar küçük), ID eşlemesini bir scratchpad dosyasına yaz, bağlantıları
+en sona bırak. Ayrıca issue numaraları oluşturma sırasıyla ardışık gelmiyor
+(814, 816, 818… atlıyor) — gövdede "bkz #N" yazarken numarayı önceden tahmin etme,
+sonradan düzelt.

--- a/docs/security-audit-playbook.md
+++ b/docs/security-audit-playbook.md
@@ -1,0 +1,227 @@
+# Güvenlik denetimi playbook'u / Security audit playbook
+
+Bu doküman, 2026-07-28'de çalışan uygulama üzerinde yapılan güvenlik denetiminin
+**tekrar çalıştırılabilir** tarifidir. Amaç: bir sonraki denetimde sıfırdan
+başlamamak, aynı tuzaklara düşmemek ve neyin zaten temiz olduğunu bilmek.
+
+Kök takip issue'su: **#951** · Epic'ler: #814, #816, #818, #821, #823, #825, #827, #829
+
+> **Kapsam kuralı:** Bu playbook yalnızca **kendi lokal ortamınızda** ve **sentetik
+> veriyle** çalıştırılmak içindir. Prod/preview ortamına yük veya saldırı testi
+> yapmayın — [`DATA_ACCESS_POLICY.md`](DATA_ACCESS_POLICY.md) gereği gerçek PII'ya
+> hiç dokunulmaz. Dışarıdan gelen zafiyet bildirimleri için `SECURITY.md` (bkz. #901).
+
+---
+
+## 1. Ortam kurulumu (Claude Code web container)
+
+Bu container'da **Docker daemon yok** — `docker compose -f docker-compose.dev.yml up -d`
+çalışmaz (`/var/run/docker.sock` yok; `service docker start` ulimit hatası verir).
+
+Çalışan yol — apt ile MariaDB:
+
+```bash
+npm install                       # bağımlılıklar preinstall DEĞİL
+
+apt-get update                    # ← bu şart: bayat apt listesi 404 verir
+DEBIAN_FRONTEND=noninteractive apt-get install -y mariadb-server
+service mariadb start
+
+# root socket-auth kullanıyor; Prisma için parolalı kullanıcı gerekiyor
+mariadb -e "CREATE DATABASE IF NOT EXISTS internship_crm;
+            CREATE USER IF NOT EXISTS 'crm'@'%' IDENTIFIED BY 'crm';
+            GRANT ALL PRIVILEGES ON *.* TO 'crm'@'%'; FLUSH PRIVILEGES;"
+```
+
+`.env` (gitignore'da — `.env` ve `.env.*` kapsanıyor):
+
+```bash
+DATABASE_URL="mysql://crm:crm@127.0.0.1:3306/internship_crm"
+NEXTAUTH_URL="http://localhost:3000"
+NEXTAUTH_SECRET="local-dev-only-secret-not-a-real-one"
+NEXT_PUBLIC_APP_URL="http://localhost:3000"
+SEED_ADMIN_EMAIL="admin@example.com"
+SEED_ADMIN_PASSWORD="ChangeMe123!"
+```
+
+```bash
+npx prisma generate && npx prisma db push --skip-generate
+npx prisma db seed        # ilk ADMIN
+npm run seed:demo         # 3 mentor · 8 mentee · 2 company · 12 interaction · 8 relation
+npm run dev
+```
+
+**Prisma `mysql` provider'ı MariaDB 10.11 ile sorunsuz çalıştı** — şema uyumsuzluğu
+yaşanmadı.
+
+⚠️ `seed:demo` bir **SOURCE** kullanıcısı üretmiyor. En kritik kapsamlama boşluğu
+tam bu rolde çıktığı için elle oluşturmak gerekti. Seed'e eklenmesi #899'un kabul
+kriterlerinde:
+
+```js
+await p.user.create({ data: { email: 'source.probe@demo.example.com',
+  password: await bcrypt.hash('DemoPass123!', 12), fullName: 'Probe Source User',
+  role: 'SOURCE', skills: [], emailVerified: true, isActive: true, sourceId: src.id } });
+```
+
+## 2. Playwright kurulumu
+
+CLAUDE.md "eksik sürümü symlink'le" diyor ama **bu işe yaramıyor**: kurulu 1194
+build'inin dizin yapısı `chrome-linux/headless_shell`, Playwright 1.61 ise
+`chrome-headless-shell-linux64/chrome-headless-shell` arıyor.
+
+Çalışan çözüm — `executablePath` ver:
+
+```js
+import { chromium } from '/home/user/Internship/node_modules/@playwright/test/index.mjs';
+//        ↑ scratchpad'den çalıştırırken mutlak yol şart, '@playwright/test' çözülmüyor
+
+const browser = await chromium.launch({
+  executablePath: '/opt/pw-browsers/chromium',
+  args: ['--no-sandbox'],
+});
+```
+
+`playwright install` **çalıştırmayın** (`PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1`).
+
+### Login otomasyonu — hidrasyonu bekleyin
+
+`goto` + hemen `click` yaparsanız React hydrate olmadan **native GET submit**
+tetiklenir ve parola URL query string'ine düşer:
+
+```
+/auth/signin?email=admin%40example.com&password=ChangeMe123%21
+```
+
+```js
+await page.goto(`${BASE}/auth/signin`, { waitUntil: 'networkidle' });
+await page.waitForTimeout(4000);                       // hidrasyon
+await page.fill('input[type="email"]', email);
+await page.fill('input[type="password"]', pass);
+await Promise.all([
+  page.waitForURL(u => !u.pathname.startsWith('/auth/signin'), { timeout: 30000 }).catch(() => {}),
+  page.click('button[type="submit"]'),
+]);
+```
+
+> Bu bir test tuzağı değil, **gerçek bulgu** çıktı: auth formlarında `method="post"`
+> yok → #873.
+
+Sonra `context.storageState()` ile her rolün çerezini kaydedin; API probe'ları
+tarayıcı açmadan bu çerezlerle atılır.
+
+## 3. Yöntem — rol × endpoint matrisi
+
+```mermaid
+flowchart TD
+  S1["1· Lokal DB + seed<br/>(SOURCE dahil 5 rol)"] --> S2
+  S2["2· Playwright ile her rolde login<br/>storageState kaydet"] --> S3
+  S3["3· Tüm sayfaları gez<br/>status + konsol hatası + screenshot"] --> S4
+  S4["4· Rol × endpoint matrisi<br/>her hücre: allow / deny / own"] --> S5
+  S5["5· Beklenti ihlali = bulgu"] --> S6
+  S6["6· Kod okuyarak kök neden<br/>+ dosya:satır"]
+  style S5 fill:#ffdddd,stroke:#d73a4a,stroke-width:2px
+```
+
+### ⚠️ En önemli ders: status kodu tek başına YETMEZ
+
+En kritik bulgu (#847 — COMPANY/SOURCE tüm görüşme kayıtlarını okuyor) **`200`
+dönüyordu**. Sızıntı dönen satırların *içeriğindeydi*. Doğru kontrol:
+
+```js
+const r = await fetch('/api/interactions', { headers: { cookie: ck(role) } });
+const j = await r.json();
+// status DEĞİL — sahiplik kontrol et:
+const owners = new Set(j.interactions.map(i => i.relation?.mentee?.fullName));
+console.log(role, r.status, 'rows:', j.interactions.length, 'distinct mentees:', owners.size);
+```
+
+### Yanlış pozitif filtreleri
+
+| Belirti | Anlamı | Yapılacak |
+|---|---|---|
+| `405` | Route o HTTP metodunu desteklemiyor | Bulgu **değil**, doğru metodu kullan |
+| `403` beklerken `403` ama iş akışı kırık | Plan/entitlement kapısı olabilir | Kodu oku, güvenlik sanma |
+| Boş `[]` dönmesi | Doğru filtreleniyor **olabilir** | Veri olan bir ilişkiyle tekrar dene |
+
+İlk taramada 10 "bulgu" çıktı; **6'sı `405` yanlış pozitifiydi**, 1'i doğru
+filtreleme. Gerçek olan 2 taneydi.
+
+## 4. Bu denetimde TEMİZ çıkanlar (regresyon koruması)
+
+Bunlar canlı test edildi ve doğru davrandı — **bir değişiklik bunları bozarsa
+regresyondur**:
+
+| Alan | Kanıt |
+|---|---|
+| CV erişimi | MENTEE → başka mentee = `403`; MENTOR → başka mentorun mentee'si = `403` |
+| Belge erişimi | `canAccessUserDocs` — aynı desen, `403` |
+| Mesaj thread'i | Katılımcı olmayan = `403`; yabancı thread'e yazma = `403` |
+| Mesaj eki | Thread katılımcısı değilse `403` |
+| İlişki notları | Mentee kendi hakkındaki **özel mentor notlarını** göremiyor ✅ |
+| Yabancı ilişkiye yazma | MENTOR → başka ilişkiye interaction = `403` |
+| Yetki yükseltme | `PUT /api/profile` ile `role: 'ADMIN'` geçmiyor (zod allowlist) |
+| Admin uçları | MENTEE/MENTOR/COMPANY hepsinden `401` |
+| Güvenlik başlıkları | CSP, HSTS, nosniff, `frame-ancestors 'none'`, `object-src 'none'` ✅ |
+| XSS sink'leri | `dangerouslySetInnerHTML` 2 yerde, ikisi de güvenli (escape'li / sabit) |
+| API anahtarı saklama | SHA-256 hash'li (`src/lib/apiKey.ts`) — token saklamada örnek alınmalı |
+| Oturum çerezi | `httpOnly` + `SameSite=Lax` |
+| Login brute-force | **E-posta** anahtarlı limit → XFF spoof'undan etkilenmiyor (bilinçli tasarım, koruyun) |
+| Inbound e-posta | Gönderenin thread katılımcısı olması ayrıca doğrulanıyor + `timingSafeEqual` |
+
+## 5. Backlog'a çevirirken (issue yazımı)
+
+- **`sub_issue_write` yanıtı ebeveynin TÜM gövdesini geri döndürür.** 37 bağlantıda
+  bu çok ciddi context tüketimi. Doğru sıra: **önce tüm issue'ları oluştur**
+  (create yanıtları küçük), ID eşlemesini bir dosyaya yaz, **bağlantıları en sona
+  bırak**. Ebeveyn gövdesi ne kadar uzunsa maliyet o kadar yüksek → kök/umbrella
+  issue'ları kısa tutun.
+- **Issue numaraları ardışık gelmiyor** (814, 816, 818… atlıyor). Gövdede "bkz #N"
+  yazarken numarayı **önceden tahmin etmeyin**; oluşturduktan sonra düzeltin
+  (veya düzeltme yorumu ekleyin).
+- `issue_write` ile `labels` + `issue_fields` (org **Priority** alanı) **create
+  anında** birlikte verilebilir → issue başına 1 çağrı tasarrufu.
+  Eşleme: `P0→Urgent`, `P1→High`, `P2→Medium`, `P3→Low`.
+- Label güncellemesi **tüm seti değiştirir** — mevcutları yeniden göndermeyi unutmayın.
+
+## 6. Denetim öncesi hızlı kod taramaları
+
+```bash
+# Session/rol kontrolü olmayan route'lar
+for f in $(find src/app/api -name route.ts); do
+  grep -q "getServerSession\|authenticateApiKey" "$f" || echo "NO AUTH: $f"; done
+
+# Allowlist-by-omission: rol zinciri var ama else-deny yok
+grep -rn "role === 'MENTOR'" src/app/api --include=route.ts -A6 | grep -B2 "else if"
+
+# Denetim kaydı olmayan ayrıcalıklı route'lar
+for f in $(find src/app/api/admin -name route.ts); do
+  grep -qE "logActivity|auditLog" "$f" || echo "UNAUDITED: $f"; done
+
+# Token üretimi ve saklama
+grep -rn "randomBytes\|createHmac\|Math.random" src/lib src/app/api --include=*.ts
+
+# Fail-open fallback'ler
+grep -rn "|| 'dev-\|if (!expected) return true" src/lib src/app/api
+
+# Bağımlılık zafiyetleri
+npm audit --json | node -e "…"   # şiddet + fixAvailable tablosu
+```
+
+## 7. Bu denetimde bulunamayan / bakılmayan alanlar
+
+Bir sonraki turda buradan başlayın:
+
+- **Yük / DoS davranışı** — `npm run test:stress` var ama güvenlik açısından
+  koşulmadı.
+- **SAML SSO akışı** — `mocksaml.com` ile uçtan uca test edilebilir
+  (bkz. `agent-experience.md`, 2026-07-24 girdisi); bu turda kod okumasıyla yetinildi.
+- **Google Calendar OAuth** — env'de dormant, test edilmedi.
+- **AI uçları** (`/api/cv/[userId]/extract-ai`, `interview-prep`) — prompt injection
+  yüzeyi hiç incelenmedi. Kullanıcı CV'si model'e giriyor; bu ayrı bir tehdit sınıfı.
+- **`prisma db push --accept-data-loss`** deploy adımının veri kaybı riski.
+- **Preview ortamının paylaşımlı DB'si** (issue #39) — çok kiracılı sızıntı senaryosu.
+
+---
+
+_Son güncelleme: 2026-07-28 · Bu playbook'u her denetimden sonra güncelleyin._


### PR DESCRIPTION
## Summary

Captures the knowledge produced by the 2026-07 security audit so the next one starts from the findings instead of from zero. The audit itself created **45 work items** (root tracking issue **#951** → 8 epics → 12 stories → 25 tasks); this PR is **documentation only** — no application code, no security fix.

Two findings were confirmed against the running app and are already filed:
- **#847** — `COMPANY` and `SOURCE` read *every* interaction log (12 rows / 8 mentees, while the SOURCE user legitimately has 0 mentees). Root cause: role scoping is allowlist-by-omission in `src/app/api/interactions/route.ts:34-38`.
- **#858** — the rate limit is bypassed by rotating `X-Forwarded-For` (control: 5/12 requests passed; attack: **12/12**).

Related: **#951**

## Changes

- **`docs/security-audit-playbook.md`** (new) — the reproducible recipe:
  - **Environment:** this container has **no Docker daemon**, so `docker-compose.dev.yml` cannot be used; `apt-get update && apt-get install mariadb-server` works, and Prisma's `mysql` provider runs fine against MariaDB 10.11. Root uses socket-auth, so a password user is required.
  - **Playwright:** the symlink workaround currently in CLAUDE.md **does not work** (the installed build's directory layout differs from what 1.61 expects) — pass `executablePath: '/opt/pw-browsers/chromium'` instead. Login automation must wait for React hydration, otherwise the browser performs a native GET and the password lands in the URL — which is how #873 was found.
  - **Method:** the role × endpoint matrix, and the load-bearing lesson that **HTTP status alone is not enough** — the most serious finding returned `200` and leaked in the response rows. Also documents the `405` false-positive class (6 of the first 10 "findings" were routes not supporting that verb).
  - **A table of areas that tested clean** — CV/document/message access control, security headers, API-key hashing, XSS sinks, the deliberately email-keyed login limiter. A change that breaks one of these is recognisable as a regression rather than a new decision.
  - **Backlog mechanics:** `sub_issue_write` echoes the entire parent body, so create every issue first and link last; issue numbers are not sequential, so don't predict them in bodies.
  - **What was never examined** (load/DoS, SAML round-trip, Google Calendar OAuth, AI-endpoint prompt injection, the shared preview DB) as the next audit's starting point.
- **`docs/agent-experience.md`** — dated session entry per the standing end-of-session instruction. Rebased onto `main`, keeping the #800/#803 entry that landed meanwhile.
- **`CLAUDE.md`** — one bullet pointing at the playbook so future sessions find it before touching security code.

No version bump: pure documentation, per the versioning rule in CLAUDE.md.

## Verification

- [x] `npm run lint` clean (only a pre-existing `no-img-element` warning in `src/app/messages/[relationId]/page.tsx`, untouched here)
- [x] `npx tsc --noEmit` — n/a, no TypeScript changed
- [x] `npm run test:e2e` — n/a, no application code changed; CI will confirm
- [x] Rebased onto current `main` (`2a1d562`); diff is exactly 3 documentation files, +274 lines
- [x] Every environment claim in the playbook was executed in this session, not assumed

---
_Generated by [Claude Code](https://claude.ai/code/session_01FUFGMtYquRUX8j2rsA5khw)_