### PR TITLE
ci: build images on GitHub-hosted runners again, restore scheduled suites (#955)

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,90 @@
+name: Build image (reusable)
+
+# Builds the app's Docker image ON A GITHUB-HOSTED RUNNER and pushes it to
+# ghcr.io. Every deploy workflow (prod / preview / topic) calls this instead of
+# running `docker build` on the Plesk server.
+#
+# WHY (2026-07-29): while this repo was private the hosted Actions quota ran out,
+# so the deploys were moved onto a self-hosted runner *on the server itself*
+# (#636) — which meant the production box did an `npm ci` + `next build` for
+# every merge and for every push to every open PR. The repo is public now, so
+# hosted standard runners are free and unmetered: the build belongs back here,
+# and the server is left with `docker pull` + container swap.
+#
+# The image is the ONLY artifact that crosses over. Secrets still never leave the
+# server (deploy-prod.sh reads /etc/internship-crm/*.env there) and no build-time
+# secret is baked in — see the Dockerfile.
+#
+# The caller must grant `packages: write`; the ghcr package inherits the repo's
+# visibility, and the deploy job pulls it with the same GITHUB_TOKEN.
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Commit SHA (or ref) to build — pass an exact SHA so the built image, the deployed commit and the baked GIT_SHA all agree'
+        required: true
+        type: string
+      tag:
+        description: 'Image tag only, e.g. prod-a1b2c3d / preview-a1b2c3d / topic-pr123'
+        required: true
+        type: string
+      app_env:
+        description: "NEXT_PUBLIC_APP_ENV build arg: 'production' or 'preview' (inlined at build time, so it must be set here)"
+        required: false
+        default: preview
+        type: string
+    outputs:
+      image:
+        description: 'Fully-qualified image reference that was pushed'
+        value: ${{ jobs.build.outputs.image }}
+
+jobs:
+  build:
+    name: Build ${{ inputs.tag }}
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+    steps:
+      - name: Checkout ${{ inputs.ref }}
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Resolve image reference
+        id: meta
+        env:
+          REPOSITORY: ${{ github.repository }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          # Docker image names must be lower-case; the repo is "21072026/Internship".
+          REPO="$(printf '%s' "$REPOSITORY" | tr '[:upper:]' '[:lower:]')"
+          echo "image=ghcr.io/${REPO}:${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.image }}
+          build-args: |
+            GIT_SHA=${{ inputs.ref }}
+            NEXT_PUBLIC_APP_ENV=${{ inputs.app_env }}
+          # Layer cache lives in the Actions cache, so repeat builds of the same
+          # dependency set skip the expensive `npm ci` layer.
+          cache-from: type=gha,scope=${{ inputs.app_env }}
+          cache-to: type=gha,mode=max,scope=${{ inputs.app_env }}
+
+      - name: Summary
+        env:
+          IMAGE: ${{ steps.meta.outputs.image }}
+        run: echo "### Pushed \`$IMAGE\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,9 +1,10 @@
-name: Deploy preview (self-hosted, auto on main)
+name: Deploy preview (hosted build → server swap, auto on main)
 
-# PREVIEW deploy — the sibling of deploy-prod.yml. Runs ON THE SERVER via the
-# self-hosted runner (no GitHub-hosted quota cost), so preview
+# PREVIEW deploy — the sibling of deploy-prod.yml. The IMAGE IS BUILT ON A
+# GITHUB-HOSTED RUNNER (build-image.yml) and pushed to ghcr; the Plesk server
+# only pulls it and swaps the container, so preview
 # (https://crm-preview.ersah.in, container internship-crm-preview on :3201) is
-# kept in step with main automatically.
+# kept in step with main without the box ever compiling anything.
 #
 # WHY THIS IS AUTOMATIC (#800): preview used to be dispatch-only. Once per-PR
 # topic previews (topic-preview.yml) took over the per-PR job, nobody remembered
@@ -56,14 +57,19 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  deploy:
-    name: Deploy ${{ inputs.ref || 'main' }} to preview
+  # ── 1. Gate (on the server: one curl + one ls-remote) ───────────────────────
+  # Stays on the self-hosted runner because the ground truth it reads is local:
+  # http://127.0.0.1:3201/api/health needs no public reachability, no firewall
+  # exception and no auth. The cost is a curl.
+  gate:
+    name: Check for drift
     runs-on: self-hosted
+    outputs:
+      deploy: ${{ steps.gate.outputs.deploy }}
+      sha: ${{ steps.gate.outputs.sha }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-        with:
-          ref: ${{ inputs.ref || 'main' }}
 
       - name: Decide whether a deploy is needed
         id: gate
@@ -72,18 +78,32 @@ jobs:
           REF: ${{ inputs.ref || 'main' }}
           HEALTH_URL: http://127.0.0.1:3201/api/health
         run: |
+          # Resolve the exact commit to deploy. Everything downstream (the image
+          # tag, the GIT_SHA baked into it, the container that ends up running) is
+          # pinned to this one sha so the build and the deploy cannot disagree.
+          #
+          # Automatic runs target the TIP of origin/main rather than github.sha:
+          # a run that queued behind a newer one must not land an older commit on
+          # top of it (the regression #794 fixed for prod). Asking the remote also
+          # beats trusting a local ref — this workspace is shared and shallow.
+          if [ "$EVENT" = workflow_dispatch ]; then
+            SHA="$(git ls-remote origin "refs/heads/$REF" | cut -f1)"
+            [ -n "$SHA" ] || SHA="$(git ls-remote origin "refs/tags/$REF" | cut -f1)"
+            [ -n "$SHA" ] || SHA="$REF"   # not a branch or tag — assume a raw sha
+          else
+            SHA="$(git ls-remote origin refs/heads/main | cut -f1)"
+          fi
+          [ -n "$SHA" ] || { echo "could not resolve '$REF'" >&2; exit 1; }
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          TARGET="${SHA:0:7}"
+
           # A manual dispatch is the explicit override: always deploy, even the
           # commit that is already live (that's how you force a rebuild).
           if [ "$EVENT" = workflow_dispatch ]; then
             echo "deploy=true" >> "$GITHUB_OUTPUT"
-            echo "### Preview: deploying \`$REF\` (manual dispatch)" >> "$GITHUB_STEP_SUMMARY"
+            echo "### Preview: deploying \`$REF\` (\`$TARGET\`, manual dispatch)" >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
-          # Ask the remote directly rather than trusting a local ref: this job's
-          # workspace is shared and shallow, so refs/remotes/origin/main can be
-          # stale or absent here.
-          TARGET="$(git ls-remote origin refs/heads/main | cut -c1-7)"
-          [ -n "$TARGET" ] || { echo "could not resolve origin/main" >&2; exit 1; }
           # Ground truth for what is actually live: the container reports the
           # GIT_SHA baked into its image at /api/health. An unreachable endpoint
           # (container down or wedged) counts as drift, so the deploy repairs it.
@@ -97,11 +117,44 @@ jobs:
             echo "### Preview drifted: live \`${LIVE:-unreachable}\` → deploying \`$TARGET\`" >> "$GITHUB_STEP_SUMMARY"
           fi
 
+  # ── 2. Build (GitHub-hosted — the expensive part) ───────────────────────────
+  # app_env=preview bakes in the green accent + "preview" badge (src/lib/appEnv.ts)
+  # so preview can't be mistaken for production. The self-hosted local build this
+  # replaces never passed the build-arg, so preview had been wearing production's
+  # blue since #636.
+  build:
+    name: Build image
+    needs: gate
+    if: needs.gate.outputs.deploy == 'true'
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/build-image.yml
+    with:
+      ref: ${{ needs.gate.outputs.sha }}
+      tag: preview-${{ needs.gate.outputs.sha }}
+      app_env: preview
+
+  # ── 3. Swap (on the server: pull + db push + restart) ───────────────────────
+  deploy:
+    name: Swap preview container
+    needs: [gate, build]
+    runs-on: self-hosted
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Checkout ${{ needs.gate.outputs.sha }}
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.gate.outputs.sha }}
+
       - name: Deploy
-        if: steps.gate.outputs.deploy == 'true'
         env:
-          EVENT: ${{ github.event_name }}
-          REF: ${{ inputs.ref || 'main' }}
+          IMAGE: ${{ needs.build.outputs.image }}
+          DEPLOY_SHA: ${{ needs.gate.outputs.sha }}
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           chmod +x infra/deploy-prod.sh
           ENV_FILE="${ENV_FILE:-/etc/internship-crm/preview.env}"
@@ -117,27 +170,18 @@ jobs:
             rm -f "$ENV_FILE" || true
           fi
 
-          # Automatic runs track the TIP of origin/main: let deploy-prod.sh
-          # hard-reset to it (no --no-pull) instead of deploying the commit this
-          # job checked out. That way a run that queued behind a newer one can
-          # never land an older commit on top of it — the regression #794 fixed
-          # for prod. A manual dispatch of a NON-main ref keeps --no-pull so an
-          # arbitrary tag/SHA (or an older PR ref) deploys exactly as checked out.
-          PULL_ARGS=()
-          if [ "$EVENT" = workflow_dispatch ] && [ "$REF" != main ]; then
-            PULL_ARGS=(--no-pull)
-          fi
-
-          # Same script as prod, with preview container/port/image/env overrides.
+          # Same script as prod, with preview container/port/env overrides.
+          # --pull-image: the image was built on the hosted runner, so this box
+          #   only fetches it — no npm ci, no next build, no buildkit.
+          # --no-pull: the checkout above already pinned the exact commit the
+          #   image was built from; don't let the script re-sync to a moving tip.
           # NETWORK=bridge: the preview DB user is granted from the docker
-          # gateway (host.docker.internal), not localhost, so preview uses bridge
-          # networking + a published port instead of host networking.
+          #   gateway (host.docker.internal), not localhost, so preview uses
+          #   bridge networking + a published port instead of host networking.
           # FORWARD_ONLY is deliberately unset — preview must stay able to deploy
-          # arbitrary/older refs on demand.
-          BRANCH="$REF" \
+          #   arbitrary/older refs on demand.
           CONTAINER=internship-crm-preview \
           PORT=3201 \
-          IMAGE=internship-crm-preview:local \
           NETWORK=bridge \
           ENV_FILE="$ENV_FILE" \
-          ./infra/deploy-prod.sh "${PULL_ARGS[@]}"
+          ./infra/deploy-prod.sh --no-pull --pull-image

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,16 +1,21 @@
-name: Deploy prod (self-hosted, auto on main)
+name: Deploy prod (hosted build → server swap, auto on main)
 
-# CI-independent production deploy that RUNS ON THE SERVER via a self-hosted
-# runner (#636). Because self-hosted minutes don't count against the
-# GitHub-hosted quota, this works even while that quota is exhausted — and it
-# can be triggered remotely (e.g. by an agent over the GitHub API) so a deploy
-# no longer needs a human at an SSH prompt.
+# Production deploy. The IMAGE IS BUILT ON A GITHUB-HOSTED RUNNER (build-image.yml)
+# and pushed to ghcr; the Plesk server only pulls it and swaps the container.
 #
-# WHY THIS IS AUTOMATIC (#800): this workflow was dispatch-only, so "merging to
-# main deploys to production" (CLAUDE.md) held only as long as somebody
-# remembered to click Run workflow — 44 consecutive manual dispatches. It now
-# follows main by itself:
+# HISTORY (why it looks like this):
+#   #636  the whole deploy moved onto a self-hosted runner ON THE SERVER because
+#         the private repo's hosted Actions quota was exhausted. That made the
+#         production box run `npm ci` + `next build` for every merge.
+#   #800  it became automatic instead of dispatch-only (44 manual dispatches in a
+#         row is not a pipeline).
+#   now   the repo is PUBLIC, so hosted runners are free and unmetered again. The
+#         build goes back to GitHub; the self-hosted runner keeps only the work
+#         that genuinely has to happen on the server — reading the live health
+#         endpoint, `docker pull`, `prisma db push`, the container swap. Nothing
+#         on the box compiles anymore.
 #
+# HOW IT TRIGGERS:
 #   push to main   → deploy (the normal path; PRs already passed the smoke gate
 #                    in e2e.yml before they could merge)
 #   every 6 hours  → deploy ONLY if prod drifted from origin/main; the
@@ -60,14 +65,19 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  deploy:
-    name: Deploy ${{ inputs.ref || 'main' }} to production
+  # ── 1. Gate (on the server: one curl + one ls-remote) ───────────────────────
+  # Stays on the self-hosted runner because the ground truth it reads is local:
+  # http://127.0.0.1:3200/api/health needs no public reachability, no firewall
+  # exception and no auth. The cost is a curl.
+  gate:
+    name: Check for drift
     runs-on: self-hosted
+    outputs:
+      deploy: ${{ steps.gate.outputs.deploy }}
+      sha: ${{ steps.gate.outputs.sha }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-        with:
-          ref: ${{ inputs.ref || 'main' }}
 
       - name: Decide whether a deploy is needed
         id: gate
@@ -76,18 +86,32 @@ jobs:
           REF: ${{ inputs.ref || 'main' }}
           HEALTH_URL: http://127.0.0.1:3200/api/health
         run: |
+          # Resolve the exact commit to deploy. Everything downstream (the image
+          # tag, the GIT_SHA baked into it, the forward-only guard) is pinned to
+          # this one sha so the build and the deploy can never disagree.
+          #
+          # Automatic runs target the TIP of origin/main rather than github.sha:
+          # a run that queued behind a newer one must not land an older commit on
+          # top of it (the regression #794 fixed for prod). Asking the remote also
+          # beats trusting a local ref — this workspace is shared and shallow.
+          if [ "$EVENT" = workflow_dispatch ]; then
+            SHA="$(git ls-remote origin "refs/heads/$REF" | cut -f1)"
+            [ -n "$SHA" ] || SHA="$(git ls-remote origin "refs/tags/$REF" | cut -f1)"
+            [ -n "$SHA" ] || SHA="$REF"   # not a branch or tag — assume a raw sha
+          else
+            SHA="$(git ls-remote origin refs/heads/main | cut -f1)"
+          fi
+          [ -n "$SHA" ] || { echo "could not resolve '$REF'" >&2; exit 1; }
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          TARGET="${SHA:0:7}"
+
           # A manual dispatch is the explicit override: always deploy, even the
           # commit that is already live (that's how you force a rebuild).
           if [ "$EVENT" = workflow_dispatch ]; then
             echo "deploy=true" >> "$GITHUB_OUTPUT"
-            echo "### Production: deploying \`$REF\` (manual dispatch)" >> "$GITHUB_STEP_SUMMARY"
+            echo "### Production: deploying \`$REF\` (\`$TARGET\`, manual dispatch)" >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
-          # Ask the remote directly rather than trusting a local ref: this job's
-          # workspace is shared and shallow, so refs/remotes/origin/main can be
-          # stale or absent here.
-          TARGET="$(git ls-remote origin refs/heads/main | cut -c1-7)"
-          [ -n "$TARGET" ] || { echo "could not resolve origin/main" >&2; exit 1; }
           # Ground truth for what is actually live: the container reports the
           # GIT_SHA baked into its image at /api/health. An unreachable endpoint
           # (container down or wedged) counts as drift, so the deploy repairs it.
@@ -101,25 +125,53 @@ jobs:
             echo "### Production drifted: live \`${LIVE:-unreachable}\` → deploying \`$TARGET\`" >> "$GITHUB_STEP_SUMMARY"
           fi
 
+  # ── 2. Build (GitHub-hosted — the expensive part) ───────────────────────────
+  build:
+    name: Build image
+    needs: gate
+    if: needs.gate.outputs.deploy == 'true'
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/build-image.yml
+    with:
+      ref: ${{ needs.gate.outputs.sha }}
+      tag: prod-${{ needs.gate.outputs.sha }}
+      app_env: production
+
+  # ── 3. Swap (on the server: pull + db push + restart) ───────────────────────
+  deploy:
+    name: Swap production container
+    needs: [gate, build]
+    runs-on: self-hosted
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Checkout ${{ needs.gate.outputs.sha }}
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.gate.outputs.sha }}
+          # Full history: the forward-only guard in deploy-prod.sh asks
+          # `git merge-base --is-ancestor` whether this commit predates the live
+          # one, which a shallow clone can't answer.
+          fetch-depth: 0
+
       - name: Deploy
