### PR TITLE
feat(evaluations): delete an evaluation recorded by mistake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.38.0-beta] - 2026-08-01
+
+### Added
+- **An evaluation can be deleted** (`DELETE /api/evaluations/[id]`, trash icon in
+  `EvaluationPanel`). Until now a mis-clicked rating was permanent: the panel only ever
+  appended, and there was no route to remove a row. Only the evaluation's **own author**
+  (or an ADMIN) may delete it — an evaluation is the author's judgement, so the other
+  side of the relation cannot erase one written about them. The list endpoint now returns
+  a `canDelete` flag per evaluation so the button only appears where the DELETE route
+  would actually allow it, and the deletion is recorded in the activity log
+  (`evaluation.deleted`).
+
 ## [0.37.0-beta] - 2026-08-01
 
 ### Added

--- a/e2e/evaluation.spec.ts
+++ b/e2e/evaluation.spec.ts
@@ -33,6 +33,41 @@ test('a mentor can record an evaluation for their mentee', async ({ page }) => {
   }
 });
 
+test('a mentor can delete an evaluation they recorded by mistake, but not the mentee’s', async ({ page }) => {
+  const mentorEmail = uniqueEmail('evdel-mentor');
+  const menteeEmail = uniqueEmail('evdel-mentee');
+  const mentor = await seedUser(mentorEmail, 'MentorPass123', 'MENTOR', 'EvDel Mentor');
+  const mentee = await seedUser(menteeEmail, 'x', 'MENTEE', 'EvDel Mentee');
+  const rel = await prisma.mentorshipRelation.create({ data: { mentorId: mentor.id, menteeId: mentee.id } });
+  const mine = await prisma.evaluation.create({
+    data: { relationId: rel.id, authorId: mentor.id, scores: { technical: 5 } },
+  });
+  const theirs = await prisma.evaluation.create({
+    data: { relationId: rel.id, authorId: mentee.id, scores: { guidance: 5 } },
+  });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', mentorEmail);
+    await page.fill('input[type="password"]', 'MentorPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/mentor'), { timeout: 20_000 });
+
+    // The mentee's evaluation of the mentor is not the mentor's to remove.
+    const forbidden = await page.request.delete(`/api/evaluations/${theirs.id}`);
+    expect(forbidden.status()).toBe(403);
+    expect(await prisma.evaluation.findUnique({ where: { id: theirs.id } })).not.toBeNull();
+
+    const res = await page.request.delete(`/api/evaluations/${mine.id}`);
+    expect(res.ok()).toBeTruthy();
+    expect(await prisma.evaluation.findUnique({ where: { id: mine.id } })).toBeNull();
+  } finally {
+    await prisma.mentorshipRelation.deleteMany({ where: { id: rel.id } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+  }
+});
+
 test('a mentee can self-assess their skill levels', async ({ page }) => {
   const email = uniqueEmail('sl-mentee');
   const mentee = await seedUser(email, 'MenteePass123', 'MENTEE', 'SL Mentee');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.37.0-beta",
+  "version": "0.38.0-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/app/api/evaluations/[id]/route.ts
+++ b/src/app/api/evaluations/[id]/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { withTenantScope } from '@/lib/orgContext';
+import { logActivity } from '@/lib/activity';
+
+// DELETE — remove an evaluation that was recorded by mistake. Only its own
+// author (or an admin) may do so: an evaluation is the author's own judgement,
+// so the other side of the relation cannot erase it.
+export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  return await withTenantScope(session, async () => {
+    const { id } = await params;
+    const evaluation = await prisma.evaluation.findUnique({
+      where: { id },
+      select: { id: true, authorId: true, relationId: true, type: true },
+    });
+    if (!evaluation) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    if (evaluation.authorId !== session.user.id && session.user.role !== 'ADMIN') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    await prisma.evaluation.delete({ where: { id } });
+    await logActivity({
+      action: 'evaluation.deleted',
+      actorId: session.user.id,
+      actorEmail: session.user.email,
+      targetType: 'Evaluation',
+      targetId: evaluation.id,
+      detail: `relation=${evaluation.relationId} type=${evaluation.type}`,
+      request,
+    });
+
+    return NextResponse.json({ ok: true });
+  });
+}

--- a/src/app/api/evaluations/route.ts
+++ b/src/app/api/evaluations/route.ts
@@ -20,11 +20,14 @@ export async function GET(request: Request) {
   if (!allowed) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
 
   const evaluations = await prisma.evaluation.findMany({ where: { relationId }, orderBy: { createdAt: 'desc' } });
-  // Tag each evaluation with its direction so the UI can pick the right rubric.
+  // Tag each evaluation with its direction so the UI can pick the right rubric,
+  // and with whether the viewer may remove it (author or admin) so the panel
+  // only offers a delete button where the DELETE route would actually allow it.
   return NextResponse.json({
     evaluations: evaluations.map((e) => ({
       ...e,
       direction: e.authorId === rel.menteeId ? 'MENTEE_ON_MENTOR' : 'MENTOR_ON_MENTEE',
+      canDelete: e.authorId === session.user.id || session.user.role === 'ADMIN',
     })),
   });
   });

--- a/src/components/EvaluationPanel.tsx
+++ b/src/components/EvaluationPanel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
+import { Trash2 } from 'lucide-react';
 import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { Badge } from '@/components/ui/Badge';
@@ -16,6 +17,7 @@ interface Evaluation {
   comment: string | null;
   direction: 'MENTOR_ON_MENTEE' | 'MENTEE_ON_MENTOR';
   createdAt: string;
+  canDelete?: boolean;
 }
 
 // Shows a relation's evaluation history. When not read-only, the current user
