### PR TITLE
feat(ux): make chat screens a real app shell on a phone (#1006)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.35.1-beta] - 2026-08-01
+
+### Changed
+- **Chat screens are a real app shell on a phone** (#1006). A thread was a plain
+  document: the page title, the bubble list (its own `max-h-[55vh]` scroller) and the
+  composer all scrolled *together*, so on an iPhone 13 the document overflowed by
+  ~1200px and writing a reply meant scrolling the page down while the bubbles scrolled
+  up — two nested scrolls for one conversation.
+  - New `MessagesShell` (used by `/messages/layout.tsx`) is, below `lg:`, a fixed-height
+    flex column — `calc(100dvh - var(--fixed-bottom-inset))`, so it also shrinks around
+    the cookie banner from #935 — with the content area as `min-h-0 flex-1`. The thread,
+    the support chat and the inbox fill that area; the bubble list is the only scroller
+    (`overscroll-contain`), the composer never moves, and the document does not scroll
+    at all. Desktop keeps the previous document flow and the `55vh` bubble box.
+  - The shell also renders the **mobile header** the message screens never had: a back
+    arrow (to the inbox, or to the role home when already there), the thread's title —
+    the person you are talking to — and a home shortcut. There is no sidebar below
+    `lg:`, so the browser's back button used to be the only way out.
+  - The pages drop their own heading on mobile (the header is the `<h1>` there), which
+    is what buys the list its space back. Rendered via `useIsNarrow()` rather than
+    `lg:hidden` so only one variant is ever in the DOM (strict-mode locators).
+  - `viewport.interactiveWidget = 'resizes-content'`: the on-screen keyboard now shrinks
+    the layout viewport instead of overlaying it, so a full-height screen keeps its
+    composer above the keyboard.
+  - New `e2e/mobile-chat-layout.spec.ts` asserts it geometrically at 390×664 (document
+    overflow ≤ 1px, composer on screen and clickable, the list is the scroller and stays
+    pinned to the newest message) plus header navigation, and that desktop still shows
+    the page heading. Verified by negative control: with the old document flow the same
+    spec reports 1208px of overflow.
+
 ## [0.35.0-beta] - 2026-08-01
 
 ### Added

--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -1660,3 +1660,44 @@ timeout veriyor; koşudan önce `pkill -f "next dev"` + portu doğrula.
 - Çakışan sürüm numarasını **rebase'den önce** kendi commit'inde değiştir; iki taraf
   farklı numara taşıyınca conflict önemsiz bir ekleme hâline geliyor.
 - Aynı temaya ait iki iş varsa (burada #935 + #936) **tek PR** yap: iki yarış yerine bir.
+
+---
+
+## 2026-07-31 — Mobil sohbet kabuğu (#1006)
+
+**"Gereksiz scroll" şikâyeti neredeyse her zaman iki iç içe scroll'dur.** Mesaj
+thread'i normal bir dokümandı: başlık + `max-h-[55vh]` baloncuk kutusu + composer
+birlikte kayıyordu, yani cevap yazmak için sayfayı aşağı, baloncukları yukarı
+kaydırmak gerekiyordu. Doğru düzeltme "biraz padding kısmak" değil, **ekranı çerçeve
+yapmak**: `h-[calc(100dvh_-_var(--fixed-bottom-inset))] + overflow-hidden` bir flex
+kolon, içinde tek `min-h-0 flex-1 overflow-y-auto` liste. Ölçüsü de nesnel:
+`documentElement.scrollHeight - innerHeight` → düzeltmeden önce **1208 px**, sonra 0.
+
+**Tailwind arbitrary value içinde `calc()` boşluk ister:** `h-[calc(100dvh-var(--x))]`
+geçersiz CSS üretir (sessizce çalışmaz), `h-[calc(100dvh_-_var(--x))]` doğrusu —
+alt çizgi Tailwind'in boşluğu. Bir önceki oturumun `--fixed-bottom-inset` değişkeni
+(#935) burada bedavaya geldi: çerez bandı açıkken çerçeve kendiliğinden kısalıyor.
+
+**`bg-white/95` globals.css'in retint ettiği `bg-white` DEĞİLDİR.** Opaklık ekli
+utility ayrı bir sınıf adı, dolayısıyla dark mode'da bembeyaz kalır — sticky/blur
+başlıklarda `dark:bg-gray-900/95`'i elle yazın (computed style ile doğrulayın).
+
+**Mobil-özel başlık eklerken sayfanın kendi `<h1>`'ini kaldırın.** İkisi birden
+kalırsa hem telefonda ekranın üçte biri boşa gider hem de `getByText(ad)` iki eşleşme
+bulup strict-mode'u patlatır. `useIsNarrow()` ile **tek varyant** render edin
+(`lg:hidden` DOM'da ikisini de bırakır) — kabuktaki başlık mobilde `<h1>` olsun,
+sayfa başlığı sadece `lg:`'de.
+
+**Animasyonlu scroll'u tek ölçümle assert etmeyin.** `scrollIntoView({behavior:
+'smooth'})` sonrası `scrollTop` daha yolda: ilk denemede liste dibe 67 px uzaktı.
+`expect.poll(...)` ile ölçün.
+
+**Bu container'da bilinen iki kırmızı, benimle ilgisiz:** `pipeline.spec.ts`
+("Navigation ... is interrupted by another navigation") ve `smoke.spec.ts` admin
+sayfaları (`[next-auth][error][CLIENT_FETCH_ERROR]`) — `git stash` ile baseline'da da
+kırmızı. Ayrıca elle başlatılan `npm run dev`'i Playwright yeniden kullandığı için
+`webServer.env` (HEALTH_TOKEN, TRUSTED_PROXY_COUNT) uygulanmıyor: `health.spec` ve
+`rate-limit.spec` bu yüzden düşer. Playwright tarayıcısı için playbook'taki
+`executablePath` numarasını geçici bir `playwright.local.config.ts` ile verdim
+(`{...base, use: {...base.use, launchOptions: {executablePath: '/opt/pw-browsers/chromium'}}}`)
+— commit etmeyin.

--- a/e2e/mobile-chat-layout.spec.ts
+++ b/e2e/mobile-chat-layout.spec.ts
@@ -1,0 +1,152 @@
+import { test, expect, type Page } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { signInAndSettle } from './helpers/auth';
+
+/**
+ * #1006 — a thread on a phone used to be a normal document: the page title, the
+ * bubble list (its own `max-h-[55vh]` scroller) and the composer scrolled
+ * *together*, so replying meant scrolling the document down and the bubbles up.
+ * There was also no way back other than the browser's own button.
+ *
+ * Geometric assertions (bounding boxes / scroll metrics), not screenshots: the
+ * document must not scroll, the composer must be on screen without scrolling, the
+ * bubble list must be the thing that scrolls, and the header must navigate.
+ */
+
+const IPHONE_13 = { width: 390, height: 664 };
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+/** Vertical overflow of the document itself — 0 means "no page scroll". */
+function documentOverflow(page: Page) {
+  return page.evaluate(() =>
+    Math.max(
+      document.documentElement.scrollHeight - window.innerHeight,
+      document.body.scrollHeight - window.innerHeight,
+    ),
+  );
+}
+
+test('mobile: a thread fills the viewport, only the bubble list scrolls', async ({ page }) => {
+  const mentorEmail = uniqueEmail('mobchat-mentor');
+  const menteeEmail = uniqueEmail('mobchat-mentee');
+  const mentor = await seedUser(mentorEmail, 'MentorPass123', 'MENTOR', 'MobChat Mentor');
+  const mentee = await seedUser(menteeEmail, 'MenteePass123', 'MENTEE', 'MobChat Mentee');
+  const rel = await prisma.mentorshipRelation.create({ data: { mentorId: mentor.id, menteeId: mentee.id } });
+  // Enough history that the list overflows a phone screen several times over.
+  for (let i = 0; i < 14; i++) {
+    await prisma.message.create({
+      data: {
+        relationId: rel.id,
+        senderId: i % 3 === 0 ? mentee.id : mentor.id,
+        channel: 'IN_APP',
+        body: `Thread message ${i + 1} — long enough to wrap on a narrow screen.`,
+      },
+    });
+  }
+
+  try {
+    await page.setViewportSize(IPHONE_13);
+    await signInAndSettle(page, mentorEmail, 'MentorPass123', '/mentor');
+    await page.goto(`/messages/${rel.id}`);
+
+    const composer = page.getByTestId('message-input');
+    await expect(composer).toBeVisible({ timeout: 15_000 });
+
+    // 1. The page itself does not scroll (1px of slack for sub-pixel rounding).
+    expect(await documentOverflow(page)).toBeLessThanOrEqual(1);
+
+    // 2. The bubble list is the scroller, and it settles on the newest message
+    //    (the scroll is animated, hence the poll).
+    const list = page.getByTestId('thread-messages');
+    expect(
+      await list.evaluate((el) => el.scrollHeight - el.clientHeight),
+      'the bubble list overflows and scrolls internally',
+    ).toBeGreaterThan(50);
+    await expect
+      .poll(() => list.evaluate((el) => el.scrollHeight - el.clientHeight - el.scrollTop), {
+        message: 'the list settles pinned to the newest message',
+      })
+      .toBeLessThan(8);
+
+    // 3. The composer is reachable where it stands — no scrolling, nothing on top
+    //    of it (Playwright fails the click if another element intercepts it).
+    const box = await composer.boundingBox();
+    expect(box, 'composer has a box').not.toBeNull();
+    expect(box!.y + box!.height).toBeLessThanOrEqual(IPHONE_13.height);
+    await composer.click();
+
+    // 4. Scrolling the history does not move the composer.
+    await list.evaluate((el) => { el.scrollTop = 0; });
+    const afterScroll = await composer.boundingBox();
+    expect(afterScroll!.y).toBeCloseTo(box!.y, 0);
+    expect(await documentOverflow(page)).toBeLessThanOrEqual(1);
+  } finally {
+    await prisma.message.deleteMany({ where: { relationId: rel.id } });
+    await prisma.notification.deleteMany({ where: { userId: { in: [mentor.id, mentee.id] } } });
+    await prisma.mentorshipRelation.deleteMany({ where: { id: rel.id } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+  }
+});
+
+test('mobile: the chat header names the thread and navigates out of it', async ({ page }) => {
+  const mentorEmail = uniqueEmail('mobnav-mentor');
+  const menteeEmail = uniqueEmail('mobnav-mentee');
+  const mentor = await seedUser(mentorEmail, 'MentorPass123', 'MENTOR', 'MobNav Mentor');
+  const mentee = await seedUser(menteeEmail, 'MenteePass123', 'MENTEE', 'MobNav Mentee');
+  const rel = await prisma.mentorshipRelation.create({ data: { mentorId: mentor.id, menteeId: mentee.id } });
+
+  try {
+    await page.setViewportSize(IPHONE_13);
+    await signInAndSettle(page, mentorEmail, 'MentorPass123', '/mentor');
+    await page.goto(`/messages/${rel.id}`);
+
+    // The header is the thread's title on mobile — the other party's name.
+    await expect(page.getByTestId('messages-header-title')).toHaveText('MobNav Mentee', { timeout: 15_000 });
+
+    // Back goes to the inbox, and the header retitles itself there.
+    await page.getByTestId('messages-back').click();
+    await expect(page).toHaveURL(/\/messages$/);
+    await expect(page.getByTestId('messages-header-title')).toHaveText('Messages');
+
+    // From the inbox, back leaves the messages area for the role's home.
+    await page.getByTestId('messages-back').click();
+    await expect(page).toHaveURL(/\/mentor/);
+
+    // The home shortcut works from inside a thread too.
+    await page.goto(`/messages/${rel.id}`);
+    await page.getByTestId('messages-home').click();
+    await expect(page).toHaveURL(/\/mentor/);
+  } finally {
+    await prisma.message.deleteMany({ where: { relationId: rel.id } });
+    await prisma.notification.deleteMany({ where: { userId: { in: [mentor.id, mentee.id] } } });
+    await prisma.mentorshipRelation.deleteMany({ where: { id: rel.id } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+  }
+});
+
+test('desktop keeps the page heading and the plain document flow', async ({ page }) => {
+  const mentorEmail = uniqueEmail('deskchat-mentor');
+  const menteeEmail = uniqueEmail('deskchat-mentee');
+  const mentor = await seedUser(mentorEmail, 'MentorPass123', 'MENTOR', 'DeskChat Mentor');
+  const mentee = await seedUser(menteeEmail, 'MenteePass123', 'MENTEE', 'DeskChat Mentee');
+  const rel = await prisma.mentorshipRelation.create({ data: { mentorId: mentor.id, menteeId: mentee.id } });
+
+  try {
+    await signInAndSettle(page, mentorEmail, 'MentorPass123', '/mentor');
+    await page.goto(`/messages/${rel.id}`);
+
+    await expect(page.getByRole('heading', { level: 1, name: 'Messages' })).toBeVisible({ timeout: 15_000 });
+    // The mobile-only header title is not in the DOM at all at this width.
+    await expect(page.getByTestId('messages-header-title')).toHaveCount(0);
+    await expect(page.getByTestId('messages-home')).toHaveCount(0);
+  } finally {
+    await prisma.mentorshipRelation.deleteMany({ where: { id: rel.id } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+  }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "internship-crm",
-  "version": "0.35.0-beta",
+  "version": "0.35.1-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "internship-crm",
-      "version": "0.35.0-beta",
+      "version": "0.35.1-beta",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.35.0-beta",
+  "version": "0.35.1-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,6 +25,10 @@ export const metadata: Metadata = {
 
 export const viewport: Viewport = {
   themeColor: '#1D4ED8',
+  // Shrink the layout viewport when the on-screen keyboard opens instead of
+  // letting it overlay the page, so a full-height screen (the chat shell, #1006)
+  // keeps its composer above the keyboard rather than behind it.
+  interactiveWidget: 'resizes-content',
 };
 
 // Runs before paint to set the dark class from the saved preference or the OS,

--- a/src/app/messages/layout.tsx
+++ b/src/app/messages/layout.tsx
@@ -1,27 +1,15 @@
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { redirect } from 'next/navigation';
-import Link from 'next/link';
-import { ArrowLeft } from 'lucide-react';
 import { roleHome } from '@/lib/roleHome';
+import { MessagesShell } from '@/components/MessagesShell';
 
 // Conversation threads are available to any authenticated participant.
+// MessagesShell provides the mobile app shell (full-height frame + header with
+// back/home) and the desktop document flow — see the comment in that file.
 export default async function MessagesLayout({ children }: { children: React.ReactNode }) {
   const session = await getServerSession(authOptions);
   if (!session) redirect('/auth/signin');
 
-  return (
-    <div className="min-h-screen bg-gray-50">
-      <div className="max-w-3xl mx-auto p-4 lg:p-8">
-        <Link
-          href={roleHome(session.user.role)}
-          className="inline-flex items-center gap-2 text-sm text-gray-500 hover:text-gray-700 mb-6"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          {session.user.name ?? 'Back'}
-        </Link>
-        {children}
-      </div>
-    </div>
-  );
+  return <MessagesShell homeHref={roleHome(session.user.role)}>{children}</MessagesShell>;
 }

--- a/src/app/messages/page.tsx
+++ b/src/app/messages/page.tsx
@@ -124,7 +124,9 @@ export default async function MessagesInboxPage() {
 
   return (
     <div>
-      <div className="mb-6">
+      {/* Mobile gets its title from the shell header (see MessagesShell), so this
+          block only shows where there is room for it. */}
+      <div className="hidden lg:block mb-6">
         <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.messages.title}</h1>
         <p className="text-gray-500 mt-1">{t.messages.inboxSubtitle}</p>
       </div>

--- a/src/app/messages/support/page.tsx
+++ b/src/app/messages/support/page.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import Link from 'next/link';
-import { ArrowLeft, LifeBuoy } from 'lucide-react';
+import { LifeBuoy } from 'lucide-react';
 import { Card } from '@/components/ui/Card';
 import { Badge } from '@/components/ui/Badge';
 import { useT, useLocale } from '@/i18n/client';
 import { relativeTime } from '@/lib/relativeTime';
 import { SupportAttachmentList } from '@/components/SupportAttachmentList';
+import { useMessagesHeaderTitle } from '@/components/MessagesShell';
+import { useIsNarrow } from '@/hooks/useIsNarrow';
 import {
   MessageBubble,
   MessageComposer,
@@ -36,6 +37,7 @@ export default function SupportChatPage() {
   const t = useT();
   const s = t.support;
   const locale = useLocale();
+  const narrow = useIsNarrow();
   const [tickets, setTickets] = useState<Ticket[] | null>(null);
   const [me, setMe] = useState('');
   const [body, setBody] = useState('');
@@ -44,6 +46,7 @@ export default function SupportChatPage() {
   const [attachments, setAttachments] = useState<PendingSupportAttachment[]>([]);
   const bottomRef = useRef<HTMLDivElement>(null);
   const fileRef = useRef<HTMLInputElement>(null);
+  useMessagesHeaderTitle(s.title);
 
   const load = () =>
     fetch('/api/support')
@@ -98,25 +101,28 @@ export default function SupportChatPage() {
   };
 
   return (
-    <div className="max-w-3xl">
-      <Link href="/messages" className="inline-flex items-center gap-1.5 text-sm text-blue-600 hover:underline mb-4">
-        <ArrowLeft className="h-4 w-4" /> {t.messages.title}
-      </Link>
+    // Same full-height mobile frame as a normal thread: only the ticket history
+    // scrolls, the composer stays put (see MessagesShell).
+    <div className="flex h-full min-h-0 max-w-3xl flex-col lg:h-auto lg:block">
+      {/* The shell header is the heading on mobile (see MessagesShell). */}
+      {!narrow && (
+        <div className="mb-6">
+          <div className="flex items-center gap-2 mb-1">
+            <LifeBuoy className="h-6 w-6 text-blue-600" />
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{s.title}</h1>
+          </div>
+          <p className="text-gray-500">{s.subtitle}</p>
+        </div>
+      )}
 
-      <div className="flex items-center gap-2 mb-1">
-        <LifeBuoy className="h-6 w-6 text-blue-600" />
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{s.title}</h1>
-      </div>
-      <p className="text-gray-500 mb-6">{s.subtitle}</p>
-
-      <div data-testid="support-chat">
-        <Card className="mb-4">
+      <div data-testid="support-chat" className="flex min-h-0 flex-1 flex-col lg:block">
+        <Card className="mb-3 flex min-h-0 flex-1 flex-col overflow-hidden p-3 lg:mb-4 lg:block lg:p-6">
           {tickets === null ? (
           <p className="text-center py-10 text-gray-400">{t.common.loading}</p>
         ) : tickets.length === 0 ? (
           <p className="text-center py-10 text-gray-400">{s.empty}</p>
         ) : (
-          <div className="space-y-6 max-h-[50vh] overflow-y-auto pr-1">
+          <div className="min-h-0 flex-1 space-y-6 overflow-y-auto overscroll-contain pr-1 lg:max-h-[50vh] lg:flex-none">
             {[...tickets].reverse().map((ticket) => (
               <div key={ticket.id} data-testid={`ticket-${ticket.id}`}>
                 <div className="flex items-center gap-2 mb-2">
@@ -138,6 +144,7 @@ export default function SupportChatPage() {
           )}
         </Card>
 
+        <div className="shrink-0">
         {err && <p className="text-xs text-red-600 mb-2">{err}</p>}
         <PendingAttachmentList
           attachments={attachments}
@@ -166,6 +173,7 @@ export default function SupportChatPage() {
           attachTestId="support-attach"
           sendTestId="support-send"
         />
+        </div>
       </div>
     </div>
   );

--- a/src/components/MessageThreadView.tsx
+++ b/src/components/MessageThreadView.tsx
@@ -14,6 +14,8 @@ import {
   PendingAttachmentList,
   type PendingMessageAttachment,
 } from '@/components/MessageThread';
+import { useMessagesHeaderTitle } from '@/components/MessagesShell';
+import { useIsNarrow } from '@/hooks/useIsNarrow';
 
 interface Attachment {
   id: string;
@@ -51,6 +53,7 @@ export function MessageThreadView({ target }: { target: ThreadTarget }) {
 
   const t = useT();
   const locale = useLocale();
+  const narrow = useIsNarrow();
   const { data: session } = useSession();
   const myId = session?.user?.id;
   const [messages, setMessages] = useState<Msg[]>([]);
@@ -131,7 +134,9 @@ export function MessageThreadView({ target }: { target: ThreadTarget }) {
   }, [target.kind, target.id]);
 
   useEffect(() => { load(); }, [load]);
-  useEffect(() => { endRef.current?.scrollIntoView({ behavior: 'smooth' }); }, [messages]);
+  // `block: 'end'` keeps this inside the bubble scroller instead of nudging the
+  // page: on mobile the list is the only scrollable box (see MessagesShell).
+  useEffect(() => { endRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' }); }, [messages]);
 
   const addFiles = (list: FileList | File[]) => {
     const picked = Array.from(list).filter(Boolean);
@@ -236,23 +241,33 @@ export function MessageThreadView({ target }: { target: ThreadTarget }) {
     finally { setRowBusy(false); }
   };
 
-  if (loading) return <p className="text-center py-12 text-gray-400">{t.common.loading}</p>;
-  if (forbidden) return <p className="text-center py-12 text-gray-400">{t.common.notFound}</p>;
-
   const nameFor = (id: string) => parties.find((p) => p.id === id)?.fullName ?? '—';
   // Header shows the other side (the only other party in a 1:1 thread).
   const other = parties.find((p) => p.id !== myId) ?? null;
+  // On mobile the shell's header is the only title, so it carries the name.
+  useMessagesHeaderTitle(other?.fullName);
+
+  if (loading) return <p className="text-center py-12 text-gray-400">{t.common.loading}</p>;
+  if (forbidden) return <p className="text-center py-12 text-gray-400">{t.common.notFound}</p>;
 
   return (
-    <div>
-      <h1 className="text-2xl font-bold text-gray-900 mb-1">{t.messages.title}</h1>
-      <p className="text-gray-500 mb-6">{other?.fullName}</p>
+    // Below lg this fills the shell's content area exactly: only the bubble list
+    // scrolls, and the composer stays visible without any document scroll.
+    <div className="flex h-full min-h-0 flex-col lg:h-auto lg:block">
+      {/* On mobile the shell header is the heading (and names the thread), so this
+          block would be a duplicate title eating a third of a phone screen. */}
+      {!narrow && (
+        <div className="mb-6">
+          <h1 className="text-2xl font-bold text-gray-900 mb-1">{t.messages.title}</h1>
+          <p className="text-gray-500">{other?.fullName}</p>
+        </div>
+      )}
 
-      <Card className="mb-4">
+      <Card className="mb-3 flex min-h-0 flex-1 flex-col overflow-hidden p-3 lg:mb-4 lg:block lg:p-6">
         {messages.length === 0 ? (
           <p className="text-center py-10 text-gray-400 text-sm">{t.messages.empty}</p>
         ) : (
-          <div className="space-y-3 max-h-[55vh] overflow-y-auto">
+          <div data-testid="thread-messages" className="min-h-0 flex-1 space-y-3 overflow-y-auto overscroll-contain lg:max-h-[55vh] lg:flex-none">
             {messages.map((m) => {
               const mine = m.senderId === myId;
               return (
@@ -408,6 +423,7 @@ export function MessageThreadView({ target }: { target: ThreadTarget }) {
         )}
       </Card>
 
+      <div className="shrink-0" data-testid="thread-composer">
       {attachError && <p className="text-xs text-red-600 mb-2">{attachError}</p>}
       {!canPost && (
         <p className="text-center py-3 text-sm text-gray-400" data-testid="thread-readonly">
@@ -436,7 +452,8 @@ export function MessageThreadView({ target }: { target: ThreadTarget }) {
         sendTestId="message-send"
       />
       <div className="mt-1.5 flex items-center justify-between gap-3">
-        <span className="text-xs text-gray-400 truncate">{t.messages.pasteHint}</span>
+        {/* Keyboard-only hint — no room for it on a phone. */}
+        <span className="hidden lg:inline text-xs text-gray-400 truncate">{t.messages.pasteHint}</span>
         <button
           type="button"
           role="switch"
@@ -453,6 +470,7 @@ export function MessageThreadView({ target }: { target: ThreadTarget }) {
       </div>
       </>
       )}
+      </div>
     </div>
   );
 }

--- a/src/components/MessagesShell.tsx
+++ b/src/components/MessagesShell.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { createContext, useCallback, useContext, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { ArrowLeft, Home } from 'lucide-react';
+import { useT } from '@/i18n/client';
+import { useIsNarrow } from '@/hooks/useIsNarrow';
+
+/**
+ * App shell for every /messages screen (#1006).
+ *
+ * On a phone a chat has to behave like a chat app: the viewport is the frame,
+ * the message list is the only thing that scrolls, and the composer stays put.
+ * The old layout was a plain document — the page title, the bubble list (its own
+ * `max-h-[55vh]` scroller) and the composer all scrolled *together*, so writing a
+ * reply meant scrolling the document down and the bubbles up: two nested scrolls
+ * for one thread.
+ *
+ * So below `lg` this is a fixed-height flex column (`100dvh` minus any fixed
+ * bottom bar — see `--fixed-bottom-inset`/#935): header, then a `min-h-0 flex-1`
+ * content area. A chat page fills that area with `h-full` and scrolls internally;
+ * a page that flows (the inbox) scrolls the area itself. Desktop keeps the plain
+ * document flow.
+ *
+ * The header is also the way *out* on mobile, where there is no sidebar: a back
+ * arrow (to the inbox, or to the role home when already there) and a home button.
+ */
+
+// Lets the current page name itself in the header — on a phone the person you are
+// talking to is the only title worth the row.
+const SetTitleContext = createContext<(title: string | null) => void>(() => {});
+
+/** Publish this screen's header title for as long as the component is mounted. */
+export function useMessagesHeaderTitle(title: string | null | undefined) {
+  const setTitle = useContext(SetTitleContext);
+  useEffect(() => {
+    setTitle(title ?? null);
+    return () => setTitle(null);
+  }, [setTitle, title]);
+}
+
+export function MessagesShell({
+  homeHref,
+  children,
+}: {
+  homeHref: string;
+  children: React.ReactNode;
+}) {
+  const t = useT();
+  const pathname = usePathname();
+  const narrow = useIsNarrow();
+  const [title, setTitle] = useState<string | null>(null);
+  const publishTitle = useCallback((next: string | null) => setTitle(next), []);
+
+  // On the inbox itself, "back" leaves the messages area altogether.
+  const atInbox = pathname === '/messages';
+  const backHref = atInbox ? homeHref : '/messages';
+  const backLabel = atInbox ? t.nav.dashboard : t.messages.title;
+
+  return (
+    <SetTitleContext.Provider value={publishTitle}>
+      {/* Underscores are Tailwind's spaces: calc() needs them around the minus. */}
+      <div className="flex h-[calc(100dvh_-_var(--fixed-bottom-inset))] flex-col overflow-hidden bg-gray-50 lg:h-auto lg:min-h-screen lg:overflow-visible">
+        {/* `bg-white/95` is not the `bg-white` globals.css retints, so dark mode
+            needs its own surface here. */}
+        <header className="shrink-0 border-b border-gray-200 bg-white/95 backdrop-blur dark:border-gray-800 dark:bg-gray-900/95 lg:border-0 lg:bg-transparent lg:backdrop-blur-none dark:lg:bg-transparent">
+          <div className="mx-auto flex w-full max-w-3xl items-center gap-1 px-2 py-1.5 lg:px-8 lg:pb-0 lg:pt-8">
+            <Link
+              href={backHref}
+              data-testid="messages-back"
+              aria-label={backLabel}
+              className="inline-flex shrink-0 items-center gap-2 rounded-lg p-2 text-sm text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-800 lg:p-0 lg:hover:bg-transparent"
+            >
+              <ArrowLeft className="h-5 w-5 lg:h-4 lg:w-4" />
+              {!narrow && <span>{backLabel}</span>}
+            </Link>
+            {/* Mobile-only, and deliberately the page's <h1>: the pages below drop
+                their own heading on mobile, so the DOM keeps exactly one (also why
+                this is rendered conditionally rather than hidden with `lg:hidden`
+                — see useIsNarrow). */}
+            {narrow && (
+              <h1
+                data-testid="messages-header-title"
+                className="min-w-0 flex-1 truncate text-sm font-semibold text-gray-900 dark:text-gray-100"
+              >
+                {title ?? t.messages.title}
+              </h1>
+            )}
+            {narrow && (
+              <Link
+                href={homeHref}
+                data-testid="messages-home"
+                aria-label={t.nav.dashboard}
+                className="shrink-0 rounded-lg p-2 text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-800"
+              >
+                <Home className="h-5 w-5" />
+              </Link>
+            )}
+          </div>
+        </header>
+        {/* Scrolls on pages that flow (the inbox); a chat page takes `h-full` here
+            and keeps its own scroller, so the document itself never scrolls. */}
+        <main
+          id="main-content"
+          className="mx-auto min-h-0 w-full max-w-3xl flex-1 overflow-y-auto overscroll-contain px-4 pb-3 pt-2 lg:overflow-visible lg:px-8 lg:pb-8"
+        >
+          {children}
+        </main>
+      </div>
+    </SetTitleContext.Provider>
+  );
+}

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,27 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.35.1-beta',
+    date: '2026-08-01',
+    highlights: {
+      en: [
+        'Messages now fill the screen on a phone. A conversation used to be a long page you had to scroll down before you could even reach the reply box — now the message list is the only thing that scrolls, and the reply box stays where it is at the bottom of the screen.',
+        'Every message screen also has a header on a phone: it shows who you are talking to, with a back arrow to your conversations and a home button — no more relying on the browser\'s back button to get out.',
+        'When the on-screen keyboard opens, the reply box stays visible above it instead of disappearing behind it.',
+      ],
+      tr: [
+        'Mesajlar telefonda artık ekranı tam kullanıyor. Bir sohbet, cevap kutusuna ulaşmak için önce aşağı kaydırmanız gereken uzun bir sayfaydı — artık yalnızca mesaj listesi kayıyor, cevap kutusu ekranın altında sabit duruyor.',
+        'Her mesaj ekranında telefonda bir başlık çubuğu var: kiminle konuştuğunuzu gösteriyor, geri okuyla sohbetlerinize, ev butonuyla ana ekranınıza dönüyorsunuz — çıkmak için tarayıcının geri tuşuna ihtiyaç kalmadı.',
+        'Ekran klavyesi açıldığında cevap kutusu klavyenin arkasında kaybolmuyor, üstünde görünür kalıyor.',
+      ],
+      de: [
+        'Nachrichten nutzen auf dem Handy jetzt den ganzen Bildschirm. Eine Unterhaltung war eine lange Seite, die man erst nach unten scrollen musste, um überhaupt das Antwortfeld zu erreichen — jetzt scrollt nur noch die Nachrichtenliste, und das Antwortfeld bleibt unten am Bildschirm stehen.',
+        'Jeder Nachrichten-Bildschirm hat auf dem Handy außerdem eine Kopfzeile: Sie zeigt, mit wem du schreibst, mit einem Zurück-Pfeil zu deinen Unterhaltungen und einer Start-Schaltfläche — der Zurück-Button des Browsers ist nicht mehr der einzige Ausweg.',
+        'Wenn die Bildschirmtastatur aufgeht, bleibt das Antwortfeld darüber sichtbar statt dahinter zu verschwinden.',
+      ],
+    },
+  },
+  {
     version: '0.35.0-beta',
     date: '2026-08-01',
     highlights: {


### PR DESCRIPTION
## Summary

Maintainer report (phone screenshot, `/messages/<id>`): "bu ekranda gereksiz scroll oluyor, mobilde ekranı tam kullanıp scroll'u engellenmeli — ve bu ekranlardan diğer ekranlara dönebilmek kolay olmalı, bir header veya bir alt bar fena olmazdı."

A thread was a plain document: the page title, the bubble list (its own `max-h-[55vh]` scroller) and the composer all scrolled **together**. On an iPhone 13 (390×664) the document overflowed by **1208px**, so writing a reply meant scrolling the page down while the bubbles scrolled up — two nested scrolls for one conversation. And below `lg:` there is no sidebar, so the browser's back button was the only way out of a thread.

Now, below `lg:`, the viewport is the frame: header → message list (the only scroller) → composer, and the document does not scroll at all. Desktop is unchanged.

| before (reported) | after |
|---|---|
| document overflows by 1208px; title block eats ~⅓ of the screen; no back affordance | overflow 0px; list scrolls internally; composer pinned; header with back + title + home |

Closes #1006

## Changes

- **New `src/components/MessagesShell.tsx`**, wired into `src/app/messages/layout.tsx`. Below `lg:` it is a fixed-height flex column — `calc(100dvh - var(--fixed-bottom-inset))`, so it also shrinks around the cookie banner from #935 — with the content area as `min-h-0 flex-1`. Chat pages fill that area with `h-full` and keep their own scroller; a page that flows (the inbox) scrolls the area itself. Desktop keeps the previous document flow and the `55vh` bubble box.
- The shell renders the **mobile header** these screens never had: back arrow (to the inbox; to the role home when already on the inbox), the screen's title — for a thread, the person you are talking to, published via a small context — and a home shortcut. It also finally gives `/messages` a `main#main-content` for the skip link.
- The thread (`MessageThreadView`), the support chat and the inbox **drop their own heading on mobile** (the header is the `<h1>` there), which is what buys the list its space back. Rendered via `useIsNarrow()` rather than `lg:hidden`, so only one variant is ever in the DOM (strict-mode locators, same rule as the board in #982). The keyboard-only paste hint is hidden on mobile too.
- Bubble list / ticket history are `min-h-0 flex-1 overflow-y-auto overscroll-contain` below `lg:` (`lg:max-h-[55vh]` / `lg:max-h-[50vh]` unchanged above it); `scrollIntoView` now uses `block: 'end'` so it stays inside that scroller. The support page's own inline back link is gone — the header covers it.
- `viewport.interactiveWidget = 'resizes-content'`: the on-screen keyboard shrinks the layout viewport instead of overlaying it, so a full-height screen keeps its composer above the keyboard.
- Dark mode: `bg-white/95` is not the `bg-white` that `globals.css` retints, so the sticky header carries an explicit `dark:bg-gray-900/95` (verified by computed style).
- Version ledger: `0.35.1-beta` + `CHANGELOG.md` + `releaseNotes.ts` (EN/TR/DE), and a dated retrospective entry in `docs/agent-experience.md`.

## Verification

- [x] `npm run lint` + `npx tsc --noEmit` clean (only pre-existing warnings), `npm run check:i18n` OK (1612 keys × 3 locales), `npm run build` OK
- [x] New `e2e/mobile-chat-layout.spec.ts` (3 tests) — geometric, not screenshots: at 390×664 the document overflow is ≤ 1px, the composer is on screen and really clickable, the bubble list is the scroller and settles pinned to the newest message, scrolling history does not move the composer; header back/home navigation; and desktop still renders the page `<h1>` with no mobile-only nodes in the DOM.
- [x] **Negative control**: with the old document flow restored, the same spec reports **1208px** of overflow.
- [x] Regression run against a local MariaDB + demo seed: `messaging`, `messages-inbox`, `project-dm`, `support-chat`, `message-attachments`, `support-attachments`, `mobile-fixed-bars` — 19/19 pass. Manually checked thread / inbox / support at 390×664 in light **and** dark mode, plus the desktop thread.
- [x] Two pre-existing failures in this container are unrelated and red on the baseline too (`git stash` check): `pipeline.spec.ts` ("Navigation … interrupted by another navigation") and `smoke.spec.ts` admin pages (`[next-auth][error][CLIENT_FETCH_ERROR]`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01H7Sy9XdrPAdP9iBjTTk37U)_