### PR TITLE
fix: trim quote attribution lines other than "On … wrote:"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.29.1-beta] - 2026-07-31
+
+### Fixed
+- **Quote trimming missed most clients' attribution line.** `stripQuoted` only
+  knew the `On … wrote:` form, so a reply that actually arrived through the new
+  bridge — `"cevap veriyorum\n\nJuly 2, 2026 at 3:50 PM, noreply@crm.ersah.in
+  wrote:\n> …"` — kept that attribution line in the threaded message. It now
+  cuts at any line ending in the local "wrote:" verb (`wrote` / `yazdı` /
+  `schrieb` — the app's three locales), at an Outlook `____` divider, or at the
+  first `>` line, whichever comes first. Covered in `e2e/inbound-email.spec.ts`
+  with the exact body that exposed it.
+- The bridge no longer fails a message silently: a UID that the search returned
+  but whose source can't be fetched (a stale dovecot index entry, or mail
+  expunged under it) is now logged instead of just incrementing a counter. Found
+  because a hand-deleted probe left exactly that state behind.
+
 ## [0.29.0-beta] - 2026-07-31
 
 ### Added
@@ -17,8 +33,10 @@ version is shown in the sidebar footer of every page (links to the
   `POST /api/inbound-email` has been able to thread such a reply since it
   shipped — but nothing ever *read the mailbox*, so every reply sat there
   unprocessed. `docs/EMAIL_DELIVERABILITY.md` recorded this honestly ("what's
-  still required in infrastructure is a mail bridge"); 21 real replies had
-  accumulated in the catch-all mailbox since 2026-07-01.
+  still required in infrastructure is a mail bridge"). Unprocessed replies had
+  been accumulating in the catch-all mailbox since 2026-07-01 — 9 mails, which
+  are 5 distinct replies (the catch-all delivered most of them twice, which is
+  exactly what `inboundMessageId` now guards against).
   - `src/services/inboundMailBridge.ts` — IMAP poller (`imapflow` +
     `mailparser`). Every `INBOUND_IMAP_POLL_SECONDS` (default 60) it drains
     unseen mail from the reply mailbox, pulls the token out of whichever

--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -10,6 +10,61 @@ Newest entries on top.
 
 ---
 
+## 2026-07-31 — Inbound mail bridge (#974, 0.29.0/0.29.1-beta)
+
+**"The email can't go out" was actually "the email arrives and nothing reads
+it."** Before touching code, check the whole path on the server. Here MX,
+catch-all, `Reply-To` generation and `/api/inbound-email` were all fine; the
+missing piece was the mailbox reader, which `docs/EMAIL_DELIVERABILITY.md` had
+been honestly flagging as "still required in infrastructure" all along. Read the
+feature's own doc before assuming a bug.
+
+**`docker run` in `infra/deploy-prod.sh` passes an explicit `-e` allowlist.**
+Adding a key to `/etc/internship-crm/prod.env` is *not* enough — unlisted keys
+never reach the container, silently. Any new runtime env var needs a line in that
+`docker run` **and** in the env-derivation `for k in …` fallback above it (that
+fallback rebuilds the env file from the running container, so a var missing there
+gets dropped on some later deploy). Verify with
+`docker exec internship-crm printenv | grep YOUR_VAR` after deploying.
+
+**`instrumentation.ts` is compiled for the edge runtime too, because this repo
+has `src/middleware.ts`.** A `process.env.NEXT_RUNTIME === 'nodejs'` guard does
+not help: webpack still traces the import graph, so importing anything with
+node-only deps (here `imapflow` → `net`/`tls`/`stream`) fails the build, and
+`serverExternalPackages` does not apply to the edge bundle. Workaround used: keep
+instrumentation dependency-free (`fetch` only) and have it call a node-runtime
+route handler that does the socket work.
+
+**Probing SMTP from `127.0.0.1` on the mail server proves nothing.** localhost is
+in `mynetworks`, so `permit_mynetworks` accepts any recipient and you get a
+misleading `250`. To learn whether an address is really deliverable, inspect the
+maps instead — `postmap -q "@domain" hash:/var/spool/postfix/plesk/virtual`
+reveals a catch-all, and `postconf recipient_delimiter` tells you whether
+`user+ext@` collapses to `user@`.
+
+**Plesk plus-addressing beats a catch-all, in that order.** With
+`recipient_delimiter = +`, creating mailbox `reply@` captures every
+`reply+<token>@` before the domain catch-all sees it — a clean way to divert
+machine mail out of a personal inbox without touching the catch-all.
+
+**Don't `rm` mail out of a Maildir behind dovecot's back.** It leaves a stale
+index entry, so IMAP `search` returns a UID whose source won't fetch. It
+self-heals on the next rescan, but it looks exactly like a bridge bug for a
+minute. Delete via IMAP, or expect the noise.
+
+**`npm run lint` fails in a `.claude/worktrees/…` worktree** with `Plugin
+"@next/next" was conflicted between ".eslintrc.json" and "../../../.eslintrc.json"`
+— the worktree sits inside the parent repo, so ESLint finds both configs. It is
+not your change: confirm by linting an untouched file, and trust CI (which
+checks out flat). Same cause as the "multiple lockfiles" Next warning.
+
+**Count before you claim a number.** Grepping the maildir for `reply+` matched 21
+files, but that pattern also hits *outbound* copies whose `Reply-To` carries the
+token. Anchoring on recipient headers (`To|Cc|Delivered-To|X-Original-To`) gave
+the real figure: 9 files, 5 distinct replies, of which only 1 was still
+recoverable (the other threads had been deleted). Anchor the grep, and check the
+relation still exists before promising a backfill.
+
 ## 2026-07-24 — Shared messaging UI and attachment-only support messages
 
 **Extract UI primitives before aligning parallel chat pages.** The mentorship

--- a/e2e/inbound-email.spec.ts
+++ b/e2e/inbound-email.spec.ts
@@ -58,6 +58,20 @@ test('inbound email reply is routed to the thread (token + sender verified)', as
     }
     expect(await prisma.message.count({ where: { relationId: rel.id, inboundMessageId: messageId } })).toBe(1);
     expect(await prisma.message.count({ where: { relationId: rel.id } })).toBe(2);
+
+    // Quote attribution lines other than "On … wrote:" are trimmed too — this
+    // exact shape arrived from a real client and used to leak into the thread.
+    const quoted = await request.post('/api/inbound-email', {
+      data: {
+        to: `reply+${token}@crm.ersah.in`,
+        from: menteeEmail,
+        text: 'cevap veriyorum\n\nJuly 2, 2026 at 3:50 PM, noreply@crm.ersah.in wrote:\n> earlier message',
+        messageId: `<attribution-${rel.id}@mail.example>`,
+      },
+    });
+    expect(quoted.status()).toBe(200);
+    const quotedMsg = await prisma.message.findFirst({ where: { inboundMessageId: `<attribution-${rel.id}@mail.example>` } });
+    expect(quotedMsg?.body).toBe('cevap veriyorum');
   } finally {
     await prisma.message.deleteMany({ where: { relationId: rel.id } });
     await prisma.notification.deleteMany({ where: { userId: { in: [mentor.id, mentee.id] } } });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.29.0-beta",
+  "version": "0.29.1-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/lib/inboundEmail.ts
+++ b/src/lib/inboundEmail.ts
@@ -23,8 +23,17 @@ export type InboundResult =
 export const emailOf = (s: string) => (s.match(/[^<>\s]+@[^<>\s]+/)?.[0] || s).trim().toLowerCase();
 
 // Strip a quoted reply history (best-effort) so only the new text is kept.
+//
+// The attribution line clients put above the quote varies more than the old
+// `On … wrote:` pattern allowed — a real reply arrived as
+// "July 2, 2026 at 3:50 PM, noreply@crm.ersah.in wrote:", which matched nothing
+// and leaked into the thread. So: cut at any line that *ends* in the local
+// "wrote:" verb (EN/TR/DE, the app's locales), at an Outlook divider, or at the
+// first quoted `>` line — whichever comes first.
+const QUOTE_START = /^\s*(.*\b(wrote|yazdı|schrieb):\s*$|-{2,} ?Original Message|_{10,}|>)/m;
+
 export function stripQuoted(text: string): string {
-  const cut = text.search(/^\s*(On .+ wrote:|-{2,} ?Original Message|>)/m);
+  const cut = text.search(QUOTE_START);
   return (cut > 0 ? text.slice(0, cut) : text).trim();
 }
 

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,22 +13,34 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.29.1-beta',
+    date: '2026-07-31',
+    highlights: {
+      en: [
+        'When you reply to a notification by email, the quoted copy of the earlier message is now trimmed more reliably — your reply appears in the thread as just what you typed, without your mail app\'s "…wrote:" line above the quote.',
+      ],
+      tr: [
+        'Bir bildirime e-postayla cevap verdiğinizde, önceki mesajın alıntılanan kopyası artık daha güvenilir biçimde kırpılıyor — cevabınız thread\'de yalnızca yazdığınız kadarıyla, e-posta uygulamanızın alıntı üstüne koyduğu "…yazdı:" satırı olmadan görünüyor.',
+      ],
+      de: [
+        'Wenn du per E-Mail auf eine Benachrichtigung antwortest, wird der zitierte Teil der vorherigen Nachricht jetzt zuverlässiger entfernt — deine Antwort erscheint im Thread nur mit dem, was du geschrieben hast, ohne die „…schrieb:“-Zeile deines Mailprogramms über dem Zitat.',
+      ],
+    },
+  },
+  {
     version: '0.29.0-beta',
     date: '2026-07-31',
     highlights: {
       en: [
         'Replying to a message notification by email now works. Those emails have always invited you to "reply to this email", but nothing was picking the replies up on our side, so they never reached the conversation. Your reply now shows up in the thread within about a minute, marked as sent by email, and the other person is notified as usual. Quoted history from the email is trimmed off automatically.',
-        'Replies you sent earlier that never arrived have been recovered and added to their conversations.',
         'Reply-by-email works for mentor ↔ mentee conversations. Project group chats do not support it — replying to one of those notifications still will not post to the group, so use the app for those.',
       ],
       tr: [
         'Mesaj bildirimine e-postayla cevap vermek artık çalışıyor. Bu e-postalar hep "bu e-postayı yanıtlayın" diyordu ama bizim tarafta cevapları alan bir şey yoktu, dolayısıyla sohbete hiç ulaşmıyorlardı. Cevabınız artık bir dakika içinde thread\'de görünüyor, e-postayla gönderildiği belirtiliyor ve karşı tarafa her zamanki gibi bildirim gidiyor. E-postadaki alıntılanmış geçmiş otomatik olarak kırpılıyor.',
-        'Daha önce gönderdiğiniz ama ulaşmayan cevaplar kurtarılıp ilgili sohbetlere eklendi.',
         'E-postayla cevaplama mentor ↔ menti sohbetleri için geçerli. Proje grup sohbetleri bunu desteklemiyor — o bildirimlere verilen cevaplar gruba düşmüyor, onlar için uygulamayı kullanın.',
       ],
       de: [
         'Auf eine Nachrichten-Benachrichtigung per E-Mail zu antworten funktioniert jetzt. Diese E-Mails haben immer dazu eingeladen, „auf diese E-Mail zu antworten“, aber auf unserer Seite hat niemand die Antworten abgeholt — sie kamen also nie im Gespräch an. Deine Antwort erscheint jetzt innerhalb einer Minute im Thread, als per E-Mail gesendet markiert, und die andere Person wird wie gewohnt benachrichtigt. Zitierter Verlauf aus der E-Mail wird automatisch entfernt.',
-        'Früher gesendete Antworten, die nie angekommen sind, wurden wiederhergestellt und ihren Gesprächen hinzugefügt.',
         'Antworten per E-Mail gilt für Mentor-↔-Mentee-Gespräche. Projekt-Gruppenchats unterstützen es nicht — eine Antwort auf eine solche Benachrichtigung landet weiterhin nicht in der Gruppe, nutze dafür die App.',
       ],
     },

--- a/src/services/inboundMailBridge.ts
+++ b/src/services/inboundMailBridge.ts
@@ -83,7 +83,12 @@ export async function pollInboundMailbox(): Promise<PollSummary> {
         try {
           const msg = await client.fetchOne(String(uid), { source: true }, { uid: true });
           if (!msg || !msg.source) {
+            // Usually a stale index entry: the UID was in the search result but
+            // the mail is already gone (expunged, or removed under dovecot's
+            // feet). Nothing to deliver, and left unflagged so a genuinely
+            // transient fetch failure still gets another chance.
             summary.failed++;
+            logger.warning('Inbound mail had no fetchable source', { uid });
             continue;
           }
           const mail = await simpleParser(msg.source);


### PR DESCRIPTION
Follow-up to #974, found by inspecting the replies that had been stranded in the mailbox — i.e. real inbound mail, not a hypothetical.

## 1. Quote trimming missed most clients' attribution line

`stripQuoted` only knew the `On … wrote:` form. The one recoverable stranded reply looked like this:

```
cevap veriyorum

July 2, 2026 at 3:50 PM, noreply@crm.ersah.in wrote:
> earlier message
```

The `>` line matched, so the quote was cut — but one line too late, leaving `July 2, 2026 at 3:50 PM, noreply@crm.ersah.in wrote:` sitting in the threaded message.

Now cuts at whichever comes first: any line **ending** in the local "wrote:" verb (`wrote` / `yazdı` / `schrieb` — the app's three locales), an Outlook `____` divider, or the first `>` line. `e2e/inbound-email.spec.ts` asserts the exact body that exposed this.

## 2. A silent failure in the bridge

When IMAP `search` returned a UID whose source couldn't be fetched, the bridge incremented `failed` and moved on without logging anything — the poll summary said `failed: 1` with no way to find out why. Now logged with the UID.

I hit this for real: I had `rm`'d a test probe out of the Maildir behind dovecot's back, which leaves a stale index entry in exactly that state. It self-heals on the next rescan (verified: three subsequent polls returned `fetched: 0`), so the message is left unflagged and a genuinely transient fetch failure still gets another chance.

## 3. Corrections to what #974 claimed

**The "21 stranded replies" figure was wrong.** That grep matched any occurrence of `reply+…`, which also hits *outbound* notification copies carrying the token in `Reply-To`. Anchored on recipient headers (`To` / `Cc` / `Delivered-To` / `X-Original-To`) the real numbers are **9 mails = 5 distinct replies** — most were delivered twice by the catch-all, which is a neat real-world justification for the `inboundMessageId` guard #974 added.

Of those 5: **4 belong to relation `cmqxx6oo6…`, which no longer exists** (deleted since), so they'd 404. The 1 survivor is a test reply whose entire body is "cevap veriyorum". So the 0.29.0 release note promising *"replies you sent earlier … have been recovered"* is dropped from all three locales rather than left to over-promise, and the changelog figure is corrected.

## Verification

- `npx tsc --noEmit` clean, `npm run check:i18n` OK (1570 keys × 3 locales).
- Live prod checks after #974 deployed (`0.29.0-beta`, `eeea8af`): `[MailBridge] started — polling every 60s`; `INBOUND_*` confirmed inside the container; `POST /api/inbound-email/poll` returns a summary and rejects both a missing and a wrong secret with 401.
- `npm run lint` fails identically on untouched files in this worktree (two `.eslintrc.json` up the tree) — a nested-worktree artifact, not this change; CI lints a flat checkout.

Also appends the session retrospective to `docs/agent-experience.md` per the standing convention, including the two traps most likely to bite the next agent: the `docker run` `-e` allowlist in `infra/deploy-prod.sh`, and `instrumentation.ts` being edge-compiled because `middleware.ts` exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)