-        if: steps.gate.outputs.deploy == 'true'
         env:
-          EVENT: ${{ github.event_name }}
-          REF: ${{ inputs.ref || 'main' }}
+          IMAGE: ${{ needs.build.outputs.image }}
+          DEPLOY_SHA: ${{ needs.gate.outputs.sha }}
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           chmod +x infra/deploy-prod.sh
-          # Automatic runs deploy the TIP of origin/main: deploy-prod.sh syncs to
-          # it (hard reset — NOT --no-pull, so the build reflects origin/main at
-          # deploy time rather than whatever the shared self-hosted workspace
-          # happened to be left at). A manual dispatch of a NON-main ref keeps
-          # --no-pull so an arbitrary tag/SHA deploys exactly as checked out.
-          PULL_ARGS=()
-          if [ "$EVENT" = workflow_dispatch ] && [ "$REF" != main ]; then
-            PULL_ARGS=(--no-pull)
-          fi
-          # FORWARD_ONLY=1 makes prod refuse to regress to an older commit.
+          # --pull-image: the image was built on the hosted runner, so this box
+          #   only fetches it — no npm ci, no next build, no buildkit.
+          # --no-pull: the checkout above already pinned the exact commit the
+          #   image was built from; don't let the script re-sync to a moving tip.
+          # FORWARD_ONLY=1 makes prod refuse to regress to an older commit
+          #   (FORCE=1 for a deliberate rollback).
           # Secrets come from the server-side env file, never from the repo/workflow.
