### PR TITLE
fix(security): X-Forwarded-For spoof'u ile rate-limit atlatmayı kapat (#858)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -92,3 +92,14 @@ GOOGLE_OAUTH_REDIRECT_URI=
 # Leave unset/false to keep the app single-tenant (default). Do NOT enable in
 # production until the guarded rollout checklist in that doc is complete.
 MT_ENFORCE_ISOLATION=false
+
+# How many reverse proxies in front of the app append to X-Forwarded-For (#858).
+# The rate limiter counts back from the RIGHT of that header by this many hops
+# to find the real client IP — the leftmost entries are written by the client
+# and rotating them used to bypass every IP-based limit.
+#   1 (default) — one nginx in front, our Plesk topology
+#   0           — no proxy (local dev, direct container): ignore the header
+#   2+          — add a hop for each extra proxy (e.g. Cloudflare in front of nginx)
+# Set this too HIGH and legitimate visitors share one bucket and throttle each
+# other; too LOW and the limit is spoofable again. It must match the real chain.
+TRUSTED_PROXY_COUNT=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.31.1-beta] - 2026-07-31
+
+### Security
+- **Every IP-based rate limit could be bypassed with a rotating
+  `X-Forwarded-For`** (#858). `clientIp()` returned `xff.split(',')[0]` — the
+  *leftmost* entry, which is whatever the client wrote. Our nginx uses
+  `$proxy_add_x_forwarded_for`, which **appends** the real peer address, so the
+  trustworthy value is on the right and the code was reading the one part of the
+  header an attacker fully controls. Measured on `/api/auth/forgot` (5 per 15 min):
+  12 spoofed requests all returned 200 where the honest control got 7× 429. Each
+  fabricated value also opened a new key in the in-memory bucket map, so the spoof
+  doubled as unbounded memory growth.
+  `clientIp()` now counts back from the right by `TRUSTED_PROXY_COUNT` hops
+  (default `1` = our single nginx; `0` ignores the header entirely), falls back to
+  the rightmost entry when the list is shorter than the configured chain, and
+  validates the result as an IPv4/IPv6 literal before it becomes a bucket key.
+  `enforceRateLimit`'s signature is unchanged, so all six calling endpoints are
+  untouched. The login limit is keyed on email, not IP, and was never affected.
+
+### Documentation
+- `.env.example` and `infra/README.md` cover `TRUSTED_PROXY_COUNT`: what the value
+  means per environment, and that it must be raised to `2` if a hostname is ever
+  moved behind Cloudflare's proxy (verified today that `crm.ersah.in` is not —
+  no `cf-ray`, so one hop).
+
 ## [0.31.0-beta] - 2026-07-31
 
 ### Security

--- a/e2e/rate-limit.spec.ts
+++ b/e2e/rate-limit.spec.ts
@@ -1,6 +1,10 @@
 import { test, expect } from '@playwright/test';
 
 // The forgot-password endpoint is limited to 5 requests / 15 min per IP.
