### PR TITLE
feat: actually run the scheduled jobs, and stop the reminder spam

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,15 @@ INBOUND_IMAP_PASS=
 INBOUND_IMAP_MAILBOX="INBOX"
 INBOUND_IMAP_POLL_SECONDS="60"
 
+# Scheduled jobs (mentor reminders, meeting reminders, digests, analytics report)
+# CRON_SECRET: set it and the server registers the node-cron schedules at boot
+# (src/instrumentation.ts → POST /api/cron/start). Leave it EMPTY everywhere but
+# production: these jobs email real people, and the preview DB is shared with
+# every topic env, so a scheduler running there would mail real users.
+CRON_SECRET=
+# CRON_ENABLED: set to 0 to stop the schedules without removing CRON_SECRET.
+CRON_ENABLED=
+
 # LOG_LEVEL: minimum level the structured logger emits — debug | info |
 # warning | error. Defaults to "info" if unset.
 LOG_LEVEL="info"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,63 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.30.0-beta] - 2026-07-31
+
+### Added
+- **The scheduled jobs now actually run.** `initCronJobs()` had no caller
+  anywhere in the repo, and nothing on the server drove `GET /api/cron` either
+  (no crontab entry, no systemd timer) — so mentor-interaction reminders, stage
+  deadline reminders, meeting reminders, the weekly mentor digest, the daily
+  activity digest, the analytics report and the hourly unread-message digest had
+  never fired on a schedule in production. Noted as a follow-up in 0.29.0; this
+  closes it.
+  - `POST /api/cron/start` (node runtime, `CRON_SECRET` required) registers the
+    schedules in the server process; `src/instrumentation.ts` calls it shortly
+    after boot. Same edge-runtime workaround as the mail bridge — instrumentation
+    can't import `emailService` directly, because `middleware.ts` makes Next
+    compile instrumentation for the edge runtime too, where Prisma and nodemailer
+    don't resolve.
+  - The call is **deferred onto a timer, not awaited** in `register()`: that hook
+    resolves before the server accepts connections, so awaiting a request to
+    ourselves would deadlock.
+  - Gated on `CRON_SECRET`, which belongs in production only — the preview DB is
+    shared with every topic env and holds the same addresses, so a scheduler
+    running there would email real users. `CRON_ENABLED=0` is the kill switch.
+  - `GET /api/cron` (admin, runs everything once) is unchanged.
+
+### Fixed
+- **Mentor interaction reminders: one mail per mentee per day, with no way to
+  opt out.** `checkMentorInteractionReminders` sent a separate email for every
+  stale relation on every run, and — alone among the scheduled jobs — never
+  consulted `emailAllowed`. On the production data that meant one mentor would
+  have received 7 emails a day, indefinitely, with no opt-out. Now grouped into a
+  single summary per mentor listing each mentee and how long it has been, and it
+  honours the `deadlines` preference (the same category as the stage-deadline
+  nudge). Returns `emailed` alongside `checked`/`reminded`.
+
+### Infrastructure
+- `prisma/backfill-cron-baseline.mjs`, wired into `deploy-prod.sh` — a **one-shot**
+  baseline so the first tick doesn't mail out history. The unread-message digest
+  selects every message with `digestedAt: null` and no lower bound on age, and
+  `digestedAt` had never been set, so switching the scheduler on would have sent
+  3 people a digest of messages up to 3 weeks old. It marks the pre-existing
+  backlog handled and records `Setting['cronBaselineAt']`, skipping every
+  subsequent run — deliberately one-shot rather than merely idempotent, since
+  re-running it would mark *newly* stale work as handled on every deploy and
+  permanently suppress the very reminders it protects.
+  Not baselined on purpose: `retentionReminderSentAt` (consent renewal is a
+  compliance path — and nothing is due, retention is 12 months and the oldest
+  `consentAt` is 2026-06-30), `Meeting.reminderSentAt` (only looks 60 minutes
+  ahead, so it has no backlog), and `stalenessReminderSentAt` (it gates only the
+  in-app bell, not the email — the daily-mail problem was the ungrouped send,
+  fixed above).
+- `CRON_SECRET` / `CRON_ENABLED` forwarded by `infra/deploy-prod.sh` (explicit
+  `-e` allowlist, plus the env-derivation fallback).
+
+### Tests
+- `e2e/cron-start.spec.ts` (`@smoke`) — neither `/api/cron/start` nor
+  `/api/inbound-email/poll` may return 200 to an unauthenticated caller.
+
 ## [0.29.1-beta] - 2026-07-31
 
 ### Fixed

