### PR TITLE
feat(security): webhook SSRF guard, giden istek timeout'ları, health detay kapısı (#893, #895, #897)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -106,3 +106,14 @@ MT_ENFORCE_ISOLATION=false
 # Set this too HIGH and legitimate visitors share one bucket and throttle each
 # other; too LOW and the limit is spoofable again. It must match the real chain.
 TRUSTED_PROXY_COUNT=1
+
+# Optional — closes the information leak on GET /api/health (#897). While UNSET,
+# the endpoint answers every caller with version, git sha, subsystem status and
+# uptime, which tells an attacker exactly which CVEs apply to this deployment.
+# Set it (any long random string) and those fields are released only to an admin
+# session or a caller sending `X-Health-Token: <value>`; everyone else gets
+# `{ status, timestamp }` — all an uptime monitor acts on.
+# Set it on the SERVER env file, not here: infra/deploy-prod.sh passes it into
+# the container and both deploy drift gates read it from the same file, so the
+# "is the live sha current?" check keeps working.
+HEALTH_TOKEN=

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -107,8 +107,19 @@ jobs:
           # Ground truth for what is actually live: the container reports the
           # GIT_SHA baked into its image at /api/health. An unreachable endpoint
           # (container down or wedged) counts as drift, so the deploy repairs it.
-          LIVE="$(curl -fsS --max-time 10 "$HEALTH_URL" \
-                  | sed -n 's/.*"sha"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' || true)"
+          # `sha` is gated on HEALTH_TOKEN when that is configured (#897); the
+          # server env file is the same one deploy-prod.sh reads, so source it
+          # if present and pass the header through. Absent token = old behaviour.
+          HEALTH_ENV="${ENV_FILE:-/etc/internship-crm/preview.env}"
+          # Sourced in a subshell so quoting matches how deploy-prod.sh reads it.
+          [ -r "$HEALTH_ENV" ] && HEALTH_TOKEN="$( set -a; . "$HEALTH_ENV" >/dev/null 2>&1; printf '%s' "${HEALTH_TOKEN:-}" )"
+          if [ -n "${HEALTH_TOKEN:-}" ]; then
+            LIVE="$(curl -fsS --max-time 10 -H "X-Health-Token: $HEALTH_TOKEN" "$HEALTH_URL" \
+                    | sed -n 's/.*"sha"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' || true)"
+          else
+            LIVE="$(curl -fsS --max-time 10 "$HEALTH_URL" \
+                    | sed -n 's/.*"sha"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' || true)"
+          fi
           if [ "$LIVE" = "$TARGET" ]; then
             echo "deploy=false" >> "$GITHUB_OUTPUT"
             echo "### Preview already current at \`$TARGET\` — nothing to deploy" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -115,8 +115,19 @@ jobs:
           # Ground truth for what is actually live: the container reports the
           # GIT_SHA baked into its image at /api/health. An unreachable endpoint
           # (container down or wedged) counts as drift, so the deploy repairs it.
-          LIVE="$(curl -fsS --max-time 10 "$HEALTH_URL" \
-                  | sed -n 's/.*"sha"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' || true)"
+          # `sha` is gated on HEALTH_TOKEN when that is configured (#897); the
+          # server env file is the same one deploy-prod.sh reads, so source it
+          # if present and pass the header through. Absent token = old behaviour.
+          HEALTH_ENV="${ENV_FILE:-/etc/internship-crm/prod.env}"
+          # Sourced in a subshell so quoting matches how deploy-prod.sh reads it.
+          [ -r "$HEALTH_ENV" ] && HEALTH_TOKEN="$( set -a; . "$HEALTH_ENV" >/dev/null 2>&1; printf '%s' "${HEALTH_TOKEN:-}" )"
+          if [ -n "${HEALTH_TOKEN:-}" ]; then
+            LIVE="$(curl -fsS --max-time 10 -H "X-Health-Token: $HEALTH_TOKEN" "$HEALTH_URL" \
+                    | sed -n 's/.*"sha"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' || true)"
+          else
+            LIVE="$(curl -fsS --max-time 10 "$HEALTH_URL" \
+                    | sed -n 's/.*"sha"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' || true)"
+          fi
           if [ "$LIVE" = "$TARGET" ]; then
             echo "deploy=false" >> "$GITHUB_OUTPUT"
             echo "### Production already current at \`$TARGET\` — nothing to deploy" >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.32.1-beta] - 2026-07-31
