### PR TITLE
fix(ux): land the mobile chat frame on the visible bottom, not behind the nav bar (#1009)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.35.2-beta] - 2026-08-01
+
+### Fixed
+- **The chat frame's bottom edge now lands on the *visible* bottom** (#1009). Follow-up
+  to #1006, reported from an installed PWA on Android: the end of the composer (and the
+  last row of the inbox) sat behind the system navigation bar and could not be scrolled
+  into view. `100dvh` is the *layout* viewport, and an edge-to-edge PWA draws behind the
+  navigation bar, so it is ~48px taller than what you can see — and since the frame
+  fits `100dvh` exactly, the document has no overflow either, which is why nothing
+  scrolled. Two independent corrections, neither of which does anything when there is
+  nothing hidden:
+  - The frame subtracts `env(safe-area-inset-bottom)`, and `/messages` opts into real
+    inset values with a **route-scoped** `viewport-fit=cover` (`viewport` export in
+    `src/app/messages/layout.tsx`, so no other route changes behaviour). The header
+    picks up `env(safe-area-inset-top)` and the frame the left/right insets for
+    landscape notches. `max(--fixed-bottom-inset, env(safe-area-inset-bottom))` rather
+    than a sum — the cookie banner already pads itself past the inset (#935), so
+    subtracting both would leave a gap above it.
+  - New `useVisibleViewportHeight` publishes `min(innerHeight, visualViewport.height)`
+    as `--visible-viewport-height`, which the frame applies as a **`max-height`
+    clamp**. Being a clamp and not a second subtraction is the point: if both signals
+    report the same hidden strip, the smaller one simply wins instead of the strip
+    being deducted twice. Pinch-zoom (`scale > 1.01`) is ignored, and the clamp also
+    tracks the on-screen keyboard.
+- `e2e/mobile-chat-layout.spec.ts` grew two assertions: the frame's height equals the
+  visible height (a malformed `calc()` shows up immediately), and — reproducing the
+  reported condition through the same signal the shell listens to — with 48px of the
+  viewport hidden the whole composer still fits inside what is left. Negative control:
+  without the clamp the send button sits 630px into a 616px visible area. A third test
+  pins the `viewport-fit=cover` scoping (present on `/messages`, absent on `/mentor`).
+
 ## [0.35.1-beta] - 2026-08-01
 
 ### Changed

--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -1701,3 +1701,29 @@ kırmızı. Ayrıca elle başlatılan `npm run dev`'i Playwright yeniden kulland
 `executablePath` numarasını geçici bir `playwright.local.config.ts` ile verdim
 (`{...base, use: {...base.use, launchOptions: {executablePath: '/opt/pw-browsers/chromium'}}}`)
 — commit etmeyin.
+
+### Ek: 2026-08-01 — "alt kısım tam sıfıra dayanmıyor" (#1009)
+
+**`100dvh` görünür yükseklik DEĞİL.** Android'de kurulu PWA (edge-to-edge) sistem
+gezinme çubuğunun *arkasına* çiziyor, yani `100dvh` gördüğünüzden ~48 px fazla. Tam
+`100dvh` yüksekliğinde bir çerçeve kurunca dokümanda taşma da olmuyor → gizli kalan
+şerit **kaydırılarak da erişilemiyor**. Kullanıcının tarifi tam buydu: "en aşağı kısım
+tam sıfıra dayanmıyor, biraz fazladan aşağı gidiyor, scroll yapılamıyor."
+
+- `env(safe-area-inset-bottom)` bunun tek CSS sinyali, ama **`viewport-fit=cover`
+  olmadan 0 döner**. Next App Router'da `viewport` export'u **layout başına** yapılabilir
+  (`src/app/messages/layout.tsx`), yani cover'ı tüm uygulamaya açmak zorunda değilsiniz —
+  iç içe export kök export'u *değiştirir* (merge etmez), o yüzden kökteki alanları
+  (themeColor, interactiveWidget) tekrar yazın.
+- İki düzeltmeyi **toplamayın**: biri çıkarma (`height: calc(100dvh - env(...))`), diğeri
+  **clamp** (`max-height: var(--visible-viewport-height)`) olsun. İkisi de aynı 48 px'i
+  bildirdiğinde clamp'te küçük olan kazanır; toplarsanız 96 px çıkarıp boşluk açarsınız.
+  Aynı sebeple `max(--fixed-bottom-inset, env(safe-area-inset-bottom))`: sabit alt bar
+  zaten kendi içinde inset kadar padding taşıyor (#935).
+- Tailwind arbitrary value içinde `max()`/`env()` sorunsuz derleniyor
+  (`h-[calc(100dvh_-_max(var(--x),env(safe-area-inset-bottom,0px)))]`), üretilen CSS'i
+  `grep "height:calc(100dvh" .next/static/css/*.css` ile doğrulayın.
+- **Cihaz elinizde olmasa da test edilebilir:** gizli şeridi, kabuğun dinlediği aynı
+  sinyali JS'ten kısarak taklit edin (`--visible-viewport-height = innerHeight - 48`) ve
+  composer'ın kalan alanda kaldığını assert edin. Negatif kontrol clamp'i silmekle
+  yapılıyor (630 > 616).

--- a/e2e/mobile-chat-layout.spec.ts
+++ b/e2e/mobile-chat-layout.spec.ts
@@ -71,18 +71,45 @@ test('mobile: a thread fills the viewport, only the bubble list scrolls', async 
       })
       .toBeLessThan(8);
 
-    // 3. The composer is reachable where it stands — no scrolling, nothing on top
+    // 3. The frame ends exactly at the bottom of the visible viewport (#1009): its
+    //    height must track the *visible* height, not just `100dvh`. Nothing is
+    //    hidden here (no system-bar insets in a headless browser), so the two are
+    //    equal — a malformed calc()/max-height would show up as a mismatch.
+    const frame = await page.getByTestId('messages-frame').evaluate((el) => {
+      const box = el.getBoundingClientRect();
+      return { bottom: Math.round(box.bottom), height: Math.round(box.height), visible: window.innerHeight };
+    });
+    expect(frame.height, 'frame fills the visible viewport').toBe(frame.visible);
+    expect(frame.bottom, 'and its bottom edge lands on it').toBeLessThanOrEqual(frame.visible);
+
+    // 4. The composer is reachable where it stands — no scrolling, nothing on top
     //    of it (Playwright fails the click if another element intercepts it).
     const box = await composer.boundingBox();
     expect(box, 'composer has a box').not.toBeNull();
     expect(box!.y + box!.height).toBeLessThanOrEqual(IPHONE_13.height);
     await composer.click();
 
-    // 4. Scrolling the history does not move the composer.
+    // 5. Scrolling the history does not move the composer.
     await list.evaluate((el) => { el.scrollTop = 0; });
     const afterScroll = await composer.boundingBox();
     expect(afterScroll!.y).toBeCloseTo(box!.y, 0);
     expect(await documentOverflow(page)).toBeLessThanOrEqual(1);
+
+    // 6. The reported bug (#1009): a strip of the viewport is not actually visible
+    //    — a system navigation bar drawn over the bottom 48px. Headless Chromium
+    //    has no system bars, so the condition is reproduced through the same signal
+    //    the shell listens to, and the whole composer must end up inside what is
+    //    left. Without the clamp the send button sat 48px below the visible bottom
+    //    with nothing to scroll, which is exactly what was reported.
+    const HIDDEN = 48;
+    await page.evaluate((hidden) => {
+      document.documentElement.style.setProperty('--visible-viewport-height', `${window.innerHeight - hidden}px`);
+    }, HIDDEN);
+    const send = await page.getByTestId('message-send').boundingBox();
+    expect(send, 'send button has a box').not.toBeNull();
+    expect(send!.y + send!.height, 'the composer stays inside the visible area').toBeLessThanOrEqual(
+      IPHONE_13.height - HIDDEN,
+    );
   } finally {
     await prisma.message.deleteMany({ where: { relationId: rel.id } });
     await prisma.notification.deleteMany({ where: { userId: { in: [mentor.id, mentee.id] } } });
@@ -126,6 +153,30 @@ test('mobile: the chat header names the thread and navigates out of it', async (
     await prisma.mentorshipRelation.deleteMany({ where: { id: rel.id } });
     await cleanupByEmail(menteeEmail);
     await cleanupByEmail(mentorEmail);
+  }
+});
+
+test('the messages routes opt into safe-area insets, other routes do not', async ({ page }) => {
+  const email = uniqueEmail('vpfit-mentor');
+  await seedUser(email, 'MentorPass123', 'MENTOR', 'ViewportFit Mentor');
+
+  const viewportMeta = () =>
+    page.locator('meta[name="viewport"]').getAttribute('content');
+
+  try {
+    await page.setViewportSize(IPHONE_13);
+    await signInAndSettle(page, email, 'MentorPass123', '/mentor');
+
+    // `viewport-fit=cover` is what makes env(safe-area-inset-*) report the real
+    // system-bar insets the chat frame subtracts (#1009) — and it is deliberately
+    // scoped to /messages, since those are the only screens that reserve them.
+    expect(await viewportMeta()).not.toContain('viewport-fit=cover');
+
+    await page.goto('/messages');
+    await expect(page.getByTestId('messages-frame')).toBeVisible({ timeout: 15_000 });
+    expect(await viewportMeta()).toContain('viewport-fit=cover');
+  } finally {
+    await cleanupByEmail(email);
   }
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "internship-crm",
-  "version": "0.35.1-beta",
+  "version": "0.35.2-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "internship-crm",
-      "version": "0.35.1-beta",
+      "version": "0.35.2-beta",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.35.1-beta",
+  "version": "0.35.2-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/app/messages/layout.tsx
+++ b/src/app/messages/layout.tsx
@@ -1,8 +1,25 @@
+import type { Viewport } from 'next';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import { roleHome } from '@/lib/roleHome';
 import { MessagesShell } from '@/components/MessagesShell';
+
+/**
+ * Route-scoped viewport (#1009). `viewportFit: 'cover'` is what makes
+ * `env(safe-area-inset-*)` report the real system-bar insets, which the
+ * full-height chat frame subtracts so its bottom edge lands on the visible
+ * bottom instead of behind the navigation bar. Scoped to /messages on purpose:
+ * these are the only screens built to reserve the insets themselves.
+ *
+ * A nested export replaces the root one for these routes, so the root's fields
+ * are repeated here rather than inherited.
+ */
+export const viewport: Viewport = {
+  themeColor: '#1D4ED8',
+  interactiveWidget: 'resizes-content',
+  viewportFit: 'cover',
+};
 
 // Conversation threads are available to any authenticated participant.
 // MessagesShell provides the mobile app shell (full-height frame + header with

--- a/src/components/MessagesShell.tsx
+++ b/src/components/MessagesShell.tsx
@@ -6,6 +6,7 @@ import { usePathname } from 'next/navigation';
 import { ArrowLeft, Home } from 'lucide-react';
 import { useT } from '@/i18n/client';
 import { useIsNarrow } from '@/hooks/useIsNarrow';
+import { useVisibleViewportHeight } from '@/hooks/useVisibleViewportHeight';
 
 /**
  * App shell for every /messages screen (#1006).
@@ -50,6 +51,8 @@ export function MessagesShell({
   const t = useT();
   const pathname = usePathname();
   const narrow = useIsNarrow();
+  // Second, independent measure of the usable height — see the frame below.
+  useVisibleViewportHeight(narrow);
   const [title, setTitle] = useState<string | null>(null);
   const publishTitle = useCallback((next: string | null) => setTitle(next), []);
 
@@ -60,11 +63,27 @@ export function MessagesShell({
 
   return (
     <SetTitleContext.Provider value={publishTitle}>
-      {/* Underscores are Tailwind's spaces: calc() needs them around the minus. */}
-      <div className="flex h-[calc(100dvh_-_var(--fixed-bottom-inset))] flex-col overflow-hidden bg-gray-50 lg:h-auto lg:min-h-screen lg:overflow-visible">
+      {/*
+        Underscores are Tailwind's spaces: calc() needs them around the minus.
+        The safe-area insets are what keep the frame's bottom edge *at* the visible
+        bottom (#1009): on an installed PWA the layout viewport extends behind the
+        system navigation bar, so `100dvh` is ~48px taller than what you can see —
+        and since the document then has no overflow either, the covered strip (the
+        end of the composer, the last inbox row) is unreachable by scrolling. The
+        route's `viewport-fit=cover` is what makes these report the real insets;
+        they resolve to 0px everywhere else, so desktop is unchanged.
+        `max()` rather than a sum: a fixed bottom bar pads itself past the inset
+        already (CookieConsent), so subtracting both would leave a gap above it.
+        `--visible-viewport-height` (useVisibleViewportHeight) clamps the same thing
+        from the other direction — as a max-height, so if both signals report the
+        same hidden strip the smaller one simply wins instead of it being subtracted
+        twice.
+      */}
+      <div className="flex h-[calc(100dvh_-_max(var(--fixed-bottom-inset),env(safe-area-inset-bottom,0px)))] max-h-[var(--visible-viewport-height,100dvh)] flex-col overflow-hidden bg-gray-50 pl-[env(safe-area-inset-left,0px)] pr-[env(safe-area-inset-right,0px)] lg:h-auto lg:max-h-none lg:min-h-screen lg:overflow-visible lg:px-0" data-testid="messages-frame">
         {/* `bg-white/95` is not the `bg-white` globals.css retints, so dark mode
-            needs its own surface here. */}
-        <header className="shrink-0 border-b border-gray-200 bg-white/95 backdrop-blur dark:border-gray-800 dark:bg-gray-900/95 lg:border-0 lg:bg-transparent lg:backdrop-blur-none dark:lg:bg-transparent">
+            needs its own surface here. `viewport-fit=cover` also puts the status
+            bar inside the viewport, hence the top inset on the header. */}
+        <header className="shrink-0 border-b border-gray-200 bg-white/95 pt-[env(safe-area-inset-top,0px)] backdrop-blur dark:border-gray-800 dark:bg-gray-900/95 lg:border-0 lg:bg-transparent lg:pt-0 lg:backdrop-blur-none dark:lg:bg-transparent">
           <div className="mx-auto flex w-full max-w-3xl items-center gap-1 px-2 py-1.5 lg:px-8 lg:pb-0 lg:pt-8">
             <Link
               href={backHref}