+//
+// Both tests share one process-wide bucket keyed on the caller's IP, so they
+// must stay in this file and in this order: the first exhausts the limit, the
+// second checks that a spoofed header can't hand the caller a fresh one.
 test('repeated forgot-password requests are rate limited (429)', async ({ request }) => {
   const statuses: number[] = [];
   for (let i = 0; i < 8; i++) {
@@ -11,4 +15,29 @@ test('repeated forgot-password requests are rate limited (429)', async ({ reques
   }
   expect(statuses).toContain(200); // early requests pass
   expect(statuses).toContain(429); // later ones are throttled
+});
+
+/**
+ * #858: `clientIp()` read the *leftmost* `X-Forwarded-For` entry — the part the
+ * client writes. Rotating it per request bought a fresh bucket every time and
+ * bypassed every IP-based limit in the app (measured: 12/12 spoofed requests
+ * passed where the honest control got 7× 429).
+ *
+ * Playwright talks to Next directly, so `TRUSTED_PROXY_COUNT=0` is set for the
+ * webServer (playwright.config.ts) and the header must be ignored outright.
+ */
+test('a rotating X-Forwarded-For does not buy a fresh rate-limit bucket', { tag: '@smoke' }, async ({ request }) => {
+  const statuses: number[] = [];
+  for (let i = 0; i < 12; i++) {
+    const res = await request.post('/api/auth/forgot', {
+      data: { email: `spoof-${i}@example.com` },
+      headers: { 'X-Forwarded-For': `9.9.9.${i}` },
+    });
+    statuses.push(res.status());
+  }
+  // 12 requests against a limit of 5 must hit the ceiling regardless of the
+  // rotating header. Before the fix all 12 returned 200. (Run as part of the
+  // full suite the bucket is already spent by the test above and every one of
+  // them is a 429; run alone in the smoke subset the first few still pass.)
+  expect(statuses).toContain(429);
 });

--- a/infra/README.md
+++ b/infra/README.md
@@ -77,6 +77,25 @@ self-contained nginx server block for `crm-<topic>.ersah.in` into `$NGINX_CONF_D
 from step 2 and `proxy_pass`es to the topic's port; teardown removes it. Both
 reload nginx afterwards.
 
+### Proxy hops and `TRUSTED_PROXY_COUNT` (#858)
+
+Every vhost sets `X-Forwarded-For $proxy_add_x_forwarded_for`, which **appends**
+the peer address to whatever the client sent. The header therefore reads
+`<whatever the client made up>, <what nginx actually saw>` and only the
+right-hand entries can be trusted. The rate limiter counts back from the right
+by `TRUSTED_PROXY_COUNT` hops (`src/lib/rateLimit.ts`).
+
+**One hop today**, so the default of `1` is correct for all three environments.
+The wildcard DNS record in step 1 is orange-clouded, but the explicit `crm`
+record is not — `curl -sI https://crm.ersah.in` returns no `cf-ray`, i.e. the
+request reaches nginx directly. **If a hostname is ever moved behind
+Cloudflare's proxy, bump `TRUSTED_PROXY_COUNT` to `2` for it in the same
+change**, or every visitor will be bucketed as the Cloudflare edge and one
+person's rate limit will throttle everyone.
+
+`0` disables the header entirely — right for a container reached directly, and
+what `playwright.config.ts` sets for the e2e webServer.
+
 ### One-time server setup this requires
 - The stock `include /etc/nginx/conf.d/*.conf;` must be active (default on Plesk).
   These hostnames are **not** Plesk-managed domains (only `crm`/`crm-preview` are),

--- a/infra/deploy-prod.sh
+++ b/infra/deploy-prod.sh
@@ -261,6 +261,7 @@ docker run -d \
   -e INBOUND_IMAP_ENABLED="${INBOUND_IMAP_ENABLED:-}" \
   -e CRON_SECRET="${CRON_SECRET:-}" \
   -e CRON_ENABLED="${CRON_ENABLED:-}" \
+  -e TRUSTED_PROXY_COUNT="${TRUSTED_PROXY_COUNT:-1}" \
   "$IMAGE"
 
 # ── 6. Health check + prune ──────────────────────────────────────────────────

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.31.0-beta",
+  "version": "0.31.1-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -41,5 +41,9 @@ export default defineConfig({
         url: localURL,
         reuseExistingServer: !process.env.CI,
         timeout: 120_000,
+        // Playwright talks to Next directly — there is no nginx appending to
+        // X-Forwarded-For here, so 0 is the honest setting and it is what makes
+        // the spoofing assertions in rate-limit-spoof.spec.ts meaningful (#858).
+        env: { TRUSTED_PROXY_COUNT: '0' },
       },
 });

--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -9,10 +9,61 @@ interface Entry {
 }
 const buckets = new Map<string, Entry>();
 