--- a/docs/EMAIL_DELIVERABILITY.md
+++ b/docs/EMAIL_DELIVERABILITY.md
@@ -108,6 +108,33 @@ curl -X POST https://crm.ersah.in/api/inbound-email \
 A `{ ok: true, created: true }` response means the message was threaded; open
 `/messages/<relationId>` to see it.
 
+## 4. Scheduled jobs (reminders & digests)
+
+`initCronJobs()` in `src/services/emailService.ts` registers the node-cron
+schedules: mentor-interaction + stage-deadline + retention reminders and
+company-need alerts (daily 09:00), meeting reminders (every 15 min, firing
+45–60 min ahead), the daily activity digest (07:30), the hourly unread-message
+digest (:20), and the weekly mentor digest + analytics report (Mondays 08:00 /
+08:15).
+
+It is started at boot by `src/instrumentation.ts`, which POSTs
+`/api/cron/start` — the same edge-runtime workaround as the mail bridge, and
+deferred onto a timer because `register()` resolves before the server accepts
+connections. `GET /api/cron` still runs every job once for an authenticated
+ADMIN.
+
+> ⚠️ **`CRON_SECRET` belongs in production only.** These jobs email real people,
+> and the preview DB is shared with every topic env holding the same addresses —
+> a scheduler there would mail real users. `CRON_ENABLED=0` stops it without
+> removing the secret.
+
+`prisma/backfill-cron-baseline.mjs` (run by `deploy-prod.sh`) is a **one-shot**
+baseline: several jobs are "everything not yet marked" queries — the unread
+digest has no lower bound on message age — so without it the first tick mails out
+the whole backlog. It records `Setting['cronBaselineAt']` and self-skips
+afterwards; do not make it run every deploy, or it will mark newly stale work as
+handled and suppress the reminders permanently.
+
 ## Relevant env
 
 | Var | Purpose |
@@ -118,3 +145,5 @@ A `{ ok: true, created: true }` response means the message was threaded; open
 | `INBOUND_IMAP_HOST` / `INBOUND_IMAP_PORT` / `INBOUND_IMAP_USER` / `INBOUND_IMAP_PASS` | Reply mailbox the bridge drains (production only) |
 | `INBOUND_IMAP_MAILBOX` / `INBOUND_IMAP_POLL_SECONDS` | Folder (default `INBOX`) and poll interval (default 60s, min 30) |
 | `INBOUND_IMAP_ENABLED` | Set to `0` to stop the bridge while keeping the credentials |
+| `CRON_SECRET` | Registers the scheduled jobs at boot (production only) |
+| `CRON_ENABLED` | Set to `0` to stop the schedules while keeping the secret |

--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -58,6 +58,32 @@ minute. Delete via IMAP, or expect the noise.
 not your change: confirm by linting an untouched file, and trust CI (which
 checks out flat). Same cause as the "multiple lockfiles" Next warning.
 
+**`register()` in `instrumentation.ts` resolves *before* the server accepts
+connections.** So `await fetch('http://127.0.0.1:PORT/…')` inside it can never
+succeed — it deadlocks or burns every retry against a closed port. Defer
+self-calls onto a `setTimeout`. (Caught before shipping, but only by asking why
+the mail bridge's `setInterval` worked while the cron start-call wouldn't.)
+
+**Before enabling anything that sends email, measure the first tick.** Several
+scheduled jobs here are "everything not yet marked" queries and the marker had
+never been set, so the first run would have mailed the whole backlog: 3 people a
+digest of 3-week-old messages. Count it against the prod DB first, then write a
+one-shot baseline. Make it **one-shot** (a `Setting` key), not just idempotent —
+an every-deploy backfill would keep marking *newly* stale work as handled and
+permanently suppress the feature it protects.
+
+**Check `emailAllowed` when touching any job that mails users.** Every scheduled
+job in `emailService.ts` consults it except `checkMentorInteractionReminders`,
+which also sent one mail per relation rather than per mentor — 7 unstoppable
+emails a day for one mentor. Worth grepping for the odd one out before assuming
+the batch is uniform.
+
+**A guard field may not guard what its name suggests.**
+`stalenessReminderSentAt` gates only the in-app bell; the email loop reads every
+stale relation on every run. Read where a field is *consumed* before designing a
+backfill around it — baselining it would have hidden notifications without
+preventing a single email.
+
 **Count before you claim a number.** Grepping the maildir for `reply+` matched 21
 files, but that pattern also hits *outbound* copies whose `Reply-To` carries the
 token. Anchoring on recipient headers (`To|Cc|Delivered-To|X-Original-To`) gave