-          BRANCH="$REF" \
           FORWARD_ONLY=1 \
           ENV_FILE="${ENV_FILE:-/etc/internship-crm/prod.env}" \
-          ./infra/deploy-prod.sh "${PULL_ARGS[@]}"
+          ./infra/deploy-prod.sh --no-pull --pull-image

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,12 @@
 name: Deploy to Plesk Server
 
 on:
-  # PAUSED (GitHub Actions quota exhausted) — this hosted preview/prod deploy is
-  # disabled so failing runs stop emailing the team. Production now deploys via
-  # deploy-prod.yml (self-hosted runner, no hosted-quota cost). Re-enable the
-  # pull_request / workflow_run blocks below once the quota is restored.
+  # SUPERSEDED — do not extend or re-enable. deploy-prod.yml / deploy-preview.yml /
+  # topic-preview.yml now do what this workflow did (build on a GitHub-hosted
+  # runner, push to ghcr, swap the container) but hand the swap to the self-hosted
+  # runner instead of SSH-ing in, so no SSH key or application secret has to live
+  # in GitHub secrets. Kept dispatch-only as a break-glass path for when the
+  # self-hosted runner is unavailable.
   workflow_dispatch:
   # pull_request:
   #   branches: [main]

--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -1,26 +1,23 @@
 name: E2E Full Suite (scheduled)
 
-# The PR gate (e2e.yml) runs only the @smoke subset; this workflow is the
-# safety net behind it (#621/#624): the FULL Playwright suite, once a day, with
-# an email alert to the team when it goes red. Can also be run on demand.
+# The PR gate (e2e.yml) runs only the @smoke subset; this workflow is the safety
+# net behind it (#621/#624): the FULL Playwright suite, 4× a day, 4-way sharded,
+# with an email alert to the team when a run goes red. Can also be run on demand.
 #
-# Cost note (#636): a single job, NOT sharded. Sharding cuts wall-clock but
-# MULTIPLIES billed minutes — each shard repeats the whole setup (npm ci +
-# prisma + build + browser install, several minutes) before running its slice.
-# For a daily safety net wall-clock doesn't matter, so one serial run is the
-# cheapest. Frequency dropped from 4×/day to 1×/day for the same reason.
+# Cost note: this repo is PUBLIC since 2026-07, so GitHub-hosted standard runners
+# are free and unmetered. Sharding multiplies billed minutes (each shard repeats
+# npm ci + prisma + build + browser install) but cuts wall-clock ~4×, and with
+# 200+ spec files at `workers: 1` a serial run is hours long. Free minutes make
+# that trade obvious, so the 4×/day sharded cadence from #627 is back — it had
+# been cut to 1×/day serial while the private-repo quota was exhausted (#636/#648).
 #
 # Note: GitHub scheduled workflows can lag a few minutes and are disabled
 # automatically after 60 days without repository activity.
 on:
-  # PAUSED (GitHub Actions quota exhausted) — the daily schedule is disabled so
-  # failing runs stop emailing the team (this workflow also emails on red via the
-  # notify job). Re-enable the schedule below once the quota is restored. Manual
-  # runs still work via "Run workflow".
+  schedule:
+    # 4× a day at 03/09/15/21 UTC (~05/11/17/23 Europe/Berlin in summer).
+    - cron: '0 3,9,15,21 * * *'
   workflow_dispatch:
-  # schedule:
-  #   # Once a day at 03:00 UTC (~05:00 Europe/Berlin in summer).
-  #   - cron: '0 3 * * *'
 
 concurrency:
   group: e2e-full
@@ -28,8 +25,12 @@ concurrency:
 
 jobs:
   e2e-full:
-    name: Playwright full
+    name: Playwright full (shard ${{ matrix.shard }}/4)
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
 
     services:
       mysql:
@@ -87,19 +88,19 @@ jobs:
       - name: Install Playwright browser
         run: npx playwright install --with-deps chromium
 
-      - name: Run full E2E suite
-        run: npm run test:e2e
+      - name: Run full E2E suite (shard ${{ matrix.shard }}/4)
+        run: npx playwright test --shard=${{ matrix.shard }}/4
 
       - name: Upload Playwright report
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: playwright-report-full
+          name: playwright-report-full-shard-${{ matrix.shard }}
           path: playwright-report/
           retention-days: 7
 
-  # Single alert when the run goes red. Reuses the app's SMTP_* secrets via
-  # scripts/send-alert-email.mjs, same as stress.yml.
+  # Single alert for the whole run (not one per shard). Reuses the app's SMTP_*
+  # secrets via scripts/send-alert-email.mjs, same as stress.yml.
   notify:
     name: Email alert on failure
     runs-on: ubuntu-latest
@@ -122,9 +123,10 @@ jobs:
           ALERT_EMAIL_TO: ${{ secrets.ALERT_EMAIL_TO || 'mehmetersahin@gmail.com' }}
           ALERT_SUBJECT: '⚠️ Internship CRM — scheduled full e2e FAILED'
           ALERT_BODY: |