+/**
+ * How many reverse proxies in front of this app append to `X-Forwarded-For`.
+ *
+ * Our nginx vhost uses `$proxy_add_x_forwarded_for`, which *appends* the peer
+ * address to whatever the client sent. So the header reads
+ * `<whatever the client made up>, <the address nginx actually saw>` and only
+ * the rightmost entries are trustworthy — one per proxy hop.
+ *
+ * 1 (the default) = a single nginx in front, our current topology. Put another
+ * proxy in the path (a Cloudflare orange-cloud record, a load balancer) and
+ * this has to grow to match, or every request looks like it comes from that
+ * proxy and one visitor's rate limit throttles everyone.
+ *
+ * 0 = no proxy: ignore the header entirely and trust nothing from it.
+ */
+const TRUSTED_PROXY_COUNT = Math.max(0, parseInt(process.env.TRUSTED_PROXY_COUNT || '1', 10) || 0);
+
+// Deliberately permissive shape checks rather than full parsers: the value is a
+// rate-limit map key, and the only thing that matters is that a client can't
+// smuggle arbitrary text into it.
+const IPV4 = /^(\d{1,3}\.){3}\d{1,3}$/;
+const IPV6 = /^[0-9a-fA-F:]+$/;
+
+function validIp(value: string): string | null {
+  const ip = value.trim().replace(/^\[|\]$/g, '');
+  if (!ip) return null;
+  if (IPV4.test(ip)) return ip.split('.').every((o) => Number(o) <= 255) ? ip : null;
+  if (ip.includes(':') && IPV6.test(ip)) return ip.toLowerCase();
+  return null;
+}
+
+/**
+ * The caller's IP, as far as it can be trusted.
+ *
+ * This used to return `xff.split(',')[0]` — the *leftmost* entry, which is
+ * whatever the client put there. Rotating it per request bypassed every
+ * IP-based limit in the app: measured on `/api/auth/forgot` (5 per 15 min),
+ * 12 spoofed requests all returned 200 where the honest control got 7× 429
+ * (#858). It also opened an unbounded key in `buckets` per fabricated value.
+ */
 export function clientIp(request: Request): string {
-  const xff = request.headers.get('x-forwarded-for');
-  if (xff) return xff.split(',')[0].trim();
-  return request.headers.get('x-real-ip') || 'unknown';
+  if (TRUSTED_PROXY_COUNT > 0) {
+    const xff = request.headers.get('x-forwarded-for');
+    if (xff) {
+      const parts = xff.split(',').map((p) => p.trim()).filter(Boolean);
+      // Count back from the right, one entry per trusted hop. A list shorter
+      // than expected means the request did not traverse the proxy chain we
+      // think it did — fall back to the rightmost (nearest, least
+      // client-controlled) entry rather than reaching into client-written text.
+      const candidate = parts[Math.max(0, parts.length - TRUSTED_PROXY_COUNT)];
+      const ip = candidate ? validIp(candidate) : null;
+      if (ip) return ip;
+    }
+  }
+  return validIp(request.headers.get('x-real-ip') || '') || 'unknown';
 }
 
 // Returns { ok } or { ok:false, retryAfter } when the limit is exceeded.

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,21 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.31.1-beta',
+    date: '2026-07-31',
+    highlights: {
+      en: [
+        'Security fix: the limits that cap how often password-reset, registration and application forms can be submitted could be sidestepped by faking a network header. They now count real visitors again.',
+      ],
+      tr: [
+        'Güvenlik düzeltmesi: parola sıfırlama, kayıt ve başvuru formlarının ne sıklıkta gönderilebileceğini sınırlayan kurallar, sahte bir ağ başlığıyla aşılabiliyordu. Artık gerçek ziyaretçileri sayıyorlar.',
+      ],
+      de: [
+        'Sicherheitskorrektur: Die Limits dafür, wie oft Passwort-Zurücksetzung, Registrierung und Bewerbungsformulare abgeschickt werden können, ließen sich mit einem gefälschten Netzwerk-Header umgehen. Sie zählen jetzt wieder echte Besucher.',
+      ],
+    },
+  },
+  {
     version: '0.31.0-beta',
     date: '2026-07-31',
     highlights: {


### PR DESCRIPTION
Closes #858

Denetimin **ikinci doğrulanmış kritik bulgusu** (epic #816). Birincisi #978'de kapandı.

## Kök neden

```ts
// önce
const xff = request.headers.get('x-forwarded-for');
if (xff) return xff.split(',')[0].trim();   // ← istemcinin yazdığı değer
```

nginx vhost'umuz `X-Forwarded-For $proxy_add_x_forwarded_for` kullanıyor; bu, gerçek peer adresini listenin **sonuna ekler**. Yani başlık `<istemcinin uydurduğu>, <nginx'in gerçekten gördüğü>` şeklinde ve güvenilir değer **sağda**. Kod tam da istemcinin tamamen kontrol ettiği parçayı okuyordu.

### Canlı kanıt

`POST /api/auth/forgot`, limit 5/15dk, 12 istek:

| Senaryo | Geçen | 429 |
|---|---|---|
| Kontrol (başlık yok) | 5 | **7** ✅ |
| `X-Forwarded-For: 9.9.9.<i>` döndürerek | **12** | **0** ❌ |

Yan etki: uydurulan her değer `buckets` Map'inde yeni bir anahtar açıyordu — sınırsız bellek büyümesi (#835 ile ilişkili).

## Düzeltme

`clientIp()` artık sağdan `TRUSTED_PROXY_COUNT` hop geri sayıyor:

- **`1` (varsayılan)** — tek nginx, mevcut topolojimiz
- **`0`** — proxy yok: başlık tamamen yok sayılır
- **`2+`** — her ek proxy için bir hop (ör. nginx önünde Cloudflare)

Liste beklenenden kısaysa **fail-closed**: en sağdaki (en yakın, en az istemci kontrollü) değer kullanılır — istemcinin yazdığı metne uzanılmaz. Sonuç bucket anahtarı olmadan önce IPv4/IPv6 literal olarak doğrulanıyor.

`enforceRateLimit` imzası **değişmedi** → altı çağıran uç (`/api/auth/forgot`, `/api/auth/reset`, `/api/register`, `/api/public-contact/[userId]`, `/api/apply`, `/api/v1/candidates`) dokunulmadı. Login limiti e-posta anahtarlı, hiç etkilenmiyordu — o tasarım tercihi korundu.

## Prod için doğru değer: 1 (ölçüldü)

infra/README step 1'deki wildcard kaydı orange-cloud, ama açık `crm` kaydı değil — `curl -sI https://crm.ersah.in` **`cf-ray` döndürmüyor**, yani istek nginx'e doğrudan ulaşıyor. Tek hop. Bir hostname ileride Cloudflare proxy'sinin arkasına alınırsa `2`'ye çıkarılmalı; **aksi hâlde tüm ziyaretçiler Cloudflare edge olarak sayılır ve bir kişinin limiti herkesi kilitler.** Bu uyarı `infra/README.md` ve `.env.example`'a yazıldı; `deploy-prod.sh` değişkeni container'a geçiriyor (varsayılan `1`).

## Test

`e2e/rate-limit.spec.ts` genişletildi (`@smoke`): dönen `X-Forwarded-For` ile 12 istek → en az bir `429`. Düzeltmeden önce 12'si de `200`'dü.

Assertion'ın anlamlı olması için `playwright.config.ts` webServer'a `TRUSTED_PROXY_COUNT=0` verildi — Playwright Next'e doğrudan konuşuyor, araya XFF ekleyen nginx yok, dolayısıyla `0` zaten **doğru** ayar.

İki test aynı süreç içi bucket'ı paylaştığı için bilerek tek dosyada ve bu sırada tutuldu (dosyada not düşüldü).

`npm run build` ✅ · `npx tsc --noEmit` ✅

## Sürüm

`0.31.1-beta` + CHANGELOG + releaseNotes (EN/TR/DE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
