### PR TITLE
refactor(security): merkezî fail-closed scopeForRole() + rol-erişim matrisi (#849, #851)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.30.3-beta] - 2026-07-31
+
+### Security
+- **`/api/projects` let SOURCE read every project, private ones included** (#849).
+  Same allowlist-by-omission shape as #847/#848: the role chain covered
+  MENTOR/COMPANY/MENTEE and SOURCE fell through to an unfiltered query. SOURCE now
+  gets the public showcase only (and the same PII stripping mentees get — member and
+  relation names removed, count kept).
+
+### Changed
+- **Role scoping is now centralised in `scopeForRole(user, resource)`**
+  (`src/lib/authzScope.ts`), used by `/api/interactions`, `/api/mentorship` and
+  `/api/projects`. Scopes are declared as a per-resource, per-role builder table
+  instead of an `if/else if` chain in each route, so a role missing from the table
+  gets `403` + an `authz.scope_denied` warning rather than an unfiltered query.
+  Adding a role to the `Role` enum can no longer silently grant it access.
+
+### Documentation
+- **`docs/role-access-matrix.md`** (#851) — the role × resource read matrix, why
+  fail-closed, which areas deliberately sit outside it (CV/document/messaging access
+  and the role-gated routes, all already fail-closed and not to be regressed), and
+  the three steps to follow when adding a role or a scoped resource.
+
 ## [0.30.2-beta] - 2026-07-31
 
 ### Security

--- a/docs/role-access-matrix.md
+++ b/docs/role-access-matrix.md
@@ -1,0 +1,121 @@
+# Rol-erişim matrisi / Role access matrix
+
+Bu doküman, her rolün hangi veriyi görebildiğini tek yerde tanımlar. Kaynak kod
+karşılığı: [`src/lib/authzScope.ts`](../src/lib/authzScope.ts). Kod ile bu tablo
+ayrışırsa **kod doğrudur** — tabloyu güncelleyin.
+
+İlgili: epic [#814](https://github.com/21072026/Internship/issues/814), story
+[#831](https://github.com/21072026/Internship/issues/831), denetim playbook'u
+[`security-audit-playbook.md`](security-audit-playbook.md).
+
+## Neden fail-closed / Why fail-closed
+
+Route'lar kapsamı "tanıdığım rolü filtrele" mantığıyla kuruyordu:
+
+```ts
+if (role === 'MENTOR')      where.relation = { mentorId: self };
+else if (role === 'MENTEE') where.relation = { menteeId: self };
+// else YOK → COMPANY, SOURCE ve sonradan eklenen her rol filtresiz sorgu çalıştırır
+```
+
+`else` dalı olmadığı için, zincirin adını anmadığı rol boş bir `where` ile
+devam ediyor ve **ADMIN görünürlüğü** alıyordu. Bu "allowlist-by-omission"
+deseni, `COMPANY` ve `SOURCE` rolleri eklendiğinde sessizce yetki yükseltmesine
+dönüştü ([#847](https://github.com/21072026/Internship/issues/847),
+[#848](https://github.com/21072026/Internship/issues/848)).
+
+Bugünkü kural: **kapsamı tanımlı olmayan rol reddedilir.**
+
+```mermaid
+flowchart TD
+  R[İstek] --> SW["scopeForRole(user, resource)"]
+  SW --> K{rol için builder var mı?}
+  K -- evet --> F[kapsanmış where] --> Q[(Prisma)]
+  K -- hayır --> D403["403 Forbidden<br/>+ authz.scope_denied (warning)"]
+  style D403 fill:#ddffdd,stroke:#0e8a16,stroke-width:2px
+```
+
+`schema.prisma`'daki `Role` enum'una yeni bir rol eklemek, `authzScope.ts`'e
+builder eklenmediği sürece o role **erişim vermez** — sessizce genişletmek
+artık mümkün değil.
+
+## Kapsanan kaynaklar / Scoped resources
+
+`scopeForRole(user, resource)` iki kaynak tanıyor. `{}` = kasıtlı olarak
+kapsamsız; `—` = builder yok, yani **403**.
+
+### `relation` — `MentorshipRelation` ve üzerinden erişilen her şey
+
+`GET /api/mentorship`, `GET /api/interactions`
+
+| Rol | Kapsam | Gerekçe |
+|---|---|---|
+| `ADMIN` | `{}` (tümü) | Tenant'ın tamamı tasarım gereği |
+| `MENTOR` | `mentorId = self` | Kendi mentilerini takip eder |
+| `MENTEE` | `menteeId = self` | Kendi ilişkisi |
+| `COMPANY` | `companyId = self.companyId ?? '__none__'` | Salt-okunur; yalnız kendi şirketine atanmış ilişkiler |
+| `SOURCE` | `mentee.sourceId = <kendi sourceId'si> ?? '__none__'` | Yalnız kendi yönlendirdiği adaylar |
+| diğer | — | 403 |
+
+`companyId`/`sourceId` boşsa `'__none__'` sentinel'i devreye girer: hiçbir cuid
+ile eşleşmediği için sonuç kümesi **boş** olur. Bu önemli — şirketi atanmamış
+bir `COMPANY` hesabı "filtre yok" değil "hiçbir şey" görmeli.
+
+### `project` — `Project`
+
+`GET /api/projects`
+
+| Rol | Kapsam | Gerekçe |
+|---|---|---|
+| `ADMIN` | `{}` (tümü) | |
+| `MENTOR` | sahibi **veya** üyesi olduğu projeler | [#617](https://github.com/21072026/Internship/issues/617) / [#619](https://github.com/21072026/Internship/issues/619) |
+| `MENTEE` | `isPublic = true` | Yalnız açık vitrin |
+| `COMPANY` | `ownerCompanyId = self.companyId ?? '__none__'` | Kendi şirketinin projeleri |
+| `SOURCE` | `isPublic = true` | Kendine ait proje akışı yok; menti ile aynı vitrin |
+| diğer | — | 403 |
+
+Vitrin rolleri (`MENTEE`, `SOURCE`) için yanıt ayrıca **PII'dan arındırılıyor**:
+üye ve ilişki isimleri çıkarılıp yalnız sayı bırakılıyor.
+
+## Bu matrisin dışında kalanlar / Out of scope for this matrix
+
+Aşağıdaki alanlar `scopeForRole` kullanmıyor çünkü zaten fail-closed bir desenle
+yazılmışlar; denetimde temiz çıktılar ve **bozulmamalı**:
+
+| Alan | Desen | Dosya |
+|---|---|---|
+| CV erişimi | `canAccessCv()` — sonda açık `return false` | [`src/lib/cvAccess.ts`](../src/lib/cvAccess.ts) |
+| Belge erişimi | aynı desen | [`src/lib/documentAccess.ts`](../src/lib/documentAccess.ts) |
+| Mesajlaşma | `getThreadIfAllowed()` | [`src/lib/messaging.ts`](../src/lib/messaging.ts) |
+| Proje detayı/üyeleri | `isProjectMember()` + sahiplik | [`src/lib/projectAccess.ts`](../src/lib/projectAccess.ts) |
+| Rol-kapılı route'lar | Girişte rol allowlist'i → 401 (`/api/users`, `/api/search`, `/api/meetings`, `/api/availability`, `/api/company/*`, `/api/mentor/*`, `/api/admin/*`) | ilgili `route.ts` |
+| Kayıt bazlı yetki | `allowed = ADMIN \|\| katılımcı` (varsayılan `false`) | `/api/evaluations`, `/api/questions/[id]`, `/api/mentorship/[id]`, `/api/users/[id]/activity` |
+
+Tenant (organizasyon) izolasyonu **ayrı bir katman**: `withTenantScope()` /
+`MT_ENFORCE_ISOLATION` — bkz. [`tenant-isolation.md`](tenant-isolation.md). Bu
+matris tenant *içi* rol kapsamlamasını tanımlar.
+
+## Yazma işlemleri / Write access
+
+Bu matris **okuma** kapsamıdır. Yazma yolları ayrı korunuyor ve bu değişiklikle
+ellenmedi; en kritikleri:
+
+| İşlem | Kural |
+|---|---|
+| `POST /api/interactions` | `ADMIN` veya ilişkinin mentoru |
+| `POST /api/mentorship` | yalnız `ADMIN` |
+| `POST /api/projects` | `ADMIN` veya `MENTOR` (mentor daima sahip olur) |
+| `POST /api/source/mentees` | yalnız `SOURCE`, kendi `sourceId`'si ile |
+
+## Regresyon testi / Regression test
+
+[`e2e/role-scoping.spec.ts`](../e2e/role-scoping.spec.ts) (`@smoke`) matrisin
+sızıntı üreten hücrelerini kilitliyor. Test **satır sahipliğini** doğruluyor,
+HTTP status'unu değil — sızıntı boyunca her istek `200` dönüyordu, dolayısıyla
+yalnız status kontrol eden bir test bunu yakalayamazdı.
+
+Yeni bir rol veya yeni bir kapsanan kaynak eklerken:
+
+1. `authzScope.ts` içindeki `BUILDERS`'a rolü ekleyin (eklemezseniz rol 403 alır — güvenli varsayılan).
+2. Bu dokümandaki tabloyu güncelleyin.
+3. `role-scoping.spec.ts`'e negatif bir vaka ekleyin (kapsam dışı bir kaydın **görünmediğini** doğrulayın).

--- a/e2e/role-scoping.spec.ts
+++ b/e2e/role-scoping.spec.ts
@@ -21,6 +21,7 @@ let relationId = '';
 let otherCompanyId = '';
 let ownCompanyId = '';
 let sourceRecordId = '';
+let privateProjectId = '';
 
 test.beforeAll(async () => {
   const [mentor, mentee] = await Promise.all([
@@ -54,9 +55,16 @@ test.beforeAll(async () => {
   await prisma.interactionLog.create({
     data: { relationId: relation.id, date: new Date(), notes: 'scope-probe-note', type: 'Meeting' },
   });
+
+  // A private project nobody in this test owns — SOURCE used to read it (#849).
+  const project = await prisma.project.create({
+    data: { name: `Scope Private ${Date.now()}`, ownerType: 'MENTOR', ownerUserId: mentor.id, isPublic: false },
+  });
+  privateProjectId = project.id;
 });
 
 test.afterAll(async () => {
+  await prisma.project.deleteMany({ where: { id: privateProjectId } });
   await prisma.interactionLog.deleteMany({ where: { relationId } });
   await prisma.mentorshipRelation.deleteMany({ where: { id: relationId } });
   for (const email of [mentorEmail, menteeEmail, companyEmail, sourceEmail]) {
@@ -89,6 +97,10 @@ test('SOURCE with no referrals reads no relations and no interaction logs', { ta
 
   const relations = await (await page.request.get('/api/mentorship')).json();
   expect(relations.relations.map((r: { id: string }) => r.id)).not.toContain(relationId);
+
+  // #849: SOURCE fell through the project role chain and read private projects.
+  const projects = await (await page.request.get('/api/projects')).json();
+  expect(projects.projects.map((p: { id: string }) => p.id)).not.toContain(privateProjectId);
 });
 
 test('MENTOR and MENTEE still see their own relation and its logs', async ({ page }) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.30.2-beta",
+  "version": "0.30.3-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/app/api/interactions/route.ts
+++ b/src/app/api/interactions/route.ts
@@ -3,7 +3,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { withTenantScope } from '@/lib/orgContext';
-import { relationScopeForRole, logScopeDenial } from '@/lib/authzScope';
+import { scopeForRole, logScopeDenial } from '@/lib/authzScope';
 import { z } from 'zod';
 import { dispatchWebhook } from '@/lib/webhooks';
 import { TEXT_LIMITS } from '@/lib/textLimits';
@@ -36,7 +36,7 @@ export async function GET(request: Request) {
     // Fail-closed scoping (#847): COMPANY and SOURCE used to fall past this
     // chain with an empty `where` and read every mentee's interaction log.
     // A role with no defined scope is now denied outright.
-    const relationScope = await relationScopeForRole(session.user);
+    const relationScope = await scopeForRole(session.user, 'relation');
     if (!relationScope) {
       await logScopeDenial(session.user, 'GET /api/interactions');
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 });

--- a/src/app/api/mentorship/route.ts
+++ b/src/app/api/mentorship/route.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 import { dispatchWebhook } from '@/lib/webhooks';
 import { checkActiveRelationLimit, planLimitError } from '@/lib/planGate';
 import { withTenantScope } from '@/lib/orgContext';
-import { relationScopeForRole, logScopeDenial } from '@/lib/authzScope';
+import { scopeForRole, logScopeDenial } from '@/lib/authzScope';
 import { notify } from '@/lib/notify';
 import { emailAllowed } from '@/lib/notificationPrefs';
 import { sendMentorAssignedEmail, sendMenteeAssignedEmail } from '@/services/emailService';
@@ -43,7 +43,7 @@ export async function GET(request: Request) {
     // Fail-closed scoping (#848): SOURCE was missing from this chain and read
     // every relation in the tenant. Roles without a defined scope are denied.
     // COMPANY stays read-only and limited to its own company's relations.
-    const scope = await relationScopeForRole(session.user);
+    const scope = await scopeForRole(session.user, 'relation');
     if (!scope) {
       await logScopeDenial(session.user, 'GET /api/mentorship');
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 });

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -3,8 +3,8 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { z } from 'zod';
-import type { Prisma } from '@prisma/client';
 import { resolveOwner } from '@/lib/projectAccess';
+import { scopeForRole, logScopeDenial } from '@/lib/authzScope';
 import { logActivity } from '@/lib/activity';
 import { withTenantScope } from '@/lib/orgContext';
 import { createOrGetProjectConversation } from '@/lib/conversations';
@@ -32,18 +32,19 @@ export async function GET() {
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
   return withTenantScope(session, async () => {
-  let where: Prisma.ProjectWhereInput = {};
-  // Mentors see projects they own OR are members of (#617/#619).
-  if (session.user.role === 'MENTOR') {
-    where = { OR: [{ ownerUserId: session.user.id }, { members: { some: { userId: session.user.id } } }] };
+  // Fail-closed scoping (#849): SOURCE used to fall past the role chain here
+  // and read every project, private ones included. Per-role scopes now live in
+  // authzScope.ts and an unlisted role is denied instead of unfiltered.
+  const where = await scopeForRole(session.user, 'project');
+  if (!where) {
+    await logScopeDenial(session.user, 'GET /api/projects');
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
-  else if (session.user.role === 'COMPANY') where = { ownerCompanyId: session.user.companyId ?? '__none__' };
-  else if (session.user.role === 'MENTEE') where = { isPublic: true };
 
   const projects = await prisma.project.findMany({ where, include, orderBy: { updatedAt: 'desc' } });
-  // Mentees only browse the public showcase set — keep it PII-free
-  // (member/relation names stripped, count only).
-  if (session.user.role === 'MENTEE') {
+  // Showcase-only roles (mentee, source) browse the public set — keep it
+  // PII-free (member/relation names stripped, count only).
+  if (session.user.role === 'MENTEE' || session.user.role === 'SOURCE') {
     return NextResponse.json({
       projects: projects.map(({ relations: _relations, members: _members, ...rest }) => rest),
     });

--- a/src/lib/authzScope.ts
+++ b/src/lib/authzScope.ts
@@ -3,13 +3,22 @@ import { prisma } from '@/lib/prisma';
 import { logActivity } from '@/lib/activity';
 
 /**
- * Fail-closed data scoping (#814 / #831).
+ * Fail-closed data scoping (#814 / #831 / #849).
  *
  * The API routes used to scope with "if I recognise the role, filter it" —
  * an `if/else if` chain with no final `else`. Any role the chain didn't name
  * (COMPANY, SOURCE, and every role added later) fell through with an empty
- * `where` and got ADMIN visibility. The helpers here invert that: a role with
- * no defined scope yields `null`, and the caller answers 403.
+ * `where` and got ADMIN visibility. `scopeForRole()` inverts that: every role
+ * needs an entry, a role without one yields `null`, and the caller answers 403.
+ *
+ * Adding a role to `Role` in schema.prisma without adding it to the builders
+ * below now costs that role its access — it never silently grants it.
+ *
+ *     const scope = await scopeForRole(session.user, 'relation');
+ *     if (!scope) {
+ *       await logScopeDenial(session.user, 'GET /api/thing');
+ *       return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+ *     }
  */
 
 /** Sentinel that can never match a cuid, used to force an empty result set. */
@@ -21,6 +30,15 @@ export interface ScopeUser {
   email?: string | null;
   companyId?: string | null;
 }
+
+/** The `where` shape each scoped resource expects. */
+export interface ScopeMap {
+  /** MentorshipRelation itself, and anything reached through it (interaction logs). */
+  relation: Prisma.MentorshipRelationWhereInput;
+  project: Prisma.ProjectWhereInput;
+}
+
+export type ScopedResource = keyof ScopeMap;
 
 /**
  * The source a SOURCE user represents. Mirrors `/api/source/mentees` — a SOURCE
@@ -35,28 +53,48 @@ export async function sourceIdForUser(userId: string): Promise<string | null> {
 }
 
 /**
- * Scope for anything reachable through a MentorshipRelation (the relations
- * themselves and their interaction logs). Returns `{}` for ADMIN — deliberately
- * unscoped — and `null` for a role with no defined scope, which the caller must
- * turn into a 403.
+ * One builder per role, per resource. `{}` means "deliberately unscoped"
+ * (ADMIN); a missing key means "no scope defined" and denies the role.
  */
-export async function relationScopeForRole(
-  user: ScopeUser
-): Promise<Prisma.MentorshipRelationWhereInput | null> {
-  switch (user.role) {
-    case 'ADMIN':
-      return {};
-    case 'MENTOR':
-      return { mentorId: user.id };
-    case 'MENTEE':
-      return { menteeId: user.id };
-    case 'COMPANY':
-      return { companyId: user.companyId ?? NO_MATCH };
-    case 'SOURCE':
-      return { mentee: { sourceId: (await sourceIdForUser(user.id)) ?? NO_MATCH } };
-    default:
-      return null;
-  }
+const BUILDERS: {
+  [K in ScopedResource]: Partial<Record<string, (user: ScopeUser) => Promise<ScopeMap[K]>>>;
+} = {
+  relation: {
+    // Admins see the whole tenant by design.
+    ADMIN: async () => ({}),
+    MENTOR: async (u) => ({ mentorId: u.id }),
+    MENTEE: async (u) => ({ menteeId: u.id }),
+    // Read-only: only relations linked to this company.
+    COMPANY: async (u) => ({ companyId: u.companyId ?? NO_MATCH }),
+    // Only the mentees this source referred.
+    SOURCE: async (u) => ({ mentee: { sourceId: (await sourceIdForUser(u.id)) ?? NO_MATCH } }),
+  },
+  project: {
+    ADMIN: async () => ({}),
+    // Mentors see projects they own OR are members of (#617/#619).
+    MENTOR: async (u) => ({
+      OR: [{ ownerUserId: u.id }, { members: { some: { userId: u.id } } }],
+    }),
+    MENTEE: async () => ({ isPublic: true }),
+    COMPANY: async (u) => ({ ownerCompanyId: u.companyId ?? NO_MATCH }),
+    // A source has no project workflow of its own; it used to fall through and
+    // read every project, private ones included. Limited to the public
+    // showcase, same as a mentee.
+    SOURCE: async () => ({ isPublic: true }),
+  },
+};
+
+/**
+ * The `where` fragment this user may read for `resource`, or `null` when the
+ * role has no defined scope — which the caller must turn into a 403.
+ */
+export async function scopeForRole<K extends ScopedResource>(
+  user: ScopeUser,
+  resource: K
+): Promise<ScopeMap[K] | null> {
+  const build = BUILDERS[resource][user.role];
+  if (!build) return null;
+  return (await build(user)) as ScopeMap[K];
 }
 
 /** Audit a denial so an unscoped role showing up in production is visible. */

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,21 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.30.3-beta',
+    date: '2026-07-31',
+    highlights: {
+      en: [
+        'Security fix: referral-source accounts could see every project, including private ones. They now see the public showcase only, without member names.',
+      ],
+      tr: [
+        'Güvenlik düzeltmesi: yönlendiren kurum hesapları özel olanlar dâhil tüm projeleri görebiliyordu. Artık yalnızca açık vitrini, üye isimleri olmadan görüyorlar.',
+      ],
+      de: [
+        'Sicherheitskorrektur: Vermittlerkonten konnten alle Projekte sehen, auch private. Sie sehen jetzt nur noch die öffentliche Übersicht, ohne Mitgliedsnamen.',
+      ],
+    },
+  },
+  {
     version: '0.30.2-beta',
     date: '2026-07-31',
     highlights: {


### PR DESCRIPTION
Closes #849
Closes #851

Devamı: #978 (iki acil sızıntıyı kapattı). Bu PR deseni merkezîleştiriyor ve aynı sınıfın **üçüncü** örneğini kapatıyor.

## Merkezî kapsamlama / Central scoping

`src/lib/authzScope.ts` → `scopeForRole(user, resource)`. Kapsamlar artık her route'ta `if/else if` zinciri değil, kaynak × rol builder tablosu:

```ts
const BUILDERS = {
  relation: { ADMIN, MENTOR, MENTEE, COMPANY, SOURCE },
  project:  { ADMIN, MENTOR, MENTEE, COMPANY, SOURCE },
};
```

Builder'ı olmayan rol → `null` → çağıran `403` + `authz.scope_denied` (warning) aktivite kaydı. `schema.prisma`'daki `Role` enum'una rol eklemek artık **sessizce erişim veremiyor**; builder eklenmezse rol 403 alır.

Taşınan route'lar: `/api/interactions`, `/api/mentorship`, `/api/projects`.

## Üçüncü sızıntı: `/api/projects` (#849)

`#847`/`#848` ile aynı şekil — zincir MENTOR/COMPANY/MENTEE'yi kapsıyordu, `SOURCE` filtresiz kalıyordu ve **özel projeler dâhil hepsini** okuyordu.

`SOURCE` artık menti ile aynı vitrini görüyor (`isPublic: true`) ve yanıt aynı şekilde PII'dan arındırılıyor (üye/ilişki isimleri çıkarılıyor, sayı kalıyor). Kendine ait proje akışı olmadığı için (`/source` yalnız `/api/source/mentees` çağırıyor) en dar kapsam seçildi.

## Doküman (#851)

`docs/role-access-matrix.md` — matris, fail-closed gerekçesi, ve **matrisin dışında kalan** alanlar: `cvAccess` / `documentAccess` / `messaging` / rol-kapılı route'lar. Bunlar denetimde temiz çıktı ve zaten fail-closed; dokümanda "bozmayın" olarak işaretli. Yeni rol/kaynak eklerken izlenecek 3 adım de yazılı.

## Test

`e2e/role-scoping.spec.ts` (`@smoke`) genişletildi: SOURCE özel projeyi görmüyor. Mevcut COMPANY/SOURCE/MENTOR/MENTEE vakaları #978'de yeşil geçti.

`npm run build` ✅ · `npx tsc --noEmit` ✅ · `next lint` ✅

## Sürüm / Versioning

`0.30.3-beta` + CHANGELOG + releaseNotes (EN/TR/DE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
