### PR TITLE
fix(messages): project group chat emptied the "New chat" picker

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,7 +4,15 @@ on:
   # Re-enabled 2026-07-21 after the repo transfer reset the Actions quota. This
   # is the @smoke-only PR gate (~3.5 min) — cheap enough to run per PR. The full
   # suite (e2e-full) stays workflow_dispatch-only to protect the monthly budget.
+  # A manual run takes an optional Playwright --grep filter, so a single
+  # non-smoke spec can be re-verified on a branch without dispatching the whole
+  # 4-shard e2e-full suite (which also emails a summary on every run).
   workflow_dispatch:
+    inputs:
+      grep:
+        description: 'Playwright --grep filter (e.g. @smoke, or a test title)'
+        required: false
+        default: '@smoke'
   push:
     branches: [main]
   pull_request:
@@ -78,8 +86,12 @@ jobs:
 
       # PR gate runs the @smoke subset only (#623); the FULL suite runs 4x a
       # day via e2e-full.yml (sharded, email on failure) and on demand.
-      - name: Run E2E smoke tests
-        run: npm run test:e2e:smoke
+      # The filter is passed through an env var, not interpolated into the
+      # shell — a dispatch input is untrusted text.
+      - name: Run E2E tests
+        env:
+          E2E_GREP: ${{ inputs.grep || '@smoke' }}
+        run: npx playwright test --grep "$E2E_GREP"
 
       - name: Upload Playwright report
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.32.2-beta] - 2026-07-31
+
+### Fixed
+- **"New chat" picker was empty for anyone in a project** — a regression from the
+  project group chats landing in the inbox. `/messages` builds the set of people the
+  viewer already has a DM with in order to exclude them from the picker, and that set
+  was taken from *all* the viewer's conversations. Since every project co-member is
+  also a participant of the shared project's GROUP chat, every candidate matched the
+  exclusion, `candidates` came out empty and `StartConversationPicker` rendered
+  `null` — so the "new chat" toggle disappeared entirely and no project DM could be
+  started from the UI. The exclusion set is now built from `DIRECT` conversations
+  only. Caught by `e2e/project-dm.spec.ts` in the scheduled full run.
+
+### Changed
+- The `E2E Tests` workflow takes an optional `grep` input on manual dispatch
+  (default `@smoke`), so a single non-smoke spec can be re-verified on a branch
+  without dispatching the 4-shard `e2e-full` suite and its summary email.
+
 ## [0.32.1-beta] - 2026-07-31
 
 ### Security

--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -1400,3 +1400,44 @@ beklerken tekrar açılıyor. Pratik sonuç: çözümü push ettikten sonra dal�
 merge olana kadar `gh pr view --json mergeable` ile izle, tekrar `DIRTY` olursa aynı
 mekanik kuralı uygula. Üçüncü turda `npx tsc --noEmit` + `check:i18n` tam `npm run build`
 yerine yeterli hızlı güvence (çakışan dosyalar sadece CHANGELOG/releaseNotes/sürüm ise).
