### PR TITLE
feat(security): çalıştırılabilir yetki matrisi, CodeQL, açıklama politikası (#899, #901, #903)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,59 @@
+# Static application security testing (#903).
+#
+# The 2026-07 audit found its issues by reading code. CodeQL catches a slice of
+# that class automatically — SSRF, header injection, ReDoS-prone regexes,
+# sensitive data reaching logs. It will NOT catch role-scoping bugs, which were
+# the most serious findings; that is what e2e/authz-matrix.spec.ts is for. The
+# two are complements, not alternatives.
+#
+# Deliberately NOT a required check. The first run on an existing codebase
+# always surfaces a backlog, and blocking every PR on triage that hasn't
+# happened yet just teaches people to ignore the gate — the same call taken for
+# the npm audit gate (#885). Findings land in the Security tab; make it required
+# once the backlog is at zero.
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly, so a newly published query still finds old code.
+    - cron: '27 4 * * 1'
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    # GitHub-hosted: CodeQL is CPU-hungry and the self-hosted runner is the
+    # production box. Free for public repositories.
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          # security-extended adds lower-confidence queries. Worth the noise on
+          # a codebase handling PII; drop back to the default set if triage
+          # becomes busywork.
+          queries: security-extended
+
+      # No build step: the JS/TS extractor reads source directly, and a Next.js
+      # production build would only add minutes without improving the analysis.
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:javascript-typescript

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.33.1-beta] - 2026-07-31
+
+### Added
+
+- **The role × endpoint read matrix is now executable** (#899).
+  `e2e/fixtures/authz-matrix.ts` declares, per role and per endpoint, whether the
+  answer should be `all`, `own` or `deny`; `e2e/authz-matrix.spec.ts` (`@smoke`)
+  enforces it. Crucially an `own` cell asserts **ownership of every row returned**,
+  not the status code — the original leak answered `200` throughout, so a
+  status-only test would have passed against it. The audit's worst finding survived
+  a *closed* RBAC epic (#278) precisely because nothing executable said "this role
+  must not see that".
+- **`.github/workflows/codeql.yml`** (#903) — static analysis on PRs, pushes to
+  `main`, and weekly, with the `security-extended` query set. Not a required check:
+  the first run on an existing codebase always surfaces a backlog, and blocking every
+  PR on triage that hasn't happened teaches people to ignore the gate. CodeQL cannot
+  see role-scoping bugs — that is what the matrix spec above is for; the two are
+  complements.
+
+### Documentation
+- **`SECURITY.md` now leads with a disclosure policy** (#901) — the file previously
+  described the security *model* and offered two lines on reporting ("email the
+  maintainer"). It now opens with GitHub private vulnerability reporting, response
+  targets, scope, and explicit limits for researchers (no load testing against live,
+  no touching real user data — the same line `docs/DATA_ACCESS_POLICY.md` draws for
+  contributors). The security overview follows underneath, unchanged.
+
 ## [0.33.0-beta] - 2026-07-31
 
 ### Fixed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,91 @@
+# Security policy
+
+This repository is public and the application it builds handles personal data:
+candidate profiles, CVs, mentor notes. We would much rather hear about a problem
+from you than read about it later.
+
+The security *model* — what protects what — is documented further down, under
+[Security overview](#security-overview).
+
+## Reporting a vulnerability
+
+**Please do not open a public issue.** That discloses the problem to everyone
+before a fix exists, including to anyone running their own copy of this
+AGPL-licensed code.
+
+Use **GitHub's private vulnerability reporting** instead:
+
+> Repository → **Security** tab → **Report a vulnerability**
+
+It opens a private thread with the maintainers, needs no separate account or
+email address, and keeps the whole exchange in one place until a fix is out.
+
+Useful things to include, roughly in order:
+
+- what an attacker can actually do with it — the impact, not just the pattern
+- steps to reproduce, and which role you were signed in as (`ADMIN`, `MENTOR`,
+  `MENTEE`, `COMPANY`, `SOURCE`)
+- the affected endpoint or file, if you know it
+- whether the response *status* looked normal. Our most serious finding to date
+  returned `200` on every request — the leak was in the rows that came back.
+
+## Supported versions
+
+This project deploys continuously: every merge to `main` lands on production
+(`crm.ersah.in`) and preview (`crm-preview.ersah.in`). There are no maintained
+release branches, so **only the current `main` is supported**. Fixes ship as a
+new version rather than as backports.
+
+## What to expect
+
+| | Target |
+|---|---|
+| First response | within 5 working days |
+| Assessment and severity | within 10 working days |
+| Fix for a critical issue | as soon as it is ready — production deploys on merge |
+
+We will tell you when the fix is live. If we disagree that a report is a
+vulnerability we will say so plainly and explain why, rather than letting the
+thread go quiet.
+
+## Scope
+
+**In scope** — the application code in this repository, and the deployments at
+`crm.ersah.in` and `crm-preview.ersah.in`.
+
+**Out of scope**
+
+- Known CVEs in third-party dependencies. Those are tracked through `npm audit`
+  and its CI gate; telling us a dependency has a published advisory tells us
+  nothing we don't have. Showing that one is *exploitable through this
+  application* is very much in scope.
+- Automated-scanner output with no demonstrated impact.
+- Missing hardening headers or best practices with no path to exploitation.
+- Social engineering of maintainers or users.
+
+## Please do not
+
+- **Run load or denial-of-service tests against the live environments.** One
+  small server sits behind both; a stress test is indistinguishable from an
+  outage.
+- **Access, modify, or download real user data.** If a proof of concept needs
+  someone's record, stop once you have demonstrated access and describe the
+  rest. Our own contributors are held to this — see
+  [`docs/DATA_ACCESS_POLICY.md`](docs/DATA_ACCESS_POLICY.md), which keeps
+  developers off real PII entirely — and the same line applies to researchers.
+- **Point automated scanners at production.** Ask, and we will point you at an
+  environment where it is fine.
+
+Work inside these lines is welcome, and we will not pursue anyone who reports in
+good faith and follows this policy.
+
+## Credit
+
+We are glad to name you in the changelog entry for the fix. Tell us how you'd
+like to be credited — or that you'd rather not be — when you report.
+
+---
+
 # Security overview
 
 This document summarizes the security model of Internship CRM and the controls
@@ -35,9 +123,6 @@ Set for all routes in `next.config.js`: Content-Security-Policy (self by default
 ## Auditing & privacy
 - **Activity log** (`ActivityLog`) records auth events, profile/stage changes, account email/password change and deletion, impersonation, and failed logins. Viewable by admins at `/admin/activity`.
 - **Data export** (`/api/account/export`) lets a user download all their own data; **consent** is recorded at registration; see `/privacy`.
-
-## Reporting a vulnerability
-Email the maintainer (see repository owner). Do not open public issues for sensitive reports.
 
 ## Inbound email (reply-by-email)
 Mentor↔mentee threads accept replies by email. Outgoing thread emails set

--- a/docs/role-access-matrix.md
+++ b/docs/role-access-matrix.md
@@ -112,8 +112,16 @@ ellenmedi; en kritikleri:
 
 ## Regresyon testi / Regression test
 
-[`e2e/role-scoping.spec.ts`](../e2e/role-scoping.spec.ts) (`@smoke`) matrisin
-sızıntı üreten hücrelerini kilitliyor. Test **satır sahipliğini** doğruluyor,
+İki spec bu matrisi kilitliyor:
+
+- [`e2e/authz-matrix.spec.ts`](../e2e/authz-matrix.spec.ts) (`@smoke`) — matrisin
+  **çalıştırılabilir** hâli. Tablo [`e2e/fixtures/authz-matrix.ts`](../e2e/fixtures/authz-matrix.ts)
+  içinde; her rol × uç hücresi `all` / `own` / `deny`. Yeni bir kaynak veya rol
+  eklerken **önce oraya satır ekleyin**.
+- [`e2e/role-scoping.spec.ts`](../e2e/role-scoping.spec.ts) (`@smoke`) — özgün
+  sızıntının somut senaryosu.
+
+Her ikisi de Test **satır sahipliğini** doğruluyor,
 HTTP status'unu değil — sızıntı boyunca her istek `200` dönüyordu, dolayısıyla
 yalnız status kontrol eden bir test bunu yakalayamazdı.
 
@@ -121,4 +129,5 @@ Yeni bir rol veya yeni bir kapsanan kaynak eklerken:
 
 1. `authzScope.ts` içindeki `BUILDERS`'a rolü ekleyin (eklemezseniz rol 403 alır — güvenli varsayılan).
 2. Bu dokümandaki tabloyu güncelleyin.
-3. `role-scoping.spec.ts`'e negatif bir vaka ekleyin (kapsam dışı bir kaydın **görünmediğini** doğrulayın).
+3. [`e2e/fixtures/authz-matrix.ts`](../e2e/fixtures/authz-matrix.ts) tablosuna rolü/ucu ekleyin — `own` hücresi
+   için `ownership` yüklemini de yazın.

--- a/e2e/authz-matrix.spec.ts
+++ b/e2e/authz-matrix.spec.ts
@@ -1,0 +1,174 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { signInAsFreshUser } from './helpers/auth';
+import { MATRIX, type MatrixUser, type Role } from './fixtures/authz-matrix';
+
+/**
+ * Executable role × endpoint read matrix (#899).
+ *
+ * The audit's worst finding — COMPANY and SOURCE reading every mentee's
+ * interaction log — was found by hand and survived a closed RBAC epic (#278),
+ * because nothing in the suite said "this role must not see that".
+ *
+ * The important part is what an `own` cell asserts: not the status code, but
+ * that **every row returned belongs to the caller**. The leak answered `200`
+ * throughout, so a status-only test would have passed against it.
+ *
+ * This seeds its own two-sided world rather than leaning on `seed:demo`, so it
+ * is self-contained and safe to run against any environment.
+ */
+
+const PASSWORD = 'MatrixPass123';
+const LANDING: Record<Role, string> = {
+  ADMIN: '/admin',
+  MENTOR: '/mentor',
+  MENTEE: '/portal',
+  COMPANY: '/company',
+  SOURCE: '/source',
+};
+
+const emails: Record<Role, string> = {
+  ADMIN: uniqueEmail('mx-admin'),
+  MENTOR: uniqueEmail('mx-mentor'),
+  MENTEE: uniqueEmail('mx-mentee'),
+  COMPANY: uniqueEmail('mx-company'),
+  SOURCE: uniqueEmail('mx-source'),
+};
+// The "other side": a second mentor/mentee pair nobody above may see.
+const otherMentorEmail = uniqueEmail('mx-other-mentor');
+const otherMenteeEmail = uniqueEmail('mx-other-mentee');
+
+const users = {} as Record<Role, MatrixUser>;
+let ownCompanyId = '';
+let otherCompanyId = '';
+let ownSourceId = '';
+let ownRelationId = '';
+let foreignRelationId = '';
+/** Mentee ids this SOURCE referred — the ground truth for its `own` cells. */
+const sourcedMenteeIds = new Set<string>();
+
+test.beforeAll(async () => {
+  const [admin, mentor, mentee, company, source, otherMentor, otherMentee] = await Promise.all([
+    seedUser(emails.ADMIN, PASSWORD, 'ADMIN', 'Matrix Admin'),
+    seedUser(emails.MENTOR, PASSWORD, 'MENTOR', 'Matrix Mentor'),
+    seedUser(emails.MENTEE, PASSWORD, 'MENTEE', 'Matrix Mentee'),
+    seedUser(emails.COMPANY, PASSWORD, 'COMPANY', 'Matrix Company'),
+    seedUser(emails.SOURCE, PASSWORD, 'SOURCE', 'Matrix Source'),
+    seedUser(otherMentorEmail, 'x', 'MENTOR', 'Other Mentor'),
+    seedUser(otherMenteeEmail, 'x', 'MENTEE', 'Other Mentee'),
+  ]);
+
+  const [own, other] = await Promise.all([
+    prisma.company.create({ data: { name: `Matrix Own ${Date.now()}` } }),
+    prisma.company.create({ data: { name: `Matrix Other ${Date.now()}` } }),
+  ]);
+  ownCompanyId = own.id;
+  otherCompanyId = other.id;
+
+  const src = await prisma.source.create({ data: { name: `Matrix Source ${Date.now()}` } });
+  ownSourceId = src.id;
+
+  await Promise.all([
+    prisma.user.update({ where: { id: company.id }, data: { companyId: own.id } }),
+    prisma.user.update({ where: { id: source.id }, data: { sourceId: src.id } }),
+    // The mentee in "our" relation was referred by this source, so SOURCE has a
+    // non-empty legitimate scope — an all-empty scope would make `own` vacuous.
+    prisma.user.update({ where: { id: mentee.id }, data: { sourceId: src.id } }),
+  ]);
+  sourcedMenteeIds.add(mentee.id);
+
+  const [ours, foreign] = await Promise.all([
+    prisma.mentorshipRelation.create({
+      data: { mentorId: mentor.id, menteeId: mentee.id, companyId: own.id },
+    }),
+    prisma.mentorshipRelation.create({
+      data: { mentorId: otherMentor.id, menteeId: otherMentee.id, companyId: other.id },
+    }),
+  ]);
+  ownRelationId = ours.id;
+  foreignRelationId = foreign.id;
+
+  await prisma.interactionLog.createMany({
+    data: [
+      { relationId: ours.id, date: new Date(), notes: 'matrix own note', type: 'Meeting' },
+      { relationId: foreign.id, date: new Date(), notes: 'matrix foreign note', type: 'Meeting' },
+    ],
+  });
+
+  users.ADMIN = { id: admin.id, role: 'ADMIN' };
+  users.MENTOR = { id: mentor.id, role: 'MENTOR' };
+  users.MENTEE = { id: mentee.id, role: 'MENTEE' };
+  users.COMPANY = { id: company.id, role: 'COMPANY', companyId: own.id };
+  users.SOURCE = { id: source.id, role: 'SOURCE', sourceId: src.id };
+});
+
+test.afterAll(async () => {
+  await prisma.interactionLog.deleteMany({ where: { relationId: { in: [ownRelationId, foreignRelationId] } } });
+  await prisma.mentorshipRelation.deleteMany({ where: { id: { in: [ownRelationId, foreignRelationId] } } });
+  for (const email of [...Object.values(emails), otherMentorEmail, otherMenteeEmail]) {
+    await cleanupByEmail(email);
+  }
+  await prisma.company.deleteMany({ where: { id: { in: [ownCompanyId, otherCompanyId] } } });
+  await prisma.source.deleteMany({ where: { id: ownSourceId } });
+  await prisma.$disconnect();
+});
+
+/**
+ * SOURCE ownership needs the mentee's `sourceId`, which the list payloads don't
+ * carry. Resolve it against what we seeded instead of trusting the response to
+ * describe itself.
+ */
+function sourceOwns(row: Record<string, unknown>, path: string): boolean {
+  if (path === '/api/mentorship') return sourcedMenteeIds.has((row as { menteeId: string }).menteeId);
+  if (path === '/api/interactions') {
+    const rel = (row as { relation?: { menteeId?: string } }).relation;
+    return !!rel?.menteeId && sourcedMenteeIds.has(rel.menteeId);
+  }
+  return true;
+}
+
+for (const role of Object.keys(LANDING) as Role[]) {
+  test(`authorization matrix · ${role}`, { tag: '@smoke' }, async ({ page }) => {
+    await signInAsFreshUser(page, emails[role], PASSWORD, LANDING[role]);
+    const user = users[role];
+
+    for (const entry of MATRIX) {
+      const expectation = entry.expect[role];
+      const res = await page.request.get(entry.path);
+
+      if (expectation === 'deny') {
+        expect([401, 403], `${role} ${entry.path} must be refused`).toContain(res.status());
+        continue;
+      }
+
+      expect(res.status(), `${role} ${entry.path}`).toBe(200);
+      if (!entry.collection) continue;
+
+      const rows = (await res.json())[entry.collection] as Record<string, unknown>[] | undefined;
+      expect(Array.isArray(rows), `${entry.path} should return ${entry.collection}[]`).toBe(true);
+
+      if (expectation === 'own') {
+        const owns = (row: Record<string, unknown>) =>
+          role === 'SOURCE' ? sourceOwns(row, entry.path) : entry.ownership(row, user);
+        const foreign = (rows ?? []).filter((row) => !owns(row));
+        expect(
+          foreign,
+          `${role} received ${foreign.length} row(s) from ${entry.path} it does not own`
+        ).toEqual([]);
+      }
+    }
+  });
+}
+
+/**
+ * The specific shape of the original leak, kept as its own named case so a
+ * regression reads as itself rather than as "the matrix broke".
+ */
+test('COMPANY and SOURCE cannot read a foreign relation\'s interaction log', { tag: '@smoke' }, async ({ page }) => {
+  for (const role of ['COMPANY', 'SOURCE'] as const) {
+    await signInAsFreshUser(page, emails[role], PASSWORD, LANDING[role]);
+    const body = await (await page.request.get('/api/interactions')).json();
+    const ids = (body.interactions as { relationId: string }[]).map((i) => i.relationId);
+    expect(ids, `${role} must not see the foreign relation`).not.toContain(foreignRelationId);
+  }
+});

--- a/e2e/fixtures/authz-matrix.ts
+++ b/e2e/fixtures/authz-matrix.ts
@@ -1,0 +1,113 @@
+/**
+ * Declarative role × endpoint read matrix (#899).
+ *
+ * The 2026-07 audit's most serious finding — COMPANY and SOURCE reading every
+ * mentee's interaction log — was found by hand, and it survived a *closed* RBAC
+ * epic (#278) because nothing executable said "this role must not see that".
+ * This table is that statement.
+ *
+ * ⚠️ Checking the status code is not enough. The leak returned `200` on every
+ * request; it lived in the rows. So an `'own'` cell asserts that **every row
+ * that came back belongs to the caller**, via the `ownership` predicate.
+ *
+ * The prose version, and what to do when adding a role, live in
+ * `docs/role-access-matrix.md`. Keep the two in step.
+ */
+
+export type Role = 'ADMIN' | 'MENTOR' | 'MENTEE' | 'COMPANY' | 'SOURCE';
+
+/**
+ * - `all`  — sees the whole tenant, by design.
+ * - `own`  — may see rows, but only rows `ownership` accepts.
+ * - `deny` — must be refused (401/403).
+ */
+export type Expectation = 'all' | 'own' | 'deny';
+
+export interface MatrixUser {
+  id: string;
+  role: Role;
+  companyId?: string | null;
+  sourceId?: string | null;
+}
+
+export interface MatrixEntry {
+  path: string;
+  /** Key in the JSON response holding the array of rows. */
+  collection: string;
+  expect: Record<Role, Expectation>;
+  /** True when `row` legitimately belongs to `user`. Only consulted for `own`. */
+  ownership: (row: Record<string, unknown>, user: MatrixUser) => boolean;
+}
+
+type Relation = {
+  mentorId?: string;
+  menteeId?: string;
+  companyId?: string | null;
+  mentee?: { id?: string; sourceId?: string | null };
+};
+
+function relationBelongsTo(rel: Relation | undefined, user: MatrixUser): boolean {
+  if (!rel) return false;
+  switch (user.role) {
+    case 'MENTOR':
+      return rel.mentorId === user.id;
+    case 'MENTEE':
+      return rel.menteeId === user.id;
+    case 'COMPANY':
+      return !!user.companyId && rel.companyId === user.companyId;
+    case 'SOURCE':
+      // The list payload doesn't carry the mentee's sourceId, so the spec
+      // resolves ownership against the seeded set instead of guessing here.
+      return false;
+    default:
+      return false;
+  }
+}
+
+export const MATRIX: MatrixEntry[] = [
+  {
+    path: '/api/mentorship',
+    collection: 'relations',
+    expect: { ADMIN: 'all', MENTOR: 'own', MENTEE: 'own', COMPANY: 'own', SOURCE: 'own' },
+    ownership: (row, user) => relationBelongsTo(row as Relation, user),
+  },
+  {
+    path: '/api/interactions',
+    collection: 'interactions',
+    expect: { ADMIN: 'all', MENTOR: 'own', MENTEE: 'own', COMPANY: 'own', SOURCE: 'own' },
+    ownership: (row, user) => relationBelongsTo((row as { relation?: Relation }).relation, user),
+  },
+  {
+    path: '/api/users',
+    collection: 'users',
+    // Admin-only listing; MENTOR gets a deliberately PII-free picker instead.
+    expect: { ADMIN: 'all', MENTOR: 'all', MENTEE: 'deny', COMPANY: 'deny', SOURCE: 'deny' },
+    ownership: () => true,
+  },
+  {
+    // Needs `q` (a shorter query short-circuits to an empty result), so the
+    // point of this row is the deny side: it is admin/mentor-only.
+    path: '/api/search?q=matrix',
+    collection: 'users',
+    expect: { ADMIN: 'all', MENTOR: 'all', MENTEE: 'deny', COMPANY: 'deny', SOURCE: 'deny' },
+    ownership: () => true,
+  },
+  {
+    path: '/api/admin/analytics',
+    collection: '',
+    expect: { ADMIN: 'all', MENTOR: 'deny', MENTEE: 'deny', COMPANY: 'deny', SOURCE: 'deny' },
+    ownership: () => true,
+  },
+  {
+    path: '/api/admin/activity',
+    collection: 'items',
+    expect: { ADMIN: 'all', MENTOR: 'deny', MENTEE: 'deny', COMPANY: 'deny', SOURCE: 'deny' },
+    ownership: () => true,
+  },
+  {
+    path: '/api/source/mentees',
+    collection: 'mentees',
+    expect: { ADMIN: 'deny', MENTOR: 'deny', MENTEE: 'deny', COMPANY: 'deny', SOURCE: 'own' },
+    ownership: () => true, // the route scopes to the caller's own source by construction
+  },
+];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.33.0-beta",
+  "version": "0.33.1-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {


### PR DESCRIPTION
Closes #899
Closes #901
Closes #903

Epic #829 — sürekli güvenlik testi ve DevSecOps. Bu denetimin **tekrarlanmaması** için gereken altyapı.

## 1. Yetki matrisi artık çalıştırılabilir (#899)

Bu oturumun en kritik bulgusunu (COMPANY/SOURCE tüm görüşme kayıtlarını okuyor) **elle** bulduk. Daha rahatsız edici olan: boşluk **kapalı** bir RBAC epic'inden (#278) sağ çıktı — çünkü "bu rol şunu görmemeli" diyen çalıştırılabilir hiçbir şey yoktu.

`e2e/fixtures/authz-matrix.ts` beyan, `e2e/authz-matrix.spec.ts` (`@smoke`) icra:

```ts
{ path: '/api/interactions', collection: 'interactions',
  expect: { ADMIN: 'all', MENTOR: 'own', MENTEE: 'own', COMPANY: 'own', SOURCE: 'own' },
  ownership: (row, user) => relationBelongsTo(row.relation, user) }
```

### ⚠️ Kritik tasarım noktası

**`own` hücresi status kodunu değil, dönen HER SATIRIN sahipliğini doğruluyor.** Özgün sızıntı baştan sona `200` dönüyordu — yalnız status kontrol eden bir test onun karşısında **geçerdi**.

Spec kendi iki taraflı dünyasını seed'liyor (bizim ilişki + kimsenin görmemesi gereken yabancı ilişki), `seed:demo`'ya bağlı değil, dolayısıyla her ortamda çalışıyor. SOURCE sahipliği yanıt yükünde `sourceId` taşınmadığı için seed'lenen kümeye karşı çözülüyor — yanıtın kendini tarif etmesine güvenilmiyor.

Ayrıca özgün sızıntının somut şekli ayrı adlandırılmış bir vaka olarak duruyor, ki regresyon "matris bozuldu" değil kendisi olarak okunsun.

## 2. CodeQL (#903)

PR + `main` + haftalık, `security-extended`.

**Zorunlu kapı yapılmadı** — mevcut bir kod tabanında ilk koşu her zaman bir birikim çıkarır ve henüz yapılmamış triage üzerinden her PR'ı bloke etmek, insanlara kapıyı yok saymayı öğretir. Aynı karar `npm audit` kapısında da alındı. Bulgular Security sekmesine düşüyor; birikim sıfırlanınca zorunlu yapılabilir.

**Beklenti yönetimi:** CodeQL rol kapsamlama hatalarını **görmez** — bu oturumun en kritik bulgusu tam olarak o sınıftaydı. Yukarıdaki matris spec'i onun için. İkisi alternatif değil, tamamlayıcı.

## 3. SECURITY.md açıklama politikası (#901)

Dosya **vardı** ama güvenlik *modelini* anlatıyordu; bildirim bölümü iki satırdı: *"Email the maintainer (see repository owner)."* Depo public — bir araştırmacı bugün bir şey bulsa büyük ihtimalle public issue açardı.

Artık GitHub Private Vulnerability Reporting ile başlıyor; yanıt hedefleri, kapsam ve araştırmacılar için açık sınırlar var: canlıda yük testi yok, gerçek kullanıcı verisine dokunma yok — `docs/DATA_ACCESS_POLICY.md`'nin katkıcılara çizdiği çizginin aynısı. Güvenlik modeli altta, değişmeden duruyor.

### ❓ Bakımcıya soru

Issue, depoya kişisel e-posta yazmadan önce sormamı istiyordu — **yazmadım**. Politika yalnız GitHub'ın private reporting akışına yönlendiriyor.

**Bunun çalışması için repo ayarından açman gerekiyor:** Settings → Security → *Private vulnerability reporting* → Enable. Alternatif/ek bir iletişim adresi istersen söyle, ekleyeyim.

## Test

`npm run build` ✅ · `npx tsc --noEmit` ✅

## Sürüm

`0.32.3-beta` + CHANGELOG. (releaseNotes girişi yok: üçü de kullanıcıya görünmeyen altyapı.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