-            The scheduled full Playwright suite failed.
+            The scheduled full Playwright suite failed (at least one shard red).
             Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-            The report is attached to the run as the playwright-report-full artifact.
+            Per-shard reports are attached to the run as artifacts
+            (playwright-report-full-shard-N).
         run: |
           # Install from the lockfile so nodemailer matches the version the app
           # pins (single source of truth); skip postinstall (prisma generate).

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -4,18 +4,18 @@ name: Nightly Stress Test
 # the team if any latency/error-rate threshold is breached. Can also be run
 # on demand from the Actions tab (with an optional target URL override).
 on:
-  # PAUSED (GitHub Actions quota exhausted) — the weekly schedule is disabled so
-  # failing runs stop emailing the team. Re-enable the schedule below once the
-  # quota is restored. Manual runs still work via "Run workflow".
+  # Un-paused 2026-07-29: the repo is public, so hosted runners are free again
+  # (the schedule had been disabled while the private-repo Actions quota was
+  # exhausted). The load itself is small — 25 concurrent for 30s, once a week.
   workflow_dispatch:
     inputs:
       base_url:
         description: 'Target URL to stress (defaults to the STRESS_TARGET_URL secret / production)'
         required: false
         type: string
-  # schedule:
-  #   # 02:30 UTC every Monday (~03:30/04:30 Europe/Berlin depending on DST).
-  #   - cron: '30 2 * * 1'
+  schedule:
+    # 02:30 UTC every Monday (~03:30/04:30 Europe/Berlin depending on DST).
+    - cron: '30 2 * * 1'
 
 concurrency:
   group: stress-test

--- a/.github/workflows/topic-preview.yml
+++ b/.github/workflows/topic-preview.yml
@@ -1,4 +1,4 @@
-name: Topic Preview (self-hosted, auto per-PR)
+name: Topic Preview (hosted build → server swap, auto per-PR)
 
 # Per-PR ephemeral preview environments (issue #583).
 #
@@ -6,19 +6,19 @@ name: Topic Preview (self-hosted, auto per-PR)
 #   PR #123 → container internship-crm-pr123 on a dedicated port →
 #             https://crm-pr123.ersah.in  (wildcard *.ersah.in DNS + TLS)
 # A bot comment on the PR carries the URL (updated on every push). When the PR
-# is merged or closed, the environment (container + image + nginx route) is torn
+# is merged or closed, the environment (container + image + Plesk route) is torn
 # down so it stops consuming server resources.
 #
-# RUNS ON THE SERVER via the self-hosted runner (same as deploy-prod.yml), so it
-# costs no GitHub-hosted Actions minutes — cheap enough to run on every push. The
-# image is built locally on the server (no GHCR round-trip) and the topic scripts
-# do the container swap + nginx routing.
+# THE IMAGE IS BUILT ON A GITHUB-HOSTED RUNNER (build-image.yml) and pushed to
+# ghcr; the server only pulls it and does the container swap + routing. This was
+# the single heaviest load the CI put on the production box: while the repo was
+# private and out of Actions quota (#636) the server ran a full `npm ci` +
+# `next build` for EVERY push to EVERY open PR. The repo is public now, so hosted
+# runners are free — the compiling belongs there.
 #
 # PREREQUISITES (one-time, on the Plesk server — see infra/README.md):
-#   1. The self-hosted runner is registered and its user can run docker AND
-#      write ${NGINX_CONF_DIR} + reload nginx (topic-deploy.sh does both). If the
-#      runner user isn't root, set NGINX_RELOAD_CMD to a sudo-wrapped command and
-#      grant the matching sudoers entry.
+#   1. The self-hosted runner is registered and its user can run docker AND the
+#      `plesk` CLI (topic-deploy.sh creates the subdomain + injects the proxy).
 #   2. Wildcard DNS *.ersah.in → the server (infra/setup-dns-cloudflare.sh) and a
 #      wildcard TLS cert in ${CERT_DIR} (infra/acme-issue-wildcard.sh).
 #   3. /etc/internship-crm/preview.env (chmod 600) with DATABASE_URL (the SHARED
@@ -26,6 +26,11 @@ name: Topic Preview (self-hosted, auto per-PR)
 #
 # ⚠️ The preview DB is SHARED across all topics (see infra/README.md) — a schema
 # `db push` here affects every topic. Coordinate concurrent schema changes.
+#
+# FORK PRs get no topic environment: GitHub keeps their GITHUB_TOKEN read-only
+# (so the image cannot be pushed to ghcr) and withholds repo secrets, and running
+# unreviewed fork code on the production host is not something to work around.
+# ci.yml + e2e.yml still gate those PRs.
 
 on:
   pull_request:
@@ -43,45 +48,64 @@ env:
   ENV_FILE: /etc/internship-crm/preview.env
 
 jobs:
-  topic:
+  # ── Build (GitHub-hosted — the expensive part) ───────────────────────────────
+  # app_env=preview so a topic env wears the green accent + "preview" badge and
+  # can't be mistaken for production (src/lib/appEnv.ts).
+  build:
+    name: Build image
+    if: >-
+      github.event.action != 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/build-image.yml
+    with:
+      # The PR branch tip, not the synthetic merge commit: a topic preview exists
+      # to show the author their own commit, and this sha is what /api/health and
+      # the version footer will report.
+      ref: ${{ github.event.pull_request.head.sha }}
+      tag: topic-pr${{ github.event.pull_request.number }}
+      app_env: preview
+
+  # ── Deploy / update (PR opened, pushed to, or reopened) ──────────────────────
+  deploy:
+    name: Deploy topic environment
+    needs: build
     runs-on: self-hosted
     permissions:
       contents: read
+      packages: read
       pull-requests: write
     steps:
       - name: Derive topic + port from PR number
         id: t
+        env:
+          PR: ${{ github.event.pull_request.number }}
         run: |
-          PR='${{ github.event.pull_request.number }}'
           echo "topic=pr${PR}" >> "$GITHUB_OUTPUT"
           # Deterministic port in 3300–3399 (prod=3200, preview=3201). 100 slots;
           # PRs whose numbers collide mod 100 would clash — fine at our volume.
           echo "port=$((3300 + PR % 100))" >> "$GITHUB_OUTPUT"
-          echo "image=internship-crm:topic-pr${PR}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
-        uses: actions/checkout@v4
-
-      # ── Deploy / update (PR opened, pushed to, or reopened) ──────────────────
-      - name: Build image locally
-        if: github.event.action != 'closed'
-        run: docker build --build-arg GIT_SHA=${{ github.sha }} -t "${{ steps.t.outputs.image }}" .
+        uses: actions/checkout@v7
 
       - name: Deploy topic environment
-        if: github.event.action != 'closed'
         env:
           TOPIC: ${{ steps.t.outputs.topic }}
           PORT: ${{ steps.t.outputs.port }}
-          IMAGE: ${{ steps.t.outputs.image }}
+          IMAGE: ${{ needs.build.outputs.image }}
           BASE_DOMAIN: ${{ env.BASE_DOMAIN }}
           ENV_FILE: ${{ env.ENV_FILE }}
-          SKIP_PULL: '1'
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           chmod +x infra/server/topic-deploy.sh
+          # No SKIP_PULL: the image comes from ghcr, built on the hosted runner.
           ./infra/server/topic-deploy.sh
 
       - name: Comment topic URL on the PR
-        if: github.event.action != 'closed'
         uses: actions/github-script@v7
         with:
           script: |
@@ -103,11 +127,20 @@ jobs:
               await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, body });
             }
 