--- a/e2e/cron-start.spec.ts
+++ b/e2e/cron-start.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test';
+
+// The endpoint that registers the scheduled jobs must never be startable by an
+// anonymous request — the jobs send email to real people. CI sets no
+// CRON_SECRET, so the expected answer there is 503 ("not configured"); where a
+// secret IS set, a wrong or missing one must be 401. Both are "refused", and
+// neither is 200 — that is the property under test.
+test('POST /api/cron/start refuses an unauthenticated caller', { tag: '@smoke' }, async ({ request }) => {
+  const cases: Record<string, string>[] = [{}, { 'x-cron-secret': 'wrong-secret' }];
+  for (const headers of cases) {
+    const res = await request.post('/api/cron/start', { headers });
+    expect(res.status()).not.toBe(200);
+    expect([401, 503]).toContain(res.status());
+  }
+});
+
+// Same contract for the mail-bridge poller: it opens an outbound IMAP
+// connection, so it must never run for an anonymous caller.
+test('POST /api/inbound-email/poll refuses an unauthenticated caller', { tag: '@smoke' }, async ({ request }) => {
+  const cases: Record<string, string>[] = [{}, { 'x-inbound-secret': 'wrong-secret' }];
+  for (const headers of cases) {
+    const res = await request.post('/api/inbound-email/poll', { headers });
+    expect(res.status()).not.toBe(200);
+    expect([401, 503]).toContain(res.status());
+  }
+});

--- a/infra/deploy-prod.sh
+++ b/infra/deploy-prod.sh
@@ -80,7 +80,8 @@ if [ ! -f "$ENV_FILE" ] && docker inspect "$CONTAINER" >/dev/null 2>&1; then
   : > "$ENV_FILE"; chmod 600 "$ENV_FILE"
   for k in DATABASE_URL NEXTAUTH_SECRET NEXTAUTH_URL SMTP_HOST SMTP_PORT SMTP_USER SMTP_PASS SMTP_FROM \
            INBOUND_EMAIL_DOMAIN INBOUND_SECRET INBOUND_IMAP_HOST INBOUND_IMAP_PORT INBOUND_IMAP_USER \