+
+## 2026-07-31 — Zamanlanmış tam koşudaki "timeout" her zaman flake değil
+
+`e2e-full` raporu `project-dm.spec.ts` için `locator.click: Timeout 15000ms exceeded —
+waiting for getByTestId('new-chat-toggle')` dedi. Timeout + tek test = refleks olarak
+"flake, rerun" demek cazip; ama burada element **yavaş değildi, hiç render edilmiyordu**.
+Ayırt eden sinyal: aynı koşudaki 5 gerçek flake'in hepsi `failed,passed` (retry'da geçti),
+bu test `failed,failed`. **Retry deseni, hata tipinden daha iyi bir flake göstergesi.**
+
+Deseni çıkarmanın hızlı yolu (log kazmaya gerek yok) — shard JSON'larını indirip
+`status !== "expected"` olanları dök:
+
+```
+gh run download <run-id> -D <dir> -p 'e2e-json-shard-*'
+# sonra suites'i özyinelemeli gezip t.status + t.results.map(r=>r.status)
+```
+
+Kalan 5 flake'in hepsi aynı kökten: signin sonrası yönlendirme, hemen ardından gelen
+`page.goto`'yu kesiyor (`Navigation to /mentor/mentees/X is interrupted by another
+navigation to /mentor`) ya da signin formu 15 sn içinde gelmiyor. Kod değişikliğiyle
+ilgisi yok.
+
+**Kök neden dersi:** `/messages`, "zaten DM'i olanlar" kümesini *yüklediği tüm*
+conversation'lardan kuruyordu. 988d791 sorguya proje GROUP sohbetlerini ekleyince, her
+proje arkadaşı grup sohbetinin de katılımcısı olduğu için tüm adaylar elendi;
+`StartConversationPicker` boş listede `null` döndürüyor, dolayısıyla toggle DOM'a hiç
+girmedi. Bir sorgunun kapsamı genişletildiğinde, **o sorgunun sonucunu kullanan her
+türetilmiş kümeyi** gözden geçir — tip alanı (`DIRECT`/`GROUP`) select'e eklenmişti ama
+filtreye eklenmemişti.
+
+**Doğrulama, MySQL'siz makinede:** bu Mac'te docker daemon kapalı ve MySQL yok, yani
+spec yerelde koşmuyor. `e2e.yml`'ye manuel dispatch için opsiyonel `grep` input'u
+eklemek (varsayılan `@smoke`) tek bir non-smoke spec'i dalda doğrulamayı sağlıyor —
+`e2e-full`'ü dispatch etmek 4 shard koşturur *ve* her koşuda özet e-postası gönderir,
+sırf bir testi görmek için istenmeyecek bir yan etki. Input'u shell'e interpolate etme,
+env değişkeniyle geçir.
+
+**Worktree'de `npm run lint` çalışmıyor:** worktree ana repo checkout'unun içinde durduğu
+için ESLint iki `.eslintrc.json` görüyor ve `Plugin "@next/next" was conflicted` ile
+düşüyor. Ortam kaynaklı, değişiklikle ilgisi yok; `npx tsc --noEmit` + `npm run check:i18n`
+yerel güvence olarak yeterli, lint'i CI'ya bırak.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "internship-crm",
-  "version": "0.30.1-beta",
+  "version": "0.32.2-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "internship-crm",
-      "version": "0.30.1-beta",
+      "version": "0.32.2-beta",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.32.1-beta",
+  "version": "0.32.2-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/app/messages/page.tsx
+++ b/src/app/messages/page.tsx
@@ -103,11 +103,16 @@ export default async function MessagesInboxPage() {
     return bt - at;
   });
 
-  // Offer only people we don't already have a conversation with — the existing
-  // ones are in the list above. Deduped, since two shared projects would
-  // otherwise surface the same person twice.
+  // Offer only people we don't already have a DM with — those threads are in
+  // the list above. DIRECT only: every co-member is also a participant of the
+  // shared project's GROUP chat, so counting group participants here would
+  // empty the picker for everyone who is in a project. Deduped, since two
+  // shared projects would otherwise surface the same person twice.
   const existingDmPartnerIds = new Set(
-    conversations.flatMap((c) => c.participants.map((p) => p.userId)).filter((id) => id !== me),
+    conversations
+      .filter((c) => c.type === 'DIRECT')
+      .flatMap((c) => c.participants.map((p) => p.userId))
+      .filter((id) => id !== me),
   );
   const candidates = [
     ...new Map(

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,21 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.32.2-beta',
+    date: '2026-07-31',
+    highlights: {
+      en: [
+        'Messages: the "New chat" button is back. Since project group chats appeared in the inbox, everyone who was in a project saw no "New chat" option at all — so there was no way to start a private message with someone you share a project with. The people you can write to are listed again.',
+      ],
+      tr: [
+        'Mesajlar: "Yeni sohbet" düğmesi geri geldi. Proje grup sohbetleri gelen kutusuna eklendiğinden beri bir projede yer alan herkes için "Yeni sohbet" seçeneği hiç görünmüyordu — yani aynı projede olduğunuz biriyle özel mesaj başlatmanın yolu yoktu. Yazabileceğiniz kişiler yeniden listeleniyor.',
+      ],
+      de: [
+        'Nachrichten: Die Schaltfläche „Neuer Chat“ ist zurück. Seit die Projekt-Gruppenchats im Posteingang erscheinen, wurde sie allen, die in einem Projekt sind, gar nicht mehr angezeigt — eine private Nachricht an jemanden aus dem eigenen Projekt ließ sich also nicht mehr beginnen. Die möglichen Empfänger werden wieder aufgelistet.',
+      ],
+    },
+  },
+  {
     version: '0.32.1-beta',
     date: '2026-07-31',
     highlights: {


### PR DESCRIPTION
## Why

The scheduled full e2e run ([run 30648248486](https://github.com/21072026/Internship/actions/runs/30648248486)) went red on `e2e/project-dm.spec.ts`:

```
TimeoutError: locator.click: Timeout 15000ms exceeded.
  - waiting for getByTestId('new-chat-toggle')
```

The toggle wasn't slow — it was never rendered, and this is a real user-facing regression, not a flaky test.

## Root cause

[src/app/messages/page.tsx](src/app/messages/page.tsx) excludes people the viewer already has a DM with from the "new chat" candidate list, and built that exclusion set from **every** conversation it had loaded:

```ts
const existingDmPartnerIds = new Set(
  conversations.flatMap((c) => c.participants.map((p) => p.userId)).filter((id) => id !== me),
);
```

That was correct while the query was `type: 'DIRECT'` only. 988d791 ("expose project group chats") widened it to `DIRECT ∪ the viewer's project GROUP chats` — and every project co-member is a participant of the shared project's group chat. So every candidate matched the exclusion, `candidates` came out empty, and `StartConversationPicker` returns `null` on an empty list.

Net effect: **anyone who is a member of any project saw no "New chat" option at all** and could not start a project DM from the UI. Not just the test.

## Fix

Build the exclusion set from `DIRECT` conversations only.

## Also in this PR

`E2E Tests` takes an optional `grep` input on manual dispatch (default `@smoke`), so a single non-smoke spec can be re-verified on a branch without dispatching the 4-shard `e2e-full` suite and its summary email. The filter is passed through an env var rather than interpolated into the shell (a dispatch input is untrusted text).

## Verification

- `tsc --noEmit` and `npm run check:i18n` clean.
- No local MySQL in this environment, so the spec itself is verified in CI: `E2E Tests` dispatched on this branch with `grep` set to the failing test title (linked in a comment below).

## Checklist

- [x] `package.json` → `0.32.2-beta`
- [x] `CHANGELOG.md` entry
- [x] `src/lib/releaseNotes.ts` entry (EN/TR/DE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)