### PR TITLE
fix(security): tenant auto-scoping now covers lazily-awaited Prisma queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [Unreleased]
 
+## [0.28.1-beta] - 2026-07-29
+
+### Fixed
+- **Tenant auto-scoping now also covers lazily-awaited Prisma queries** (#958) — Prisma's
+  query promises only execute on their first `.then()`, so
+  `runWithOrg(org, () => prisma.x.findMany())` awaited *outside* the call ran the query
+  after the AsyncLocalStorage context was gone and the central middleware silently skipped
+  the org filter. `runWithOrg` now subscribes to thenable results inside the bound context,
+  so the query always fires with the tenant attached. This was also the deterministic red
+  (`e2e/tenant-isolation.spec.ts:85`) that had kept the scheduled full e2e suite failing
+  since 2026-07-11. No behavior change when `MT_ENFORCE_ISOLATION` is off.
+
+
 ## [0.28.0] - 2026-07-28
 
 ### Fixed

--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -1123,3 +1123,21 @@ yazdım; merge öncesi kontrolde başka bir oturumun **#951 `Initiative` şemsiy
 açıp 8 epic'i ona bağladığı çıktı (ama #951'in kendisi parentsız → board'da iki
 kök). Not yanlış yayınlanacaktı. Kural: hiyerarşi/durum iddiasını `issue_read`
 (`get`/`get_parent`/`get_sub_issues`) ile teyit et, sonra yaz.