+
+### Security
+- **Webhook URLs were called from the server with no restriction (SSRF)** (#893).
+  Validation was `z.string().url()`, which happily accepts `http://127.0.0.1:3306`
+  and `http://169.254.169.254/latest/meta-data/` — the database and the cloud
+  metadata service, both reachable from the server's network position but not from
+  the admin's browser. `src/lib/ssrfGuard.ts` now requires https, no embedded
+  credentials, and a hostname that **resolves** to a public address (every answer
+  checked, not just the first — one private record is enough for a resolver to hand
+  `fetch` the internal one). Checked at registration *and* again at delivery: DNS
+  moves, and rows created before the guard existed were never checked at all. The
+  HMAC signature was never the problem and is untouched.
+- **`/api/health` told anonymous callers the version and git sha** (#897) — a
+  ready-made answer to "which CVEs apply to this deployment?". Setting `HEALTH_TOKEN`
+  narrows the anonymous response to `{ status, timestamp }` (all an uptime monitor
+  acts on) and releases the detail only to an admin session or a caller sending
+  `X-Health-Token`. **With the token unset the response is unchanged** — a
+  fail-closed default would blind the production and preview deploy drift gates,
+  which read `sha` from this endpoint, the moment it merged. `infra/deploy-prod.sh`
+  and both gates now send the header when the server env has it, so turning it on is
+  a one-variable change.
+
+### Fixed
+- **Outgoing HTTP had no timeouts** (#895). Webhook delivery ran under `Promise.all`
+  with no deadline, so one unresponsive receiver stalled the whole batch and held the
+  request handler open indefinitely — now 5s. The Anthropic SDK's default is 10
+  minutes, long enough for a user to give up first; the five AI clients now pass 60s,
+  which fits how long generation actually takes. `dispatchWebhook` still never throws:
+  an abort lands in the existing catch and is logged like any other delivery failure.
+
 ## [0.32.0-beta] - 2026-07-31
 
 ### Security

--- a/e2e/health.spec.ts
+++ b/e2e/health.spec.ts
@@ -1,9 +1,20 @@
 import { test, expect } from '@playwright/test';
+import { E2E_HEALTH_TOKEN } from '../playwright.config';
 
 // The /api/health probe backs uptime monitoring and the nightly stress test.
 // It must stay public, cheap, and side-effect free.
+//
+// What it may *say* to an anonymous caller is narrower since #897: version and
+// git sha told an attacker which CVEs apply to this deployment. Those fields
+// are gated on HEALTH_TOKEN, which the local webServer sets (playwright.config).
+// Against a deployed BASE_URL the token is whatever that env uses, so the
+// gated-shape assertions only run locally.
+const local = !process.env.BASE_URL;
+
 test('health endpoint reports ok without a DB check', { tag: '@smoke' }, async ({ request }) => {
-  const res = await request.get('/api/health');
+  const res = await request.get('/api/health', {
+    headers: local ? { 'X-Health-Token': E2E_HEALTH_TOKEN } : {},
+  });
   expect(res.status()).toBe(200);
   const body = await res.json();
   expect(body.status).toBe('ok');
@@ -13,9 +24,28 @@ test('health endpoint reports ok without a DB check', { tag: '@smoke' }, async (
 });
 
 test('health endpoint verifies DB connectivity when asked', { tag: '@smoke' }, async ({ request }) => {
-  const res = await request.get('/api/health?db=1');
+  const res = await request.get('/api/health?db=1', {
+    headers: local ? { 'X-Health-Token': E2E_HEALTH_TOKEN } : {},
+  });
   // 200 when the DB is reachable (CI/preview), 503 if it is degraded.
   expect([200, 503]).toContain(res.status());
   const body = await res.json();
   expect(['ok', 'error']).toContain(body.db);
+});
+
+test('an anonymous caller sees liveness only, not the version or sha', { tag: '@smoke' }, async ({ request }) => {
+  test.skip(!local, 'the deployed env may not have HEALTH_TOKEN configured');
+  const res = await request.get('/api/health');
+  expect(res.status()).toBe(200);
+  const body = await res.json();
+  // Still everything an uptime monitor acts on…
+  expect(body.status).toBe('ok');
+  // …and nothing that answers "which CVEs apply here?".
+  expect(body.version).toBeUndefined();
+  expect(body.sha).toBeUndefined();
+  expect(body.uptimeMs).toBeUndefined();
+
+  // A wrong token is no better than none.
+  const wrong = await request.get('/api/health', { headers: { 'X-Health-Token': 'not-the-token' } });
+  expect((await wrong.json()).version).toBeUndefined();
 });

--- a/infra/deploy-prod.sh
+++ b/infra/deploy-prod.sh
@@ -142,7 +142,16 @@ warn() {
 # deploy from any other path (the legacy deploy.yml over SSH, a manual
 # `docker run`) leaves it stale and the guard then reasons about a commit that
 # has not been live for weeks.
-LIVE_SHA="$(curl -fsS --max-time 10 "http://127.0.0.1:$PORT/api/health" 2>/dev/null \
+# The detailed fields (incl. sha) are gated on HEALTH_TOKEN when it is set
+# (#897); sending it here keeps the drift gate working once it is configured.
+# Kept as a plain string, not an array: `set -u` plus an empty array is a
+# portability trap in bash < 4.4, and this runs on whatever the box ships.
+HEALTH_HDR=""
+[ -n "${HEALTH_TOKEN:-}" ] && HEALTH_HDR="X-Health-Token: ${HEALTH_TOKEN}"
+health_curl() { # health_curl <url>
+  if [ -n "$HEALTH_HDR" ]; then curl -fsS --max-time 10 -H "$HEALTH_HDR" "$1"; else curl -fsS --max-time 10 "$1"; fi
+}
+LIVE_SHA="$(health_curl "http://127.0.0.1:$PORT/api/health" 2>/dev/null \
             | sed -n 's/.*"sha"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' || true)"
 if [ "${FORWARD_ONLY:-0}" = "1" ] && [ "${FORCE:-0}" != "1" ]; then
   LAST_SHA="$LIVE_SHA"
@@ -262,6 +271,7 @@ docker run -d \
   -e CRON_SECRET="${CRON_SECRET:-}" \
   -e CRON_ENABLED="${CRON_ENABLED:-}" \
   -e TRUSTED_PROXY_COUNT="${TRUSTED_PROXY_COUNT:-1}" \
+  -e HEALTH_TOKEN="${HEALTH_TOKEN:-}" \
   "$IMAGE"
 
 # ── 6. Health check + prune ──────────────────────────────────────────────────
@@ -275,7 +285,7 @@ log "Health check http://127.0.0.1:$PORT/api/health?db=1"
 ok=0
 health=''
 for i in $(seq 1 30); do
-  health="$(curl -fsS --max-time 10 "http://127.0.0.1:$PORT/api/health?db=1" 2>/dev/null || true)"
+  health="$(health_curl "http://127.0.0.1:$PORT/api/health?db=1" 2>/dev/null || true)"
   if [ -n "$health" ]; then ok=1; break; fi
   sleep 2
 done

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.32.0-beta",
+  "version": "0.32.1-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,6 +12,8 @@ import { defineConfig, devices } from '@playwright/test';
 const externalBase = process.env.BASE_URL;
 const PORT = 3000;
 const localURL = `http://localhost:${PORT}`;
+// Shared with e2e/health.spec.ts, which asserts both sides of the token gate.
+export const E2E_HEALTH_TOKEN = 'e2e-health-token';
 
 export default defineConfig({
   testDir: './e2e',
@@ -44,6 +46,12 @@ export default defineConfig({
         // Playwright talks to Next directly — there is no nginx appending to
         // X-Forwarded-For here, so 0 is the honest setting and it is what makes
         // the spoofing assertions in rate-limit-spoof.spec.ts meaningful (#858).
-        env: { TRUSTED_PROXY_COUNT: '0' },
+        env: {
+          TRUSTED_PROXY_COUNT: '0',
+          // Exercises the gated shape of /api/health (#897). Unset, the endpoint
+          // keeps its legacy fully-public response and health.spec.ts's
+          // assertions about what an anonymous caller may see would be vacuous.
+          HEALTH_TOKEN: E2E_HEALTH_TOKEN,
+        },
       },
 });

--- a/src/app/api/admin/webhooks/route.ts
+++ b/src/app/api/admin/webhooks/route.ts
@@ -6,6 +6,7 @@ import { prisma } from '@/lib/prisma';
 import { logActivity } from '@/lib/activity';
 import { z } from 'zod';
 import { WEBHOOK_EVENTS } from '@/lib/webhooks';
+import { assertPublicHttpsUrl, SsrfBlockedError } from '@/lib/ssrfGuard';
 
 async function requireAdmin() {
   const session = await getServerSession(authOptions);
@@ -31,6 +32,17 @@ export async function POST(request: Request) {
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   const parsed = schema.safeParse(await request.json());
   if (!parsed.success) return NextResponse.json({ error: 'Validation failed' }, { status: 400 });
+  // The URL is called from the server's network position, so a schema check is
+  // not enough — 127.0.0.1 and the cloud metadata address both pass `.url()`.
+  try {
+    await assertPublicHttpsUrl(parsed.data.url);
+  } catch (e) {
+    return NextResponse.json(
+      { error: e instanceof SsrfBlockedError ? e.message : 'Invalid webhook URL' },
+      { status: 400 }
+    );
+  }
+
   const secret = randomBytes(24).toString('hex');
   const webhook = await prisma.webhook.create({ data: { url: parsed.data.url, events: parsed.data.events, secret } });
   await logActivity({

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,4 +1,7 @@
 import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { timingSafeEqual } from 'crypto';
+import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { APP_VERSION, GIT_SHA } from '@/lib/version';
 import { verifySmtpConnection } from '@/services/emailService';
@@ -9,7 +12,40 @@ import { verifySmtpConnection } from '@/services/emailService';
 // message sent — see #483, where SMTP silently failing had no visibility
 // outside of a user reporting a missing email). Never touches or mutates
 // domain data.
+//
+// Liveness stays public — a monitor cannot log in. The *detail* (version, git
+// sha, subsystem status, uptime) is a different matter: to an attacker it is a
+// ready-made answer to "which CVEs apply to this deployment?" (#897). It is now
+// released only to an admin session or a caller holding HEALTH_TOKEN.
 export const dynamic = 'force-dynamic';
+
+/**
+ * Whether this caller may see the detailed fields.
+ *
+ * When `HEALTH_TOKEN` is unset the endpoint keeps its old, fully public shape.
+ * That is deliberate rather than lazy: the production deploy gate reads `sha`
+ * from this endpoint to decide whether the live container has drifted
+ * (`deploy-prod.yml`, `infra/deploy-prod.sh`), and the same is true of the
+ * preview gate. Defaulting to closed would blind all of them the moment this
+ * merges, before anyone had a chance to configure the token. Set `HEALTH_TOKEN`
+ * in the server env and on the probes, and the endpoint closes.
+ */
+async function maySeeDetail(request: Request): Promise<boolean> {
+  const expected = process.env.HEALTH_TOKEN;
+  if (!expected) return true;
+
+  const got = request.headers.get('x-health-token') || '';
+  try {
+    if (got.length === expected.length && timingSafeEqual(Buffer.from(got), Buffer.from(expected))) {
+      return true;
+    }
+  } catch {
+    // fall through to the session check
+  }
+
+  const session = await getServerSession(authOptions);
+  return session?.user.role === 'ADMIN';
+}
 
 export async function GET(request: Request) {
   const started = Date.now();
@@ -36,9 +72,21 @@ export async function GET(request: Request) {
   }
 
   const healthy = db !== 'error' && smtp !== 'error';
+  const status = healthy ? 'ok' : 'degraded';
+
+  // An anonymous caller learns whether the app is up, and nothing else. The
+  // status code still distinguishes healthy from degraded, which is all an
+  // uptime monitor acts on.
+  if (!(await maySeeDetail(request))) {
+    return NextResponse.json(
+      { status, timestamp: new Date().toISOString() },
+      { status: healthy ? 200 : 503 }
+    );
+  }
+
   return NextResponse.json(
     {
-      status: healthy ? 'ok' : 'degraded',
+      status,
       version: APP_VERSION,
       sha: GIT_SHA,
       db,

--- a/src/lib/aiCvFeedback.ts
+++ b/src/lib/aiCvFeedback.ts
@@ -5,13 +5,19 @@
 
 import Anthropic from '@anthropic-ai/sdk';
 
+// A generation that has not answered in a minute is not going to.
+const AI_TIMEOUT_MS = 60_000;
+
 const MODEL = process.env.ANTHROPIC_CV_MODEL || 'claude-opus-4-8';
 const MAX_INPUT_CHARS = 24_000;
 
 const SYSTEM = `You review a student/junior CV and give constructive improvement feedback, written directly to the CV owner in the same language the CV is written in. Return three short sections with these exact markdown headers: "**Strengths**", "**Improvements**", "**Missing**". Under each, 2-5 concise bullet points grounded in the actual CV content (never invent experience). Improvements should be specific and actionable (wording, structure, quantification); Missing lists sections or details worth adding. Keep the whole answer under 250 words.`;
 
 export async function aiCvFeedback(text: string): Promise<string> {
-  const client = new Anthropic(); // reads ANTHROPIC_API_KEY
+  // reads ANTHROPIC_API_KEY. The SDK's own default timeout is 10 minutes, long
+  // enough to hold a request handler open until the user gives up (#895).
+  // Generation genuinely takes tens of seconds, so 60s — not the 5s webhooks get.
+  const client = new Anthropic({ timeout: AI_TIMEOUT_MS });
   const res = await client.messages.create({
     model: MODEL,
     max_tokens: 700,

--- a/src/lib/aiInterviewPrep.ts
+++ b/src/lib/aiInterviewPrep.ts
@@ -5,12 +5,18 @@
 
 import Anthropic from '@anthropic-ai/sdk';
 
+// A generation that has not answered in a minute is not going to.
+const AI_TIMEOUT_MS = 60_000;
+
 const MODEL = process.env.ANTHROPIC_CV_MODEL || 'claude-opus-4-8';
 
 const SYSTEM = `You are an interview preparation coach for a student/junior candidate. Given a target position and skills, produce, in the same language as the input: (1) "**Questions**" — 6-8 realistic interview questions for that position (mix of technical and behavioral, ordered easy→hard); (2) "**Tips**" — 3-5 short, concrete preparation tips specific to the position and skills. Keep the whole answer under 350 words. Do not invent facts about the candidate.`;
 
 export async function aiInterviewPrep(targetPosition: string, skills: string[], focus?: string): Promise<string> {
-  const client = new Anthropic(); // reads ANTHROPIC_API_KEY
+  // reads ANTHROPIC_API_KEY. The SDK's own default timeout is 10 minutes, long
+  // enough to hold a request handler open until the user gives up (#895).
+  // Generation genuinely takes tens of seconds, so 60s — not the 5s webhooks get.
+  const client = new Anthropic({ timeout: AI_TIMEOUT_MS });
   const res = await client.messages.create({
     model: MODEL,
     max_tokens: 900,

--- a/src/lib/aiMentorMatch.ts
+++ b/src/lib/aiMentorMatch.ts
@@ -7,6 +7,9 @@
 
 import Anthropic from '@anthropic-ai/sdk';
 
+// A generation that has not answered in a minute is not going to.
+const AI_TIMEOUT_MS = 60_000;
+
 const MODEL = process.env.ANTHROPIC_CV_MODEL || 'claude-opus-4-8';
 
 export interface MatchCandidate {
@@ -49,7 +52,10 @@ export async function aiRankMentors(
   mentee: MatchMentee,
   candidates: MatchCandidate[]
 ): Promise<{ label: string; reason: string }[]> {
-  const client = new Anthropic(); // reads ANTHROPIC_API_KEY
+  // reads ANTHROPIC_API_KEY. The SDK's own default timeout is 10 minutes, long
+  // enough to hold a request handler open until the user gives up (#895).
+  // Generation genuinely takes tens of seconds, so 60s — not the 5s webhooks get.
+  const client = new Anthropic({ timeout: AI_TIMEOUT_MS });
   const payload = {
     mentee: { skills: mentee.skills, targetPosition: mentee.targetPosition ?? '', interests: mentee.interests ?? '' },
     mentors: candidates.map((c) => ({

--- a/src/lib/aiSummary.ts
+++ b/src/lib/aiSummary.ts
@@ -5,6 +5,9 @@
 
 import Anthropic from '@anthropic-ai/sdk';
 
+// A generation that has not answered in a minute is not going to.
+const AI_TIMEOUT_MS = 60_000;
+
 const MODEL = process.env.ANTHROPIC_SUMMARY_MODEL || process.env.ANTHROPIC_CV_MODEL || 'claude-opus-4-8';
 const MAX_INPUT_CHARS = 24_000;
 
@@ -18,7 +21,10 @@ export interface SummaryInteraction {
 const SYSTEM = `You summarize a mentor's interaction log with one mentee. Write for the mentor. Use the same language the log entries are written in. Return 4-8 short bullet lines covering: overall progress, recurring themes, open risks or blockers, and 1-2 concrete suggested next steps. Be specific to the log content; do not invent facts.`;
 
 export async function aiSummarizeInteractions(menteeName: string, interactions: SummaryInteraction[]): Promise<string> {
-  const client = new Anthropic(); // reads ANTHROPIC_API_KEY
+  // reads ANTHROPIC_API_KEY. The SDK's own default timeout is 10 minutes, long
+  // enough to hold a request handler open until the user gives up (#895).
+  // Generation genuinely takes tens of seconds, so 60s — not the 5s webhooks get.
+  const client = new Anthropic({ timeout: AI_TIMEOUT_MS });
   const log = interactions
     .map((i) => `${i.date.toISOString().slice(0, 10)} · ${i.type}${i.subject ? ` · ${i.subject}` : ''}\n${i.notes}`)
     .join('\n---\n')

--- a/src/lib/cvExtractAi.ts
+++ b/src/lib/cvExtractAi.ts
@@ -9,6 +9,9 @@
 
 import Anthropic from '@anthropic-ai/sdk';
 
+// A generation that has not answered in a minute is not going to.
+const AI_TIMEOUT_MS = 60_000;
+
 export interface AiCvSuggestions {
   fullName: string;
   city: string;
@@ -58,7 +61,10 @@ const SYSTEM = `You extract structured profile fields from a CV/résumé. Return
  * already verified consent and isAiConfigured(). Throws on API failure.
  */
 export async function aiExtractFromText(text: string): Promise<AiCvSuggestions> {
-  const client = new Anthropic(); // reads ANTHROPIC_API_KEY
+  // reads ANTHROPIC_API_KEY. The SDK's own default timeout is 10 minutes, long
+  // enough to hold a request handler open until the user gives up (#895).
+  // Generation genuinely takes tens of seconds, so 60s — not the 5s webhooks get.
+  const client = new Anthropic({ timeout: AI_TIMEOUT_MS });
   const trimmed = text.slice(0, MAX_INPUT_CHARS);
 
   const res = await client.messages.create({

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,24 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.32.1-beta',
+    date: '2026-07-31',
+    highlights: {
+      en: [
+        'Security fix: a webhook could be pointed at the server\'s own internal network. Webhook addresses must now be public https endpoints, checked both when saved and each time one is sent.',
+        'A slow or unresponsive webhook receiver or AI service can no longer hold the app up — outgoing requests now time out and are logged instead.',
+      ],
+      tr: [
+        'Güvenlik düzeltmesi: bir webhook, sunucunun kendi iç ağına yönlendirilebiliyordu. Webhook adresleri artık genel erişime açık https uçları olmak zorunda ve hem kaydedilirken hem her gönderimde denetleniyor.',
+        'Yavaş veya yanıt vermeyen bir webhook alıcısı ya da yapay zekâ servisi artık uygulamayı bekletemiyor — giden istekler zaman aşımına uğrayıp kayda geçiyor.',
+      ],
+      de: [
+        'Sicherheitskorrektur: Ein Webhook konnte auf das interne Netz des Servers gerichtet werden. Webhook-Adressen müssen jetzt öffentliche https-Endpunkte sein und werden beim Speichern sowie bei jedem Versand geprüft.',
+        'Ein langsamer oder nicht antwortender Webhook-Empfänger bzw. KI-Dienst kann die Anwendung nicht mehr aufhalten — ausgehende Anfragen laufen jetzt in ein Timeout und werden protokolliert.',
+      ],
+    },
+  },
+  {
     version: '0.32.0-beta',
     date: '2026-07-31',
     highlights: {

--- a/src/lib/ssrfGuard.ts
+++ b/src/lib/ssrfGuard.ts
@@ -1,0 +1,103 @@
+import { lookup } from 'node:dns/promises';
+import { isIP } from 'node:net';
+
+/**
+ * Guard for URLs the server will fetch on someone else's say-so (#893).
+ *
+ * A webhook URL is admin-supplied and then called *from the server's network
+ * position*, which is a very different place from the admin's browser:
+ * `http://127.0.0.1:3306` reaches the database, and
+ * `http://169.254.169.254/latest/meta-data/` reaches the cloud metadata service
+ * and, with it, instance credentials. `z.string().url()` accepted both.
+ */
+
+/** Hostnames that are never legitimate outbound targets, whatever they resolve to. */
+const BLOCKED_SUFFIXES = ['.localhost', '.local', '.internal', '.home.arpa'];
+const BLOCKED_NAMES = ['localhost'];
+
+function isPrivateV4(ip: string): boolean {
+  const [a, b] = ip.split('.').map(Number);
+  if (a === 10 || a === 127 || a === 0) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 169 && b === 254) return true; // link-local, incl. cloud metadata
+  if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT
+  if (a >= 224) return true; // multicast + reserved
+  return false;
+}
+
+function isPrivateV6(ip: string): boolean {
+  const v = ip.toLowerCase().replace(/^\[|\]$/g, '');
+  if (v === '::' || v === '::1') return true;
+  if (v.startsWith('fe80')) return true; // link-local
+  if (/^f[cd]/.test(v)) return true; // unique local fc00::/7
+  // IPv4-mapped (::ffff:127.0.0.1) — judge by the embedded address.
+  const mapped = v.match(/::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  if (mapped) return isPrivateV4(mapped[1]);
+  return false;
+}
+
+export function isPrivateAddress(ip: string): boolean {
+  const family = isIP(ip);
+  if (family === 4) return isPrivateV4(ip);
+  if (family === 6) return isPrivateV6(ip);
+  return true; // not an address we can reason about — refuse
+}
+
+export class SsrfBlockedError extends Error {}
+
+/**
+ * Throws `SsrfBlockedError` unless `raw` is an https URL on a public address.
+ *
+ * The check is on the **resolved** addresses, not the hostname string: a name
+ * an attacker controls can point at 127.0.0.1 just as easily as a literal can.
+ * (This narrows DNS rebinding rather than eliminating it — the name is resolved
+ * again by `fetch`, and a short TTL can return something different the second
+ * time. Closing that fully means pinning the connection to the checked IP,
+ * which `fetch` gives no hook for; it is a much smaller window than accepting
+ * `http://169.254.169.254` outright.)
+ */
+export async function assertPublicHttpsUrl(raw: string): Promise<URL> {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new SsrfBlockedError('Not a valid URL');
+  }
+
+  // https only: plaintext would send the payload — real business data, see
+  // WEBHOOK_EVENTS — over the wire in the clear.
+  if (url.protocol !== 'https:') {
+    throw new SsrfBlockedError('Only https:// webhook URLs are allowed');
+  }
+  if (url.username || url.password) {
+    throw new SsrfBlockedError('Credentials in the URL are not allowed');
+  }
+
+  const host = url.hostname.toLowerCase().replace(/\.$/, '');
+  if (BLOCKED_NAMES.includes(host) || BLOCKED_SUFFIXES.some((s) => host.endsWith(s))) {
+    throw new SsrfBlockedError('That host is not a permitted target');
+  }
+
+  // A literal address needs no DNS round-trip.
+  if (isIP(host)) {
+    if (isPrivateAddress(host)) throw new SsrfBlockedError('That address is not a permitted target');
+    return url;
+  }
+
+  let addresses;
+  try {
+    addresses = await lookup(host, { all: true });
+  } catch {
+    throw new SsrfBlockedError('That host could not be resolved');
+  }
+  if (addresses.length === 0) throw new SsrfBlockedError('That host could not be resolved');
+  // Every answer must be public: one private record among them is enough for a
+  // resolver to hand `fetch` the internal one.
+  for (const a of addresses) {
+    if (isPrivateAddress(a.address)) {
+      throw new SsrfBlockedError('That host resolves to a private address');
+    }
+  }
+  return url;
+}

--- a/src/lib/webhooks.ts
+++ b/src/lib/webhooks.ts
@@ -1,6 +1,11 @@
 import { createHmac } from 'crypto';
 import { prisma } from '@/lib/prisma';
 import { logger } from '@/lib/logger';
+import { assertPublicHttpsUrl } from '@/lib/ssrfGuard';
+
+// A receiver that cannot answer in five seconds is not worth blocking a request
+// handler on; delivery is fire-and-forget anyway.
+const WEBHOOK_TIMEOUT_MS = 5_000;
 
 // Known webhook event types.
 export const WEBHOOK_EVENTS = [
@@ -30,11 +35,19 @@ export async function dispatchWebhook(event: WebhookEvent, data: Record<string, 
       .filter((h) => Array.isArray(h.events) && (h.events as string[]).includes(event))
       .map(async (h) => {
         try {
+          // Re-checked at delivery, not just at registration (#893): DNS moves,
+          // and rows created before the guard existed have never been checked
+          // at all.
+          await assertPublicHttpsUrl(h.url);
           const signature = createHmac('sha256', h.secret).update(body).digest('hex');
           await fetch(h.url, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json', 'X-Signature': signature, 'X-Event': event },
             body,
+            // Without this a single unresponsive endpoint held the request
+            // handler open indefinitely — and these run under Promise.all, so
+            // the slowest target stalled the whole batch (#895).
+            signal: AbortSignal.timeout(WEBHOOK_TIMEOUT_MS),
           });
         } catch (e) {
           logger.warning('Webhook delivery failed', { url: h.url, event, error: String(e) });


### PR DESCRIPTION
Closes #893
Closes #895
Closes #897

Epic #827 — dış entegrasyon güvenliği. Üçü de "sunucu, başkasının söylediği yere/şekilde bağlanıyor" temasında.

## 1. Webhook SSRF (#893)

Doğrulama `z.string().url()` idi ve URL **sunucunun ağ konumundan** çağrılıyordu — admin'in tarayıcısından çok farklı bir yer:

```
http://127.0.0.1:3306                        → veritabanı
http://169.254.169.254/latest/meta-data/     → cloud metadata (instance kimlik bilgileri)
```

`src/lib/ssrfGuard.ts`: yalnız `https`, URL içinde kimlik bilgisi yok, ve hostname'in **çözümlenen** adresi public olmak zorunda — **tüm** yanıtlar kontrol ediliyor, çünkü aralarındaki tek bir private kayıt resolver'ın `fetch`'e iç adresi vermesi için yeterli.

Kontrol hem **kayıt anında hem her gönderimde**: DNS değişir, üstelik guard'dan önce oluşturulmuş satırlar hiç kontrol edilmemiş.

> Dürüst sınır: bu DNS rebinding'i **daraltıyor, bitirmiyor** — ismi `fetch` bir kez daha çözüyor. Tam kapatmak bağlantıyı doğrulanan IP'ye pinlemeyi gerektirir, `fetch` buna kanca vermiyor. `http://169.254.169.254`'ü düpedüz kabul etmekten çok daha küçük bir pencere.

HMAC imzası **sorun değildi**, dokunulmadı.

## 2. Giden isteklerde timeout (#895)

Webhook gönderimi `Promise.all` altında ve **deadline'sız** çalışıyordu → yanıt vermeyen tek bir alıcı tüm grubu ve request handler'ı süresiz bekletiyordu. Artık 5 sn.

Anthropic SDK'nın varsayılanı **10 dakika** — kullanıcının vazgeçmesine fazlasıyla yeter. Beş AI istemcisi 60 sn geçiyor (üretim gerçekten onlarca saniye sürüyor, webhook'un 5 sn'si buraya uymaz). SDK'nın kendi `timeout` seçeneği kullanıldı, elle `AbortSignal` sarılmadı.

`dispatchWebhook` hâlâ **throw etmiyor** — abort mevcut catch'e düşüp diğer teslimat hataları gibi loglanıyor.

## 3. `/api/health` bilgi sızıntısı (#897)

Anonim çağrı sürüm ve git SHA veriyordu — "bu kurulumda hangi CVE'ler geçerli?" sorusunun hazır cevabı.

`HEALTH_TOKEN` **set edildiğinde**: anonim yanıt `{ status, timestamp }` (uptime aracının baktığı her şey); detay yalnız admin oturumu veya `X-Health-Token` ile.

### ⚠️ Neden varsayılan fail-open

**Set edilmediğinde yanıt değişmiyor.** Bu bilinçli: prod **ve** preview deploy drift gate'leri canlı container'ın `sha`'sını tam bu uçtan okuyor (`deploy-prod.yml`, `deploy-preview.yml`, `infra/deploy-prod.sh`). Fail-closed varsayılan, merge olduğu anda üçünü birden kör ederdi — ve secret'ı benim ayarlama imkânım yok.

Bunun yerine boru hattı **hazır bırakıldı**: `deploy-prod.sh` değişkeni container'a geçiriyor ve her iki gate sunucu env dosyasından okuyup header'ı gönderiyor. Sızıntıyı kapatmak artık tek bir değişken eklemek.

`.env.example` bunu ve yanlış yapılandırmanın etkisini açıklıyor.

## Test

`e2e/health.spec.ts` genişletildi (`@smoke`): `playwright.config.ts` webServer'a `HEALTH_TOKEN` veriyor, böylece gate'in **iki yanı da** test ediliyor — token ile detay geliyor, tokensiz ve yanlış token ile gelmiyor. Aksi hâlde assertion'lar boşa düşerdi.

`npm run build` ✅ · `npx tsc --noEmit` ✅ · `bash -n infra/deploy-prod.sh` ✅

## Sürüm

`0.32.1-beta` + CHANGELOG + releaseNotes (EN/TR/DE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
