### PR TITLE
feat(security): mentorluk sonrası erişim penceresi + /api/users veri minimizasyonu (#854, #855)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,43 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.31.0-beta] - 2026-07-31
+
+### Security
+- **A mentor kept CV and document access to a former mentee forever** (#854).
+  `canAccessCv` / `canAccessUserDocs` asked only whether a `MentorshipRelation`
+  existed, never what its `status` was, so marking a mentorship COMPLETED changed
+  nothing. Access now expires `POST_MENTORSHIP_ACCESS_MONTHS` (6) after completion.
+  **Product decision — a window, not an immediate cut-off:** writing a reference
+  after the internship is real work, and revoking on the spot pushes mentors to keep
+  private copies, which moves the data outside the app's audit trail entirely. What
+  was indefensible was the *indefinite* part. Rationale, the alternative considered
+  and the legal basis: `docs/pii-access-lifecycle.md`. Owner and ADMIN access are
+  unaffected.
+- **`/api/users` dumped every user's full PII in one request** (#855). The admin
+  branch had no `take`/`skip` and returned email, phone, university, department and
+  more for the entire tenant — one compromised admin session walked off with the lot.
+  Added a `?view=` field set (`picker` = id/name/role, `directory` =
+  id/name/email/role/active/verified) and opt-in pagination
+  (`?page=`, `perPage` default 25, max 100, response carries `total`/`archivedCount`).
+  `/admin/users` now paginates, filters and searches server-side instead of pulling
+  the whole table and slicing it in the browser; `/admin/mentorship` and
+  `ProjectsManager` switched to `view=picker`, so their requests no longer carry any
+  PII at all. The MENTOR branch is untouched.
+
+### Added
+- `MentorshipRelation.completedAt`, stamped when a relation is marked COMPLETED and
+  cleared if it is reopened — the anchor for the access window above.
+  `prisma/backfill-relation-completed-at.mjs` (idempotent, wired into
+  `infra/deploy-prod.sh`) stamps relations that were already COMPLETED before the
+  column existed, so they get a window instead of losing access the moment this
+  deploys.
+
+### Documentation
+- **`docs/pii-access-lifecycle.md`** — how long access lasts and how much data each
+  caller gets, plus what is deliberately left for later (`/admin/candidates` and
+  `/admin/mentors` still fetch full lists; PII access logging is #821).
+
 ## [0.30.3-beta] - 2026-07-31
 
 ### Security

--- a/docs/pii-access-lifecycle.md
+++ b/docs/pii-access-lifecycle.md
@@ -1,0 +1,105 @@
+# PII erişiminde yaşam döngüsü / PII access lifecycle
+
+Yetkilendirme "**erişebilir mi?**" sorusunu doğru cevaplıyordu; bu doküman
+"**ne kadar süre**" ve "**ne kadarına**" sorularının cevabını yazıyor.
+
+Kaynak kod: [`src/lib/retention.ts`](../src/lib/retention.ts)
+(`accessGrantingRelation`), [`src/lib/cvAccess.ts`](../src/lib/cvAccess.ts),
+[`src/lib/documentAccess.ts`](../src/lib/documentAccess.ts),
+[`src/app/api/users/route.ts`](../src/app/api/users/route.ts).
+
+İlgili: story [#832](https://github.com/21072026/Internship/issues/832),
+task'lar [#854](https://github.com/21072026/Internship/issues/854) ·
+[#855](https://github.com/21072026/Internship/issues/855). Rol bazlı kapsamlama
+ayrı bir katman: [`role-access-matrix.md`](role-access-matrix.md).
+
+## 1. Ne kadar süre — mentorluk sonrası erişim penceresi
+
+### Ürün kararı
+
+**Mentorluk `COMPLETED` olarak işaretlendikten sonra mentorun (ve bağlı
+şirketin) mentee'nin CV ve belgelerine erişimi 6 ay daha sürer, sonra kapanır.**
+
+`POST_MENTORSHIP_ACCESS_MONTHS = 6` — [`src/lib/retention.ts`](../src/lib/retention.ts).
+
+### Önceki durum
+
+`canAccessCv` ve `canAccessUserDocs`, ilişkinin **var olup olmadığına** bakıyor,
+`status` alanına hiç bakmıyordu. Yani ilişki bittikten sonra da erişim
+sürüyordu — süresiz. `MentorshipRelation.status` (`ACTIVE | COMPLETED`) şemada
+zaten vardı, bu kontrollerde kullanılmıyordu.
+
+### Değerlendirilen alternatif
+
+| | Seçenek A — anında kapat | Seçenek B — 6 ay pencere ✅ |
+|---|---|---|
+| Amaçla sınırlılık (KVKK m.4, GDPR Art. 5(1)(b)) | En sıkı | Uyumlu; süre sınırlı ve gerekçeli |
+| Referans yazma / staj sonrası soru | Kırılıyor | Karşılanıyor |
+| Gerçek dünyadaki davranış | Mentoru **özel kopya tutmaya** iter — veri kontrolden çıkar | Erişim sistem içinde ve denetlenebilir kalır |
+
+Seçilen: **B**. Savunulamayan şey erişimin *var olması* değil, **süresiz**
+olmasıydı. Mentorun stajdan sonra referans yazması işin gerçek bir parçası;
+ilişkiyi `COMPLETED` işaretler işaretlemez erişimi kesmek, mentorları CV'yi
+kendi diskine indirmeye iter ve veriyi uygulamanın denetim izinin dışına
+taşır — mahremiyet açısından net bir kayıp.
+
+### Uygulama
+
+`MentorshipRelation.completedAt` (yeni, nullable) pencereyi çapalıyor:
+
+- `PUT /api/mentorship/[id]` durumu `COMPLETED`'a çevirdiğinde damgalanıyor.
+- Aynı ilişki tekrar `ACTIVE` yapılırsa `null`'a dönüyor — pencere yeniden başlar.
+- Erişim koşulu: `status = ACTIVE` **veya** (`status = COMPLETED` ve
+  `completedAt >= bugün - 6 ay`).
+
+**Sahip ve ADMIN etkilenmez** — kendi CV'sine erişim ve admin erişimi her zaman
+açık.
+
+#### Eski kayıtlar
+
+`completedAt: { gte: ... }` karşılaştırması `NULL`'ları **eşleştirmez**, yani
+kolon eklenmeden önce `COMPLETED` olmuş ilişkiler bu özellik canlıya çıktığı an
+erişimi kaybederdi. [`prisma/backfill-relation-completed-at.mjs`](../prisma/backfill-relation-completed-at.mjs)
+bu satırları deploy anıyla damgalıyor: pencereleri yükseltme anından başlıyor,
+6 ay içinde normal şekilde kapanıyorlar. Sadece `NULL` doldurduğu için
+idempotent; `infra/deploy-prod.sh` içinde kalıcı olarak duruyor.
+
+## 2. Ne kadarına — veri minimizasyonu
+
+`GET /api/users` ADMIN dalı **tüm** kullanıcıları, e-posta ve telefon dahil tüm
+alanlarla, tek yanıtta döndürüyordu. Ele geçirilmiş tek bir admin oturumu tek
+istekte tüm PII tablosunu alabiliyordu.
+
+### Alan kümeleri / Field sets
+
+`?view=` parametresi çağıranın **gerçekten render ettiği** alanları istemesini
+sağlıyor:
+
+| `view` | Alanlar | Kullanan |
+|---|---|---|
+| `picker` | `id, fullName, role` | `/admin/mentorship` atama menüleri, `ProjectsManager` |
+| `directory` | `id, fullName, email, role, isActive, emailVerified` | `/admin/users` listesi |
+| *(yok)* | tarihsel tam küme | `/admin/candidates`, `/admin/mentors` — üniversite/beceri/kapasite sütunlarını gösteriyorlar |
+
+MENTOR dalı zaten PII'sız (`id, fullName, role`) ve **değişmedi**.
+
+### Sayfalama
+
+`?page=` verildiğinde sayfalanıyor: varsayılan `perPage=25`, üst sınır `100`,
+yanıt `{ users, total, page, perPage, archivedCount }`.
+
+Sayfalama **opt-in** — bu, `/api/mentorship`'in zaten kullandığı sözleşmenin
+aynısı. Varsayılan olarak sayfalamak `/admin/candidates` ve `/admin/mentors`
+ekranlarını sessizce bozardı: ikisi de tüm kümeyi çekip tarayıcıda filtreliyor
+ve kırpılmış bir listeyi tam liste sanardı.
+
+`/admin/users` artık sunucu tarafında sayfalanıyor; rol filtresi, arşiv sekmesi
+ve arama da sunucuya taşındı (arama 300 ms debounce'lu).
+
+### Kalan iş
+
+`/admin/candidates` ve `/admin/mentors` hâlâ tam listeyi tam alan kümesiyle
+çekiyor. İkisi de gerçekten PII sütunları gösteriyor, dolayısıyla düzeltme
+"alanları kırp" değil "sunucu tarafı filtre + sayfalama"dan geçiyor — ayrı bir
+iş. Erişim **loglanmıyor**; PII erişim kaydı
+[#821](https://github.com/21072026/Internship/issues/821) kapsamında.

--- a/docs/role-access-matrix.md
+++ b/docs/role-access-matrix.md
@@ -91,6 +91,9 @@ yazılmışlar; denetimde temiz çıktılar ve **bozulmamalı**:
 | Rol-kapılı route'lar | Girişte rol allowlist'i → 401 (`/api/users`, `/api/search`, `/api/meetings`, `/api/availability`, `/api/company/*`, `/api/mentor/*`, `/api/admin/*`) | ilgili `route.ts` |
 | Kayıt bazlı yetki | `allowed = ADMIN \|\| katılımcı` (varsayılan `false`) | `/api/evaluations`, `/api/questions/[id]`, `/api/mentorship/[id]`, `/api/users/[id]/activity` |
 
+Erişimin *süresi* ve *kapsamı* (mentorluk sonrası pencere, alan minimizasyonu)
+da ayrı bir katman: [`pii-access-lifecycle.md`](pii-access-lifecycle.md).
+
 Tenant (organizasyon) izolasyonu **ayrı bir katman**: `withTenantScope()` /
 `MT_ENFORCE_ISOLATION` — bkz. [`tenant-isolation.md`](tenant-isolation.md). Bu
 matris tenant *içi* rol kapsamlamasını tanımlar.

--- a/e2e/pii-access-lifecycle.spec.ts
+++ b/e2e/pii-access-lifecycle.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { signInAndSettle } from './helpers/auth';
+
+/**
+ * The post-mentorship access window (#854). `canAccessCv` used to ask only
+ * "does a relation exist?", so a mentor kept reading a former mentee's CV
+ * forever. Access now expires `POST_MENTORSHIP_ACCESS_MONTHS` (6) after the
+ * relation is marked COMPLETED.
+ */
+
+const PASSWORD = 'LifecyclePass123';
+
+const mentorEmail = uniqueEmail('life-mentor');
+const activeMenteeEmail = uniqueEmail('life-active');
+const staleMenteeEmail = uniqueEmail('life-stale');
+const recentMenteeEmail = uniqueEmail('life-recent');
+
+let activeId = '';
+let staleId = '';
+let recentId = '';
+
+function monthsAgo(months: number) {
+  const d = new Date();
+  d.setMonth(d.getMonth() - months);
+  return d;
+}
+
+test.beforeAll(async () => {
+  const mentor = await seedUser(mentorEmail, PASSWORD, 'MENTOR', 'Lifecycle Mentor');
+  const [a, s, r] = await Promise.all([
+    seedUser(activeMenteeEmail, 'x', 'MENTEE', 'Active Mentee'),
+    seedUser(staleMenteeEmail, 'x', 'MENTEE', 'Stale Mentee'),
+    seedUser(recentMenteeEmail, 'x', 'MENTEE', 'Recent Mentee'),
+  ]);
+  activeId = a.id;
+  staleId = s.id;
+  recentId = r.id;
+
+  await Promise.all([
+    prisma.mentorshipRelation.create({ data: { mentorId: mentor.id, menteeId: a.id, status: 'ACTIVE' } }),
+    // Completed well outside the 6-month window.
+    prisma.mentorshipRelation.create({
+      data: { mentorId: mentor.id, menteeId: s.id, status: 'COMPLETED', completedAt: monthsAgo(9) },
+    }),
+    // Completed inside it.
+    prisma.mentorshipRelation.create({
+      data: { mentorId: mentor.id, menteeId: r.id, status: 'COMPLETED', completedAt: monthsAgo(1) },
+    }),
+  ]);
+
+  await prisma.cvFile.createMany({
+    data: [a.id, s.id, r.id].map((userId) => ({
+      userId,
+      filename: 'cv.pdf',
+      contentType: 'application/pdf',
+      size: 3,
+      data: Buffer.from('pdf'),
+    })),
+  });
+});
+
+test.afterAll(async () => {
+  await prisma.cvFile.deleteMany({ where: { userId: { in: [activeId, staleId, recentId] } } });
+  for (const email of [mentorEmail, activeMenteeEmail, staleMenteeEmail, recentMenteeEmail]) {
+    await cleanupByEmail(email);
+  }
+  await prisma.$disconnect();
+});
+
+test('a mentor loses CV access once the mentorship has been over for the window', { tag: '@smoke' }, async ({ page }) => {
+  await signInAndSettle(page, mentorEmail, PASSWORD, '/mentor');
+
+  // Active mentorship — unchanged behaviour.
+  expect((await page.request.get(`/api/cv/${activeId}`)).status()).toBe(200);
+  // Completed one month ago — still inside the 6-month reference window.
+  expect((await page.request.get(`/api/cv/${recentId}`)).status()).toBe(200);
+  // Completed nine months ago — access has expired.
+  expect((await page.request.get(`/api/cv/${staleId}`)).status()).toBe(403);
+});

--- a/infra/deploy-prod.sh
+++ b/infra/deploy-prod.sh
@@ -227,6 +227,10 @@ run_tool node prisma/backfill-organization.mjs || true
 # One-shot: baseline the scheduled-job backlog so the first cron tick doesn't
 # email out history. Self-skips once applied (Setting 'cronBaselineAt').
 run_tool node prisma/backfill-cron-baseline.mjs || true
+# Stamp completedAt on relations that were COMPLETED before the column existed,
+# so the post-mentorship CV access window (#854) has an anchor instead of
+# revoking access outright. Only ever fills NULLs — idempotent.
+run_tool node prisma/backfill-relation-completed-at.mjs || true
 
 # ── 5. Swap the container ────────────────────────────────────────────────────
 log "Restarting $CONTAINER on :$PORT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.30.3-beta",
+  "version": "0.31.0-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/prisma/backfill-relation-completed-at.mjs
+++ b/prisma/backfill-relation-completed-at.mjs
@@ -1,0 +1,39 @@
+// Backfill MentorshipRelation.completedAt for relations that were already
+// COMPLETED before the column existed (#854).
+//
+// Why this is needed: the post-mentorship CV/document access window is anchored
+// on `completedAt`, and `completedAt: { gte: cutoff }` never matches NULL. So
+// without this, every historical COMPLETED relation would lose mentor/company
+// access the moment the feature ships — an abrupt revocation nobody asked for,
+// and one a mentor mid-reference would experience as a bug.
+//
+// Stamping them with "now" starts each legacy relation's window at the upgrade
+// instead. It is generous by at most one window length, and it converges: six
+// months after this runs, every one of those relations has aged out normally.
+//
+// Idempotent by construction — it only ever fills NULLs on COMPLETED rows, so a
+// second run touches nothing. Safe to leave wired into deploy-prod.sh forever.
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const now = new Date();
+  const { count } = await prisma.mentorshipRelation.updateMany({
+    where: { status: 'COMPLETED', completedAt: null },
+    data: { completedAt: now },
+  });
+
+  console.log(
+    count === 0
+      ? 'backfill-relation-completed-at: nothing to do.'
+      : `backfill-relation-completed-at: stamped ${count} completed relation(s) at ${now.toISOString()}.`,
+  );
+}
+
+main()
+  .catch((e) => {
+    console.error('backfill-relation-completed-at failed:', e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -908,6 +908,11 @@ model MentorshipRelation {
   cohortId                String?
   startDate               DateTime         @default(now())
   status                  MentorshipStatus @default(ACTIVE)
+  // When the relation was marked COMPLETED. Anchors the post-mentorship CV and
+  // document access window (#854) — without it, "access ended six months ago"
+  // is unanswerable and mentors keep reading a former mentee's CV forever.
+  // Cleared if the relation is reopened as ACTIVE.
+  completedAt             DateTime?
   // Stage key. Free String (was the PipelineStatus enum) so tenants can define
   // their own stages (#747). The enum below is kept as the canonical default
   // key registry; values are unchanged for existing rows (ENUM→VARCHAR keeps

--- a/src/app/admin/mentorship/page.tsx
+++ b/src/app/admin/mentorship/page.tsx
@@ -13,10 +13,11 @@ import { SkeletonRows } from '@/components/ui/Skeleton';
 import { BookOpen, Plus } from 'lucide-react';
 import { formatDate } from '@/lib/relativeTime';
 
+// The assign dropdowns only ever show a name, so this asks the API for the
+// `picker` field set — no email/phone/university in the response (#855).
 interface User {
   id: string;
   fullName: string;
-  email: string;
 }
 
 interface Company {
@@ -75,7 +76,7 @@ export default function MentorshipPage() {
   const fetchPickers = async () => {
     try {
       const [usersRes, companiesRes] = await Promise.all([
-        fetch('/api/users'),
+        fetch('/api/users?view=picker'),
         fetch('/api/companies'),
       ]);
       const [usersData, companiesData] = await Promise.all([usersRes.json(), companiesRes.json()]);

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -33,7 +33,10 @@ export default function AdminUsersPage() {
   // stays uncluttered; the "Archived" tab reveals them for reactivation (#570).
   const [statusView, setStatusView] = useState<'ACTIVE' | 'ARCHIVED'>('ACTIVE');
   const [search, setSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
   const [page, setPage] = useState(1);
+  const [total, setTotal] = useState(0);
+  const [archivedCount, setArchivedCount] = useState(0);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [impersonateError, setImpersonateError] = useState<{ userId: string; message: string } | null>(null);
   const PAGE_SIZE = 20;
@@ -64,16 +67,40 @@ export default function AdminUsersPage() {
     setBusyId(null);
   };
 
+  // Server-side pagination (#855): this screen used to pull every user in the
+  // tenant — email, phone, university, the lot — and slice it in the browser.
+  // It now asks for one page of the `directory` field set, so a single request
+  // can no longer walk off with the whole PII table.
   const load = useCallback(async () => {
-    const res = await fetch('/api/users');
-    const { users } = await res.json();
-    setUsers(users ?? []);
+    const params = new URLSearchParams({
+      view: 'directory',
+      page: String(page),
+      perPage: String(PAGE_SIZE),
+      status: statusView === 'ACTIVE' ? 'active' : 'archived',
+    });
+    if (filter !== 'ALL') params.set('role', filter);
+    if (debouncedSearch) params.set('search', debouncedSearch);
+
+    const res = await fetch(`/api/users?${params}`);
+    const data = await res.json();
+    setUsers(data.users ?? []);
+    setTotal(data.total ?? 0);
+    setArchivedCount(data.archivedCount ?? 0);
     setLoading(false);
-  }, []);
+  }, [page, statusView, filter, debouncedSearch]);
 
   useEffect(() => {
     load();
   }, [load]);
+
+  // Debounce the search box so typing doesn't fire a query per keystroke.
+  useEffect(() => {
+    const id = setTimeout(() => {
+      setDebouncedSearch(search.trim());
+      setPage(1);
+    }, 300);
+    return () => clearTimeout(id);
+  }, [search]);
 
   const toggleActive = async (u: AdminUser) => {
     setBusyId(u.id);
@@ -83,25 +110,17 @@ export default function AdminUsersPage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ isActive: !u.isActive }),
       });
-      if (res.ok) {
-        setUsers((prev) => prev.map((x) => (x.id === u.id ? { ...x, isActive: !x.isActive } : x)));
-      }
+      // Reload rather than patching in place: the active/archived split is a
+      // server-side filter now, so the row belongs on the other tab.
+      if (res.ok) await load();
     } finally {
       setBusyId(null);
     }
   };
 
-  const q = search.trim().toLowerCase();
-  const archivedCount = users.filter((u) => !u.isActive).length;
-  const filtered = users.filter(
-    (u) =>
-      (statusView === 'ACTIVE' ? u.isActive : !u.isActive) &&
-      (filter === 'ALL' || u.role === filter) &&
-      (!q || u.fullName.toLowerCase().includes(q) || u.email.toLowerCase().includes(q))
-  );
-  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
   const currentPage = Math.min(page, totalPages);
-  const shown = filtered.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE);
+  const shown = users;
 
   return (
     <div>
@@ -149,7 +168,7 @@ export default function AdminUsersPage() {
 
       <Card>
         <CardHeader>
-          <CardTitle>{t.usersAdmin.title} ({filtered.length})</CardTitle>
+          <CardTitle>{t.usersAdmin.title} ({total})</CardTitle>
         </CardHeader>
         {loading ? (
           <SkeletonRows rows={6} />

--- a/src/app/api/mentorship/[id]/route.ts
+++ b/src/app/api/mentorship/[id]/route.ts
@@ -126,6 +126,11 @@ export async function PUT(request: Request, { params }: { params: Promise<{ id: 
 
       const { stageDeadline, ...rest } = parsed.data;
       const data: Prisma.MentorshipRelationUncheckedUpdateInput = { ...rest };
+      // Stamp/clear the end of the relation — it anchors the post-mentorship
+      // CV/document access window (#854).
+      if (parsed.data.status && parsed.data.status !== relation.status) {
+        data.completedAt = parsed.data.status === 'COMPLETED' ? new Date() : null;
+      }
       if (stageDeadline !== undefined) {
         data.stageDeadline = stageDeadline ? new Date(stageDeadline) : null;
         // A fresh deadline (or cleared) re-arms the overdue reminder.

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -3,8 +3,41 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { withTenantScope } from '@/lib/orgContext';
+import type { Prisma } from '@prisma/client';
 
-export async function GET() {
+// Field sets, narrowest first (#855). The admin list used to return every
+// column — email, phone, university, department, birth year — for every user in
+// the tenant, on every screen that needed so much as a name. `view` lets each
+// caller ask for what it renders and nothing more.
+const SELECTS = {
+  // Owner/member pickers: a name and a role badge.
+  picker: { id: true, fullName: true, role: true },
+  // The /admin/users list: name, email, role badge, active/verified state.
+  directory: { id: true, fullName: true, email: true, role: true, isActive: true, emailVerified: true },
+} as const;
+
+// No `view` → the historical full set. Still used by the candidates and mentors
+// screens, which render university/skills/capacity columns.
+const FULL_SELECT = {
+  id: true,
+  email: true,
+  fullName: true,
+  role: true,
+  university: true,
+  department: true,
+  graduationYear: true,
+  skills: true,
+  mentorCapacity: true,
+  phone: true,
+  isActive: true,
+  emailVerified: true,
+  createdAt: true,
+  _count: { select: { mentorRelations: true } },
+} as const;
+
+const ROLES = ['ADMIN', 'MENTOR', 'MENTEE', 'COMPANY', 'SOURCE'] as const;
+
+export async function GET(request: Request) {
   try {
     const session = await getServerSession(authOptions);
 
@@ -18,33 +51,55 @@ export async function GET() {
       if (session.user.role === 'MENTOR') {
         const users = await prisma.user.findMany({
           where: { role: { in: ['MENTOR', 'ADMIN'] }, isActive: true },
-          select: { id: true, fullName: true, role: true },
+          select: SELECTS.picker,
           orderBy: { fullName: 'asc' },
         });
         return NextResponse.json({ users });
       }
 
-      const users = await prisma.user.findMany({
-        select: {
-          id: true,
-          email: true,
-          fullName: true,
-          role: true,
-          university: true,
-          department: true,
-          graduationYear: true,
-          skills: true,
-          mentorCapacity: true,
-          phone: true,
-          isActive: true,
-          emailVerified: true,
-          createdAt: true,
-          _count: { select: { mentorRelations: true } },
-        },
-        orderBy: { createdAt: 'desc' },
-      });
+      const { searchParams } = new URL(request.url);
+      const view = searchParams.get('view');
+      const select = view === 'picker' || view === 'directory' ? SELECTS[view] : FULL_SELECT;
 
-      return NextResponse.json({ users });
+      const roleParam = searchParams.get('role');
+      const role = ROLES.find((r) => r === roleParam);
+      const status = searchParams.get('status');
+      const search = searchParams.get('search')?.trim();
+
+      const where: Prisma.UserWhereInput = {};
+      if (role) where.role = role;
+      if (status === 'active') where.isActive = true;
+      if (status === 'archived') where.isActive = false;
+      if (search) {
+        where.OR = [{ fullName: { contains: search } }, { email: { contains: search } }];
+      }
+
+      // Pagination is opt-in — applied only when `page` is passed, the same
+      // contract /api/mentorship uses. The candidates and mentors screens filter
+      // the whole set client-side and would break on a silently truncated list.
+      const pageParam = searchParams.get('page');
+      if (!pageParam) {
+        const users = await prisma.user.findMany({ where, select, orderBy: { createdAt: 'desc' } });
+        return NextResponse.json({ users });
+      }
+
+      const page = Math.max(1, parseInt(pageParam, 10) || 1);
+      const perPage = Math.min(100, Math.max(1, parseInt(searchParams.get('perPage') || '25', 10) || 25));
+
+      const [total, archivedCount, users] = await Promise.all([
+        prisma.user.count({ where }),
+        // For the "Archived (N)" tab: same role/search filter, opposite status.
+        prisma.user.count({ where: { ...where, isActive: false } }),
+        prisma.user.findMany({
+          where,
+          select,
+          orderBy: { createdAt: 'desc' },
+          skip: (page - 1) * perPage,
+          take: perPage,
+        }),
+      ]);
+
+      return NextResponse.json({ users, total, page, perPage, archivedCount });
     });
   } catch (error) {
     console.error('Get users error:', error);

--- a/src/components/ProjectsManager.tsx
+++ b/src/components/ProjectsManager.tsx
@@ -73,7 +73,7 @@ export function ProjectsManager({ isAdmin }: { isAdmin: boolean }) {
   useEffect(() => { load(); }, [load]);
   useEffect(() => {
     // Mentors get a minimal directory too — needed for the member picker (#618).
-    fetch('/api/users').then((r) => (r.ok ? r.json() : { users: [] }))
+    fetch('/api/users?view=picker').then((r) => (r.ok ? r.json() : { users: [] }))
       .then((d) => {
         const users = (d.users ?? []) as { id: string; fullName: string; role: string }[];
         setMentors(users.filter((u) => u.role === 'MENTOR' || u.role === 'ADMIN'));

--- a/src/lib/cvAccess.ts
+++ b/src/lib/cvAccess.ts
@@ -1,4 +1,5 @@
 import { prisma } from '@/lib/prisma';
+import { accessGrantingRelation } from '@/lib/retention';
 
 interface SessionUser {
   id: string;
@@ -8,19 +9,23 @@ interface SessionUser {
 
 // A CV is accessible to the owner, any admin, a mentor who mentors that user,
 // or a company the user has a mentorship relation with.
+//
+// For mentors and companies the relation must still confer access: ACTIVE, or
+// COMPLETED within the post-mentorship window (#854). Before that check existed
+// the mentorship's end changed nothing and access was effectively permanent.
 export async function canAccessCv(user: SessionUser, targetUserId: string) {
   if (user.id === targetUserId) return true;
   if (user.role === 'ADMIN') return true;
   if (user.role === 'MENTOR') {
     const rel = await prisma.mentorshipRelation.findFirst({
-      where: { mentorId: user.id, menteeId: targetUserId },
+      where: { mentorId: user.id, menteeId: targetUserId, ...accessGrantingRelation() },
       select: { id: true },
     });
     return !!rel;
   }
   if (user.role === 'COMPANY' && user.companyId) {
     const rel = await prisma.mentorshipRelation.findFirst({
-      where: { companyId: user.companyId, menteeId: targetUserId },
+      where: { companyId: user.companyId, menteeId: targetUserId, ...accessGrantingRelation() },
       select: { id: true },
     });
     return !!rel;

--- a/src/lib/documentAccess.ts
+++ b/src/lib/documentAccess.ts
@@ -1,4 +1,5 @@
 import { prisma } from '@/lib/prisma';
+import { accessGrantingRelation } from '@/lib/retention';
 
 interface SessionUser {
   id: string;
@@ -6,13 +7,14 @@ interface SessionUser {
 }
 
 // A user's documents are accessible to the owner, any admin, or a mentor who
-// mentors that user. (Same rule as CVs.)
+// mentors that user. (Same rule as CVs — including the post-mentorship access
+// window, #854: the relation must be ACTIVE or recently COMPLETED.)
 export async function canAccessUserDocs(user: SessionUser, ownerId: string) {
   if (user.id === ownerId) return true;
   if (user.role === 'ADMIN') return true;
   if (user.role === 'MENTOR') {
     const rel = await prisma.mentorshipRelation.findFirst({
-      where: { mentorId: user.id, menteeId: ownerId },
+      where: { mentorId: user.id, menteeId: ownerId, ...accessGrantingRelation() },
       select: { id: true },
     });
     return !!rel;

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,24 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.31.0-beta',
+    date: '2026-07-31',
+    highlights: {
+      en: [
+        'A mentor\'s access to a former mentee\'s CV and documents now ends six months after the mentorship is marked complete, instead of lasting indefinitely. Six months rather than immediately, so you can still write a reference or answer a follow-up. You always have access to your own CV, and admins are unaffected.',
+        'The admin user list now loads one page at a time, with search and role filters handled by the server. Faster on large lists, and a single request no longer returns everyone\'s contact details.',
+      ],
+      tr: [
+        'Bir mentorun eski mentisinin CV ve belgelerine erişimi artık süresiz değil: mentorluk tamamlandı olarak işaretlendikten altı ay sonra sona eriyor. Hemen değil altı ay, çünkü referans yazmak veya sonraki bir soruyu yanıtlamak hâlâ mümkün olmalı. Kendi CV\'nize erişiminiz her zaman açık; yöneticiler etkilenmiyor.',
+        'Yönetici kullanıcı listesi artık sayfa sayfa yükleniyor; arama ve rol filtresi sunucuda çalışıyor. Uzun listelerde daha hızlı ve tek bir istek artık herkesin iletişim bilgisini döndürmüyor.',
+      ],
+      de: [
+        'Der Zugriff eines Mentors auf Lebenslauf und Dokumente eines ehemaligen Mentees endet jetzt sechs Monate nach Abschluss des Mentorings statt unbegrenzt zu gelten. Sechs Monate statt sofort, damit ein Zeugnis oder eine Rückfrage weiterhin möglich bleibt. Auf den eigenen Lebenslauf haben Sie immer Zugriff, Admins sind nicht betroffen.',
+        'Die Admin-Benutzerliste lädt jetzt seitenweise, Suche und Rollenfilter laufen auf dem Server. Schneller bei langen Listen — und eine einzelne Anfrage liefert nicht mehr die Kontaktdaten aller Nutzer.',
+      ],
+    },
+  },
+  {
     version: '0.30.3-beta',
     date: '2026-07-31',
     highlights: {

--- a/src/lib/retention.ts
+++ b/src/lib/retention.ts
@@ -29,6 +29,40 @@ function monthsAgo(months: number): Date {
   return d;
 }
 
+/**
+ * How long after a mentorship ends the mentor (and the linked company) keep
+ * read access to the mentee's CV and documents (#854).
+ *
+ * Product decision: a limited window rather than an immediate cut-off. Writing
+ * a reference or answering a follow-up question after the internship ends is a
+ * real part of the job, and revoking access the moment a mentor marks a
+ * relation COMPLETED would push them to keep private copies instead. Indefinite
+ * access is the thing that is not defensible — KVKK m.4 / GDPR Art. 5(1)(b)
+ * purpose limitation. Rationale and the alternative considered:
+ * docs/DATA_ACCESS_POLICY.md.
+ */
+export const POST_MENTORSHIP_ACCESS_MONTHS = 6;
+
+/**
+ * `where` fragment matching relations that still confer access: active ones,
+ * plus those completed inside the window above.
+ *
+ * A COMPLETED relation with no `completedAt` matches nothing — the comparison
+ * excludes nulls. `prisma/backfill-relation-completed-at.mjs` stamps legacy
+ * rows at first deploy so they get a window rather than an abrupt cut-off.
+ */
+export function accessGrantingRelation() {
+  return {
+    OR: [
+      { status: 'ACTIVE' as const },
+      {
+        status: 'COMPLETED' as const,
+        completedAt: { gte: monthsAgo(POST_MENTORSHIP_ACCESS_MONTHS) },
+      },
+    ],
+  };
+}
+
 export async function getRetentionMonths(): Promise<number> {
   return parseInt(await getSetting('retentionMonths'), 10) || 12;
 }


### PR DESCRIPTION
Closes #854
Closes #855
Closes #832

Epic #814'ün ikinci story'si. Yetkilendirme "**erişebilir mi?**" sorusunu doğru cevaplıyordu; bu PR "**ne kadar süre**" ve "**ne kadarına**" sorularını cevaplıyor.

## 1. Ne kadar süre — mentorluk sonrası erişim penceresi (#854)

`canAccessCv` / `canAccessUserDocs` ilişkinin **var olup olmadığına** bakıyor, `status` alanına hiç bakmıyordu. Mentorluğu `COMPLETED` işaretlemek hiçbir şeyi değiştirmiyordu — erişim süresizdi.

### Ürün kararı: pencere, anında kesme değil

Issue iki seçenek sunuyordu; **B (6 ay)** seçildi:

| | A — anında kapat | **B — 6 ay** ✅ |
|---|---|---|
| Amaçla sınırlılık (KVKK m.4 / GDPR 5(1)(b)) | En sıkı | Uyumlu; süre sınırlı ve gerekçeli |
| Staj sonrası referans yazmak | Kırılıyor | Karşılanıyor |
| Gerçek davranış | Mentoru **özel kopya tutmaya** iter → veri denetim izinin dışına çıkar | Erişim sistem içinde ve denetlenebilir kalır |

Savunulamayan şey erişimin *var olması* değil, **süresiz** olmasıydı. Gerekçe ve hukuki dayanak: `docs/pii-access-lifecycle.md`.

Sahip ve ADMIN erişimi **etkilenmiyor**.

### Uygulama

Yeni `MentorshipRelation.completedAt` pencereyi çapalıyor — `PUT /api/mentorship/[id]` durumu `COMPLETED` yaptığında damgalanıyor, tekrar `ACTIVE` yapılırsa `null`'a dönüyor.

⚠️ **Eski kayıtlar:** `completedAt: { gte: … }` `NULL`'ları eşleştirmez, yani kolon eklenmeden önce `COMPLETED` olmuş ilişkiler bu deploy'da erişimi **bir anda** kaybederdi. `prisma/backfill-relation-completed-at.mjs` (idempotent, `infra/deploy-prod.sh`'a bağlı) onları deploy anıyla damgalıyor: pencere yükseltmeden başlıyor, 6 ay içinde normal şekilde kapanıyor.

## 2. Ne kadarına — veri minimizasyonu (#855)

`GET /api/users` ADMIN dalı `take`/`skip` olmadan **tüm** kullanıcıları e-posta, telefon, üniversite, bölüm dahil döndürüyordu.

**Alan kümeleri** — `?view=`:

| `view` | Alanlar | Kullanan |
|---|---|---|
| `picker` | `id, fullName, role` | `/admin/mentorship` atama menüleri, `ProjectsManager` |
| `directory` | `id, fullName, email, role, isActive, emailVerified` | `/admin/users` |
| *(yok)* | tarihsel tam küme | `/admin/candidates`, `/admin/mentors` (üniversite/beceri/kapasite sütunları gerçekten gösteriliyor) |

İki picker çağıranın isteği artık **hiç PII taşımıyor**. MENTOR dalı **değişmedi**.

**Sayfalama** — `?page=` verildiğinde: `perPage` varsayılan 25, üst sınır 100, yanıt `{ users, total, page, perPage, archivedCount }`. Rol/durum/arama filtreleri de sunucuya taşındı.

`/admin/users` artık sunucu tarafında sayfalanıyor/filtreleniyor/arıyor (arama 300 ms debounce'lu) — tüm tabloyu çekip tarayıcıda dilimlemek yerine.

### ⚠️ Issue'dan sapma: sayfalama opt-in

Issue "varsayılan 25 kayıt" diyor. Bunu varsayılan yapmak `/admin/candidates`, `/admin/mentors`, `/admin/mentorship` ve `ProjectsManager`'ı **sessizce bozardı** — dördü de tüm kümeyi çekip tarayıcıda filtreliyor ve kırpılmış listeyi tam liste sanardı. Bunun yerine `/api/mentorship`'in repoda zaten kullandığı sözleşme uygulandı: `page` açıkça verilirse sayfala. En büyük PII dökümü olan ekran (`/admin/users`) sayfalandı, diğerleri kırılmadı.

## Kalan iş (bilerek dışarıda)

`/admin/candidates` ve `/admin/mentors` hâlâ tam listeyi tam alan kümesiyle çekiyor — ikisi de gerçekten PII sütunu gösterdiği için düzeltme "alan kırp" değil "sunucu tarafı filtre + sayfalama"dan geçiyor, ayrı bir iş. PII erişim kaydı zaten #821'de.

## Test

`e2e/pii-access-lifecycle.spec.ts` (`@smoke`): aynı mentor için üç menti — ACTIVE (`200`), 1 ay önce COMPLETED (`200`, pencere içinde), 9 ay önce COMPLETED (`403`).

Mevcut `/admin/users` spec'leri (`list-search`, `admin-users-archive`, `admin-user-active`, `users-company-filter`, `role-badge`, `impersonation*`, `xss-injection`) sunucu tarafı filtreyle uyumlu — hepsi arama/rol sekmesi üzerinden hedefliyor.

`npm run build` ✅ · `npx tsc --noEmit` ✅ · `prisma generate` ✅

## Sürüm / Versioning

`0.31.0-beta` (minor — şema değişikliği + yeni API sözleşmesi) + CHANGELOG + releaseNotes (EN/TR/DE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