-           INBOUND_IMAP_PASS INBOUND_IMAP_MAILBOX INBOUND_IMAP_POLL_SECONDS INBOUND_IMAP_ENABLED; do
+           INBOUND_IMAP_PASS INBOUND_IMAP_MAILBOX INBOUND_IMAP_POLL_SECONDS INBOUND_IMAP_ENABLED \
+           CRON_SECRET CRON_ENABLED; do
     v=$(docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$CONTAINER" | sed -n "s/^$k=//p" | head -1)
     # Single-quote the value so `. "$ENV_FILE"` sources it verbatim — a
     # DATABASE_URL/password can contain characters ($, spaces, @, :) that the
@@ -223,6 +224,9 @@ log "seed-templates + project-member backfill (idempotent)"
 run_tool node prisma/seed-templates.mjs || true
 run_tool node prisma/backfill-project-members.mjs || true
 run_tool node prisma/backfill-organization.mjs || true
+# One-shot: baseline the scheduled-job backlog so the first cron tick doesn't
+# email out history. Self-skips once applied (Setting 'cronBaselineAt').
+run_tool node prisma/backfill-cron-baseline.mjs || true
 
 # ── 5. Swap the container ────────────────────────────────────────────────────
 log "Restarting $CONTAINER on :$PORT"
@@ -251,6 +255,8 @@ docker run -d \
   -e INBOUND_IMAP_MAILBOX="${INBOUND_IMAP_MAILBOX:-}" \
   -e INBOUND_IMAP_POLL_SECONDS="${INBOUND_IMAP_POLL_SECONDS:-}" \
   -e INBOUND_IMAP_ENABLED="${INBOUND_IMAP_ENABLED:-}" \
+  -e CRON_SECRET="${CRON_SECRET:-}" \
+  -e CRON_ENABLED="${CRON_ENABLED:-}" \
   "$IMAGE"
 
 # ── 6. Health check + prune ──────────────────────────────────────────────────

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.29.1-beta",
+  "version": "0.30.0-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/prisma/backfill-cron-baseline.mjs
+++ b/prisma/backfill-cron-baseline.mjs
@@ -1,0 +1,75 @@
+// One-shot baseline for the scheduled jobs (see src/services/emailService.ts).
+//
+// Why this exists: `initCronJobs()` had no caller, and nothing on the server
+// drove `GET /api/cron` either, so the scheduled jobs never ran in production.
+// Several of them are "everything not yet marked" queries — the unread-message
+// digest selects every message with `digestedAt: null`, with no lower bound on
+// age. Switching the scheduler on without a baseline therefore mails out the
+// entire accumulated backlog on the first tick: measured on prod before this
+// landed, 3 people would have received a digest of messages up to 3 weeks old,
+// and one mentor a burst of 7 staleness reminders at once.
+//
+// So: mark the pre-existing backlog as already handled, once. From then on the
+// jobs only ever see genuinely new work.
+//
+// This is deliberately ONE-SHOT, not merely idempotent. It records
+// `cronBaselineAt` in Setting and exits early if that key exists — because
+// re-running it would mark *newly* stale relations as reminded on every deploy
+// and permanently suppress the reminder feature it is meant to protect. Safe to
+// leave wired into deploy-prod.sh forever.
+//
+// NOT baselined on purpose:
+//   - User.retentionReminderSentAt — consent renewal is a compliance path, and
+//     suppressing it would silently skip a due renewal. (Nothing is due today:
+//     retention is 12 months and the oldest consentAt is 2026-06-30.)
+//   - Meeting.reminderSentAt — sendMeetingReminders only looks at meetings in
+//     the next 60 minutes, so it has no backlog to suppress.
+//   - MentorshipRelation.stalenessReminderSentAt — it gates only the in-app bell
+//     item, not the email (the email loop reads every stale relation every run),
+//     so baselining it would hide the notification without preventing any mail.
+//     The daily-mail problem it looked like it caused was really the ungrouped
+//     per-relation send, fixed in checkMentorInteractionReminders instead.
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+const BASELINE_KEY = 'cronBaselineAt';
+
+async function main() {
+  const existing = await prisma.setting.findUnique({ where: { key: BASELINE_KEY } });
+  if (existing) {
+    console.log(`backfill-cron-baseline: already applied at ${existing.value} — skipping.`);
+    return;
+  }
+
+  const now = new Date();
+  // Match sendUnreadMessageDigests' own cutoff (UNREAD_DIGEST_AFTER_MIN = 60):
+  // anything newer than that is not yet digest-eligible, so leave it for the
+  // first real tick to pick up normally.
+  const digestCutoff = new Date(now.getTime() - 60 * 60 * 1000);
+
+  const digested = await prisma.message.updateMany({
+    where: { readAt: null, digestedAt: null, deletedForEveryoneAt: null, createdAt: { lt: digestCutoff } },
+    data: { digestedAt: now },
+  });
+
+  // Already-overdue stage deadlines (0 rows when this first ran, but a deploy
+  // could land after some went overdue).
+  const deadlines = await prisma.mentorshipRelation.updateMany({
+    where: { stageDeadline: { lt: now }, deadlineReminderSentAt: null },
+    data: { deadlineReminderSentAt: now },
+  });
+
+  await prisma.setting.create({ data: { key: BASELINE_KEY, value: now.toISOString() } });
+
+  console.log(
+    `backfill-cron-baseline: baselined ${digested.count} undigested message(s) and ` +
+      `${deadlines.count} overdue deadline(s) at ${now.toISOString()}.`,
+  );
+}
+
+main()
+  .catch((e) => {
+    console.error('backfill-cron-baseline failed:', e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/src/app/api/cron/start/route.ts
+++ b/src/app/api/cron/start/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+import { timingSafeEqual } from 'crypto';
+import { initCronJobs } from '@/services/emailService';
+
+// node-cron timers live in this process; nothing about them works on the edge.
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+// POST — register the node-cron schedules in this server process. Called once at
+// boot by src/instrumentation.ts, which cannot import emailService directly:
+// middleware.ts makes Next compile instrumentation for the edge runtime too,
+// where Prisma/nodemailer fail to resolve (the same constraint the mail bridge
+// works around).
+//
+// initCronJobs() is idempotent — it returns early once 'mentor-reminders' is
+// registered — so a retried call is harmless.
+//
+// Distinct from `GET /api/cron`, which runs every job once, right now, for an
+// authenticated ADMIN. This only starts the schedule.
+export async function POST(request: Request) {
+  const expected = process.env.CRON_SECRET;
+  if (!expected) return NextResponse.json({ error: 'Not configured' }, { status: 503 });
+
+  const got = request.headers.get('x-cron-secret') || '';
+  const ok = got.length === expected.length
+    && (() => { try { return timingSafeEqual(Buffer.from(got), Buffer.from(expected)); } catch { return false; } })();
+  if (!ok) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  initCronJobs();
+  return NextResponse.json({ ok: true, started: true });
+}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -2,23 +2,71 @@
 // place to start long-lived background work in the App Router (a route handler
 // or layout would start it per request).
 //
-// It ticks the mail bridge by calling the app's own `/api/inbound-email/poll`
-// rather than importing it. That indirection is deliberate: this project has
-// `src/middleware.ts`, so Next also compiles instrumentation for the **edge**
-// runtime, where imapflow's `net`/`tls`/`stream` imports cannot resolve and the
-// build fails — even behind a `NEXT_RUNTIME` guard, because webpack still traces
-// the import. Reaching the IMAP code over HTTP keeps this file dependency-free
-// (`fetch` only) and leaves the node-only work in the node-only route handler.
+// Both jobs below are kicked off by calling one of the app's own endpoints
+// rather than by importing the code that does the work. That indirection is
+// deliberate: this project has `src/middleware.ts`, so Next also compiles
+// instrumentation for the **edge** runtime, where imapflow's `net`/`tls`/`stream`
+// (and Prisma, and nodemailer) cannot resolve and the build fails — even behind a
+// `NEXT_RUNTIME` guard, because webpack still traces the import graph. Keeping
+// this file dependency-free (`fetch` only) leaves the node-only work in
+// node-only route handlers.
 //
-// Deliberately narrow: it starts the mail bridge and nothing else. The node-cron
-// jobs in `src/services/emailService.ts` (`initCronJobs`) are NOT wired up here —
-// nothing calls them today, and switching them on would start sending reminder
-// and digest email as a side effect of this change.
-export async function register() {
+// Nothing here is awaited to completion: `register()` resolves before the server
+// starts accepting connections, so awaiting a request to ourselves would
+// deadlock. Both starts are deferred onto timers instead.
+export function register() {
   if (process.env.NEXT_RUNTIME !== 'nodejs') return;
 
-  // Same gate as bridgeConfig(): no credentials (dev, CI, preview, topic envs)
-  // means no polling at all.
+  startMailBridge();
+  startCron();
+}
+
+const BOOT_DELAY_MS = 5000;
+
+function localUrl(path: string): string {
+  return `http://127.0.0.1:${process.env.PORT || 3000}${path}`;
+}
+
+// The scheduled reminder/digest jobs (`initCronJobs` in
+// `src/services/emailService.ts`). Gated on CRON_SECRET so only the environment
+// that should mail real people does: the preview DB is shared with every topic
+// env and holds the same addresses, so a scheduler running there would email
+// real users. CRON_ENABLED=0 is the kill switch.
+function startCron() {
+  const secret = process.env.CRON_SECRET;
+  if (!secret || process.env.CRON_ENABLED === '0') return;
+
+  // Registering the schedules is a one-shot call, but the server may not be
+  // listening yet — retry a few times with backoff before giving up.
+  let attempt = 0;
+  const tryStart = async () => {
+    attempt++;
+    try {
+      const res = await fetch(localUrl('/api/cron/start'), {
+        method: 'POST',
+        headers: { 'x-cron-secret': secret },
+      });
+      if (res.ok) {
+        console.log('[Cron] schedules registered');
+        return;
+      }
+      // A real answer (bad secret / not configured) — retrying repeats it.
+      console.error('[Cron] start returned', res.status);
+    } catch {
+      if (attempt < 5) {
+        setTimeout(tryStart, BOOT_DELAY_MS * attempt).unref?.();
+        return;
+      }
+      console.error('[Cron] could not reach /api/cron/start; schedules NOT registered');
+    }
+  };
+  setTimeout(tryStart, BOOT_DELAY_MS).unref?.();
+}
+
+// Drains the reply mailbox over IMAP. Gated on the IMAP credentials, which live
+// only in production — two containers polling one mailbox would race over the
+// \Seen flag.
+function startMailBridge() {
   const configured = process.env.INBOUND_IMAP_HOST && process.env.INBOUND_IMAP_USER && process.env.INBOUND_IMAP_PASS;
   if (!configured || process.env.INBOUND_IMAP_ENABLED === '0') return;
 
@@ -29,14 +77,16 @@ export async function register() {
   }
 
   const seconds = Math.max(30, Number(process.env.INBOUND_IMAP_POLL_SECONDS || 60));
-  const url = `http://127.0.0.1:${process.env.PORT || 3000}/api/inbound-email/poll`;
 
   let running = false;
   const timer = setInterval(async () => {
     if (running) return; // a slow tick must not overlap the next one
     running = true;
     try {
-      const res = await fetch(url, { method: 'POST', headers: { 'x-inbound-secret': secret } });
+      const res = await fetch(localUrl('/api/inbound-email/poll'), {
+        method: 'POST',
+        headers: { 'x-inbound-secret': secret },
+      });
       if (!res.ok) console.error('[MailBridge] poll returned', res.status);
     } catch (e) {
       // The server may still be coming up on the first tick — not fatal.

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,27 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.30.0-beta',
+    date: '2026-07-31',
+    highlights: {
+      en: [
+        'Automatic reminders and digests are now actually being sent on schedule. Interaction reminders, stage-deadline reminders, meeting reminders (about an hour before), the weekly mentor digest, the daily activity digest and the hourly unread-message digest were all built but were never running by themselves — they only went out if an admin triggered them by hand.',
+        'Your interaction reminder is now a single daily summary listing every mentee waiting for a log entry, instead of one separate email per mentee — and it respects your notification settings, so you can switch it off like any other email.',
+        'Turning this on does not send you a backlog: messages and deadlines from before the change are treated as already handled, so you only hear about what happens from now on.',
+      ],
+      tr: [
+        'Otomatik hatırlatmalar ve özetler artık gerçekten zamanında gönderiliyor. Etkileşim hatırlatmaları, aşama son tarih hatırlatmaları, toplantı hatırlatmaları (yaklaşık bir saat önce), haftalık mentor özeti, günlük aktivite özeti ve saatlik okunmamış mesaj özeti — hepsi yazılmıştı ama kendi başına hiç çalışmıyordu; yalnızca bir yönetici elle tetiklerse gidiyordu.',
+        'Etkileşim hatırlatmanız artık her menti için ayrı e-posta yerine, kayıt bekleyen tüm mentileri listeleyen tek bir günlük özet — ve bildirim tercihlerinize uyuyor, yani diğer e-postalar gibi kapatabilirsiniz.',
+        'Bunun açılması size birikmiş yığını göndermiyor: değişiklikten önceki mesaj ve son tarihler işlenmiş kabul ediliyor, yalnızca bundan sonra olanları duyuyorsunuz.',
+      ],
+      de: [
+        'Automatische Erinnerungen und Zusammenfassungen werden jetzt wirklich planmäßig verschickt. Interaktions-Erinnerungen, Fristerinnerungen, Termin-Erinnerungen (etwa eine Stunde vorher), die wöchentliche Mentor-Zusammenfassung, die tägliche Aktivitätsübersicht und die stündliche Übersicht ungelesener Nachrichten waren alle gebaut, liefen aber nie von selbst — sie gingen nur raus, wenn ein Admin sie manuell auslöste.',
+        'Deine Interaktions-Erinnerung ist jetzt eine einzige tägliche Zusammenfassung mit allen Mentees, die auf einen Eintrag warten, statt einer separaten E-Mail pro Mentee — und sie richtet sich nach deinen Benachrichtigungseinstellungen, du kannst sie also wie jede andere E-Mail abschalten.',
+        'Das Einschalten schickt dir keinen Rückstand: Nachrichten und Fristen von vor der Änderung gelten als bereits erledigt, du hörst nur von allem, was ab jetzt passiert.',
+      ],
+    },
+  },
+  {
     version: '0.29.1-beta',
     date: '2026-07-31',
     highlights: {

--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -612,28 +612,49 @@ export async function checkMentorInteractionReminders() {
     }
   }
 
+  // One email per MENTOR, not per relation. This job runs daily, so a mentor
+  // with 7 stale mentees used to get 7 separate mails every single day — and
+  // unlike every other scheduled job it never consulted the recipient's
+  // preferences, so there was no way to turn them off. Grouped + opt-out aware
+  // ('deadlines', the same category as the stage-deadline nudge): one summary
+  // listing each mentee and how long it has been.
+  const byMentor = new Map<string, typeof remindersToSend>();
   for (const relation of remindersToSend) {
-    const lastDate = relation.interactions[0]?.date;
-    const daysSince = lastDate
-      ? Math.floor((Date.now() - lastDate.getTime()) / (1000 * 60 * 60 * 24))
-      : null;
+    const list = byMentor.get(relation.mentorId) ?? [];
+    list.push(relation);
+    byMentor.set(relation.mentorId, list);
+  }
+
+  let emailed = 0;
+  for (const relations of byMentor.values()) {
+    const mentor = relations[0].mentor;
+    if (!mentor.email || !emailAllowed(mentor, 'deadlines')) continue;
+
+    const rows = relations
+      .map((relation) => {
+        const lastDate = relation.interactions[0]?.date;
+        const daysSince = lastDate
+          ? Math.floor((Date.now() - lastDate.getTime()) / (1000 * 60 * 60 * 24))
+          : null;
+        const since = daysSince !== null
+          ? `${daysSince} day${daysSince === 1 ? '' : 's'} since the last interaction`
+          : 'no interactions logged yet';
+        return `<li style="margin-bottom:6px;"><strong>${relation.mentee.fullName}</strong> — ${since}</li>`;
+      })
+      .join('');
 
     try {
       await sendEmail({
-        to: relation.mentor.email,
-        subject: `Reminder: Log interaction with ${relation.mentee.fullName}`,
+        to: mentor.email,
+        subject: relations.length === 1
+          ? `Reminder: Log interaction with ${relations[0].mentee.fullName}`
+          : `Reminder: ${relations.length} mentees need an interaction log`,
         html: `
           <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
             <h2 style="color: #2563eb;">Interaction Reminder</h2>
-            <p>Hi ${relation.mentor.fullName},</p>
-            <p>
-              ${
-                daysSince
-                  ? `It has been <strong>${daysSince} days</strong> since you last logged an interaction`
-                  : 'You have not yet logged any interactions'
-              }
-              with your mentee <strong>${relation.mentee.fullName}</strong>.
-            </p>
+            <p>Hi ${mentor.fullName},</p>
+            <p>These mentees have had no logged interaction for a while:</p>
+            <ul style="padding-left:18px;">${rows}</ul>
             <p>Please log your recent interactions to keep the mentorship record up to date.</p>
             <a href="${process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'}/mentor" style="
               display: inline-block;
@@ -649,14 +670,16 @@ export async function checkMentorInteractionReminders() {
           </div>
         `,
       });
+      emailed++;
     } catch (e) {
-      console.error('checkMentorInteractionReminders email failed:', { relationId: relation.id, mentorId: relation.mentorId, error: e });
+      console.error('checkMentorInteractionReminders email failed:', { mentorId: relations[0].mentorId, error: e });
     }
   }
 
   return {
     checked: activeRelations.length,
     reminded: remindersToSend.length,
+    emailed,
   };
 }
 


### PR DESCRIPTION
Closes the follow-up flagged in #974/0.29.0.

## The problem

`initCronJobs()` in `src/services/emailService.ts` **has no caller anywhere in the repo**, and nothing on the server drives `GET /api/cron` either — I checked the root crontab, all user crontabs, `/etc/cron.d`, `/etc/cron.*` and systemd timers. So none of these had ever run on a schedule in production:

| Job | Schedule |
|---|---|
| mentor-interaction + stage-deadline + retention reminders, company-need alerts | daily 09:00 |
| meeting reminders | every 15 min (fires 45–60 min ahead) |
| daily activity digest | 07:30 |
| unread-message digest | hourly at :20 |
| weekly mentor digest / analytics report | Mondays 08:00 / 08:15 |

They only ever went out when an admin hit `GET /api/cron` by hand.

## Two things had to be fixed before this was safe to switch on

I measured the first tick against the production DB rather than assuming, and found two real hazards.

**1. `checkMentorInteractionReminders` would have spammed a real mentor, unstoppably.** It sent a *separate* email per stale relation, and — alone among these jobs — never consulted `emailAllowed`. Prod has one active mentor with 7 stale relations, so that is **7 emails a day, indefinitely, with no opt-out**. Now grouped into one summary per mentor listing each mentee and how long it has been, honouring the `deadlines` preference (same category as the stage-deadline nudge).

**2. The first tick would have mailed out the entire backlog.** The unread digest selects every message with `digestedAt: null` and **no lower bound on age**, and `digestedAt` had never been set because the job never ran. Measured: **3 people** would each have received a digest of messages up to 3 weeks old.

`prisma/backfill-cron-baseline.mjs` (wired into `deploy-prod.sh`) baselines that backlog. It is deliberately **one-shot** — it records `Setting['cronBaselineAt']` and skips every later run — not merely idempotent: an every-deploy backfill would mark *newly* stale work as handled and permanently suppress the reminders it exists to protect.

Deliberately **not** baselined, with reasons:
- `User.retentionReminderSentAt` — consent renewal is a compliance path; suppressing it could skip a due renewal. (Nothing is due: retention is 12 months, oldest `consentAt` is 2026-06-30.)
- `Meeting.reminderSentAt` — only looks 60 minutes ahead, so there is no backlog.
- `MentorshipRelation.stalenessReminderSentAt` — it gates only the **in-app bell**, not the email (the email loop reads every stale relation every run). Baselining it would have hidden notifications without preventing a single email. The daily-mail problem was the ungrouped send, fixed above.

## How it starts

`POST /api/cron/start` (node runtime, `CRON_SECRET` required) registers the schedules; `src/instrumentation.ts` calls it shortly after boot. Same edge-runtime workaround as the mail bridge — instrumentation can't import `emailService`, because `middleware.ts` makes Next compile instrumentation for edge too, where Prisma and nodemailer don't resolve.

The call is **deferred onto a timer, not awaited**: `register()` resolves *before* the server accepts connections, so awaiting a request to ourselves would deadlock. `initCronJobs()` is idempotent, so a retry is harmless. `GET /api/cron` (admin, runs everything once) is unchanged.

## Blast radius

- Gated on `CRON_SECRET`, which I have set **in `/etc/internship-crm/prod.env` only** — verified absent from `preview.env`. The preview DB is shared with every topic env and holds the same real addresses, so a scheduler there would email real users. `CRON_ENABLED=0` is the kill switch.
- Ordering is correct on deploy: the baseline runs in step 4 (`prisma db push` + backfills) *before* the container restarts and the scheduler starts.
- After this, the mentor at `zekiyeerbas35@…` starts getting **one** daily interaction summary (opt-out-able) instead of nothing — that is the feature working as intended.

## Verification

- `npx tsc --noEmit` clean; `npm run build` succeeds (`/api/cron/start` in the route manifest); `npm run check:i18n` OK (1570 keys × 3 locales); `bash -n infra/deploy-prod.sh` OK.
- New `e2e/cron-start.spec.ts` (`@smoke`): neither `/api/cron/start` nor `/api/inbound-email/poll` may answer 200 to an unauthenticated caller.
- Post-merge I will confirm `[Cron] schedules registered` in the container log and that the baseline reports the expected counts.

Version bumped to `0.30.0-beta` with CHANGELOG + release-notes entries, and the session lessons appended to `docs/agent-experience.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)