+
+## 2026-07-29 — #958 kök neden: lazy PrismaPromise × AsyncLocalStorage
+
+Zamanlanmış tam suite'i 11 Temmuz'dan beri kırmızı tutan deterministik hata
+(`e2e/tenant-isolation.spec.ts:85`) gerçek bir ürün açığıydı: **Prisma sorgu
+promise'leri lazy** — sorgu (ve `$use` middleware'i) ilk `.then()`'de ateşlenir.
+`runWithOrg(org, () => prisma.x.findMany())` deseninde `await` dışarıda olunca
+abonelik ALS bağlamının dışında gerçekleşiyor, middleware `currentOrgId() =
+undefined` görüp org filtresini sessizce atlıyordu. Çözüm: `runWithOrg` thenable
+dönen fn'lerde aboneliği bağlamın içinde başlatır (`new Promise((res, rej) =>
+result.then(res, rej))`). Ders: ALS + lazy-client kombinasyonunda bağlam,
+promise'in YARATILDIĞI yerde değil `.then()`'in çağrıldığı yerde okunur —
+context-bağımlı her sarmalayıcı thenable'ları içeride abone etmeli.
+
+Repro tekniği: hipotezi tek dosyalık geçici bir spec ile izole et (aynı sorgu,
+await içeride vs dışarıda) — `node --experimental-strip-types` repo'nun uzantısız
+relative import'larında çalışmıyor, Playwright runner'ı kullan. Lokal DB: apt
+MariaDB (playbook'taki yol) sorunsuz.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "internship-crm",
-  "version": "0.28.0-beta",
+  "version": "0.28.1-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "internship-crm",
-      "version": "0.28.0-beta",
+      "version": "0.28.1-beta",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.28.0-beta",
+  "version": "0.28.1-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/lib/orgContext.ts
+++ b/src/lib/orgContext.ts
@@ -128,7 +128,21 @@ function ensureTenantMiddleware(): void {
 export function runWithOrg<T>(orgId: string | null, fn: () => T): T {
   if (!isIsolationEnforced()) return fn();
   ensureTenantMiddleware();
-  return storage.run({ orgId }, fn);
+  return storage.run({ orgId }, () => {
+    const result = fn();
+    // Prisma's query promises are LAZY: the request — and therefore the
+    // middleware above — only fires on the first .then() subscription. When a
+    // caller writes `runWithOrg(org, () => prisma.x.findMany())` and awaits
+    // OUTSIDE, that subscription would happen outside this context and the
+    // middleware would silently skip scoping (#958). Subscribing here forces
+    // any lazy thenable to start inside the bound context.
+    if (result && typeof (result as { then?: unknown }).then === 'function') {
+      return new Promise((resolve, reject) => {
+        (result as unknown as PromiseLike<unknown>).then(resolve, reject);
+      }) as T;
+    }
+    return result;
+  });
 }
 
 // Convenience wrapper for API route handlers: resolve the request's org from the

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,21 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.28.1-beta',
+    date: '2026-07-29',
+    highlights: {
+      en: [
+        'Reliability fix in the data-isolation layer for multi-organization setups: a rare code path could run a database query without the organization filter attached. It is now guaranteed to be applied in every case. Single-organization installations are unaffected.',
+      ],
+      tr: [
+        'Çoklu-kuruluş kurulumları için veri izolasyonu katmanında güvenilirlik düzeltmesi: nadir bir kod yolu, veritabanı sorgusunu kuruluş filtresi eklenmeden çalıştırabiliyordu. Artık filtrenin her durumda uygulanması garanti altında. Tek kuruluşlu kurulumlar bu durumdan etkilenmiyordu.',
+      ],
+      de: [
+        'Zuverlässigkeitskorrektur in der Datenisolationsschicht für Installationen mit mehreren Organisationen: Ein seltener Codepfad konnte eine Datenbankabfrage ohne den Organisationsfilter ausführen. Der Filter wird jetzt garantiert in jedem Fall angewendet. Installationen mit nur einer Organisation waren nicht betroffen.',
+      ],
+    },
+  },
+  {
     version: '0.28.0-beta',
     date: '2026-07-28',
     highlights: {


### PR DESCRIPTION
## Ne değişti

**Kök neden (#958):** Prisma sorgu promise'leri **lazy** — sorgu (ve `$use` middleware'i) ilk `.then()` aboneliğinde ateşlenir. `runWithOrg(org, () => prisma.x.findMany())` deseninde `await` dışarıda olduğunda abonelik AsyncLocalStorage bağlamının **dışında** gerçekleşiyordu: middleware `currentOrgId() = undefined` görüp org filtresini sessizce atlıyor ve **diğer tenant'ın satırlarını da döndürüyordu**.

İzole reproyla doğrulandı (lokal MariaDB):
- `await` dışarıda → **2 satır (sızıntı)**
- `await` içeride → 1 satır (doğru)

**Düzeltme:** `runWithOrg` artık thenable dönen fn'lerde aboneliği bağlamın içinde başlatıyor (`new Promise((res, rej) => result.then(res, rej))`) — lazy sorgu her durumda tenant bağlıyken çalışıyor (`src/lib/orgContext.ts:128`).

Davranış değişmeyenler: `MT_ENFORCE_ISOLATION` kapalıyken passthrough aynı; thenable olmayan dönüşler aynı; zaten içeride `await` eden çağıranlar aynı.

**Etkisi:** `e2e/tenant-isolation.spec.ts:85`'i 11 Temmuz'dan beri deterministik kırmızı tutan hata buydu — zamanlanmış tam suite'in yeşile dönmesinin (ve #944 heartbeat mailinin ✅'ya geçmesinin) önündeki bilinen engel kalktı.

## Doğrulama
- Lokal reprodüksiyon: düzeltme öncesi spec kırmızı (CI ile birebir aynı hata), sonrası `e2e/tenant-isolation.spec.ts` **4/4 yeşil** (apt MariaDB + `prisma db push`).
- Lazy/eager izole deney: düzeltme sonrası her iki path de 1 satır.
- `npx tsc --noEmit` temiz.

Sürüm üçlüsü: `0.27.1-beta` + CHANGELOG + releaseNotes (EN/TR/DE).

Closes #958

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqU3Ks9YVsiSWsjmdUuTwc

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqU3Ks9YVsiSWsjmdUuTwc)_