### PR TITLE
feat(security): yükleme içerik doğrulaması + indirme sertleştirme (#888, #890)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.32.2-beta] - 2026-07-31
+
+### Security
+- **Upload validation trusted the client's word about the file type** (#888). Every
+  route checked `file.type`, which is a multipart header the client writes; the bytes
+  were never looked at. That matters more here than usual because the declared type
+  is *stored* and returned on download — a mislabelled file arrives on an employer's
+  machine wearing the word "CV". `src/lib/fileType.ts` now checks the content
+  signature (dependency-free — a sniffing library would be one more parser inside the
+  trust boundary) on CV, avatar, document and message-attachment uploads. DOCX and
+  XLSX are both ZIP containers and cannot be told apart by signature, so the check is
+  "the bytes are a ZIP", not more: rejecting legitimate Office files would be the
+  worse failure. Support attachments already did this and are untouched.
+- **Stored uploads were served `inline` with a barely-sanitised filename** (#890).
+  CVs, documents and non-image message attachments now download as `attachment`
+  instead of rendering on our own origin; `src/lib/download.ts` strips control
+  characters (a `\r\n` in a name could have split the header), quotes, backslashes
+  and semicolons, bounds the length, and adds `filename*=UTF-8''…` so a Turkish CV
+  name survives the trip. Every file route now carries its own
+  `X-Content-Type-Options: nosniff` — the global one in `next.config.js` still
+  applies, this is the layer that survives a change to it. Avatars and images in a
+  message thread stay `inline`: the UI renders them.
+
 ## [0.32.1-beta] - 2026-07-31
 
 ### Security

--- a/e2e/file-upload-security.spec.ts
+++ b/e2e/file-upload-security.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { signInAndSettle } from './helpers/auth';
+
+/**
+ * #888 — upload validation looked only at `file.type`, a client-written
+ * multipart header. The bytes were never inspected, and the declared type is
+ * stored and handed back on download, so a mislabelled file arrived on an
+ * employer's machine wearing the word "CV".
+ *
+ * #890 — those downloads were served `inline` from our own origin with the
+ * filename dropped into the header almost raw.
+ */
+
+const PASSWORD = 'UploadPass123';
+const email = uniqueEmail('upload');
+let userId = '';
+
+const PDF_BYTES = Buffer.from('%PDF-1.4\n%âãÏÓ\n1 0 obj\n<<>>\nendobj\ntrailer\n<<>>\n', 'latin1');
+
+test.beforeAll(async () => {
+  const u = await seedUser(email, PASSWORD, 'MENTEE', 'Upload Mentee');
+  userId = u.id;
+});
+
+test.afterAll(async () => {
+  await prisma.cvFile.deleteMany({ where: { userId } });
+  await cleanupByEmail(email);
+  await prisma.$disconnect();
+});
+
+test('a file whose bytes do not match its declared type is rejected', { tag: '@smoke' }, async ({ page }) => {
+  await signInAndSettle(page, email, PASSWORD, '/portal');
+
+  // An executable-ish payload announcing itself as a PDF.
+  const disguised = await page.request.post('/api/cv', {
+    multipart: {
+      file: { name: 'cv.pdf', mimeType: 'application/pdf', buffer: Buffer.from('MZ\x90\x00not a pdf at all') },
+    },
+  });
+  expect(disguised.status()).toBe(400);
+  expect(await prisma.cvFile.findUnique({ where: { userId } })).toBeNull();
+
+  // A real PDF still uploads.
+  const genuine = await page.request.post('/api/cv', {
+    multipart: { file: { name: 'cv.pdf', mimeType: 'application/pdf', buffer: PDF_BYTES } },
+  });
+  expect(genuine.status()).toBe(200);
+});
+
+test('a CV downloads as an attachment with a sanitised filename', { tag: '@smoke' }, async ({ page }) => {
+  await signInAndSettle(page, email, PASSWORD, '/portal');
+  // A name carrying a header-splitting sequence and a non-ASCII character.
+  await page.request.post('/api/cv', {
+    multipart: {
+      file: { name: 'öz"geçmiş\r\nX-Injected: 1.pdf', mimeType: 'application/pdf', buffer: PDF_BYTES },
+    },
+  });
+
+  const res = await page.request.get(`/api/cv/${userId}`);
+  expect(res.status()).toBe(200);
+  const headers = res.headers();
+  expect(headers['content-disposition']).toContain('attachment');
+  // The quote and the CRLF are gone; the header is one line.
+  expect(headers['content-disposition']).not.toContain('"öz"');
+  expect(headers['content-disposition']).not.toContain('\n');
+  expect(headers['x-injected']).toBeUndefined();
+  // Non-ASCII survives via RFC 5987 rather than being mangled.
+  expect(headers['content-disposition']).toContain("filename*=UTF-8''");
+  expect(headers['x-content-type-options']).toBe('nosniff');
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.32.1-beta",
+  "version": "0.32.2-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/app/api/avatar/[userId]/route.ts
+++ b/src/app/api/avatar/[userId]/route.ts
@@ -19,11 +19,14 @@ export async function GET(_request: Request, { params }: { params: Promise<{ use
   const avatar = await prisma.avatarFile.findUnique({ where: { userId } });
   if (!avatar) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 
+  // Inline is right here — the avatar is displayed in an <img>. The only thing
+  // missing was a route-level nosniff (#890).
   return new NextResponse(Buffer.from(avatar.data), {
     headers: {
       'Content-Type': avatar.contentType,
       'Content-Length': String(avatar.size),
       'Cache-Control': 'private, max-age=300',
+      'X-Content-Type-Options': 'nosniff',
     },
   });
   });

--- a/src/app/api/avatar/route.ts
+++ b/src/app/api/avatar/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { withTenantScope } from '@/lib/orgContext';
+import { contentMatchesType, CONTENT_MISMATCH_ERROR } from '@/lib/fileType';
 
 const MAX_BYTES = 2 * 1024 * 1024; // 2 MB
 const ALLOWED = new Set(['image/png', 'image/jpeg', 'image/webp', 'image/gif']);
@@ -31,6 +32,9 @@ export async function POST(request: Request) {
   }
 
   const data = Buffer.from(await file.arrayBuffer());
+  if (!contentMatchesType(data, file.type)) {
+    return NextResponse.json({ error: CONTENT_MISMATCH_ERROR }, { status: 400 });
+  }
   await prisma.avatarFile.upsert({
     where: { userId: targetUserId },
     create: { userId: targetUserId, contentType: file.type, size: file.size, data },

--- a/src/app/api/cv/[userId]/route.ts
+++ b/src/app/api/cv/[userId]/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { withTenantScope } from '@/lib/orgContext';
 import { canAccessCv } from '@/lib/cvAccess';
+import { downloadHeaders } from '@/lib/download';
 
 // GET — download a user's CV (access-controlled).
 export async function GET(_request: Request, { params }: { params: Promise<{ userId: string }> }) {
@@ -19,12 +20,10 @@ export async function GET(_request: Request, { params }: { params: Promise<{ use
   const cv = await prisma.cvFile.findUnique({ where: { userId } });
   if (!cv) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 
+  // Downloaded, not rendered in place: a stored document must not run as a
+  // page on our own origin (#890).
   return new NextResponse(Buffer.from(cv.data), {
-    headers: {
-      'Content-Type': cv.contentType,
-      'Content-Disposition': `inline; filename="${cv.filename.replace(/"/g, '')}"`,
-      'Content-Length': String(cv.size),
-    },
+    headers: downloadHeaders({ filename: cv.filename, contentType: cv.contentType, size: cv.size }),
   });
   });
 }

--- a/src/app/api/cv/route.ts
+++ b/src/app/api/cv/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { withTenantScope } from '@/lib/orgContext';
 import { canAccessCv } from '@/lib/cvAccess';
+import { contentMatchesType, CONTENT_MISMATCH_ERROR } from '@/lib/fileType';
 
 const MAX_BYTES = 5 * 1024 * 1024; // 5 MB
 const ALLOWED = new Set([
@@ -36,6 +37,10 @@ export async function POST(request: Request) {
   }
 
   const data = Buffer.from(await file.arrayBuffer());
+  // `file.type` is a client-written multipart header; check the bytes too (#888).
+  if (!contentMatchesType(data, file.type)) {
+    return NextResponse.json({ error: CONTENT_MISMATCH_ERROR }, { status: 400 });
+  }
   await prisma.cvFile.upsert({
     where: { userId: targetUserId },
     create: { userId: targetUserId, filename: file.name, contentType: file.type, size: file.size, data },

--- a/src/app/api/documents/[id]/route.ts
+++ b/src/app/api/documents/[id]/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { canAccessUserDocs } from '@/lib/documentAccess';
 import { logActivity } from '@/lib/activity';
+import { downloadHeaders } from '@/lib/download';
 
 // GET — download a document (templates: any signed-in user; owned: access-controlled).
 export async function GET(_request: Request, { params }: { params: Promise<{ id: string }> }) {
@@ -31,11 +32,7 @@ export async function GET(_request: Request, { params }: { params: Promise<{ id:
   });
 
   return new NextResponse(Buffer.from(doc.data), {
-    headers: {
-      'Content-Type': doc.contentType,
-      'Content-Disposition': `inline; filename="${doc.filename.replace(/"/g, '')}"`,
-      'Content-Length': String(doc.size),
-    },
+    headers: downloadHeaders({ filename: doc.filename, contentType: doc.contentType, size: doc.size }),
   });
 }
 

--- a/src/app/api/documents/route.ts
+++ b/src/app/api/documents/route.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { canAccessUserDocs, DOCUMENT_TYPES, ALLOWED_DOC_MIME, MAX_DOC_BYTES } from '@/lib/documentAccess';
+import { contentMatchesType, CONTENT_MISMATCH_ERROR } from '@/lib/fileType';
 import { logActivity } from '@/lib/activity';
 import type { DocumentType } from '@prisma/client';
 
@@ -95,6 +96,10 @@ export async function POST(request: Request) {
     : null;
 
   const data = Buffer.from(await file.arrayBuffer());
+  // The declared MIME comes from the client; verify the bytes agree (#888).
+  if (!contentMatchesType(data, file.type)) {
+    return NextResponse.json({ error: CONTENT_MISMATCH_ERROR }, { status: 400 });
+  }
   const doc = await prisma.document.create({
     data: {
       ownerId,

--- a/src/app/api/messages/attachments/[id]/route.ts
+++ b/src/app/api/messages/attachments/[id]/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { canAccessMessage } from '@/lib/conversations';
+import { downloadHeaders } from '@/lib/download';
 
 // GET — serve a message attachment's bytes. Only the participants of the
 // message's thread or conversation (or an admin) may download it, same rule as
@@ -23,10 +24,14 @@ export async function GET(_request: Request, { params }: { params: Promise<{ id:
   }
 
   return new NextResponse(Buffer.from(attachment.data), {
-    headers: {
-      'Content-Type': attachment.contentType,
-      'Content-Disposition': `inline; filename="${attachment.filename.replace(/"/g, '')}"`,
-      'Content-Length': String(attachment.size),
-    },
+    // Images stay inline — MessageThreadView renders them in the thread with an
+    // <img>. Everything else downloads (#890), matching the support-attachment
+    // route, which already did this.
+    headers: downloadHeaders({
+      filename: attachment.filename,
+      contentType: attachment.contentType,
+      size: attachment.size,
+      inline: attachment.contentType.startsWith('image/'),
+    }),
   });
 }

--- a/src/app/api/messages/route.ts
+++ b/src/app/api/messages/route.ts
@@ -11,6 +11,7 @@ import { sendEmail } from '@/services/emailService';
 import { logger } from '@/lib/logger';
 import { emailAllowed } from '@/lib/notificationPrefs';
 import { ALLOWED_DOC_MIME, MAX_DOC_BYTES } from '@/lib/documentAccess';
+import { contentMatchesType, CONTENT_MISMATCH_ERROR } from '@/lib/fileType';
 import { withTenantScope } from '@/lib/orgContext';
 
 const ATTACHMENT_SELECT = { id: true, filename: true, contentType: true, size: true } as const;
@@ -186,6 +187,11 @@ export async function POST(request: Request) {
     const fileBufs = await Promise.all(
       files.map(async (f) => ({ filename: f.name, contentType: f.type, size: f.size, data: Buffer.from(await f.arrayBuffer()) })),
     );
+    // The MIME check above trusts a client-written header; now that the bytes
+    // are in hand, check they agree (#888).
+    if (fileBufs.some((f) => !contentMatchesType(f.data, f.contentType))) {
+      return NextResponse.json({ error: CONTENT_MISMATCH_ERROR }, { status: 400 });
+    }
 
     const message = await prisma.message.create({
       data: {

--- a/src/lib/download.ts
+++ b/src/lib/download.ts
@@ -1,0 +1,54 @@
+/**
+ * Headers for serving a stored user upload (#890).
+ *
+ * Two things were slightly wrong across the download routes: files were served
+ * `inline` from the app's own origin, and the filename went into the header
+ * with only `"` stripped — a `\r\n` in a name would have split the header.
+ *
+ * The global `nosniff` in `next.config.js` already covers the sniffing half, so
+ * this is defence in depth: a route that carries its own header keeps the
+ * protection if that global config is ever narrowed.
+ */
+
+/** Strip anything that could break out of the header, and bound the length. */
+function sanitizeFilename(name: string): string {
+  const cleaned = (name || 'file')
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\u0000-\u001f\u007f]/g, '') // control chars, incl. CR/LF
+    .replace(/["\\;]/g, '')
+    .trim();
+  return (cleaned || 'file').slice(0, 100);
+}
+
+export interface DownloadHeaderOptions {
+  filename: string;
+  contentType: string;
+  size: number;
+  /**
+   * `true` for files the UI actually renders in place (avatars, and images in a
+   * message thread). Everything else downloads, so a document can't be coaxed
+   * into rendering as a page on our own origin.
+   */
+  inline?: boolean;
+}
+
+export function downloadHeaders({
+  filename,
+  contentType,
+  size,
+  inline = false,
+}: DownloadHeaderOptions): Record<string, string> {
+  const safe = sanitizeFilename(filename);
+  // Both forms: the plain one for old clients, `filename*` so a Turkish or
+  // otherwise non-ASCII CV name survives the trip (RFC 5987).
+  const encoded = encodeURIComponent(safe);
+  const disposition = inline ? 'inline' : 'attachment';
+
+  return {
+    'Content-Type': contentType,
+    'Content-Disposition': `${disposition}; filename="${safe}"; filename*=UTF-8''${encoded}`,
+    'Content-Length': String(size),
+    'Cache-Control': 'private, no-store',
+    'X-Content-Type-Options': 'nosniff',
+  };
+}

--- a/src/lib/fileType.ts
+++ b/src/lib/fileType.ts
@@ -1,0 +1,75 @@
+/**
+ * Content-signature ("magic byte") checks for uploads (#888).
+ *
+ * Every upload route validated `file.type`, which comes from the multipart
+ * header and is written by the client — the bytes were never looked at. That
+ * matters here more than usual: the declared type is *stored* and handed back
+ * on download, so a mislabelled file arrives on an employer's machine wearing
+ * the word "CV".
+ *
+ * Deliberately dependency-free. A sniffing library would be one more parser in
+ * the trust boundary, and the signatures we care about are a handful of bytes.
+ */
+
+/** Families a signature can identify. Several MIME types map to one family. */
+type Family = 'pdf' | 'zip' | 'ole2' | 'png' | 'jpeg' | 'gif' | 'webp';
+
+function startsWith(buf: Uint8Array, bytes: number[], offset = 0): boolean {
+  if (buf.length < offset + bytes.length) return false;
+  return bytes.every((b, i) => buf[offset + i] === b);
+}
+
+export function sniffFamily(buf: Uint8Array): Family | null {
+  if (startsWith(buf, [0x25, 0x50, 0x44, 0x46, 0x2d])) return 'pdf'; // %PDF-
+  if (startsWith(buf, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) return 'png';
+  if (startsWith(buf, [0xff, 0xd8, 0xff])) return 'jpeg';
+  if (startsWith(buf, [0x47, 0x49, 0x46, 0x38])) return 'gif'; // GIF8
+  if (startsWith(buf, [0x52, 0x49, 0x46, 0x46]) && startsWith(buf, [0x57, 0x45, 0x42, 0x50], 8)) return 'webp';
+  if (startsWith(buf, [0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1])) return 'ole2'; // legacy .doc
+  // PK\x03\x04. Also PK\x05\x06 / PK\x07\x08 for empty and spanned archives —
+  // not valid Office documents, but accepting them here only means the ZIP
+  // family check passes and the file fails to open later, which is the same
+  // outcome as any other corrupt upload.
+  if (startsWith(buf, [0x50, 0x4b]) && (buf[2] === 0x03 || buf[2] === 0x05 || buf[2] === 0x07)) return 'zip';
+  return null;
+}
+
+/**
+ * Which family each accepted MIME type must have on disk.
+ *
+ * DOCX and XLSX are both ZIP containers and cannot be told apart by signature
+ * alone — the check is therefore "the bytes are a ZIP", not "the bytes are
+ * specifically a DOCX". Demanding more would reject legitimate uploads, which
+ * is a worse failure than a mislabelled Office document.
+ */
+const EXPECTED: Record<string, Family[]> = {
+  'application/pdf': ['pdf'],
+  'application/msword': ['ole2', 'zip'], // some tools emit .docx labelled as msword
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document': ['zip'],
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': ['zip'],
+  'application/vnd.ms-excel': ['ole2', 'zip'],
+  'image/png': ['png'],
+  'image/jpeg': ['jpeg'],
+  'image/jpg': ['jpeg'],
+  'image/gif': ['gif'],
+  'image/webp': ['webp'],
+};
+
+/**
+ * True when the bytes match what `declaredType` claims.
+ *
+ * A declared type we have no signature for returns `false` — the caller has
+ * already checked it against its own allowlist, so reaching here with an
+ * unknown type means the two lists have drifted, and guessing is not the
+ * behaviour we want from a security check.
+ */
+export function contentMatchesType(buf: Uint8Array, declaredType: string): boolean {
+  const expected = EXPECTED[declaredType.toLowerCase()];
+  if (!expected) return false;
+  const actual = sniffFamily(buf);
+  return actual !== null && expected.includes(actual);
+}
+
+/** Shared message so every upload route rejects in the same words. */
+export const CONTENT_MISMATCH_ERROR =
+  'The file contents do not match its type. Upload the original file rather than a renamed one.';

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,24 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.32.2-beta',
+    date: '2026-07-31',
+    highlights: {
+      en: [
+        'Uploads are now checked by their actual contents, not just the file type the browser claims. A file renamed to look like a PDF or an image is rejected.',
+        'CVs, documents and file attachments now download instead of opening in the browser, and filenames with accented characters come through correctly.',
+      ],
+      tr: [
+        'Yüklenen dosyalar artık yalnızca tarayıcının bildirdiği türe göre değil, gerçek içeriğine göre denetleniyor. PDF ya da resim gibi görünsün diye adı değiştirilmiş bir dosya reddediliyor.',
+        'CV\'ler, belgeler ve dosya ekleri artık tarayıcıda açılmak yerine indiriliyor; Türkçe karakterli dosya adları da doğru geliyor.',
+      ],
+      de: [
+        'Hochgeladene Dateien werden jetzt anhand ihres tatsächlichen Inhalts geprüft, nicht nur anhand des vom Browser gemeldeten Typs. Eine Datei, die nur so umbenannt wurde, dass sie wie ein PDF oder Bild aussieht, wird abgelehnt.',
+        'Lebensläufe, Dokumente und Dateianhänge werden jetzt heruntergeladen statt im Browser geöffnet, und Dateinamen mit Umlauten kommen korrekt an.',
+      ],
+    },
+  },
+  {
     version: '0.32.1-beta',
     date: '2026-07-31',
     highlights: {


### PR DESCRIPTION
Closes #888
Closes #890

Epic #825 — dosya yükleme ve içerik güvenliği.

## 1. Doğrulama, istemcinin beyanına güveniyordu (#888)

Her yükleme route'u `file.type`'a bakıyordu — bu multipart başlığından gelir, **istemci yazar**. Baytlara hiç bakılmıyordu.

Burada bu, alışıldığından daha önemli: beyan edilen tip **saklanıyor** ve indirmede geri veriliyor (`src/app/api/cv/[userId]/route.ts`). Yani içerik/tip uyuşmazlığı, dosyanın işveren bilgisayarına **"CV" etiketiyle** inmesi demek — İK bağlamında taşıma kanalı riski.

`src/lib/fileType.ts` içerik imzasını kontrol ediyor: CV, avatar, belge ve mesaj eki yüklemelerinde.

**Bağımlılıksız, bilerek** — sniff kütüphanesi güven sınırının içine bir parser daha koymak olurdu (repo `xlsx` deneyiminden sonra bunu istemiyor) ve önemsediğimiz imzalar birkaç bayt.

### DOCX/XLSX tuzağı

İkisi de ZIP konteyneri; imzayla ayırt **edilemezler**. Kontrol bu yüzden "baytlar bir ZIP" seviyesinde, daha fazlası değil — daha fazlasını istemek meşru Office yüklemelerini reddederdi, ki bu daha kötü bir başarısızlık.

Destek ekleri (`src/lib/supportAttachments.ts`) **zaten** magic-byte doğrulaması yapıyordu; referans desen oydu, dokunulmadı. Boyut limitleri ve erişim kontrolü de dokunulmadı (denetimde temiz çıkmışlardı).

## 2. İndirmeler `inline` ve dosya adı neredeyse ham (#890)

```ts
'Content-Disposition': `inline; filename="${cv.filename.replace(/"/g, '')}"`   // yalnız " siliniyor
```

Bir dosya adındaki `\r\n` başlığı bölebilirdi. Ve dosyalar **kendi origin'imizde** `inline` sunuluyordu.

`src/lib/download.ts`:
- CV, belge ve **resim olmayan** mesaj ekleri → `attachment`
- kontrol karakterleri (CR/LF dâhil), tırnak, ters bölü ve noktalı virgül temizleniyor; uzunluk 100 karakterle sınırlı
- `filename*=UTF-8''…` (RFC 5987) → Türkçe karakterli CV adları doğru iniyor
- her dosya sunan route kendi `X-Content-Type-Options: nosniff` başlığını taşıyor

`next.config.js`'teki global `nosniff` zaten geçerli — bu **savunma derinliği**: global yapılandırma ileride daraltılırsa koruma yerinde kalır.

**`inline` kalanlar ve neden:** avatar (`<img>` ile gösteriliyor) ve mesaj thread'indeki **resimler** (`MessageThreadView.tsx:284` bunları `<img>` ile render ediyor — `attachment` yapmak önizlemeyi bozardı). Destek eki route'u zaten tam bu ayrımı yapıyordu; aynı kural yayıldı.

## Test

`e2e/file-upload-security.spec.ts` (`@smoke`):
- `application/pdf` beyan eden ama `MZ...` ile başlayan dosya → `400`, DB'ye hiçbir şey yazılmıyor; gerçek PDF → `200`
- `öz"geçmiş\r\nX-Injected: 1.pdf` adıyla yüklenen CV → yanıt `attachment`, başlıkta tırnak/CRLF yok, `X-Injected` başlığı **oluşmuyor**, `filename*=UTF-8''` var, `nosniff` var

`npm run build` ✅ · `npx tsc --noEmit` ✅ · `next lint` ✅

## Sürüm

`0.32.2-beta` + CHANGELOG + releaseNotes (EN/TR/DE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
