### PR TITLE
fix(security): 2FA koduna deneme limiti + replay koruması (#865)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.31.3-beta] - 2026-07-31
+
+### Security
+- **The 2FA code could be guessed without limit** (#865). `clearRateLimit(failKey)`
+  ran the moment the *password* verified — before the TOTP check — so the 6-digit
+  code that followed had no limiter behind it at all: the whole 10⁶ space, as fast
+  as the server would answer. Since `twoFactorPolicy.ts` makes 2FA mandatory by role,
+  this hit the admin and mentor accounts hardest. The counter is now cleared only
+  after the credential check is completely through, and failed codes get their own
+  bucket (`totp-fail:<email>`, 5 per 15 min) so a user fumbling their code doesn't
+  spend the password allowance and an attacker past the password doesn't get a fresh
+  one. Failures are logged as `auth.totp_failed` at warning level.
+- **A used 2FA code was accepted again inside its window** (#865). Three codes are
+  valid at any moment (±1 step for clock skew, ~90s). `User.lastTotpStep` now records
+  the consumed step and a code must beat it, so one captured over a shoulder or
+  through a phishing page is spent. The skew tolerance is unchanged — nobody gets
+  locked out by a slow clock. Enabling 2FA does not burn the enrolment code: that
+  window is not the exposed one, and burning it would break enrol-then-sign-in.
+
 ## [0.31.2-beta] - 2026-07-31
 
 ### Security

--- a/e2e/two-factor.spec.ts
+++ b/e2e/two-factor.spec.ts
@@ -35,9 +35,52 @@ test('a user enables TOTP 2FA and must provide a code at sign-in', async ({ page
     await expect(page).toHaveURL(/\/auth\/signin/);
 
     // Providing a valid code completes sign-in.
-    await codeField.fill(totp(setup.secret));
+    const used = totp(setup.secret);
+    await codeField.fill(used);
     await page.click('button[type="submit"]');
     await page.waitForURL((u) => u.pathname.startsWith('/portal'), { timeout: 20_000 });
+
+    // #865: that code is spent. Three codes are valid at any moment (±1 step
+    // for clock skew), so without recording the consumed step a shoulder-surfed
+    // code could be replayed for the next ~90 seconds.
+    await fillLogin(page, email, 'UserPass123');
+    const replayField = page.getByLabel('Authenticator code');
+    await expect(replayField).toBeVisible({ timeout: 10_000 });
+    await replayField.fill(used);
+    await page.click('button[type="submit"]');
+    await expect(page).toHaveURL(/\/auth\/signin/);
+    await expect(page.getByText(/Invalid authenticator code|Too many attempts/i)).toBeVisible({ timeout: 10_000 });
+  } finally {
+    await cleanupByEmail(email);
+  }
+});
+
+/**
+ * #865: `clearRateLimit(failKey)` ran as soon as the *password* verified, so
+ * the 6-digit code that followed had no limiter behind it at all — the whole
+ * 10^6 space was guessable as fast as the server would answer. Failed codes now
+ * have their own bucket (5 per 15 min).
+ */
+test('failed authenticator codes are rate limited', async ({ page }) => {
+  const email = uniqueEmail('tfa-brute');
+  await seedUser(email, 'BrutePass123', 'MENTEE', 'TFA Brute');
+
+  try {
+    await fillLogin(page, email, 'BrutePass123');
+    await page.waitForURL((u) => u.pathname.startsWith('/portal'), { timeout: 20_000 });
+    const setup = await (await page.request.post('/api/account/2fa', { data: { action: 'setup' } })).json();
+    await page.request.post('/api/account/2fa', { data: { action: 'enable', code: totp(setup.secret) } });
+
+    // Six wrong codes: the sixth must be refused by the limiter, not the check.
+    for (let i = 0; i < 6; i++) {
+      await fillLogin(page, email, 'BrutePass123');
+      const field = page.getByLabel('Authenticator code');
+      await expect(field).toBeVisible({ timeout: 10_000 });
+      await field.fill(String(100000 + i));
+      await page.click('button[type="submit"]');
+      await expect(page.getByText(/Invalid authenticator code|Too many attempts/i)).toBeVisible({ timeout: 10_000 });
+    }
+    await expect(page.getByText(/Too many attempts/i)).toBeVisible({ timeout: 10_000 });
   } finally {
     await cleanupByEmail(email);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.31.2-beta",
+  "version": "0.31.3-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -185,6 +185,11 @@ model User {
   // Optional TOTP two-factor auth. The secret is only meaningful once enabled.
   twoFactorEnabled        Boolean       @default(false)
   twoFactorSecret         String?
+  // Highest TOTP time step already accepted for this account. Three codes are
+  // valid at any moment (±1 step for clock skew, ~90s), so without this a code
+  // captured by a phishing page or over someone's shoulder could be replayed
+  // inside that window (#865). A code must beat this value to be accepted.
+  lastTotpStep            Int?
   // "Sign out of all devices": any JWT issued before this instant is rejected at
   // the session callback. Null = never revoked. Set to now() to invalidate every
   // existing session (including the current one) on demand.

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -4,7 +4,7 @@ import bcrypt from 'bcryptjs';
 import { prisma } from '@/lib/prisma';
 import { logActivity } from '@/lib/activity';
 import { rateLimit, clearRateLimit } from '@/lib/rateLimit';
-import { verifyTotp } from '@/lib/totp';
+import { verifyTotpStep } from '@/lib/totp';
 
 export const authOptions: NextAuthOptions = {
   session: {
@@ -58,8 +58,11 @@ export const authOptions: NextAuthOptions = {
           throw new Error(within.ok ? 'Invalid email or password' : 'Too many attempts. Please try again later.');
         }
 
-        // Successful auth — reset the failure counter.
-        clearRateLimit(failKey);
+        // NOTE: the failure counter is NOT cleared here. It used to be, which
+        // meant that once the password verified the 6-digit TOTP code below
+        // could be guessed without limit — the whole 10^6 space, as fast as the
+        // server would answer (#865). It is cleared only after the credential
+        // check is *completely* through, at the bottom of this function.
 
         // Verified-but-inactive is NOT the same as never-activated. Only block
         // inactive accounts: an active-but-unverified user may still sign in
@@ -80,10 +83,38 @@ export const authOptions: NextAuthOptions = {
         if (user.twoFactorEnabled && user.twoFactorSecret) {
           const code = (credentials.totp || '').trim();
           if (!code) throw new Error('2FA_REQUIRED');
-          if (!verifyTotp(user.twoFactorSecret, code)) {
-            throw new Error('Invalid authenticator code');
+
+          // Its own bucket, separate from the password one: a legitimate user
+          // fumbling their code shouldn't consume the password allowance, and
+          // an attacker past the password shouldn't get a fresh one.
+          const totpKey = `totp-fail:${email}`;
+          const step = verifyTotpStep(user.twoFactorSecret, code);
+          const replayed = step !== null && user.lastTotpStep !== null && step <= user.lastTotpStep;
+
+          if (step === null || replayed) {
+            const within = rateLimit(totpKey, { limit: 5, windowMs: 15 * 60 * 1000 });
+            await logActivity({
+              action: 'auth.totp_failed',
+              level: 'warning',
+              actorEmail: user.email,
+              actorId: user.id,
+              detail: replayed ? 'code already used' : 'invalid code',
+            });
+            // Same message either way — which of the two it was is the
+            // attacker's business to guess, not ours to confirm.
+            throw new Error(
+              within.ok ? 'Invalid authenticator code' : 'Too many attempts. Please try again later.'
+            );
           }
+
+          // Burn the step so the same code can't be used again inside the
+          // ±1-step acceptance window.
+          await prisma.user.update({ where: { id: user.id }, data: { lastTotpStep: step } });
+          clearRateLimit(totpKey);
         }
+
+        // Fully authenticated — now the failure counter can be reset.
+        clearRateLimit(failKey);
 
         return {
           id: user.id,

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,21 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.31.3-beta',
+    date: '2026-07-31',
+    highlights: {
+      en: [
+        'Two-factor authentication is meaningfully stronger: wrong authenticator codes are now limited to five attempts per 15 minutes, and each code works only once. Previously, someone who already had your password could try codes as fast as they liked. Codes from an authenticator app with a slightly off clock still work as before.',
+      ],
+      tr: [
+        'İki adımlı doğrulama belirgin şekilde güçlendi: yanlış doğrulama kodları artık 15 dakikada beş denemeyle sınırlı ve her kod yalnızca bir kez çalışıyor. Önceden, parolanızı ele geçirmiş biri kodları istediği hızda deneyebiliyordu. Saati biraz şaşmış bir uygulamadan gelen kodlar eskisi gibi kabul edilmeye devam ediyor.',
+      ],
+      de: [
+        'Die Zwei-Faktor-Anmeldung ist deutlich stärker: Falsche Codes sind jetzt auf fünf Versuche pro 15 Minuten begrenzt, und jeder Code funktioniert nur einmal. Bisher konnte jemand mit Ihrem Passwort Codes beliebig schnell durchprobieren. Codes aus einer App mit leicht abweichender Uhr werden weiterhin akzeptiert.',
+      ],
+    },
+  },
+  {
     version: '0.31.2-beta',
     date: '2026-07-31',
     highlights: {

--- a/src/lib/totp.ts
+++ b/src/lib/totp.ts
@@ -47,16 +47,27 @@ export function totp(secretB32: string, atMs = Date.now()): string {
   return hotp(base32Decode(secretB32), Math.floor(atMs / 1000 / 30));
 }
 
-// Verify a user-supplied 6-digit code, allowing ±1 time step for clock skew.
-export function verifyTotp(secretB32: string, code: string, atMs = Date.now()): boolean {
+/**
+ * Verify a user-supplied 6-digit code, allowing ±1 time step for clock skew.
+ *
+ * Returns the matching step so the caller can reject replays: three codes are
+ * valid at any moment (~90s), and without recording which step was consumed a
+ * code shoulder-surfed or captured from a phishing page could be used again
+ * inside that window (#865). `null` means no match.
+ */
+export function verifyTotpStep(secretB32: string, code: string, atMs = Date.now()): number | null {
   const clean = (code || '').replace(/\s/g, '');
-  if (!/^\d{6}$/.test(clean)) return false;
+  if (!/^\d{6}$/.test(clean)) return null;
   const secret = base32Decode(secretB32);
   const step = Math.floor(atMs / 1000 / 30);
   for (let w = -1; w <= 1; w++) {
-    if (hotp(secret, step + w) === clean) return true;
+    if (hotp(secret, step + w) === clean) return step + w;
   }
-  return false;
+  return null;
+}
+
+export function verifyTotp(secretB32: string, code: string, atMs = Date.now()): boolean {
+  return verifyTotpStep(secretB32, code, atMs) !== null;
 }
 
 // otpauth:// URI for authenticator apps (manual entry shows the secret too).


### PR DESCRIPTION
Closes #865

Story #837 (epic #818). İki ayrı zafiyet, aynı fonksiyonda.

## 1. Sınırsız kod denemesi

```ts
if (!user || !isPasswordValid) { rateLimit(failKey, …); throw … }

clearRateLimit(failKey);      // ← parola geçer geçmez sayaç SIFIRLANIYOR
…
if (!verifyTotp(user.twoFactorSecret, code)) throw new Error('Invalid authenticator code');
                              // ← hiçbir sayaca yazılmıyor
```

Parola doğrulanır doğrulanmaz sayaç sıfırlandığı için altta gelen 6 haneli kodun **arkasında hiçbir limit yoktu** — 10⁶'lık uzay, sunucunun cevap verebildiği hızda taranabilirdi. `src/lib/twoFactorPolicy.ts` 2FA'yı rol bazlı zorunlu kıldığından bu, en çok **admin ve mentor** hesaplarını vuruyordu.

**Düzeltme:** `clearRateLimit(failKey)` kimlik kontrolünün **tamamen** bittiği yere taşındı. Başarısız kodlar kendi bucket'ında: `totp-fail:<email>`, 5 deneme / 15 dk.

Ayrı bucket olması bilinçli: kodunu yanlış giren meşru kullanıcı parola kotasını yemesin, parolayı geçmiş saldırgan da taze kota kazanmasın.

`auth.totp_failed` (warning) olarak loglanıyor → `/admin/activity`'de görünür. Hata mesajı kodun **yanlış mı yoksa kullanılmış mı** olduğunu ayırt etmiyor.

## 2. Replay

Saat kayması için ±1 adım tolerans var, yani her an **üç kod geçerli** (~90 sn). Kullanılmış kodu reddeden bir mekanizma yoktu — omuz üstünden görülen veya phishing sayfasında yakalanan bir kod o pencere boyunca tekrar kullanılabiliyordu.

`verifyTotpStep()` eşleşen adımı döndürüyor, `User.lastTotpStep` tüketilen adımı saklıyor, kod bu değeri **geçmek zorunda**. Kayma toleransı **değişmedi** — saati geri kalan kimse kilitlenmiyor.

### Bilinçli istisna: 2FA'yı etkinleştirme kodu yakılmıyor

Kayıt (enrolment) kodunun yakılması "2FA'yı aç, sonra başka cihazda giriş yap" akışını kırardı ve risk penceresi orası değil — asıl maruz kalan yüzey giriş ekranı. `POST /api/account/2fa` dokunulmadı.

## Şema

`User.lastTotpStep Int?` — nullable, additive; mevcut satırlar etkilenmiyor (ilk başarılı girişte doluyor). `prisma format` + `generate` çalıştırıldı, migration yazılmadı (repo `db push` kullanıyor).

## Test

`e2e/two-factor.spec.ts` genişletildi:
- Başarılı girişte kullanılan kod, hemen ardından **reddediliyor** (replay).
- Altı yanlış kod: altıncısı limiter'a takılıyor (`Too many attempts`).

`2FA_REQUIRED` akışı korunuyor — mevcut test onu zaten doğruluyor.

`npm run build` ✅ · `npx tsc --noEmit` ✅ · `prisma generate` ✅

## Sürüm

`0.31.3-beta` + CHANGELOG + releaseNotes (EN/TR/DE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
