### PR TITLE
fix: show selected and total email recipients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,15 @@ version is shown in the sidebar footer of every page (links to the
 
 No version bump: test and `data-testid` changes only, no user-visible behaviour change.
 
+## [0.28.4-beta] - 2026-07-31
+
+### Fixed
+- **Mentor/admin targeted-email recipient counter only showed the selected count**
+  (#680). `TargetedEmailComposer` (shared by `/mentor/email` and `/admin/email`) rendered
+  `Recipients (3)` instead of `Recipients (3/10)`, so there was no way to tell how many
+  mentees were selected out of the total without scrolling the checkbox list. Now shows
+  `chosen.length` over `relations.length`.
+
 ## [0.28.3-beta] - 2026-07-31
 
 ### Changed

--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -1341,3 +1341,27 @@ döküyor (asıl hata "Run full E2E suite" adımının içinde). İşe yarayan:
 `playwright-report-full-shard-N`'i indirip `data/*.md` (error-context) ve
 failure screenshot'ına bakmak — ekran görüntüsü "mentee portalındayız" diyerek
 hipotezi tek karede doğruladı.
+
+## 2026-07-31 — #973'ün conflict'i: iki PR aynı sürüm numarasını kaptığında
+
+#787'nin kuralı ("bump'ı main'in üstüne taşı", yukarıda) burada bir varyantla karşılaştı:
+dal **kendi sürümünü main'de zaten kullanılmış** bir numaraya bump etmişti. #973 ve
+#972 (#879 anket kopyası) bağımsız olarak `0.28.4-beta` iddia etmişti, dolayısıyla
+`CHANGELOG.md` ve `releaseNotes.ts` çakışmaları *aynı sürüm başlığının altında* iki
+farklı içerik olarak göründü — "hangi taraf?" değil, "iki taraf da ama farklı sürümde"
+sorusu. Çözüm: main'in `0.28.4-beta` bölümünü **olduğu gibi bırak** (o zaten merge oldu,
+tarih sırası doğru), dalın girdilerini main'in tepesinin bir üstüne (`0.29.1-beta` →
+`0.29.2-beta`) yeni bir bölüm/`RELEASE_NOTES` girdisi olarak taşı. Çakışma bloğunun
+içinde kendi metnini korumaya çalışmak CHANGELOG'da tek sürüm başlığı altında iki ayrı
+release yaratır.
+
+**`main`'in `package-lock.json`'ı `package.json`'la senkron olmayabilir.** Burada main'in
+lock'u hâlâ `0.28.4-beta` derken `package.json` `0.29.1-beta`'daydı — yani lock
+çakışmasında "main tarafını al" yanlış cevap. Her iki yerdeki (`version` +
+`packages[""].version`) değeri de yeni sürüme elle yaz, tarafları seçme.
+
+**Worktree'de `node_modules` yok, ama bu her şeyi durdurmuyor.** `npx prisma generate` ve
+`npm run check:i18n` (tsx'i npx indirdi) `npm install` olmadan çalıştı; `npm run build`
+için install şart. Install sonrası `package-lock.json`'a darwin'e özgü tek bir
+gürültü hunk'ı düşüyor (`fsevents` girdilerine `"dev": true`) — bunu commit'e karıştırma,
+`git checkout package-lock.json` ile at, sonra build'i çalıştır.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "internship-crm",
-  "version": "0.28.3-beta",
+  "version": "0.28.4-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "internship-crm",
-      "version": "0.28.3-beta",
+      "version": "0.28.4-beta",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.28.3-beta",
+  "version": "0.28.4-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/components/TargetedEmailComposer.tsx
+++ b/src/components/TargetedEmailComposer.tsx
@@ -75,7 +75,7 @@ export function TargetedEmailComposer() {
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <Card>
           <CardHeader>
-            <CardTitle>{t.mentorEmail.recipients} ({chosen.length})</CardTitle>
+            <CardTitle>{t.mentorEmail.recipients} ({chosen.length}/{relations.length})</CardTitle>
           </CardHeader>
           {relations.length === 0 ? (
             <p className="text-sm text-gray-400">{t.mentor.noMenteesAssigned}</p>

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,21 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.28.4-beta',
+    date: '2026-07-31',
+    highlights: {
+      en: [
+        'The recipient counter on the targeted-email page (mentor and admin) now shows how many mentees are selected out of the total, e.g. "Recipients (3/10)", instead of just the selected count.',
+      ],
+      tr: [
+        'Hedefli e-posta sayfasındaki (mentor ve admin) alıcı sayacı artık yalnızca seçilen sayıyı değil, toplam içinden kaçının seçildiğini gösteriyor, ör. "Alıcılar (3/10)".',
+      ],
+      de: [
+        'Der Empfängerzähler auf der gezielten E-Mail-Seite (Mentor und Admin) zeigt jetzt, wie viele Mentees von der Gesamtzahl ausgewählt sind, z. B. „Empfänger (3/10)“, statt nur die ausgewählte Anzahl.',
+      ],
+    },
+  },
+  {
     version: '0.28.3-beta',
     date: '2026-07-31',
     highlights: {


### PR DESCRIPTION
## Summary

Fixes the misleading recipient counter on the mentor/admin email page.

Closes #680

## Changes

- Updated the shared `TargetedEmailComposer` recipient counter to display selected/total recipients (`selected/total`) instead of only the selected count.
- Preserved the existing empty-state behavior when no mentees are assigned.
- Bumped the application version to `0.28.4-beta`.
- Added CHANGELOG and release note entries for the fix.

## Verification

- [x] `npm run build` passes
- [x] No i18n changes required (`npm run check:i18n` not needed)
- [x] Manually verified on `/admin/email`
- [x] Counter displays `0/total` on initial load
- [x] Counter updates correctly as recipients are selected and deselected