### PR TITLE
test: fix the 2 reds + 1 flake in the scheduled full e2e run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,32 @@ version is shown in the sidebar footer of every page (links to the
 ## [Unreleased]
 
 ### Fixed
+- **Scheduled full e2e suite: the 2 reds and 1 flake left by run
+  [30608852159](https://github.com/21072026/Internship/actions/runs/30608852159)**
+  (#963). Again no product bug — all three are test defects.
+  - **`evaluation-goals`** still asserted the goals panel's old `"0/2 completed"`
+    progress bar and its `0%` label. #785 (PR #786) replaced that bar with the
+    `goals-active-count` / `goals-completed-count` counters, but the merge kept
+    main's `GoalsPanel` (from #918) *and* the branch's spec, so the spec asserted
+    markup that no longer exists. It now asserts the counters, like the
+    `goals-archive-sort` spec that shipped with the same feature.
+  - **`meeting-requests`** switches user mid-test, and `clearCookies()` alone does
+    not end the old session: the page being left keeps hitting
+    `/api/auth/session`, and NextAuth re-issues the session cookie on those
+    responses — one landing just after the clear restores it. `/auth/signin` then
+    saw `status === 'authenticated'` and redirected to the *previous* user's
+    dashboard mid-typing, so `page.click('button[type="submit"]')` re-resolved
+    against the mentee portal and spent the whole action timeout retrying its
+    disabled "Add goal" button. New `signInAsFreshUser()` in `e2e/helpers/auth.ts`
+    tears the old page down (`about:blank`) before dropping the session cookie,
+    keeps the consent cookie seeded by `storageState`, and clicks the submit
+    button *inside the sign-in form*, so a stray redirect fails fast instead of
+    clicking something unrelated. `evaluation-goals` uses it too.
+  - **`notes`** (the run's flake) read the database straight after
+    `expect(page.getByText('Prepare portfolio for interview')).toBeVisible()` —
+    but Playwright's text matching includes `<textarea>` values, so that matched
+    the text just typed into the still-open editor and the read raced the PATCH.
+    It now waits for the editor to close first.
 - **The scheduled full e2e suite is green again — 9 failing specs** (#954). The suite's
   daily schedule had been left commented out since before the Actions quota was
   restored, so failures accumulated unseen while the `@smoke` PR gate stayed green.

--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -1141,3 +1141,47 @@ Repro tekniği: hipotezi tek dosyalık geçici bir spec ile izole et (aynı sorg
 await içeride vs dışarıda) — `node --experimental-strip-types` repo'nun uzantısız
 relative import'larında çalışmıyor, Playwright runner'ı kullan. Lokal DB: apt
 MariaDB (playbook'taki yol) sorunsuz.
+
+## 2026-07-31 — Zamanlanmış koşunun 2 kırmızısı: merge'den kalan "hayalet" assertion + oturum değiştirme yarışı
+
+**Bir merge, bileşeni main'den + spec'i branch'ten alabilir.** #786
+(goals sıralama/arşiv) merge edilirken `GoalsPanel` main'in sürümüyle (#918,
+sayaçlar) çözülmüş ama spec branch'in sürümüyle (ilerleme çubuğu, `0/2
+completed`) kalmış → spec artık hiç render edilmeyen markup'ı doğruluyordu. PR
+gate sadece `@smoke` koştuğu için bu drift ancak gece koşusunda görüldü. Ders:
+aynı özelliğin UI'ı ve spec'i birlikte çakıştıysa **ikisini birden oku**;
+`git log -S'<assertion metni>' -- <spec>` ve `git show <branch-tip>:<component>`
+hangi tarafın kazandığını 10 saniyede söylüyor. Yan kontrol: aynı özelliğin
+*diğer* spec'i (`goals-archive-sort`) doğru sayaçları kullanıyordu — iki spec
+aynı UI için farklı şey iddia ediyorsa biri bayattır.
+
+**`clearCookies()` NextAuth oturumunu bitirmeye yetmiyor.** Ayrılmakta olduğun
+sayfa `/api/auth/session`'ı çağırmayı sürdürüyor ve NextAuth bu yanıtlarda
+session cookie'sini yeniden yazıyor; temizlikten hemen sonra düşen bir yanıt
+oturumu geri getiriyor. `/auth/signin` `status === 'authenticated'` görüp bir
+önceki kullanıcının paneline yönleniyor — test hâlâ forma yazarken. Doğrusu:
+önce `page.goto('about:blank')` (eski sayfa ve istekleri ölsün), sonra temizlik,
+üstelik **sadece** `next-auth.session-token` — komple `clearCookies()`
+`storageState`'ten gelen consent cookie'sini de siliyor ve banner formun üstüne
+geri geliyor. `e2e/helpers/auth.ts` → `signInAsFreshUser()`.
+
+**Kapsamlanmamış locator, yönlendirmede başka sayfada bir butona bağlanıyor.**
+`page.click('button[type="submit"]')` yönlendirmeden sonra mentee portalındaki
+*disabled* "Add goal" butonuna denk geldi ve 15 sn action timeout'u boyunca
+sessizce onu denedi. Submit'i formun içine kapsamla
+(`page.locator('form', { has: page.locator('input[type="password"]') })`) —
+yönlendirme olursa test hızlı ve okunur şekilde düşer.
+
+**Playwright'ın `getByText`'i `<textarea>`/`<input>` value'larını da eşliyor.**
+`notes.spec` düzenlemeden hemen sonra `getByText('<yeni metin>')` bekliyordu; bu
+daha PATCH gönderilmeden, açık editöre yazdığımız metinle eşleşti ve peşindeki
+Prisma okuması yazmayla yarıştı (flaky). Doğrusu: editörün kapanmasını bekle
+(`expect(note.locator('textarea')).toHaveCount(0)`), sonra metni/DB'yi doğrula.
+
+**Teşhis yolu:** `gh run view --log-failed` bu repoda sadece cleanup loglarını
+döküyor (asıl hata "Run full E2E suite" adımının içinde). İşe yarayan:
+`gh run view --log --job <id>` (worktree'de cwd repo kökü değilse `-R owner/repo`
+şart) + `gh api repos/<o>/<r>/actions/artifacts/<id>/zip` ile
+`playwright-report-full-shard-N`'i indirip `data/*.md` (error-context) ve
+failure screenshot'ına bakmak — ekran görüntüsü "mentee portalındayız" diyerek
+hipotezi tek karede doğruladı.

--- a/e2e/evaluation-goals.spec.ts
+++ b/e2e/evaluation-goals.spec.ts
@@ -1,18 +1,10 @@
 import { test, expect } from '@playwright/test';
 import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { signInAsFreshUser } from './helpers/auth';
 
 test.afterAll(async () => {
   await prisma.$disconnect();
 });
-
-async function signIn(page: import('@playwright/test').Page, email: string, password: string, home: string) {
-  await page.context().clearCookies();
-  await page.goto('/auth/signin');
-  await page.fill('input[type="email"], input[name="email"]', email);
-  await page.fill('input[type="password"]', password);
-  await page.click('button[type="submit"]');
-  await page.waitForURL((u) => u.pathname.startsWith(home), { timeout: 20_000 });
-}
 
 test('two-way evaluations with interim/final type, and goal tracking', async ({ page }) => {
   const mentorEmail = uniqueEmail('eg-mentor');
@@ -23,7 +15,7 @@ test('two-way evaluations with interim/final type, and goal tracking', async ({ 
 
   try {
     // Mentor records a FINAL evaluation of the mentee and a goal.
-    await signIn(page, mentorEmail, 'MentorPass123', '/mentor');
+    await signInAsFreshUser(page, mentorEmail, 'MentorPass123', '/mentor');
     const evalRes = await page.request.post('/api/evaluations', {
       data: { relationId: rel.id, type: 'FINAL', scores: { technical: 5, communication: 4 }, comment: 'Great work' },
     });
@@ -42,7 +34,7 @@ test('two-way evaluations with interim/final type, and goal tracking', async ({ 
     });
 
     // Mentee evaluates their mentor (two-way) using the mentor rubric.
-    await signIn(page, menteeEmail, 'MenteePass123', '/portal');
+    await signInAsFreshUser(page, menteeEmail, 'MenteePass123', '/portal');
     const menteeEval = await page.request.post('/api/evaluations', {
       data: { relationId: rel.id, type: 'INTERIM', scores: { guidance: 5, support: 5 } },
     });
@@ -64,13 +56,15 @@ test('two-way evaluations with interim/final type, and goal tracking', async ({ 
     await page.goto('/portal');
     const activeGoals = page.getByTestId('active-goals').locator('[data-testid^="goal-"]');
     await expect(activeGoals).toHaveCount(2);
-    await expect(page.getByText('0/2 completed')).toBeVisible();
-    await expect(page.getByText('0/2 completed').locator('..').getByText('0%', { exact: true })).toBeVisible();
+    // Two counters, not a progress bar: the panel dropped the "x/y completed"
+    // percentage when the archive landed (#785), so assert the counters.
+    await expect(page.getByTestId('goals-active-count')).toContainText('2');
+    await expect(page.getByTestId('goals-completed-count')).toContainText('1');
     await expect(activeGoals.nth(0)).toContainText('Newer active goal');
     await expect(page.getByTestId('active-goals').getByText('Ship the project')).toHaveCount(0);
     await expect(page.getByTestId('goals-archive')).toHaveCount(0);
 
-    await page.getByRole('button', { name: 'Archive' }).click();
+    await page.getByRole('button', { name: 'Archive', exact: true }).click();
     await expect(page.getByTestId('goals-archive').getByText('Ship the project')).toBeVisible();
 
     await page.getByLabel('Sort by').selectOption('oldest');
@@ -78,7 +72,7 @@ test('two-way evaluations with interim/final type, and goal tracking', async ({ 
 
     const olderGoal = activeGoals.nth(0);
     await olderGoal.getByRole('button', { name: 'Edit' }).click();
-    await olderGoal.getByLabel('Goal').fill('Updated active goal');
+    await olderGoal.getByLabel('Goal', { exact: true }).fill('Updated active goal');
     await olderGoal.getByRole('button', { name: 'Save' }).click();
     await expect(olderGoal).toContainText('Updated active goal');
   } finally {

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -26,6 +26,40 @@ export async function signInAndSettle(page: Page, email: string, password: strin
 }
 
 /**
+ * Sign in as a *different* user than the one currently signed in.
+ *
+ * WHY THIS EXISTS: `clearCookies()` immediately before `goto('/auth/signin')`
+ * is not enough. The page we are leaving keeps talking to
+ * `/api/auth/session`, and NextAuth re-issues the session cookie on those
+ * responses — one landing just after the clear puts the old session straight
+ * back. `/auth/signin` then sees `status === 'authenticated'` and
+ * `router.replace()`s to the *previous* user's dashboard while the test is
+ * still typing into the form, so `page.click('button[type="submit"]')`
+ * re-resolves against that dashboard. In the scheduled run it settled on the
+ * mentee portal's disabled "Add goal" button and retried it until the action
+ * timeout (meeting-requests, #965 follow-up).
+ *
+ * Two guards: going to `about:blank` first tears the old page (and its
+ * requests) down *before* the session cookie is dropped, and the submit button
+ * is looked up inside the sign-in form itself, so a stray redirect fails
+ * loudly instead of clicking something unrelated on another page.
+ *
+ * Only the NextAuth session cookie is cleared — a blanket `clearCookies()`
+ * would also drop the cookie-consent state seeded via `storageState`, bringing
+ * the consent banner back over the form.
+ */
+export async function signInAsFreshUser(page: Page, email: string, password: string, landing: string) {
+  await page.goto('about:blank');
+  await page.context().clearCookies({ name: /next-auth\.session-token/ });
+  await page.goto('/auth/signin');
+  const form = page.locator('form', { has: page.locator('input[type="password"]') });
+  await form.locator('input[type="email"], input[name="email"]').fill(email);
+  await form.locator('input[type="password"]').fill(password);
+  await form.locator('button[type="submit"]').click();
+  await page.waitForURL((u) => u.pathname.startsWith(landing), { timeout: 20_000 });
+}
+
+/**
  * `page.goto()` that tolerates losing a race with an in-flight client-side
  * navigation. `signInAndSettle` should make this unnecessary, but the redirect
  * is driven by React state we don't control, so retrying once is cheaper than a

--- a/e2e/meeting-requests.spec.ts
+++ b/e2e/meeting-requests.spec.ts
@@ -1,18 +1,10 @@
 import { test, expect } from '@playwright/test';
 import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { signInAsFreshUser } from './helpers/auth';
 
 test.afterAll(async () => {
   await prisma.$disconnect();
 });
-
-async function signIn(page: import('@playwright/test').Page, email: string, password: string, home: string) {
-  await page.context().clearCookies();
-  await page.goto('/auth/signin');
-  await page.fill('input[type="email"], input[name="email"]', email);
-  await page.fill('input[type="password"]', password);
-  await page.click('button[type="submit"]');
-  await page.waitForURL((u) => u.pathname.startsWith(home), { timeout: 20_000 });
-}
 
 test('mentee requests a meeting and the mentor accepting creates a meeting', async ({ page }) => {
   const mentorEmail = uniqueEmail('mr-mentor');
@@ -24,7 +16,7 @@ test('mentee requests a meeting and the mentor accepting creates a meeting', asy
 
   try {
     // Mentee requests a meeting.
-    await signIn(page, menteeEmail, 'MenteePass123', '/portal');
+    await signInAsFreshUser(page, menteeEmail, 'MenteePass123', '/portal');
     const created = await page.request.post('/api/meeting-requests', {
       data: { relationId: rel.id, topic: 'Career advice', proposedAt: new Date(Date.now() + 86400000).toISOString() },
     });
@@ -32,7 +24,7 @@ test('mentee requests a meeting and the mentor accepting creates a meeting', asy
     reqId = (await created.json()).request.id;
 
     // Mentor accepts → a Meeting is created and the request is ACCEPTED.
-    await signIn(page, mentorEmail, 'MentorPass123', '/mentor');
+    await signInAsFreshUser(page, mentorEmail, 'MentorPass123', '/mentor');
     const accept = await page.request.patch(`/api/meeting-requests/${reqId}`, { data: { action: 'accept' } });
     expect(accept.ok()).toBeTruthy();
     expect((await accept.json()).status).toBe('ACCEPTED');

--- a/e2e/notes.spec.ts
+++ b/e2e/notes.spec.ts
@@ -44,7 +44,13 @@ test('mentee can create, edit, and delete private personal notes (owner-only)', 
     // Saving through the UI persists and displays the revised note.
     await note.locator('textarea').fill('Prepare portfolio for interview');
     await note.getByRole('button', { name: 'Save' }).click();
-    await expect(page.getByText('Prepare portfolio for interview')).toBeVisible({ timeout: 10_000 });
+    // Wait for the editor to close rather than for the text to show up:
+    // Playwright's text matching includes <textarea> values, so getByText()
+    // matched what we had just typed — before the PATCH had even been sent —
+    // and the database read below then raced the write (flaky in the scheduled
+    // run). The panel only drops the textarea after the PATCH resolved.
+    await expect(note.locator('textarea')).toHaveCount(0, { timeout: 10_000 });
+    await expect(note.getByText('Prepare portfolio for interview')).toBeVisible();
     expect((await prisma.personalNote.findUnique({ where: { id: noteId } }))?.body).toBe('Prepare portfolio for interview');
 
     // Another user cannot edit/delete it (owner-only).


### PR DESCRIPTION
Run [30608852159](https://github.com/21072026/Internship/actions/runs/30608852159) (2026-07-31 03:00 UTC) reported **288/291**: two deterministic failures and one flake. None of the three is a product bug.

Refs #963.

### 1. `evaluation-goals` — stale assertions kept by a merge

The spec still asserted the goals panel's old progress bar:

```ts
await expect(page.getByText('0/2 completed')).toBeVisible();
await expect(page.getByText('0/2 completed').locator('..').getByText('0%', { exact: true })).toBeVisible();
```

#785 (PR #786) replaced that bar with the `goals-active-count` / `goals-completed-count` counters. The merge (85df9f7) took **main's** `GoalsPanel` (the counters version from #918) together with **the branch's** spec, so the spec asserts markup that no longer renders. `goals-archive-sort.spec.ts`, which shipped with the same feature, already asserts the counters — `evaluation-goals` now does the same (3 goals: 2 active, 1 completed).

### 2. `meeting-requests` — sign-in clicked a button on the wrong page

```
locator resolved to 5 elements. Proceeding with the first one:
<button disabled type="submit" …>Add</button>
  - element is not enabled … (15s)
```

The test switches user mid-test, and `clearCookies()` alone does not end the old session: the page being left keeps calling `/api/auth/session`, and NextAuth re-issues the session cookie on those responses — one landing just after the clear restores it. `/auth/signin` then sees `status === 'authenticated'` and `router.replace()`s to the *previous* user's dashboard while the test is still typing, so the unscoped `page.click('button[type="submit"]')` re-resolves against that dashboard. The failure screenshot in `playwright-report-full-shard-3` is the **mentee portal**, and the button being retried is its disabled "Add goal".

New `signInAsFreshUser()` in `e2e/helpers/auth.ts`:
- `goto('about:blank')` first, so the old page and its in-flight requests are gone *before* the session cookie is dropped;
- clears only the NextAuth session cookie — a blanket `clearCookies()` also drops the cookie-consent state seeded via `storageState`, which brings the banner back over the form;
- clicks the submit button **inside the sign-in form**, so a stray redirect fails fast instead of clicking something unrelated.

`evaluation-goals` carried the same copy of the old helper and uses it too.

### 3. `notes` — the run's flake

`expect(page.getByText('Prepare portfolio for interview')).toBeVisible()` followed immediately by a Prisma read. Playwright's text matching includes `<textarea>` values, so that matched the text just typed into the still-open editor — before the PATCH was even sent — and the read raced the write. It now waits for the editor to close (the panel only drops the textarea after the PATCH resolves).

### Verification

`npx tsc --noEmit` clean. No local MySQL on this machine, so the specs are verified by a `workflow_dispatch` run of **e2e-full** on this branch — link in a comment below; merging once it and the smoke gate are green.

No version bump: test-only changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)