### PR TITLE
test: fix the 9 failing specs in the scheduled full e2e suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,46 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [Unreleased]
 
+### Fixed
+- **The scheduled full e2e suite is green again — 9 failing specs** (#954). The suite's
+  daily schedule had been left commented out since before the Actions quota was
+  restored, so failures accumulated unseen while the `@smoke` PR gate stayed green.
+  None of the nine was a product bug; all were test/locator defects, and three of them
+  masked a second defect behind the first. Verified locally against an apt-installed
+  MariaDB (see `docs/security-audit-playbook.md`).
+  - **`getByText` substring collisions** (`candidates-archive`, `dashboard-links`,
+    `i18n`): `getByText('Inactive')` also matched the seeded address
+    `arch-inactive-…@e2e.local`; `'660 · Hired'` matched both the filter chip and an
+    `<option>` in the stage `<select>`; the TR label `'Davet Gönder'` matched both the
+    sidebar link and the dashboard quick-action card (in EN they differ, so only the
+    Turkish half broke). Fixed with `exact: true`, a new
+    `data-testid="candidates-status-filter-chip"`, and scoping nav assertions to the
+    navigation landmark.
+  - **Post-login navigation race** (`admin-organizations`, `company-shortlist`,
+    `message-attachments`): `waitForURL()` returns as soon as the URL matches, which can
+    be before the sign-in page's push to the role landing page has committed — so a
+    deep-link `goto()` was aborted with *"interrupted by another navigation"*. New
+    `e2e/helpers/auth.ts` exposes `signInAndSettle()` and a `gotoSettled()` that retries
+    only that specific error.
+  - **`admin-organizations`** additionally used `getByLabel('Name', { exact: true })`,
+    but `Input` renders the required marker inside the `<label>`, so the label's text is
+    literally `"Name*"` and an exact match can never succeed. Now an anchored regex —
+    plain `'Name'` would also match `"Brand name"`.
+  - **`message-attachments`** asserted `getByText('screenshot.png')`, but image
+    attachments render as an `<img alt=…>` thumbnail with no text node; only non-image
+    files show the filename. Now scoped to a new `data-testid="pending-attachments"`.
+  - **`project-owners-ui`** was not a removal bug: the member-picker `<select>` lists
+    exactly the users *not* in the project, so a removed member reappears there and a
+    panel-wide text match still found them. Assertions now scope to a new
+    `data-testid="owners-members"`, and the row's remove button gained
+    `data-testid="member-remove-<userId>"` instead of being reached via
+    `locator('div', { hasText }).last()`.
+  - **`project-dm` / `support-chat`** read the database immediately after a UI
+    assertion, assuming the write had committed. Both now use `expect.poll`, which still
+    fails if the row genuinely never appears.
+
+No version bump: test and `data-testid` changes only, no user-visible behaviour change.
+
 ## [0.28.1-beta] - 2026-07-29
 
 ### Fixed

--- a/e2e/admin-organizations.spec.ts
+++ b/e2e/admin-organizations.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { signInAndSettle, gotoSettled } from './helpers/auth';
 
 // Multi-tenancy (#544): super-admin Organizations screen — create a tenant and
 // see it listed with per-tenant counts. Phase 1 is additive (orgId nullable,
@@ -23,18 +24,19 @@ test('admin creates an organization and it appears in the list', async ({ page }
   createdSlugs.push(orgSlug);
 
   try {
-    await page.goto('/auth/signin');
-    await page.fill('input[type="email"], input[name="email"]', adminEmail);
-    await page.fill('input[type="password"]', 'AdminPass123');
-    await page.click('button[type="submit"]');
-    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+    await signInAndSettle(page, adminEmail, 'AdminPass123', '/admin');
 
-    await page.goto('/admin/organizations');
-    await expect(page.getByRole('heading', { name: 'Organizations' })).toBeVisible();
+    await gotoSettled(page, '/admin/organizations');
+    // exact: the list card's title renders "Organizations (N)" and would also match.
+    await expect(page.getByRole('heading', { name: 'Organizations', exact: true })).toBeVisible();
 
     // Create via the form.
-    await page.getByLabel('Name', { exact: true }).fill(orgName);
-    await page.getByLabel('Slug', { exact: true }).fill(orgSlug);
+    // `Input` renders the required marker inside the <label>, so this label's
+    // text is literally "Name*" — getByLabel matches label text content, so an
+    // exact 'Name' never matches. A plain non-exact 'Name' would also hit
+    // "Brand name", hence the anchored regex.
+    await page.getByLabel(/^Name\*?$/).fill(orgName);
+    await page.getByLabel(/^Slug\*?$/).fill(orgSlug);
     await page.getByRole('button', { name: 'Create' }).click();
 
     // New org row shows up with its slug.

--- a/e2e/candidates-archive.spec.ts
+++ b/e2e/candidates-archive.spec.ts
@@ -32,7 +32,9 @@ test('deactivated candidates are archived and hidden from the default list', asy
     // Archive view: the deactivated candidate shows (with its Inactive badge), the active one does not.
     await page.getByTestId('candidates-tab-archived').click();
     await expect(page.getByTestId(`candidate-card-${archivedMentee.id}`)).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByTestId(`candidate-card-${archivedMentee.id}`).getByText('Inactive')).toBeVisible();
+    await expect(
+      page.getByTestId(`candidate-card-${archivedMentee.id}`).getByText('Inactive', { exact: true })
+    ).toBeVisible();
     await expect(page.getByTestId(`candidate-card-${activeMentee.id}`)).toHaveCount(0);
 
     // Back to Active.

--- a/e2e/company-shortlist.spec.ts
+++ b/e2e/company-shortlist.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import bcrypt from 'bcryptjs';
 import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { signInAndSettle, gotoSettled } from './helpers/auth';
 
 test.afterAll(async () => {
   await prisma.$disconnect();
@@ -33,13 +34,9 @@ test('a company can shortlist a linked candidate; the mentor is notified and see
 
   try {
     // Company sets a shortlist with a note.
-    await page.goto('/auth/signin');
-    await page.fill('input[type="email"], input[name="email"]', companyEmail);
-    await page.fill('input[type="password"]', pw);
-    await page.click('button[type="submit"]');
-    await page.waitForURL((u) => u.pathname.startsWith('/company'), { timeout: 20_000 });
+    await signInAndSettle(page, companyEmail, pw, '/company');
 
-    await page.goto(`/company/candidates/${mentee.id}`);
+    await gotoSettled(page, `/company/candidates/${mentee.id}`);
     await page.fill('textarea', 'Great fit for backend team.');
     await page.getByRole('button', { name: /Shortlisted/i }).click();
     await expect(page.getByText(/mentor has been notified/i)).toBeVisible({ timeout: 10_000 });

--- a/e2e/dashboard-links.spec.ts
+++ b/e2e/dashboard-links.spec.ts
@@ -36,7 +36,9 @@ test('candidates can be filtered by pipeline stage via ?status=', async ({ page 
     // Filtered candidate list (as the dashboard pipeline bar links)
     await page.goto('/admin/candidates?status=HIRED_660');
     await page.waitForTimeout(1200);
-    await expect(page.getByText('660 · Hired')).toBeVisible(); // filter chip
+    // Target the chip by testid: its label also renders as an <option> in the
+    // "All stages" select, so matching on text is a strict-mode violation.
+    await expect(page.getByTestId('candidates-status-filter-chip')).toContainText('660 · Hired');
     await expect(page.getByText('ZZ InStage Mentee')).toBeVisible();
     await expect(page.getByText('ZZ OutStage Mentee')).toHaveCount(0);
 

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -1,0 +1,43 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * Sign in through the UI and wait until the post-login redirect chain has
+ * actually settled.
+ *
+ * WHY THIS EXISTS: `page.waitForURL()` resolves the moment the URL matches, which
+ * can be *before* the sign-in page's push to the role landing page has finished
+ * committing. A deep-link `page.goto()` issued in that window is aborted by
+ * Playwright with:
+ *
+ *   page.goto: Navigation to "/admin/organizations" is interrupted by
+ *   another navigation to "/admin"
+ *
+ * That killed admin-organizations, company-shortlist and message-attachments in
+ * the scheduled full run. Waiting for the network to go quiet lets the landing
+ * navigation finish first.
+ */
+export async function signInAndSettle(page: Page, email: string, password: string, landing: string) {
+  await page.goto('/auth/signin');
+  await page.fill('input[type="email"], input[name="email"]', email);
+  await page.fill('input[type="password"]', password);
+  await page.click('button[type="submit"]');
+  await page.waitForURL((u) => u.pathname.startsWith(landing), { timeout: 20_000 });
+  await page.waitForLoadState('networkidle');
+}
+
+/**
+ * `page.goto()` that tolerates losing a race with an in-flight client-side
+ * navigation. `signInAndSettle` should make this unnecessary, but the redirect
+ * is driven by React state we don't control, so retrying once is cheaper than a
+ * flaky scheduled run. Only the specific "interrupted" error is retried —
+ * anything else propagates untouched.
+ */
+export async function gotoSettled(page: Page, url: string) {
+  try {
+    await page.goto(url);
+  } catch (error) {
+    if (!/interrupted by another navigation/i.test(String(error))) throw error;
+    await page.waitForLoadState('networkidle');
+    await page.goto(url);
+  }
+}

--- a/e2e/i18n.spec.ts
+++ b/e2e/i18n.spec.ts
@@ -4,6 +4,9 @@ const ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@example.com';
 const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'ChangeMe123!';
 
 test('language switcher toggles the admin nav between EN and TR', async ({ page }) => {
+  // The sidebar nav and the dashboard quick-action cards share labels once
+  // translated, so every nav assertion is scoped to the navigation landmark.
+  const nav = () => page.getByRole('navigation');
   await page.goto('/auth/signin');
   await page.fill('input[type="email"], input[name="email"]', ADMIN_EMAIL);
   await page.fill('input[type="password"]', ADMIN_PASSWORD);
@@ -12,20 +15,20 @@ test('language switcher toggles the admin nav between EN and TR', async ({ page 
   await page.goto('/admin');
 
   // Default locale is English (exact avoids matching the "Send Invitations" card)
-  await expect(page.getByRole('link', { name: 'Send Invitation', exact: true })).toBeVisible();
+  await expect(nav().getByRole('link', { name: 'Send Invitation', exact: true })).toBeVisible();
 
   // Switch to Turkish — the switcher lives in the account menu; open it, then
   // clicking TR sets a cookie and reloads.
-  await page.locator('button[aria-haspopup="menu"]').click();
+  await page.getByLabel('Account').click();
   await page.getByRole('button', { name: 'tr' }).click();
   await page.waitForLoadState('load');
-  await expect(page.getByRole('link', { name: 'Davet Gönder', exact: true })).toBeVisible();
-  await expect(page.getByRole('link', { name: 'Adaylar', exact: true })).toBeVisible();
+  await expect(nav().getByRole('link', { name: 'Davet Gönder', exact: true })).toBeVisible();
+  await expect(nav().getByRole('link', { name: 'Adaylar', exact: true })).toBeVisible();
 
   // Page content (not just nav) is translated too
   await expect(page.getByRole('heading', { name: 'Yönetim Paneli', level: 1 })).toBeVisible();
 
   // Preference persists across navigations (cookie-based)
   await page.goto('/admin/mentorship');
-  await expect(page.getByRole('link', { name: 'Davet Gönder', exact: true })).toBeVisible();
+  await expect(nav().getByRole('link', { name: 'Davet Gönder', exact: true })).toBeVisible();
 });

--- a/e2e/message-attachments.spec.ts
+++ b/e2e/message-attachments.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { signInAndSettle, gotoSettled } from './helpers/auth';
 
 test.afterAll(async () => {
   await prisma.$disconnect();
@@ -21,19 +22,18 @@ test('sending a message with an image attachment shows it inline and enforces ac
   const rel = await prisma.mentorshipRelation.create({ data: { mentorId: mentor.id, menteeId: mentee.id } });
 
   try {
-    await page.goto('/auth/signin');
-    await page.fill('input[type="email"], input[name="email"]', mentorEmail);
-    await page.fill('input[type="password"]', 'MentorPass123');
-    await page.click('button[type="submit"]');
-    await page.waitForURL((u) => u.pathname.startsWith('/mentor'), { timeout: 20_000 });
+    await signInAndSettle(page, mentorEmail, 'MentorPass123', '/mentor');
 
-    await page.goto(`/messages/${rel.id}`);
+    await gotoSettled(page, `/messages/${rel.id}`);
     await page.getByTestId('message-attachment-input').setInputFiles({
       name: 'screenshot.png',
       mimeType: 'image/png',
       buffer: PNG_BYTES,
     });
-    await expect(page.getByText('screenshot.png')).toBeVisible();
+    // Images render as a thumbnail in the pending list (alt=filename), not as text.
+    await expect(
+      page.getByTestId('pending-attachments').locator('img[alt="screenshot.png"]')
+    ).toBeVisible();
 
     const done = page.waitForResponse((r) => r.url().includes('/api/messages') && r.request().method() === 'POST');
     await page.getByRole('button', { name: 'Send' }).click();

--- a/e2e/project-dm.spec.ts
+++ b/e2e/project-dm.spec.ts
@@ -61,6 +61,11 @@ test('project co-members can start a DM, and lose the composer when the project 
     await expect(page.getByText('Hello from the same project!')).toBeVisible({ timeout: 10_000 });
 
     // Stored against the conversation, not a mentorship relation.
+    // Poll: the message being on screen does not guarantee the row is already
+    // committed, and asserting immediately made this flaky in the scheduled run.
+    await expect
+      .poll(async () => prisma.message.count({ where: { conversationId } }), { timeout: 10_000 })
+      .toBeGreaterThan(0);
     const stored = await prisma.message.findFirst({ where: { conversationId }, select: { relationId: true } });
     expect(stored).not.toBeNull();
     expect(stored!.relationId).toBeNull();

--- a/e2e/project-owners-ui.spec.ts
+++ b/e2e/project-owners-ui.spec.ts
@@ -35,20 +35,27 @@ test('owners panel: add an owner from the picker; last-owner removal shows the e
     await expect(card).toBeVisible({ timeout: 10_000 });
     await card.getByTestId('manage-owners').click();
     const panel = card.getByTestId('owners-panel');
+    // Scope to the member list: the panel also contains the member-picker
+    // <select>, whose options are the users NOT in the project — so a removed
+    // member reappears there and a panel-wide text match still finds them.
+    const members = panel.getByTestId('owners-members');
     await expect(panel).toBeVisible();
-    await expect(panel.getByText('Owners Admin')).toBeVisible();
+    await expect(members.getByText('Owners Admin')).toBeVisible();
 
     // Add the mentor as a second OWNER from the picker.
     await panel.getByTestId('member-picker').selectOption(mentor.id);
     await panel.locator('select').nth(1).selectOption('OWNER');
     await panel.getByTestId('member-add').click();
-    await expect(panel.getByText('Owners Mentor')).toBeVisible({ timeout: 10_000 });
+    await expect(members.getByText('Owners Mentor')).toBeVisible({ timeout: 10_000 });
     expect(await prisma.projectMember.count({ where: { projectId: project.id, role: 'OWNER' } })).toBe(2);
 
     // Remove the mentor again, then try to remove the last owner → inline error.
-    await panel.locator('div', { hasText: 'Owners Mentor' }).last().getByRole('button').click();
-    await expect(panel.getByText('Owners Mentor')).toHaveCount(0, { timeout: 10_000 });
-    await panel.locator('div', { hasText: 'Owners Admin' }).last().getByRole('button').click();
+    // Target the row's own remove button by id: `locator('div', { hasText })`
+    // matches every ancestor div containing the name, and .last() is not
+    // reliably the member row, so the click could land on another button.
+    await panel.getByTestId(`member-remove-${mentor.id}`).click();
+    await expect(members.getByText('Owners Mentor')).toHaveCount(0, { timeout: 10_000 });
+    await panel.getByTestId(`member-remove-${admin.id}`).click();
     await expect(panel.getByText('at least one owner', { exact: false })).toBeVisible({ timeout: 10_000 });
   } finally {
     await ctx.close();

--- a/e2e/support-chat.spec.ts
+++ b/e2e/support-chat.spec.ts
@@ -63,7 +63,13 @@ test('support chat: first message opens a ticket, next one appends, admin is not
     await page.getByTestId('support-input').fill('Sent from the chat box.');
     await page.getByTestId('support-send').click();
     await expect(page.getByText('Sent from the chat box.', { exact: false })).toBeVisible({ timeout: 10_000 });
-    expect(await prisma.supportMessage.count({ where: { ticketId: firstJson.ticketId } })).toBe(3);
+    // Poll rather than reading once: the rendered message does not prove the
+    // insert has committed, which made this intermittently fail at 2 of 3.
+    await expect
+      .poll(async () => prisma.supportMessage.count({ where: { ticketId: firstJson.ticketId } }), {
+        timeout: 10_000,
+      })
+      .toBe(3);
 
     // Text is optional when at least one valid attachment is present.
     const attachmentOnly = await page.request.post('/api/support', {

--- a/src/app/admin/candidates/page.tsx
+++ b/src/app/admin/candidates/page.tsx
@@ -217,7 +217,7 @@ export default function CandidatesPage() {
         <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.candidates.title}</h1>
         <p className="text-gray-500 mt-1">{t.candidates.subtitle}</p>
         {statusFilter && (
-          <div className="mt-3 inline-flex items-center gap-2 bg-blue-50 border border-blue-200 rounded-full px-3 py-1 text-sm text-blue-700">
+          <div data-testid="candidates-status-filter-chip" className="mt-3 inline-flex items-center gap-2 bg-blue-50 border border-blue-200 rounded-full px-3 py-1 text-sm text-blue-700">
             {label(statusFilter)}
             <button
               type="button"

--- a/src/components/MessageThread.tsx
+++ b/src/components/MessageThread.tsx
@@ -35,7 +35,7 @@ export function PendingAttachmentList({ attachments, onRemove, removeLabel }: {
 }) {
   if (!attachments.length) return null;
   return (
-    <div className="flex flex-wrap items-start gap-2 mb-2">
+    <div data-testid="pending-attachments" className="flex flex-wrap items-start gap-2 mb-2">
       {attachments.map((attachment, index) => (
         <div key={attachment.url} className="relative group">
           {attachment.file.type.startsWith('image/') ? (

--- a/src/components/ProjectsManager.tsx
+++ b/src/components/ProjectsManager.tsx
@@ -419,7 +419,7 @@ export function ProjectsManager({ isAdmin }: { isAdmin: boolean }) {
                   <div className="mt-3 pt-3 border-t border-gray-100 dark:border-gray-800" data-testid="owners-panel">
                     <p className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-2">{t.projects.manageOwners}</p>
                     {memberErr && <p className="text-xs text-red-600 mb-2">{memberErr}</p>}
-                    <div className="space-y-1 mb-3">
+                    <div className="space-y-1 mb-3" data-testid="owners-members">
                       {(p.members ?? []).map((m) => (
                         <div key={m.user.id} className="flex items-center gap-2 text-sm">
                           <Badge variant={m.role === 'OWNER' ? 'info' : m.role === 'MENTEE' ? 'purple' : 'default'} className="text-xs">
@@ -438,7 +438,7 @@ export function ProjectsManager({ isAdmin }: { isAdmin: boolean }) {
                               return <span className="ml-1.5 text-xs text-gray-400">· {t.membership.inProjectFor.replace('{d}', `${count} ${noun}`)}</span>;
                             })()}
                           </span>
-                          <button onClick={() => memberCall(p.id, 'DELETE', { userId: m.user.id })} aria-label={t.common.delete} className="text-gray-300 hover:text-red-600"><Trash2 className="h-3.5 w-3.5" /></button>
+                          <button onClick={() => memberCall(p.id, 'DELETE', { userId: m.user.id })} aria-label={t.common.delete} data-testid={`member-remove-${m.user.id}`} className="text-gray-300 hover:text-red-600"><Trash2 className="h-3.5 w-3.5" /></button>
                         </div>
                       ))}
                     </div>


### PR DESCRIPTION
## Summary

The scheduled full run reported **9 failures**. **None is a product bug** — all nine are test defects, and three specs were hiding a *second* defect behind the first.

Closes #954

Verified locally: I stood up MariaDB via apt in the container (the route documented in `docs/security-audit-playbook.md`) and ran every spec in CI mode, so each fix is **confirmed** rather than reasoned about. Previously these could not be run here at all.

## Changes

### `getByText` substring collisions (3)

- **`candidates-archive`** — `getByText('Inactive')` matched two nodes: the badge *and* the seeded address `arch-inactive-…@e2e.local`, which contains "inactive". Now `{ exact: true }`.
- **`dashboard-links`** — `'660 · Hired'` matched both the filter chip and an `<option>` in the stage `<select>`. The chip gained `data-testid="candidates-status-filter-chip"`.
- **`i18n`** — the Turkish label `'Davet Gönder'` matched both the sidebar link and the dashboard quick-action card. In English those strings differ (`Send Invitation` vs `Send Invitations`), so **only the Turkish half ever broke**. Nav assertions now scope to the navigation landmark. Also stopped selecting the account button via `aria-haspopup`, which `next dev` puts on its Dev Tools button too — that broke local runs while passing in CI.

### Post-login navigation race (3)

`admin-organizations`, `company-shortlist`, `message-attachments` all failed with:

```
page.goto: Navigation to "/admin/organizations" is interrupted by
another navigation to "/admin"
```

`waitForURL()` resolves the moment the URL matches, which can be *before* the sign-in page's push to the role landing page has committed — so a deep-link `goto()` issued right after gets aborted. New `e2e/helpers/auth.ts` provides `signInAndSettle()` (waits for the redirect chain to go quiet) and `gotoSettled()` (retries **only** that specific error).

### Second defects the navigation failures were masking

These never got reached in CI because the spec died earlier:

- **`admin-organizations`** used `getByLabel('Name', { exact: true })`, but `Input` renders the required marker *inside* the `<label>`, so the label's text is literally `"Name*"` — an exact match can never succeed. Now an anchored regex; plain `'Name'` would also match `"Brand name"`. Worth recording: marking the asterisk `aria-hidden` does **not** fix this — `getByLabel` matches label text content, not the accessible name. I tried it, confirmed it fails, and reverted.
- **`message-attachments`** asserted `getByText('screenshot.png')`, but image attachments render as an `<img alt=…>` thumbnail with **no text node**; only non-image files render the filename. Scoped to a new `data-testid="pending-attachments"`.

### Not what it looked like (1)

- **`project-owners-ui`** was **not** a removal bug. The member-picker `<select>` lists exactly the users *not* in the project, so a removed member immediately reappears there — and a panel-wide text match still found them. The removal was working the whole time. Assertions now scope to a new `data-testid="owners-members"`, and each row's remove button carries `data-testid="member-remove-<userId>"` instead of being reached via `locator('div', { hasText }).last()`, which matches every ancestor div and whose `.last()` is not reliably the member row.

### Read-after-write races (2)

- **`project-dm`** and **`support-chat`** both queried the database immediately after a UI assertion, assuming the insert had committed. Both now use `expect.poll`, which still fails if the row genuinely never arrives — so a real write bug would not be masked.

## Verification

- [x] `npx tsc --noEmit` clean; `next build` clean
- [x] Each of the 9 specs reproduced locally, then verified passing
- [x] Full suite locally: **274 passed**. The 9 are gone.
- [ ] Two *other* specs (`mentee-detail-feedback`, `notes`) failed and 14 went flaky when running `--workers=4` against a single local server and shared DB; all pass serially. CI shards into 4 isolated jobs with their own MySQL, so this is a local-parallelism artifact — but flagging it rather than hiding it.

No version bump: tests and `data-testid` attributes only, no user-visible behaviour change (recorded under `## [Unreleased]`).

## Note on the schedule

#956 restored the 4×/day cron while the suite was red, so alert emails have been firing at 03/09/15/21 UTC. This should stop them. The remaining known-flaky specs in CI's own run (6 in the report that prompted this) are a separate, smaller problem.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGLj5Y2FsaTjFvAYu139rq)_