-      # ── Teardown (PR merged / closed) ────────────────────────────────────────
-      - name: Tear down topic environment
-        if: github.event.action == 'closed'
+  # ── Teardown (PR merged / closed) ────────────────────────────────────────────
+  # Runs for fork PRs too: harmless (nothing to remove) and it keeps the teardown
+  # unconditional, so an environment can never outlive its PR.
+  teardown:
+    name: Tear down topic environment
+    if: github.event.action == 'closed'
+    runs-on: self-hosted
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Tear down
         env:
-          TOPIC: ${{ steps.t.outputs.topic }}
+          TOPIC: pr${{ github.event.pull_request.number }}
           BASE_DOMAIN: ${{ env.BASE_DOMAIN }}
         run: |
           chmod +x infra/server/topic-teardown.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,8 +44,9 @@ boots the dev server; set `BASE_URL=https://crm-preview.ersah.in` to run against
 deployed env instead.
 After switching branches, run `npx prisma generate` so the client matches the schema —
 a stale client causes schema-drift 500s (the smoke test will catch these).
-The **full suite** also runs on a schedule, 4× a day (`.github/workflows/e2e-full.yml`,
-4-way sharded); a red scheduled run emails the team (`ALERT_EMAIL_TO`, stress.yml pattern).
+The **full suite** also runs on a schedule, 4× a day at 03/09/15/21 UTC
+(`.github/workflows/e2e-full.yml`, 4-way sharded, GitHub-hosted); a red scheduled run
+emails the team (`ALERT_EMAIL_TO`, stress.yml pattern).
 
 ## Architecture
 
@@ -110,28 +111,41 @@ SMTP_* for email. Seeder: `SEED_ADMIN_EMAIL` / `SEED_ADMIN_PASSWORD` / `SEED_ADM
 
 ## Deployment
 
-All three environments deploy **on the self-hosted runner** (the Plesk server itself), so
-they cost no GitHub-hosted Actions minutes. Each builds the image locally from source,
-runs `prisma db push --accept-data-loss`, swaps its container and health-checks it.
+All three environments follow the same shape: the image is **built on a GitHub-hosted
+runner** (`build-image.yml`, pushed to `ghcr.io/21072026/internship`), and the Plesk
+server's **self-hosted runner** only pulls it, runs `prisma db push --accept-data-loss`
++ the idempotent backfills, swaps its container and health-checks it. **Nothing
+compiles on the server** — keep it that way (the repo is public, so `ubuntu-latest`
+is free; between 2026-06 and 2026-07-29 the builds ran on the box as a quota
+workaround, #636, and it compiled on every PR push).
 
-| Env | Container | Port | URL | Trigger |
-|-----|-----------|------|-----|---------|
-| Production | `internship-crm` | 3200 | https://crm.ersah.in | push to `main` (+6h drift check, manual) |
-| Preview | `internship-crm-preview` | 3201 | https://crm-preview.ersah.in | push to `main` (+6h drift check, manual) |
-| Topic (per PR) | `internship-crm-pr<N>` | 33xx | `https://crm-pr<N>.ersah.in` | every push to the PR |
+| Env | Container | Port | URL | Image tag | Trigger |
+|-----|-----------|------|-----|-----------|---------|
+| Production | `internship-crm` | 3200 | https://crm.ersah.in | `prod-<sha>` | push to `main` (+6h drift check, manual) |
+| Preview | `internship-crm-preview` | 3201 | https://crm-preview.ersah.in | `preview-<sha>` | push to `main` (+6h drift check, manual) |
+| Topic (per PR) | `internship-crm-pr<N>` | 33xx | `https://crm-pr<N>.ersah.in` | `topic-pr<N>` | every push to the PR |
 
 - `deploy-prod.yml` / `deploy-preview.yml` — **both follow `main` automatically**. Every merge