--- a/src/hooks/useVisibleViewportHeight.ts
+++ b/src/hooks/useVisibleViewportHeight.ts
@@ -1,0 +1,47 @@
+'use client';
+
+import { useEffect } from 'react';
+
+const CSS_VAR = '--visible-viewport-height';
+
+/**
+ * Publishes the height that is actually *visible* as `--visible-viewport-height`
+ * on `<html>`, for full-height screens to clamp themselves with (#1009).
+ *
+ * `100dvh` is the layout viewport, and that is not always what you can see: an
+ * installed PWA on Android draws behind the system navigation bar, so the bottom
+ * ~48px of `100dvh` sit under it — and because the document then has no overflow
+ * either, that strip cannot be scrolled into view. The frame subtracts
+ * `env(safe-area-inset-bottom)` for exactly this, but the visual viewport is a
+ * second, independent signal: whichever of the two is more conservative wins,
+ * because the frame *clamps* with `max-height` instead of adding another
+ * subtraction (two identical corrections would leave a gap instead of closing one).
+ *
+ * Also tracks the on-screen keyboard: with `interactive-widget=resizes-content`
+ * both signals shrink, so the composer stays above it. Pinch-zoom is ignored —
+ * a zoomed visual viewport is smaller without anything being hidden.
+ */
+export function useVisibleViewportHeight(active = true) {
+  useEffect(() => {
+    if (!active) return;
+    const root = document.documentElement;
+    const apply = () => {
+      const vv = window.visualViewport;
+      const zoomed = vv ? vv.scale > 1.01 : false;
+      const height = vv && !zoomed ? Math.min(window.innerHeight, vv.height) : window.innerHeight;
+      root.style.setProperty(CSS_VAR, `${Math.round(height)}px`);
+    };
+    apply();
+    window.addEventListener('resize', apply);
+    window.addEventListener('orientationchange', apply);
+    window.visualViewport?.addEventListener('resize', apply);
+    window.visualViewport?.addEventListener('scroll', apply);
+    return () => {
+      window.removeEventListener('resize', apply);
+      window.removeEventListener('orientationchange', apply);
+      window.visualViewport?.removeEventListener('resize', apply);
+      window.visualViewport?.removeEventListener('scroll', apply);
+      root.style.removeProperty(CSS_VAR);
+    };
+  }, [active]);
+}

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,21 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.35.2-beta',
+    date: '2026-08-01',
+    highlights: {
+      en: [
+        'Fixed the bottom edge of the message screens on a phone: the reply box (and the last row of your conversation list) could end up behind the system navigation bar, with no way to scroll it into view. The screen now ends exactly where the visible area ends.',
+      ],
+      tr: [
+        'Telefonda mesaj ekranlarının alt kenarı düzeltildi: cevap kutusu (ve sohbet listesinin son satırı) sistemin gezinme çubuğunun arkasında kalabiliyordu ve kaydırarak görünür hâle getirmek mümkün olmuyordu. Ekran artık tam olarak görünür alanın bittiği yerde bitiyor.',
+      ],
+      de: [
+        'Der untere Rand der Nachrichten-Bildschirme auf dem Handy ist korrigiert: Das Antwortfeld (und die letzte Zeile der Unterhaltungsliste) konnte hinter der System-Navigationsleiste liegen, ohne sich ins Bild scrollen zu lassen. Der Bildschirm endet jetzt genau dort, wo der sichtbare Bereich endet.',
+      ],
+    },
+  },
+  {
     version: '0.35.1-beta',
     date: '2026-08-01',
     highlights: {


### PR DESCRIPTION
## Summary

Follow-up to #1006, reported with two screenshots from the installed PWA on Android: *"en aşağı kısım tam sıfıra dayanıyor değil, biraz fazladan gidiyor aşağıya, scroll yapılamıyor."* The end of the composer — and the last row of the inbox — sat behind the system navigation bar with no way to scroll it into view.

`100dvh` is the **layout** viewport, and an edge-to-edge PWA draws behind the navigation bar, so it is ~48px taller than what you can see. And because the frame fits `100dvh` exactly, the document has no overflow either — from the browser's point of view everything was already on screen, which is why nothing scrolled.

Two independent corrections, each a no-op when nothing is hidden (desktop and every non-inset device render identically — verified: frame height 664 = `innerHeight` 664, document overflow 0, send button at the same 630px as before this PR).

Closes #1009

## Changes

- **`env(safe-area-inset-*)`, opted into per route.** The frame subtracts `max(var(--fixed-bottom-inset), env(safe-area-inset-bottom, 0px))` — `max()` and not a sum, because a fixed bottom bar already pads itself past the inset (`CookieConsent`, #935), so subtracting both would leave a gap above it. `src/app/messages/layout.tsx` now exports its own `viewport` with `viewportFit: 'cover'`, which is what makes those insets report real values; scoping it to `/messages` keeps every other route on the root viewport (a nested export replaces rather than merges, so `themeColor` + `interactiveWidget` are repeated there). The header picks up `env(safe-area-inset-top)`, the frame the left/right insets for landscape notches.
- **New `src/hooks/useVisibleViewportHeight.ts`** publishes `min(innerHeight, visualViewport.height)` as `--visible-viewport-height`; the frame applies it as a **`max-height` clamp**. A clamp rather than a second subtraction is the whole point: if both signals report the same hidden strip, the smaller one simply wins instead of the strip being deducted twice. Pinch-zoom (`scale > 1.01`) is ignored, and the clamp also tracks the on-screen keyboard. Only active below `lg:`.
- Version ledger: `0.35.2-beta` + `CHANGELOG.md` + `releaseNotes.ts` (EN/TR/DE), plus an addendum in `docs/agent-experience.md`.

## Verification

- [x] `npm run lint` + `npx tsc --noEmit` clean, `npm run check:i18n` OK (1612 keys × 3 locales), `npm run build` OK — and the generated CSS was checked directly (`height:calc(100dvh - max(var(--fixed-bottom-inset), env(safe-area-inset-bottom,0px)))`, `padding-top:env(safe-area-inset-top,0)`), since a malformed `calc()` fails silently.
- [x] `e2e/mobile-chat-layout.spec.ts` (4 tests) — new assertions: the frame's height equals the visible height and its bottom edge lands on it; and the reported condition is **reproduced** through the same signal the shell listens to (`--visible-viewport-height = innerHeight - 48`), after which the whole composer must still fit inside the remaining 616px. New third test pins the viewport-fit scoping: present on `/messages`, absent on `/mentor`.
- [x] **Negative control**: with the `max-height` clamp removed, that assertion fails exactly as reported — send button bottom at 630px in a 616px visible area.
- [x] `mobile-fixed-bars` (#935) still green, so the cookie-banner inset and the new insets do not fight; light and dark screenshots taken at 390×664 with the 48px strip simulated (composer and the "Enter to send" row both inside the visible area).
- [ ] **On-device check still needed** — the insets only have real values on the actual phone; I could reproduce the *mechanism* but not the system bar itself. The topic preview for this PR is the place to confirm.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H7Sy9XdrPAdP9iBjTTk37U)_