### PR TITLE
feat(infra): rate limit aşımlarını denetim kaydına yaz + bucket temizliği (#864)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.31.4-beta] - 2026-07-31
+
+### Added
+- **Rate-limit breaches are now recorded** (#864). `enforceRateLimit` returned 429
+  silently, so being under attack looked exactly like being idle. Breaches log
+  `ratelimit.exceeded` at warning level and show up on `/admin/activity`. Written
+  fire-and-forget so `enforceRateLimit` stays synchronous and its six callers are
+  untouched, and **coalesced to one row per bucket+IP per minute** — a flood is
+  precisely when this fires, and one DB insert per blocked request would make the
+  rate limiter an amplifier for the attack it exists to absorb.
+
+### Fixed
+- **The rate-limit bucket map grew for the life of the process** (#864).
+  `sweepRateLimitBuckets()` was written but never called anywhere. It now runs every
+  100 `rateLimit()` calls, plus immediately whenever the map passes 50 000 entries —
+  proportional to traffic, with no scheduler to own.
+
 ## [0.31.3-beta] - 2026-07-31
 
 ### Security

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.31.3-beta",
+  "version": "0.31.4-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { logActivity } from '@/lib/activity';
 
 // Simple in-memory fixed-window rate limiter. Per-process (fine for a single
 // container); resets on redeploy. Not distributed — for stronger guarantees
@@ -66,12 +67,30 @@ export function clientIp(request: Request): string {
   return validIp(request.headers.get('x-real-ip') || '') || 'unknown';
 }
 
+// Bucket housekeeping (#864). `sweepRateLimitBuckets` existed but nothing ever
+// called it, so expired entries accumulated for the life of the process. Sweep
+// every SWEEP_EVERY calls rather than on a timer — no scheduler to own, and the
+// work is proportional to traffic, which is when it is needed.
+const SWEEP_EVERY = 100;
+// Hard ceiling as a backstop: if a flood outruns the periodic sweep, drop the
+// expired entries immediately rather than letting the map grow without bound.
+const MAX_BUCKETS = 50_000;
+let callsSinceSweep = 0;
+
+function housekeep(now: number) {
+  if (++callsSinceSweep >= SWEEP_EVERY || buckets.size > MAX_BUCKETS) {
+    callsSinceSweep = 0;
+    sweepRateLimitBuckets(now);
+  }
+}
+
 // Returns { ok } or { ok:false, retryAfter } when the limit is exceeded.
 export function rateLimit(
   key: string,
   { limit, windowMs }: { limit: number; windowMs: number }
 ): { ok: boolean; retryAfter: number } {
   const now = Date.now();
+  housekeep(now);
   const entry = buckets.get(key);
   if (!entry || entry.resetAt <= now) {
     buckets.set(key, { count: 1, resetAt: now + windowMs });
@@ -84,6 +103,22 @@ export function rateLimit(
   return { ok: true, retryAfter: 0 };
 }
 
+const BREACH_LOG_EVERY_MS = 60_000;
+const breachLoggedAt = new Map<string, number>();
+
+function shouldLogBreach(key: string): boolean {
+  const now = Date.now();
+  const last = breachLoggedAt.get(key);
+  if (last && now - last < BREACH_LOG_EVERY_MS) return false;
+  breachLoggedAt.set(key, now);
+  // Piggyback on the same ceiling as the counters: this map is keyed the same
+  // way, so a flood of unique keys would otherwise grow it just as fast.
+  if (breachLoggedAt.size > MAX_BUCKETS) {
+    for (const [k, t] of breachLoggedAt) if (now - t >= BREACH_LOG_EVERY_MS) breachLoggedAt.delete(k);
+  }
+  return true;
+}
+
 // Convenience guard for route handlers: returns a 429 NextResponse when the
 // IP has exceeded `limit` requests to `bucket` within `windowMs`, else null.
 export function enforceRateLimit(
@@ -91,8 +126,23 @@ export function enforceRateLimit(
   bucket: string,
   opts: { limit: number; windowMs: number }
 ): NextResponse | null {
-  const res = rateLimit(`${bucket}:${clientIp(request)}`, opts);
+  const ip = clientIp(request);
+  const res = rateLimit(`${bucket}:${ip}`, opts);
   if (res.ok) return null;
+  // Breaches were recorded nowhere, so being under attack looked exactly like
+  // being idle (#864). Fire-and-forget keeps this function synchronous — its
+  // six callers stay untouched — and logActivity never throws by design.
+  //
+  // Coalesced to one row per key per minute: a flood is exactly when this fires,
+  // and a DB insert per blocked request would turn the rate limiter into an
+  // amplifier for the attack it is supposed to absorb.
+  if (shouldLogBreach(`${bucket}:${ip}`)) {
+    void logActivity({
+      action: 'ratelimit.exceeded',
+      level: 'warning',
+      detail: `${bucket} · ${ip}`,
+    }).catch(() => {});
+  }
   return NextResponse.json(
     { error: 'Too many requests. Please try again later.' },
     { status: 429, headers: { 'Retry-After': String(res.retryAfter) } }


### PR DESCRIPTION
Closes #864

Story #835 (epic #816). İki küçük ama gerçek boşluk.

## 1. Aşımlar hiçbir yere yazılmıyordu

`enforceRateLimit` sessizce `429` dönüyordu — yani **saldırı altında olmak, boşta olmakla birebir aynı görünüyordu.** Artık `ratelimit.exceeded` (warning) yazılıyor ve `/admin/activity`'de görünüyor.

İki tasarım kararı:

- **Fire-and-forget.** `enforceRateLimit` senkron; imzası değişmedi, altı çağıranı dokunulmadı. `logActivity` zaten tasarımı gereği hata fırlatmıyor.
- **Dakikada bir satır** (bucket+IP başına). Bu log tam olarak flood anında tetikleniyor; engellenen her istek için bir DB insert'i, rate limiter'ı **absorbe etmesi gereken saldırının amplifikatörüne** çevirirdi.

## 2. `sweepRateLimitBuckets()` hiç çağrılmıyordu

Fonksiyon yazılmıştı, repoda çağıran yoktu — süresi geçmiş kayıtlar process ömrü boyunca birikiyordu (#858'deki spoof bunu ayrıca sömürüyordu: her uydurma IP yeni bir anahtar).

Her 100 `rateLimit()` çağrısında bir, ayrıca harita 50 000 kaydı geçerse hemen süpürülüyor. Zamanlayıcı eklenmedi: temizlik trafiğe orantılı çalışıyor, ki zaten gerektiği an o.

`npm run build` ✅ · `npx tsc --noEmit` ✅

## Sürüm

`0.31.4-beta` + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