-  lands on preview and prod. Each has a *drift gate*: it reads the live container's
-  `/api/health` `sha` and skips the build when it already matches `origin/main`, so the
-  6-hourly scheduled run is a no-op unless a push was missed (the runner can be offline —
-  see `runner-watchdog.yml`). A manual `workflow_dispatch` always deploys, and takes any
-  branch/tag/SHA. Prod additionally runs with `FORWARD_ONLY=1` so it can never regress to
-  an older commit (`FORCE=1` for a deliberate rollback).
+  lands on preview and prod. Three jobs: **gate** (self-hosted; resolves the target sha and
+  reads the live container's `/api/health` `sha`) → **build** (`ubuntu-latest`) → **deploy**
+  (self-hosted). The *drift gate* skips the build when the live sha already matches
+  `origin/main`, so the 6-hourly scheduled run is a no-op unless a push was missed (the
+  runner can be offline — see `runner-watchdog.yml`). A manual `workflow_dispatch` always
+  deploys, and takes any branch/tag/SHA. Prod additionally runs with `FORWARD_ONLY=1` so it
+  can never regress to an older commit (`FORCE=1` for a deliberate rollback).
+- Everything after the gate is pinned to the **one sha the gate resolved**, so the image,
+  its baked `GIT_SHA` and the deployed checkout can't disagree. Prod builds with
+  `NEXT_PUBLIC_APP_ENV=production`; preview and topic envs use `preview` (green accent +
+  "preview" badge, `src/lib/appEnv.ts`).
 - **Planned:** prod moves to a weekly release train while preview keeps tracking `main`.
   The switch is documented in the header of `deploy-prod.yml` (drop `push:`, uncomment the
   weekly `schedule:`).
 - `topic-preview.yml` — per-PR isolated environment, torn down when the PR closes (#583).
-- `deploy.yml` is the **legacy hosted** pipeline (ghcr.io + SSH), **paused** — don't extend it.
+  **Fork PRs get none** (their `GITHUB_TOKEN` can't push to ghcr, and unreviewed fork code
+  shouldn't run on the production host).
+- `deploy.yml` is the **legacy hosted** pipeline (ghcr.io + SSH), **superseded** — don't extend it.
+- `infra/autodeploy.sh` is a break-glass poller that **builds on the server** — don't put it
+  on a cron (see `infra/README.md`).
 - ⚠️ The preview DB is **shared** by the shared preview *and* every topic env —
   `prisma db push` there affects everyone.
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -94,15 +94,21 @@ reload nginx afterwards.
 
 ## How this is wired (#583)
 
-`.github/workflows/topic-preview.yml` runs on the **self-hosted runner** (no
-GitHub-hosted Actions minutes) and gives **every open PR** its own environment,
-keyed by PR number — no branch-naming convention needed:
+`.github/workflows/topic-preview.yml` gives **every open PR** its own environment,
+keyed by PR number — no branch-naming convention needed. The image is **built on a
+GitHub-hosted runner** and pushed to ghcr; only the container swap + routing runs
+on the server:
 
-- **PR opened / pushed to / reopened** → build the image locally on the server,
-  then `infra/server/topic-deploy.sh` starts `internship-crm-pr<N>` on its derived
-  port (3300–3399, `3300 + N%100`) and **routes it through a Plesk subdomain**
-  `crm-pr<N>.ersah.in` (see below). A bot comment on the PR carries the URL
-  (updated on every push).
+- **PR opened / pushed to / reopened** → `build-image.yml` builds and pushes
+  `ghcr.io/21072026/internship:topic-pr<N>` on `ubuntu-latest`, then (on the
+  self-hosted runner) `infra/server/topic-deploy.sh` pulls it, starts
+  `internship-crm-pr<N>` on its derived port (3300–3399, `3300 + N%100`) and
+  **routes it through a Plesk subdomain** `crm-pr<N>.ersah.in` (see below). A bot
+  comment on the PR carries the URL (updated on every push).
+- **Fork PRs get no topic environment** — GitHub keeps their `GITHUB_TOKEN`
+  read-only (the image can't be pushed) and withholds repo secrets, and building
+  unreviewed fork code on the production host isn't worth working around. `ci.yml`
+  + `e2e.yml` still gate them.
 - **PR merged/closed** → `infra/server/topic-teardown.sh` removes the Plesk
   subdomain, stops/removes the container + image, and cleans any legacy route.
 
@@ -119,11 +125,12 @@ Plesk vhost bound to the server IP (`listen <IP>:443 ssl`); a raw all-addresses
 TLS is handled by Plesk (+ Cloudflare at the edge). Teardown does
 `plesk bin subdomain --remove`.
 
-Because the runner is on the server, there is **no SSH and no GHCR round-trip**:
-`topic-deploy.sh` is called with `SKIP_PULL=1` (image already built locally) and
+Because the runner is on the server, there is **no SSH hop**: `topic-deploy.sh` is
+called with `GHCR_USER`/`GHCR_TOKEN` (the run's `GITHUB_TOKEN`, for the pull) and
 `ENV_FILE=/etc/internship-crm/preview.env` (secrets sourced directly, same file
-`deploy-preview.yml` uses). The script still supports the old hosted flow (GHCR
-`IMAGE` + `ACTOR`/`B64_TOKEN` + `B64_*` secrets) for backward compatibility.
+`deploy-preview.yml` uses — they never leave the box). It also still accepts
+`SKIP_PULL=1` for a locally built image, and the old base64-over-SSH credential
+form (`ACTOR`/`B64_TOKEN` + `B64_*`), for a manual deploy from a shell.
 
 **Database: a single shared preview DB.** No per-topic DB, so no DB-admin secret
 is needed. ⚠️ Trade-off: all topics share schema/data — two concurrent PRs with
@@ -147,11 +154,32 @@ container.
 
 ---
 
-## CI-independent operations (when the Actions quota is exhausted, #636)
+## Where the work runs (2026-07-29)
+
+The repo is **public**, so GitHub-hosted standard runners are free and unmetered.
+Everything that can run there, does — the server only does what has to happen on
+the server:
+
+| Runs on GitHub-hosted | Runs on the server (self-hosted runner) |
+|---|---|
+| `docker build` + push to ghcr (`build-image.yml`) | read `127.0.0.1:<port>/api/health` for the drift gate |
+| lint / typecheck / build (`ci.yml`) | `docker pull` the prebuilt image |
+| Playwright smoke gate + 4×/day full suite | `prisma db push` + idempotent seeds/backfills |
+| weekly stress test, runner watchdog | stop/start the container, Plesk route, health check |
+
+Nothing on the box compiles anymore. Between 2026-06 and 2026-07-29 it did: with
+the private repo's Actions quota exhausted (#636) the builds were moved onto the
+self-hosted runner, so the production host ran `npm ci` + `next build` for every
+merge **and every push to every open PR**.
+
+---
+
+## CI-independent operations (deploying without Actions, #636)
 
 Everything CI does is just scripts, and the server is reachable over SSH — so
-production deploys and the topic-preview foundations can run **without any
-GitHub Actions minutes**.
+production deploys and the topic-preview foundations can also run **without
+GitHub Actions at all** (an Actions outage, or the runner being wedged).
+These paths build on the server, so use them deliberately, not on a timer.
 
 ### One-time: production secrets on the server
 Create an env file (same values as the GitHub secrets), readable only by root:
@@ -180,37 +208,56 @@ ssh <user>@<server> 'cd /path/to/Internship && sudo ENV_FILE=/etc/internship-crm
 the image (stamping `GIT_SHA`), `prisma db push --accept-data-loss`, seed +
 backfill, swap the `internship-crm` container (host net, :3200), health-check.
 
-### Push-to-deploy without a webhook (optional)
-Add a cron entry on the server — every 5 min it deploys only if `main` moved:
+### Push-to-deploy without a webhook (⚠️ not recommended anymore)
+`infra/autodeploy.sh` polls `main` and runs `deploy-prod.sh` when it moves, so a
+cron entry gives push-to-deploy with no inbound port and no listener:
 ```cron
 */5 * * * * cd /path/to/Internship && ENV_FILE=/etc/internship-crm/prod.env ./infra/autodeploy.sh >> /var/log/internship-autodeploy.log 2>&1
 ```
-No inbound port, no listener — just `git fetch` + the deploy script, lock-guarded.
 
-> Redundant now that `deploy-prod.yml` follows `main` on the self-hosted runner (see
-> below) — keep it only as a belt-and-braces poller. It is safe to run alongside the
-> workflow: `deploy-prod.sh`'s `FORWARD_ONLY=1` guard stops the two from deploying
-> out of order.
+> **Don't leave this on a cron.** It is redundant — `deploy-prod.yml` already
+> follows `main` — and unlike the workflow it **builds the image on the server**,
+> which is exactly the load that was moved to GitHub-hosted runners. If the entry
+> exists, remove it:
+> ```bash
+> crontab -l | grep -v autodeploy.sh | crontab -
+> ```
+> It is at least *safe* to run alongside the workflow: `deploy-prod.sh`'s
+> `FORWARD_ONLY=1` guard stops the two from deploying out of order.
 
-### Automatic deploys on the self-hosted runner
-Once the runner is registered (see *Permanent fix* below), `main` reaches both
-long-lived environments by itself — no dispatch, no SSH:
+### Automatic deploys: hosted build → server swap
+`main` reaches both long-lived environments by itself — no dispatch, no SSH:
 
-| Workflow | Env | Container | Port | Triggers |
-|----------|-----|-----------|------|----------|
-| `deploy-preview.yml` | https://crm-preview.ersah.in | `internship-crm-preview` | 3201 | push to `main`, every 6h (`:23`), manual |
-| `deploy-prod.yml` | https://crm.ersah.in | `internship-crm` | 3200 | push to `main`, every 6h (`:53`), manual |
+| Workflow | Env | Container | Port | Image | Triggers |
+|----------|-----|-----------|------|-------|----------|
+| `deploy-preview.yml` | https://crm-preview.ersah.in | `internship-crm-preview` | 3201 | `…:preview-<sha>` | push to `main`, every 6h (`:23`), manual |
+| `deploy-prod.yml` | https://crm.ersah.in | `internship-crm` | 3200 | `…:prod-<sha>` | push to `main`, every 6h (`:53`), manual |
 
-Both wrap this same `deploy-prod.sh`; preview just overrides
-`CONTAINER`/`PORT`/`IMAGE`/`ENV_FILE` and sets `NETWORK=bridge` (its DB user is
-granted from the docker gateway, not localhost).
+Each runs three jobs — **gate** (self-hosted, one curl + one `ls-remote`) → **build**
+(`ubuntu-latest`, via `build-image.yml`) → **deploy** (self-hosted,
+`deploy-prod.sh --no-pull --pull-image`). Both wrap the same `deploy-prod.sh`;
+preview just overrides `CONTAINER`/`PORT`/`ENV_FILE` and sets `NETWORK=bridge` (its
+DB user is granted from the docker gateway, not localhost). Prod builds with
+`NEXT_PUBLIC_APP_ENV=production`, preview and topics with `preview` (green accent +
+"preview" badge, `src/lib/appEnv.ts`).
 
-**Drift gate.** Automatic runs first read the live container's `/api/health` `sha` and
-compare it to `origin/main`. Equal → the run exits without building, so the 6-hourly
+Everything downstream of the gate is pinned to the **one sha the gate resolved**, so
+the image, its baked `GIT_SHA`, the deployed checkout and the forward-only state file
+can't disagree. Automatic runs target the *tip* of `origin/main` rather than the
+triggering commit, so a run that queued behind a newer one can't land an older commit
+on top of it (#794).
+
+**Drift gate.** Automatic runs read the live container's `/api/health` `sha` and
+compare it to `origin/main`. Equal → the run stops before the build, so the 6-hourly
 schedule is free unless something was actually missed (a push that arrived while the
 runner was offline — see `runner-watchdog.yml`) or the container is unreachable, which
 counts as drift so the deploy also repairs it. A manual `workflow_dispatch` skips the
 gate entirely: it always rebuilds, and accepts any branch/tag/SHA.
+
+**Registry.** Images live in `ghcr.io/21072026/internship`, pushed with the run's
+`GITHUB_TOKEN` (`packages: write`) and pulled on the server with the same token
+(`packages: read`) — no PAT, no extra secret. Application secrets are still read from
+`/etc/internship-crm/*.env` on the server and never enter a workflow.
 
 **Preview secrets** live in `/etc/internship-crm/preview.env`, same shape as `prod.env`
 but with `NEXTAUTH_URL=https://crm-preview.ersah.in`. There is no need to write it by
@@ -232,10 +279,15 @@ export CF_Token="<scoped Cloudflare token>"
 ./infra/acme-issue-wildcard.sh
 ```
 
-### Permanent fix: self-hosted runner
-The always-on Plesk server can register as a **self-hosted GitHub Actions
-runner** (Settings → Actions → Runners → New self-hosted runner). Self-hosted
-minutes do **not** count against the 2000-min quota, so the existing workflows
-(deploy, e2e, infra-setup) all run again for free — flip `runs-on: ubuntu-latest`
-to `runs-on: self-hosted` on the workflows you want off the hosted quota. This
-is the structural cure; the scripts above are the immediate, dependency-free path.
+### The self-hosted runner
+The always-on Plesk server is registered as a **self-hosted GitHub Actions runner**
+(Settings → Actions → Runners → New self-hosted runner), kept alive by
+`runner-watchdog.yml`. It exists so a deploy can touch the box's docker daemon,
+its `preview.env`/`prod.env` and its Plesk config **without an SSH key in GitHub
+secrets** — not to dodge a billing quota.
+
+Keep it to that. `runs-on: self-hosted` belongs only on steps that need something
+that exists only on this machine; anything that merely needs a Linux box with node
+and docker (builds, tests, linting) goes to `ubuntu-latest`, which is free for this
+public repo. Moving builds onto the runner in 2026-06 was a quota workaround
+(#636), and it made the production host compile on every PR push.

--- a/infra/autodeploy.sh
+++ b/infra/autodeploy.sh
@@ -4,6 +4,13 @@
 # (#636). Polls origin/main; when it moves, runs infra/deploy-prod.sh. No open
 # port, no listener process, no security surface — just git + the deploy script.
 #
+# ⚠️ DO NOT LEAVE THIS ON A CRON. deploy-prod.yml already follows main, and this
+# path BUILDS THE IMAGE ON THE SERVER — the exact load that was moved back to
+# GitHub-hosted runners on 2026-07-29 (the workflow pulls a prebuilt image
+# instead). Keep it for a break-glass deploy when Actions or the runner is
+# unavailable. To drop an existing entry:
+#   crontab -l | grep -v autodeploy.sh | crontab -
+#
 # ONE-SHOT (for cron/systemd-timer — the recommended way):
 #   */5 * * * *  cd /path/to/Internship && ENV_FILE=/etc/internship-crm/prod.env ./infra/autodeploy.sh
 #

--- a/infra/deploy-prod.sh
+++ b/infra/deploy-prod.sh
@@ -9,8 +9,10 @@
 #
 # WHAT IT DOES
 #   1. sync the working copy to origin/main (unless --no-pull)
-#   2. build the image FROM SOURCE (CI normally builds + pushes to ghcr; here we
-#      build locally so no registry pull is needed), stamping GIT_SHA
+#   2. obtain the image: either PULL a prebuilt one from ghcr (--pull-image, how
+#      the deploy workflows do it since 2026-07-29 — the build runs on a
+#      GitHub-hosted runner so this server never compiles) or build it locally
+#      from source, stamping GIT_SHA
 #   3. prisma db push --accept-data-loss  (schema sync, same as CI)
 #   4. seed-templates + backfill-project-members  (idempotent)
 #   5. swap the internship-crm container (host networking, port 3200, restart
@@ -31,7 +33,14 @@
 #
 # FLAGS
 #   --no-pull     deploy the current checkout as-is (skip git sync)
-#   --skip-build  reuse the existing internship-crm:local image (fast restart)
+#   --skip-build  reuse the existing $IMAGE image, as-is (fast restart)
+#   --pull-image  `docker pull $IMAGE` instead of building (implies --skip-build).
+#                 For a private registry set GHCR_USER + GHCR_TOKEN and this
+#                 logs in first; a public package needs neither.
+#
+# ENV
+#   DEPLOY_SHA    the commit the image was built from. Only needed when the
+#                 checkout can't be trusted to be that commit; defaults to HEAD.
 #
 set -euo pipefail
 
@@ -44,10 +53,13 @@ BRANCH="${BRANCH:-main}"
 
 NO_PULL=0
 SKIP_BUILD=0
+PULL_IMAGE=0
 for arg in "$@"; do
   case "$arg" in
     --no-pull) NO_PULL=1 ;;
     --skip-build) SKIP_BUILD=1 ;;
+    # The image already exists in the registry — fetching it replaces the build.
+    --pull-image) PULL_IMAGE=1; SKIP_BUILD=1 ;;
     *) echo "Unknown flag: $arg" >&2; exit 2 ;;
   esac
 done
@@ -93,8 +105,12 @@ if [ "$NO_PULL" -eq 0 ]; then
   git checkout "$BRANCH"
   git reset --hard "origin/$BRANCH"
 fi
-GIT_SHA="$(git rev-parse HEAD)"
-log "Deploying $(git rev-parse --short HEAD) — $(node -p "require('./package.json').version" 2>/dev/null || echo '?')"
+# DEPLOY_SHA lets the caller name the commit the image was built from, which is
+# what the forward-only guard and the state file below must reason about. With a
+# local build that is always HEAD; with --pull-image the workflow passes the sha
+# it built so a shared/shallow runner workspace can't disagree with the image.
+GIT_SHA="${DEPLOY_SHA:-$(git rev-parse HEAD)}"
+log "Deploying ${GIT_SHA:0:7} — $(node -p "require('./package.json').version" 2>/dev/null || echo '?')"
 
 # ── 1b. Forward-only guard (prod) ────────────────────────────────────────────
 # Production must only ever move FORWARD. Two uncoordinated deployers write the
@@ -116,8 +132,18 @@ if [ "${FORWARD_ONLY:-0}" = "1" ] && [ "${FORCE:-0}" != "1" ] && [ -f "$STATE_FI
   fi
 fi
 
-# ── 2. Build image from source ───────────────────────────────────────────────
-if [ "$SKIP_BUILD" -eq 0 ]; then
+# ── 2. Obtain the image: pull a prebuilt one, or build from source ───────────
+# Pulling is the normal path now — the deploy workflows build on a GitHub-hosted
+# runner and push to ghcr, so this box does no compiling. Building locally
+# remains supported for a manual/offline deploy from a shell on the server.
+if [ "$PULL_IMAGE" -eq 1 ]; then
+  log "Pulling $IMAGE"
+  if [ -n "${GHCR_TOKEN:-}" ]; then
+    printf '%s' "$GHCR_TOKEN" \
+      | docker login ghcr.io -u "${GHCR_USER:-github-actions}" --password-stdin
+  fi
+  docker pull "$IMAGE"
+elif [ "$SKIP_BUILD" -eq 0 ]; then
   log "Building $IMAGE (GIT_SHA=$GIT_SHA)"
   docker build --build-arg GIT_SHA="$GIT_SHA" -t "$IMAGE" .
 fi
@@ -192,4 +218,4 @@ printf '%s\n' "$GIT_SHA" > "$STATE_FILE" 2>/dev/null || true
 
 docker image prune -af >/dev/null 2>&1 || true
 docker builder prune -af --filter until=72h >/dev/null 2>&1 || true
-log "Done — $CONTAINER is up at :$PORT ($(git rev-parse --short HEAD))"
+log "Done — $CONTAINER is up at :$PORT (${GIT_SHA:0:7})"

--- a/infra/server/topic-deploy.sh
+++ b/infra/server/topic-deploy.sh
@@ -19,9 +19,11 @@
 #   TOPIC PORT IMAGE BASE_DOMAIN
 #
 # Image source — one of:
-#   (a) GHCR pull  (hosted workflow): ACTOR + B64_TOKEN, IMAGE is a ghcr.io ref.
-#   (b) Local build (self-hosted runner): SKIP_PULL=1 and IMAGE already exists
-#       locally (the workflow `docker build`s it on the server) — no registry.
+#   (a) GHCR pull (the normal path): IMAGE is a ghcr.io ref, built on a
+#       GitHub-hosted runner. Credentials as GHCR_USER + GHCR_TOKEN, or as
+#       ACTOR + B64_TOKEN when they have to survive an SSH hop.
+#   (b) Local build: SKIP_PULL=1 and IMAGE already exists locally. Kept for a
+#       manual deploy from a shell on the server; CI no longer builds here.
 #
 # Secrets — one of:
 #   (a) B64_DB B64_SEC B64_SMTP_HOST B64_SMTP_PORT B64_SMTP_USER B64_SMTP_PASS
@@ -35,6 +37,7 @@
 #   NGINX_RELOAD_CMD  (default "nginx -t && systemctl reload nginx")
 #   CERT_DIR          (default /etc/nginx/ssl)  — wildcard cert from acme-issue-wildcard.sh
 #   SKIP_PULL=1       — image is already present locally; skip ghcr login + pull.
+#   GHCR_USER/GHCR_TOKEN — registry credentials in plain form (see (a) above).
 #
 set -euo pipefail
 
@@ -69,10 +72,15 @@ CONF="${NGINX_CONF_DIR}/crm-${TOPIC}.${BASE_DOMAIN}.conf"  # legacy raw route (c
 
 echo "==> Deploying topic '${TOPIC}' → ${URL} (container ${CONTAINER}, port ${PORT})"
 
-# ── Image: pull from GHCR unless it was built locally (self-hosted) ──────────
+# ── Image: pull from GHCR unless it was built locally ────────────────────────
 if [ "${SKIP_PULL:-0}" != "1" ]; then
-  printf '%s' "${B64_TOKEN:?B64_TOKEN required when SKIP_PULL!=1}" | base64 -d \
-    | docker login ghcr.io -u "${ACTOR:?ACTOR required when SKIP_PULL!=1}" --password-stdin
+  if [ -n "${GHCR_TOKEN:-}" ]; then
+    printf '%s' "$GHCR_TOKEN" \
+      | docker login ghcr.io -u "${GHCR_USER:-github-actions}" --password-stdin
+  else
+    printf '%s' "${B64_TOKEN:?GHCR_TOKEN or B64_TOKEN required when SKIP_PULL!=1}" | base64 -d \
+      | docker login ghcr.io -u "${ACTOR:?ACTOR required with B64_TOKEN}" --password-stdin
+  fi
   docker pull "$IMAGE"
 else
   docker image inspect "$IMAGE" >/dev/null 2>&1 || {


### PR DESCRIPTION
Closes #955

The repo is **public** since 2026-07, so GitHub-hosted standard runners are free and unmetered. Everything that had been pushed onto the self-hosted runner — i.e. onto the production Plesk server — or paused outright to survive the private repo's exhausted Actions quota (#636, #648) comes back to GitHub.

## Where the work runs now

| | Before | After |
|---|---|---|
| `docker build` (prod / preview / **every push to every PR**) | 🔴 the server | 🟢 `ubuntu-latest` → ghcr |
| Drift gate (`/api/health` sha) | the server | the server (one `curl` + one `ls-remote`) |
| `docker pull`, `prisma db push`, container swap, Plesk route | the server | the server |
| Full Playwright suite | ⏸ schedule commented out | 🟢 4×/day, 4-way sharded |
| Weekly stress test | ⏸ schedule commented out | 🟢 weekly |

**Nothing on the server compiles anymore.** The self-hosted runner is kept for one reason: a deploy needs that box's docker daemon, its `prod.env`/`preview.env` and its Plesk config — so no SSH key and no application secret has to live in GitHub secrets. Everything that merely needs a Linux box with node and docker goes to `ubuntu-latest`.

## Shape of a deploy

```
gate (self-hosted)  →  build (ubuntu-latest)  →  deploy (self-hosted)
resolve target sha     build-image.yml           deploy-prod.sh
read live /api/health  push ghcr:<env>-<sha>     --no-pull --pull-image
```

The gate stays on the server on purpose: the ground truth it reads is `http://127.0.0.1:<port>/api/health`, which needs no public reachability, no firewall exception and no auth. It now also resolves the exact target sha, and **everything downstream is pinned to it** — the image, its baked `GIT_SHA`, the deployed checkout and the forward-only state file can no longer disagree. Automatic runs still target the *tip* of `origin/main` rather than the triggering commit, so a queued run can't land an older commit on top of a newer one (#794).

Images land in `ghcr.io/21072026/internship` (`prod-<sha>` / `preview-<sha>` / `topic-pr<N>`), pushed with the run's `GITHUB_TOKEN` (`packages: write`) and pulled on the server with the same token (`packages: read`) — no PAT, no new secret. Application secrets are still read from `/etc/internship-crm/*.env` on the server and never enter a workflow.

## Two behaviour changes worth calling out

1. **Preview and topic environments get their green accent + "preview" badge back.** They're now built with `NEXT_PUBLIC_APP_ENV=preview`. The on-server build they replace never passed the build-arg, so preview has been wearing production's blue since #636. Cosmetic only — `IS_PREVIEW` feeds `src/lib/accent.ts` and `BetaBadge.tsx`, nothing else.
2. **Fork PRs no longer get a topic environment.** GitHub keeps their `GITHUB_TOKEN` read-only, so the image can't be pushed, and building unreviewed fork code on the production host isn't worth working around. `ci.yml` + `e2e.yml` still gate them.

## Follow-up the maintainer has to do on the server

`infra/autodeploy.sh` is the break-glass poller and it **does** build locally. I couldn't reach the box from this session (SSH and `https://crm.ersah.in` both time out from here), so I couldn't check whether it's still on a cron. If it is, it should go — this PR documents that in the script header and `infra/README.md`:

```bash
crontab -l | grep -v autodeploy.sh | crontab -
```

## Verification

- All 11 workflow files parse (js-yaml); `bash -n` clean on both changed scripts.
- **This PR is its own end-to-end test of the new build path**: `topic-preview.yml` builds `topic-pr<N>` on `ubuntu-latest`, pushes it to ghcr, and the server pulls and serves it at the topic URL. If the bot comments a working topic-preview link below, the pipeline works.
- No version bump / CHANGELOG / release-notes entry: CI config + infra scripts + docs, which CLAUDE.md exempts. Flagging it in case you read the preview-accent change as user-visible enough to want one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)