@@ -65,6 +67,16 @@ export function EvaluationPanel({
     } finally {
       setSaving(false);
     }
+  };
+
+  // Removing an evaluation recorded by mistake. The server re-checks that the
+  // caller is its author (or an admin); this only hides the button.
+  const remove = async (id: string) => {
+    if (!window.confirm(t.evaluation.confirmDelete)) return;
+    setError(null);
+    const res = await fetch(`/api/evaluations/${id}`, { method: 'DELETE' });
+    if (res.ok) await load();
+    else setError(t.common.error);
   };
 
   const label = (c: string) => (t.evaluation.criteria as Record<string, string>)[c] ?? c;
@@ -152,6 +164,18 @@ export function EvaluationPanel({
                 <div className="flex items-center gap-2 mb-1.5">
                   <Badge variant={ev.type === 'FINAL' ? 'success' : 'info'}>{typeLabel(ev.type)}</Badge>
                   {ev.direction === 'MENTEE_ON_MENTOR' && <Badge variant="purple">{t.evaluation.onMentor}</Badge>}
+                  {ev.canDelete && (
+                    <button
+                      type="button"
+                      onClick={() => remove(ev.id)}
+                      aria-label={t.evaluation.delete}
+                      title={t.evaluation.delete}
+                      data-testid="evaluation-delete"
+                      className="ml-auto text-gray-300 hover:text-red-600 dark:text-gray-600 dark:hover:text-red-400"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </button>
+                  )}
                 </div>
                 <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm">
                   {crit.filter((c) => ev.scores[c]).map((c) => (

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -869,6 +869,8 @@ const en = {
     final: 'Final',
     onMentor: 'On mentor',
     averageScore: 'Average score (trend)',
+    delete: 'Delete evaluation',
+    confirmDelete: 'Delete this evaluation? This cannot be undone.',
   },
   goals: {
     title: 'Goals',
@@ -2534,6 +2536,8 @@ const tr: Dict = {
     final: 'Final',
     onMentor: 'Mentor için',
     averageScore: 'Ortalama skor (trend)',
+    delete: 'Değerlendirmeyi sil',
+    confirmDelete: 'Bu değerlendirme silinsin mi? Bu işlem geri alınamaz.',
   },
   goals: {
     title: 'Hedefler',
@@ -4197,6 +4201,8 @@ const de: Dict = {
     final: 'Abschlussbewertung',
     onMentor: 'Über Mentor',
     averageScore: 'Durchschnitt (Trend)',
+    delete: 'Bewertung löschen',
+    confirmDelete: 'Diese Bewertung löschen? Das lässt sich nicht rückgängig machen.',
   },
   goals: {
     title: 'Ziele',

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,21 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.38.0-beta',
+    date: '2026-08-01',
+    highlights: {
+      en: [
+        'An evaluation you added by mistake can now be deleted: click the trash icon on the entry in the evaluation list. You can only remove evaluations you wrote yourself — admins can remove any — so nobody can erase an evaluation written about them.',
+      ],
+      tr: [
+        'Yanlışlıkla eklediğiniz bir değerlendirmeyi artık silebilirsiniz: değerlendirme listesindeki kaydın üzerindeki çöp kutusu simgesine tıklayın. Yalnızca kendi yazdığınız değerlendirmeleri silebilirsiniz (yöneticiler hepsini silebilir), böylece kimse hakkında yazılan bir değerlendirmeyi kaldıramaz.',
+      ],
+      de: [
+        'Eine versehentlich eingetragene Bewertung lässt sich jetzt löschen: einfach auf das Papierkorb-Symbol beim Eintrag in der Bewertungsliste klicken. Löschen können Sie nur Ihre eigenen Bewertungen — Admins alle —, damit niemand eine Bewertung über sich selbst entfernen kann.',
+      ],
+    },
+  },
+  {
     version: '0.37.0-beta',
     date: '2026-08-01',
     highlights: {


### PR DESCRIPTION
## Problem

The evaluation panel only ever appended. A rating clicked by mistake stayed on the record forever — there was no `DELETE` route and no UI affordance.

## What changed

- **`DELETE /api/evaluations/[id]`** — removes one evaluation. Only its **own author** (or an `ADMIN`) may do so: an evaluation is the author's judgement, so the other side of the relation cannot erase one written about them. The removal is written to the activity log as `evaluation.deleted` (actor, target, relation, type, request origin).
- **`GET /api/evaluations`** now returns a `canDelete` flag per row, so the panel offers the button exactly where the DELETE route would allow it.
- **`EvaluationPanel`** — trash icon on each entry it can delete, `window.confirm` first, list reloads after.
- i18n: `evaluation.delete` / `evaluation.confirmDelete` in EN/TR/DE (`check:i18n` green).
- e2e: mentor deletes their own evaluation (200, row gone) and is refused the mentee's (403, row intact).
- Version `0.38.0-beta` + CHANGELOG + release-notes entry.

## Verification

- `npm run lint` and `tsc --noEmit` clean (only pre-existing warnings and the two optional-dep errors in `inboundMailBridge.ts`).
- The new spec is **not** `@smoke`, so the PR gate does not run it — dispatched `e2e.yml` on this branch with `--grep "delete an evaluation they recorded"` to exercise it directly; result reported in a comment below.
- No local MySQL in this environment, so the panel itself was not clicked through in a browser.

## Notes

- Rebased onto `main` after #1014 and #976 landed mid-session; the version bump was redone on top (`0.37.0-beta` → `0.38.0-beta`).
- The first push produced **zero** check-runs on the head commit — the dropped-`pull_request`-event failure already recorded in `docs/agent-experience.md`. The force-push after the rebase re-triggered all five workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)