### PR TITLE
fix: thread email replies sent from a different address than the account one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.33.0-beta] - 2026-07-31
+
+### Fixed
+- **A reply sent from any address other than the one on your profile was silently
+  dropped.** Found on live traffic hours after the mail bridge shipped: a reply to
+  a notification never appeared in its thread. The bridge had done everything
+  right — mail fetched, token verified — and then refused it, because
+  `routeInboundEmail` identified the writer *only* by matching `From` against a
+  participant's account email. The notification had gone to the mentor's
+  `@bcsit-gmbh.de` address, which forwards to Gmail; replying from there put a
+  `@gmail.com` address in `From`, so the reply was rejected with
+  `403 Sender is not a participant`. Reproduced against production with the real
+  token. Anyone whose mail forwards — which is most people — hit this.
+  - The reply token now names the **recipient** as well as the thread:
+    `reply+<relationId>~<recipientUserId>.<hmac>`. When `From` matches a
+    participant that still wins; otherwise the reply is attributed to the user the
+    token was minted for, provided they are a participant. Logged when the weaker
+    signal is used.
+  - Not a weakening of the gate: the token is delivered only to that user's own
+    registered address, and whoever holds that mail can already take the account
+    over via a password reset, so this grants no new access. The residual exposure
+    is a *forwarded* notification — the recipient of the forward can post as the
+    original addressee. The fallback stays bounded to the token's own recipient: a
+    signed token naming a non-participant is still refused.
+  - Tokens already sitting in delivered mail carry a bare `relationId`; they keep
+    verifying and fall back to `From` matching only.
+  - `src/app/api/mentor/email/route.ts` now selects `mentee.id` so it can scope the
+    token it mints.
+- `e2e/inbound-email.spec.ts` covers all four paths: legacy token + participant,
+  legacy token + stranger (403), scoped token from an unknown address (threaded,
+  attributed to the token's user), and a scoped token naming an outsider (403).
 ## [0.32.4-beta] - 2026-07-31
 
 ### Added

--- a/docs/EMAIL_DELIVERABILITY.md
+++ b/docs/EMAIL_DELIVERABILITY.md
@@ -61,11 +61,33 @@ dig +short -x 212.132.111.125          # PTR
 
 The full round trip is in place:
 
-- Outgoing message emails set `Reply-To: reply+<relationId>.<sig>@<INBOUND_EMAIL_DOMAIN>`
-  (`src/lib/replyToken.ts`). The token is an HMAC, so it can't be forged.
-- `src/lib/inboundEmail.ts` (`routeInboundEmail`) verifies the token and that the
-  sender is a participant, then stores a `Message` (`channel: EMAIL`) and notifies
-  the other party — so it appears under **/messages/<relationId>**.
+- Outgoing message emails set
+  `Reply-To: reply+<relationId>~<recipientUserId>.<sig>@<INBOUND_EMAIL_DOMAIN>`
+  (`src/lib/replyToken.ts`). The token is an HMAC, so it can't be forged, and it
+  names both the thread and the person the notification was sent to.
+- `src/lib/inboundEmail.ts` (`routeInboundEmail`) verifies the token, works out
+  who wrote the mail, then stores a `Message` (`channel: EMAIL`) and notifies the
+  other party — so it appears under **/messages/<relationId>**.
+
+### How the writer is identified
+
+Two signals, in order:
+
+1. **`From` matches a participant's account email** — the strong signal.
+2. **Otherwise, the recipient named in the signed token**, provided that user is a
+   participant of the thread. This is the common case in practice: people forward
+   work mail to a personal account and reply with *that* identity, so `From` is
+   not the address on their profile, and matching only on `From` silently dropped
+   those replies.
+
+Honouring the token is not a weakening: it is delivered only to that user's own
+registered address, and anyone holding the mail could already take the account
+over via a password reset. The residual exposure is a *forwarded* notification —
+whoever receives the forward can post as the original recipient. Attribution via
+the token (rather than `From`) is logged.
+
+Tokens minted before this carried a bare `relationId`; they still verify and fall
+back to signal 1 only.
 - Two entry points feed that one routing function:
   - **`POST /api/inbound-email`** accepts `{ to, from, text, messageId? }` (+ an
     `x-inbound-secret` header when `INBOUND_SECRET` is set) — for a provider

--- a/e2e/inbound-email.spec.ts
+++ b/e2e/inbound-email.spec.ts
@@ -8,8 +8,13 @@ test.afterAll(async () => {
 
 // Mirror src/lib/replyToken.ts so the test can craft valid/invalid tokens.
 const secret = () => process.env.NEXTAUTH_SECRET || 'dev-secret';
-const makeToken = (relationId: string) =>
-  `${relationId}.${createHmac('sha256', secret()).update(relationId).digest('hex').slice(0, 32)}`;
+const sign = (payload: string) => createHmac('sha256', secret()).update(payload).digest('hex').slice(0, 32);
+// Legacy shape: relation only, no recipient. Still minted by nothing, but tokens
+// in already-delivered mail look like this, so it must keep working.
+const makeToken = (relationId: string) => `${relationId}.${sign(relationId)}`;
+// Current shape: names the thread AND the user the notification was sent to.
+const makeScopedToken = (relationId: string, userId: string) =>
+  `${relationId}~${userId}.${sign(`${relationId}~${userId}`)}`;
 
 test('inbound email reply is routed to the thread (token + sender verified)', async ({ request }) => {
   const mentorEmail = uniqueEmail('inb-mentor');
@@ -36,7 +41,8 @@ test('inbound email reply is routed to the thread (token + sender verified)', as
     });
     expect(bad.status()).toBe(400);
 
-    // Valid token but sender is not a participant → rejected.
+    // Legacy token (no recipient) + sender is not a participant → rejected,
+    // because nothing else identifies the writer.
     const stranger = await request.post('/api/inbound-email', {
       data: { to: `reply+${token}@crm.ersah.in`, from: 'stranger@evil.com', text: 'spoof' },
     });
@@ -72,6 +78,41 @@ test('inbound email reply is routed to the thread (token + sender verified)', as
     expect(quoted.status()).toBe(200);
     const quotedMsg = await prisma.message.findFirst({ where: { inboundMessageId: `<attribution-${rel.id}@mail.example>` } });
     expect(quotedMsg?.body).toBe('cevap veriyorum');
+
+    // A recipient-scoped token threads the reply even when it arrives from a
+    // completely different address — the real case: the notification is
+    // forwarded to a personal mailbox and answered with that identity, so From
+    // never matches the profile email. Attributed to the user named in the token.
+    const scoped = makeScopedToken(rel.id, mentee.id);
+    const forwardedId = `<forwarded-${rel.id}@mail.example>`;
+    const forwarded = await request.post('/api/inbound-email', {
+      data: {
+        to: `reply+${scoped}@crm.ersah.in`,
+        from: 'personal-address-not-on-file@gmail.com',
+        text: 'ok',
+        messageId: forwardedId,
+      },
+    });
+    expect(forwarded.status()).toBe(200);
+    const forwardedMsg = await prisma.message.findFirst({ where: { inboundMessageId: forwardedId } });
+    expect(forwardedMsg?.senderId).toBe(mentee.id);
+    expect(forwardedMsg?.body).toBe('ok');
+
+    // The fallback is bounded to the token's own recipient: a signed token naming
+    // somebody who is NOT in this thread still gets nothing.
+    const outsider = await seedUser(uniqueEmail('inb-outsider'), 'x', 'MENTEE', 'Inb Outsider');
+    try {
+      const spoof = await request.post('/api/inbound-email', {
+        data: {
+          to: `reply+${makeScopedToken(rel.id, outsider.id)}@crm.ersah.in`,
+          from: 'stranger@evil.com',
+          text: 'spoof',
+        },
+      });
+      expect(spoof.status()).toBe(403);
+    } finally {
+      await cleanupByEmail(outsider.email);
+    }
   } finally {
     await prisma.message.deleteMany({ where: { relationId: rel.id } });
     await prisma.notification.deleteMany({ where: { userId: { in: [mentor.id, mentee.id] } } });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.32.4-beta",
+  "version": "0.33.0-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/app/api/mentor/email/route.ts
+++ b/src/app/api/mentor/email/route.ts
@@ -40,7 +40,7 @@ export async function POST(request: Request) {
         : { id: { in: relationIds }, mentorId: session.user.id };
     const relations = await prisma.mentorshipRelation.findMany({
       where,
-      include: { mentee: { select: { email: true, fullName: true, emailNotifications: true, notificationPrefs: true } } },
+      include: { mentee: { select: { id: true, email: true, fullName: true, emailNotifications: true, notificationPrefs: true } } },
     });
 
     // Template placeholders (e.g. "{name}") are filled per recipient with the
@@ -60,7 +60,9 @@ export async function POST(request: Request) {
       if (emailAllowed(rel.mentee, 'messages')) {
         try {
           // Reply-To routes mentee replies back into this thread (inbound email).
-          await sendEmail({ to: rel.mentee.email, subject: personalSubject, html, replyTo: replyAddress(rel.id) });
+          // The recipient is baked into the token so a reply still threads when
+          // the mentee answers from a different address than their profile one.
+          await sendEmail({ to: rel.mentee.email, subject: personalSubject, html, replyTo: replyAddress(rel.id, rel.mentee.id) });
         } catch (e) {
           console.error('Mentor email failed for', rel.mentee.email, e);
         }

--- a/src/app/api/messages/route.ts
+++ b/src/app/api/messages/route.ts
@@ -236,7 +236,7 @@ export async function POST(request: Request) {
           // Email replies are routed by a relation-scoped token, so only the
           // mentorship path can offer reply-by-email today; conversation
           // recipients get the same notification without a Reply-To.
-          ...(rel ? { replyTo: replyAddress(rel.id) } : {}),
+          ...(rel ? { replyTo: replyAddress(rel.id, recipient) } : {}),
           // Mirror the attachments (incl. pasted images) into the email too.
           attachments: fileBufs.map((fb) => ({ filename: fb.filename, content: fb.data, contentType: fb.contentType })),
         }).catch((e) => logger.error('Failed to mirror message email', { error: String(e) }));

--- a/src/lib/inboundEmail.ts
+++ b/src/lib/inboundEmail.ts
@@ -39,8 +39,9 @@ export function stripQuoted(text: string): string {
 
 export async function routeInboundEmail(input: InboundEmail): Promise<InboundResult> {
   const token = extractReplyToken(input.to);
-  const relationId = token && verifyReplyToken(token);
-  if (!relationId) return { ok: false, status: 400, reason: 'No valid reply token' };
+  const payload = token ? verifyReplyToken(token) : null;
+  if (!payload) return { ok: false, status: 400, reason: 'No valid reply token' };
+  const { relationId, recipientUserId } = payload;
 
   const rel = await prisma.mentorshipRelation.findUnique({
     where: { id: relationId },
@@ -48,11 +49,23 @@ export async function routeInboundEmail(input: InboundEmail): Promise<InboundRes
   });
   if (!rel) return { ok: false, status: 404, reason: 'Thread not found' };
 
-  // The sender must be a participant of this thread.
+  // Who wrote this? Preferred: the From address is one of the two participants.
   const from = emailOf(input.from);
-  const senderId = from === rel.mentor.email.toLowerCase() ? rel.mentor.id
+  let senderId = from === rel.mentor.email.toLowerCase() ? rel.mentor.id
     : from === rel.mentee.email.toLowerCase() ? rel.mentee.id
     : null;
+
+  // Otherwise fall back to the recipient named in the signed token. People read
+  // mail forwarded to a personal account and reply with *that* identity, so the
+  // From address often isn't the one on their profile — which used to drop the
+  // reply. The token was only ever delivered to this user's registered address,
+  // so honouring it grants nothing a mailbox holder couldn't already get from a
+  // password reset. Logged, because it is the weaker of the two signals.
+  if (!senderId && recipientUserId && (recipientUserId === rel.mentor.id || recipientUserId === rel.mentee.id)) {
+    senderId = recipientUserId;
+    logger.info('Inbound reply attributed via reply token, not From', { relationId, from, senderId });
+  }
+
   if (!senderId) {
     logger.warning('Inbound email from non-participant rejected', { relationId, from });
     return { ok: false, status: 403, reason: 'Sender is not a participant' };

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,21 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.33.0-beta',
+    date: '2026-07-31',
+    highlights: {
+      en: [
+        'Replying by email now works even when you answer from a different address than the one on your account. If your work mail forwards to a personal inbox and you reply from there, your answer used to be dropped without a trace — it now lands in the thread as before, credited to you.',
+      ],
+      tr: [
+        'E-postayla cevaplama artık hesabınızdaki adresten farklı bir adresten yanıtlasanız da çalışıyor. İş mailiniz kişisel bir kutuya yönleniyorsa ve oradan cevap veriyorsanız, cevabınız eskiden iz bırakmadan kayboluyordu — artık eskisi gibi thread\'e düşüyor ve size ait olarak görünüyor.',
+      ],
+      de: [
+        'Antworten per E-Mail funktioniert jetzt auch, wenn du von einer anderen Adresse als der in deinem Konto antwortest. Wenn deine Arbeitsmail an ein privates Postfach weitergeleitet wird und du von dort antwortest, ging deine Antwort früher spurlos verloren — sie landet jetzt wie gewohnt im Thread und wird dir zugeordnet.',
+      ],
+    },
+  },
+  {
     version: '0.32.4-beta',
     date: '2026-07-31',
     highlights: {

--- a/src/lib/replyToken.ts
+++ b/src/lib/replyToken.ts
@@ -2,36 +2,67 @@ import { createHmac, timingSafeEqual } from 'crypto';
 import { requireServerSecret } from '@/lib/serverSecret';
 
 // Per-thread reply token used in email Reply-To addresses
-// (reply+<relationId>.<sig>@domain). The signature is an HMAC of the relation
-// id with the server secret, so tokens are unguessable and tamper-evident —
-// an inbound email can only be routed to a thread if its token verifies.
+// (reply+<payload>.<sig>@domain). The signature is an HMAC of the payload with
+// the server secret, so tokens are unguessable and tamper-evident — an inbound
+// email can only be routed to a thread if its token verifies.
 // No fallback secret: a public default would make every token forgeable (#870).
-function sign(relationId: string): string {
-  return createHmac('sha256', requireServerSecret()).update(relationId).digest('hex').slice(0, 32);
+//
+// The payload is `<relationId>~<recipientUserId>`: it names both the thread and
+// the person the notification went to. That second half is what makes a reply
+// work when someone answers from a different address than the one on their
+// account — a notification forwarded to Gmail gets replied to with the Gmail
+// identity, and matching `From` against the account email rejected exactly those
+// replies. Since the notification is only ever delivered to that user's
+// registered address, anyone holding it could already take the account over via a
+// password reset, so honouring the token grants no access they didn't have.
+//
+// Tokens minted before this carry a bare relationId and still verify; they name
+// no recipient, so those replies fall back to matching `From`. See
+// `routeInboundEmail` in src/lib/inboundEmail.ts.
+//
+// `~` separates the two ids: it is valid in an email local part (RFC 5322 atext)
+// and cannot occur inside a cuid or a uuid.
+const SEP = '~';
+
+function sign(payload: string): string {
+  return createHmac('sha256', requireServerSecret()).update(payload).digest('hex').slice(0, 32);
 }
 
-export function makeReplyToken(relationId: string): string {
-  return `${relationId}.${sign(relationId)}`;
+export type ReplyTokenPayload = { relationId: string; recipientUserId: string | null };
+
+export function makeReplyToken(relationId: string, recipientUserId?: string): string {
+  const payload = recipientUserId ? `${relationId}${SEP}${recipientUserId}` : relationId;
+  return `${payload}.${sign(payload)}`;
 }
 
-export function verifyReplyToken(token: string): string | null {
+export function verifyReplyToken(token: string): ReplyTokenPayload | null {
   const dot = token.lastIndexOf('.');
   if (dot <= 0) return null;
-  const relationId = token.slice(0, dot);
+  const payload = token.slice(0, dot);
   const sig = token.slice(dot + 1);
-  const expected = sign(relationId);
+  const expected = sign(payload);
   if (sig.length !== expected.length) return null;
   try {
     if (!timingSafeEqual(Buffer.from(sig), Buffer.from(expected))) return null;
   } catch {
     return null;
   }
-  return relationId;
+
+  const sep = payload.indexOf(SEP);
+  if (sep < 0) return { relationId: payload, recipientUserId: null };
+  const relationId = payload.slice(0, sep);
+  const recipientUserId = payload.slice(sep + 1);
+  // A signed payload can't normally be malformed, but never hand back a blank id.
+  if (!relationId || !recipientUserId) return null;
+  return { relationId, recipientUserId };
 }
 
-export function replyAddress(relationId: string): string {
+// Build the Reply-To for a notification about `relationId` being sent to
+// `recipientUserId`. Always pass the recipient — without it, the reply only works
+// when they answer from their account address.
+export function replyAddress(relationId: string, recipientUserId?: string): string {
   const domain = process.env.INBOUND_EMAIL_DOMAIN || 'crm.ersah.in';
-  return `reply+${makeReplyToken(relationId)}@${domain}`;
+  return `reply+${makeReplyToken(relationId, recipientUserId)}@${domain}`;
 }
 
 // Extract the reply token from a recipient address like


### PR DESCRIPTION
Follow-up to #974. Found on **live traffic**, hours after the bridge shipped: a reply to a notification never appeared in its thread.

## What happened

The bridge did everything right — mail delivered to `reply@crm.ersah.in`, fetched, token verified — and then **deliberately refused it**:

```
HTTP 403 {"error":"Sender is not a participant"}
```

`routeInboundEmail` identified the writer *only* by matching `From` against a participant's account email:

| | Address |
|---|---|
| Account email (thread's mentor) | `ersahin@bcsit-gmbh.de` |
| Address the reply came from | `mehmetersahin@gmail.com` |

The notification went to the `@bcsit-gmbh.de` address, which forwards to Gmail. Replying from Gmail puts the Gmail address in `From`, so the reply was rejected. Confirmed against production by replaying the real token — 403, nothing written; the thread's last row was still the incoming message. (The 2 July reply that *did* work was sent from the bcsit address directly.)

This affects **anyone whose mail forwards**, which is most people. It also fails silently from the sender's point of view: the mail is accepted by SMTP, flagged read, and vanishes.

## The fix

The reply token now names the **recipient** as well as the thread:

```
reply+<relationId>~<recipientUserId>.<hmac>
```

Identification is two signals, in order:

1. `From` matches a participant's account email — unchanged, still preferred.
2. Otherwise the reply is attributed to the user the token was minted for, **provided that user is a participant of the thread**. Logged, since it is the weaker signal.

## Why this isn't a weakening of the gate

The token is only ever delivered to that user's own registered address, and **whoever holds that mail can already take the account over via a password reset** — so honouring the token grants no access they didn't already have.

The residual exposure is a **forwarded** notification: whoever receives the forward can post as the original addressee. That is the same trust model as GitHub's and Jira's reply-by-email, and it is the price of the feature working at all for forwarded mail. Worth knowing about rather than hidden.

Bounds that are kept:
- The HMAC is unchanged — a token still can't be forged (`requireServerSecret`, no fallback, #870).
- The fallback is **bounded to the token's own recipient**: a validly signed token naming someone who is not in the thread is still refused with 403.
- `From` matching still wins when it works, so normal replies are attributed exactly as before.

## Backward compatibility

Tokens already sitting in delivered mail carry a bare `relationId`. They keep verifying and fall back to signal 1 only — so old notifications behave exactly as they did, and the legacy path stays under test.

## Verification

- `npx tsc --noEmit` clean; `npm run build` succeeds; `npm run check:i18n` OK (1583 keys × 3 locales).
- `e2e/inbound-email.spec.ts` now covers all four paths: legacy token + participant → threaded; legacy token + stranger → 403; **scoped token from an address not on file → threaded and attributed to the token's user**; scoped token naming an outsider → 403.
- `src/app/api/mentor/email/route.ts` had to select `mentee.id` to scope the token it mints — caught by `tsc`, not by luck.

Version `0.33.0-beta` with CHANGELOG + release-notes entries, and `docs/EMAIL_DELIVERABILITY.md` gains a "How the writer is identified" section stating the trust model explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)