### PR TITLE
feat(admin): switch the whole app into mentor view, and back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.37.0-beta] - 2026-08-01
+
+### Added
+- **A view switch for admins who also mentor** (`ModeSwitcher`, pinned above the account
+  menu in both the admin and the mentor shell, `ADMIN`-only). An admin was already
+  *allowed* into `/mentor/*` — the mentor layout's role check has always accepted `ADMIN`
+  — but nothing in the UI led there, so the only way in was to follow a link that happened
+  to point at it (a reminder notification, say), and the entire shell would change with no
+  visible cause. Now it is a deliberate, reversible control, and the active segment
+  doubles as the "why does this look different" marker that was missing.
+- The switch **keeps your place**: sections that exist in both shells map 1:1
+  (`/admin/board` ⇄ `/mentor/board`, and the same for projects, meetings, calendar,
+  email, mentee-activity, analytics), `candidates`/`mentorship` map to `mentees` and back,
+  and anything without a counterpart falls back to the target dashboard rather than
+  guessing (`src/lib/appMode.ts`).
+
+### Notes
+- The mode is **derived from the URL**, never stored. A persisted flag is exactly what
+  would let the sidebar, the page and the address bar disagree after an inbound link drops
+  an admin into the other shell — the bug this feature grew out of. No schema change, no
+  session change, no new API surface: an admin in mentor view is just an admin on a
+  `/mentor` route, with the same per-mentor data scoping (`where: { mentorId }`) every
+  mentor page already applies.
+
 ## [0.36.0-beta] - 2026-08-01
 
 ### Added

--- a/e2e/admin-mentor-mode.spec.ts
+++ b/e2e/admin-mentor-mode.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+const switcher = 'mode-switcher';
+
+test('an admin can switch between the admin and mentor views', { tag: '@smoke' }, async ({ page }) => {
+  const adminEmail = uniqueEmail('mode-admin');
+  await seedUser(adminEmail, 'AdminPass123', 'ADMIN', 'Mode Admin');
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', 'AdminPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    const box = page.getByTestId(switcher);
+    await expect(box).toBeVisible();
+
+    // Admin mode: the admin half is the inert state marker, the mentor half a link.
+    await expect(box.getByText('Admin', { exact: true })).toHaveAttribute('aria-current', 'page');
+    await box.getByRole('link', { name: 'Mentor', exact: true }).click();
+
+    await page.waitForURL((u) => u.pathname.startsWith('/mentor'), { timeout: 20_000 });
+    // The whole shell is now the mentor one, and it says so.
+    await expect(page.getByRole('link', { name: 'My Mentees', exact: true })).toBeVisible();
+    await expect(box.getByText('Mentor', { exact: true })).toHaveAttribute('aria-current', 'page');
+    await expect(box.getByText(/only the mentees you mentor yourself/i)).toBeVisible();
+
+    // Switching back returns to the admin shell.
+    await box.getByRole('link', { name: 'Admin', exact: true }).click();
+    await page.waitForURL((u) => u.pathname === '/admin', { timeout: 20_000 });
+    await expect(page.getByRole('link', { name: 'Companies', exact: true })).toBeVisible();
+  } finally {
+    await cleanupByEmail(adminEmail);
+  }
+});
+
+test('the mode switch keeps the current section when both views have one', async ({ page }) => {
+  const adminEmail = uniqueEmail('mode-section-admin');
+  await seedUser(adminEmail, 'AdminPass123', 'ADMIN', 'Section Admin');
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', 'AdminPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    // A shared section maps 1:1 …
+    await page.goto('/admin/board');
+    await page.getByTestId(switcher).getByRole('link', { name: 'Mentor', exact: true }).click();
+    await page.waitForURL((u) => u.pathname === '/mentor/board', { timeout: 20_000 });
+
+    // … an aliased one maps to its equivalent …
+    await page.goto('/admin/candidates');
+    await page.getByTestId(switcher).getByRole('link', { name: 'Mentor', exact: true }).click();
+    await page.waitForURL((u) => u.pathname === '/mentor/mentees', { timeout: 20_000 });
+
+    // … and an admin-only section falls back to the mentor dashboard.
+    await page.goto('/admin/settings');
+    await page.getByTestId(switcher).getByRole('link', { name: 'Mentor', exact: true }).click();
+    await page.waitForURL((u) => u.pathname === '/mentor', { timeout: 20_000 });
+  } finally {
+    await cleanupByEmail(adminEmail);
+  }
+});
+
+test('a plain mentor never sees the mode switch', async ({ page }) => {
+  const mentorEmail = uniqueEmail('mode-mentor');
+  await seedUser(mentorEmail, 'MentorPass123', 'MENTOR', 'Mode Mentor');
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', mentorEmail);
+    await page.fill('input[type="password"]', 'MentorPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/mentor'), { timeout: 20_000 });
+
+    await expect(page.getByTestId(switcher)).toHaveCount(0);
+  } finally {
+    await cleanupByEmail(mentorEmail);
+  }
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.36.0-beta",
+  "version": "0.37.0-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -8,6 +8,7 @@ import { APP_VERSION } from '@/lib/version';
 import { ResponsiveShell } from '@/components/ResponsiveShell';
 import { BrandWordmark } from '@/components/BrandWordmark';
 import { AdminNav } from '@/components/AdminNav';
+import { ModeSwitcher } from '@/components/ModeSwitcher';
 import { GlobalSearch } from '@/components/GlobalSearch';
 import { prisma } from '@/lib/prisma';
 import { is2faRequiredFor } from '@/lib/twoFactorPolicy';
@@ -51,6 +52,8 @@ export default async function AdminLayout({ children }: { children: React.ReactN
         </div>
 
         <AdminNav />
+
+        <ModeSwitcher />
 
         <AccountMenu
           name={session.user.name}

--- a/src/app/mentor/layout.tsx
+++ b/src/app/mentor/layout.tsx
@@ -15,6 +15,7 @@ import { prisma } from '@/lib/prisma';
 import { is2faRequiredFor } from '@/lib/twoFactorPolicy';
 import { PipelineStagesProvider } from '@/lib/pipelineStagesClient';
 import { resolveCustomStages } from '@/lib/pipelineStages';
+import { ModeSwitcher } from '@/components/ModeSwitcher';
 
 export default async function MentorLayout({ children }: { children: React.ReactNode }) {
   const session = await getServerSession(authOptions);
@@ -131,6 +132,10 @@ export default async function MentorLayout({ children }: { children: React.React
           </Link>
           <InstallAppButton />
         </nav>
+
+        {/* Admins reach this shell to work their own mentees; the switch is both
+            their way back and the marker that says why the layout looks different. */}
+        {session.user.role === 'ADMIN' && <ModeSwitcher />}
 
         <AccountMenu
           name={session.user.name}

--- a/src/components/ModeSwitcher.tsx
+++ b/src/components/ModeSwitcher.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { ShieldCheck, GraduationCap } from 'lucide-react';
+import { useT } from '@/i18n/client';
+import { counterpartPath, modeOf, type AppMode } from '@/lib/appMode';
+
+// Admin-only view switch, pinned above the account menu in both shells: it lets
+// an admin who also mentors see the app the way their mentors do (own mentees
+// only, no org-wide tooling) instead of always working from the dense admin
+// pages. The active segment doubles as a "where am I" marker — the mentor shell
+// used to be reachable only by following a link (e.g. a notification), which
+// made the whole layout appear to change for no visible reason.
+const MODES: { mode: AppMode; icon: typeof ShieldCheck; active: string }[] = [
+  { mode: 'admin', icon: ShieldCheck, active: 'text-blue-700 dark:text-blue-300' },
+  { mode: 'mentor', icon: GraduationCap, active: 'text-green-700 dark:text-green-300' },
+];
+
+export function ModeSwitcher() {
+  const t = useT();
+  const pathname = usePathname();
+  const current = modeOf(pathname) ?? 'admin';
+
+  return (
+    <div className="px-4 pt-2" data-testid="mode-switcher">
+      <p id="mode-switch-label" className="px-1 pb-1.5 text-[11px] font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">
+        {t.modeSwitch.label}
+      </p>
+      <div
+        role="group"
+        aria-labelledby="mode-switch-label"
+        className="grid grid-cols-2 gap-1 rounded-lg bg-gray-100 dark:bg-gray-800 p-1"
+      >
+        {MODES.map(({ mode, icon: Icon, active }) => {
+          const isActive = current === mode;
+          const label = t.modeSwitch[mode];
+          const classes = `flex items-center justify-center gap-1.5 rounded-md px-2 py-1.5 text-xs font-medium transition-colors ${
+            isActive
+              ? `bg-white dark:bg-gray-700 shadow-sm ${active}`
+              : 'text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100'
+          }`;
+
+          // The active half is inert on purpose: it is a state indicator, and a
+          // link back to the page you are already on is a dead control.
+          return isActive ? (
+            <span key={mode} aria-current="page" className={classes}>
+              <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden />
+              {label}
+            </span>
+          ) : (
+            <Link
+              key={mode}
+              href={counterpartPath(pathname, mode)}
+              title={t.modeSwitch.switchTo.replace('{mode}', label)}
+              className={classes}
+            >
+              <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden />
+              {label}
+            </Link>
+          );
+        })}
+      </div>
+      {current === 'mentor' && (
+        <p className="px-1 pt-1.5 text-[11px] leading-snug text-gray-400 dark:text-gray-500">
+          {t.modeSwitch.mentorHint}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -614,6 +614,13 @@ const en = {
     return: 'Return to your account',
     stopFailed: 'Could not return to your account. Please try again.',
   },
+  modeSwitch: {
+    label: 'View as',
+    admin: 'Admin',
+    mentor: 'Mentor',
+    switchTo: 'Switch to the {mode} view',
+    mentorHint: 'Mentor view: only the mentees you mentor yourself.',
+  },
   board: {
     moveTo: 'Move to stage',
     stageFilter: 'Stage',
@@ -2272,6 +2279,13 @@ const tr: Dict = {
     return: 'Kendi hesabına dön',
     stopFailed: 'Kendi hesabına dönülemedi. Lütfen tekrar deneyin.',
   },
+  modeSwitch: {
+    label: 'Görünüm',
+    admin: 'Yönetici',
+    mentor: 'Mentor',
+    switchTo: '{mode} görünümüne geç',
+    mentorHint: 'Mentor görünümü: yalnızca kendi mentorluk yaptığın mentee’ler.',
+  },
   board: {
     moveTo: 'Aşamaya taşı',
     stageFilter: 'Aşama',
@@ -3927,6 +3941,13 @@ const de: Dict = {
     viewingAs: 'Du siehst die App als {name}.',
     return: 'Zu deinem Konto zurückkehren',
     stopFailed: 'Rückkehr zu deinem Konto fehlgeschlagen. Bitte versuche es erneut.',
+  },
+  modeSwitch: {
+    label: 'Ansicht',
+    admin: 'Admin',
+    mentor: 'Mentor',
+    switchTo: 'Zur {mode}-Ansicht wechseln',
+    mentorHint: 'Mentoren-Ansicht: nur die Mentees, die du selbst betreust.',
   },
   board: {
     moveTo: 'In Phase verschieben',

--- a/src/lib/appMode.ts
+++ b/src/lib/appMode.ts
@@ -1,0 +1,57 @@
+// Admin ↔ mentor "view mode" for admins who also mentor.
+//
+// An ADMIN is allowed into /mentor/* (see the mentor layout's role check), so
+// switching modes is pure navigation — the mode is *derived from the URL*, never
+// stored. That keeps the sidebar, the page and the address bar from disagreeing:
+// there is no persisted flag that can go stale when a link (a notification, a
+// bookmark) drops the admin straight into the other mode.
+
+export type AppMode = 'admin' | 'mentor';
+
+/** Sections that exist under both /admin and /mentor with the same slug. */
+const SHARED_SECTIONS = [
+  'board',
+  'projects',
+  'meetings',
+  'calendar',
+  'email',
+  'mentee-activity',
+  'analytics',
+] as const;
+
+/**
+ * Sections whose counterpart lives under a different slug. Only the pairs where
+ * the two pages really answer the same question are mapped; anything else falls
+ * back to the mode's dashboard rather than guessing.
+ */
+const ALIASES: Record<AppMode, Record<string, string>> = {
+  // Viewing candidates/mentorships as an admin → the mentees you personally mentor.
+  admin: { candidates: 'mentees', mentorship: 'mentees' },
+  // Your own mentees → the full candidate list.
+  mentor: { mentees: 'candidates' },
+};
+
+/** The mode a pathname belongs to, or null for pages outside both shells. */
+export function modeOf(pathname: string): AppMode | null {
+  if (pathname === '/admin' || pathname.startsWith('/admin/')) return 'admin';
+  if (pathname === '/mentor' || pathname.startsWith('/mentor/')) return 'mentor';
+  return null;
+}
+
+/**
+ * Where the mode switch should land, keeping the user's context when the current
+ * section has a counterpart (admin board → mentor board) and falling back to the
+ * target dashboard when it doesn't (mentor availability → admin home).
+ */
+export function counterpartPath(pathname: string, target: AppMode): string {
+  const from = modeOf(pathname);
+  if (!from || from === target) return `/${target}`;
+
+  const section = pathname.split('/').filter(Boolean)[1];
+  if (!section) return `/${target}`;
+
+  if ((SHARED_SECTIONS as readonly string[]).includes(section)) return `/${target}/${section}`;
+
+  const alias = ALIASES[from][section];
+  return alias ? `/${target}/${alias}` : `/${target}`;
+}

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,24 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.37.0-beta',
+    date: '2026-08-01',
+    highlights: {
+      en: [
+        'Admins who also mentor can now switch the whole app into the mentor view and back, from a new "View as" control at the bottom of the sidebar. Mentor view shows only the mentees you mentor yourself, without the org-wide admin pages — handy for actually working with your own mentees instead of reading the dense admin screens.',
+        'The switch keeps your place: from the admin board you land on the mentor board, from the candidate list on your own mentees, and so on. Pages that exist only for admins take you to the mentor dashboard instead.',
+      ],
+      tr: [
+        'Aynı zamanda mentorluk yapan yöneticiler artık uygulamayı tümüyle mentor görünümüne alıp geri dönebilir; kenar çubuğunun altındaki yeni "Görünüm" düğmesiyle. Mentor görünümü, kurum genelindeki yönetim sayfaları olmadan yalnızca kendi mentorluk yaptığınız mentee’leri gösterir — yoğun yönetim ekranlarıyla uğraşmak yerine kendi mentee’lerinizle çalışmak için pratik bir yol.',
+        'Düğme bulunduğunuz yeri korur: yönetici panosundan mentor panosuna, aday listesinden kendi mentee’lerinize geçersiniz. Yalnızca yöneticilere özel sayfalarda ise mentor paneline yönlendirilirsiniz.',
+      ],
+      de: [
+        'Admins, die selbst mentorieren, können die App jetzt komplett in die Mentoren-Ansicht umschalten und zurück — über das neue Feld „Ansicht“ unten in der Seitenleiste. Die Mentoren-Ansicht zeigt nur die Mentees, die Sie selbst betreuen, ohne die organisationsweiten Admin-Seiten.',
+        'Der Umschalter behält Ihren Kontext: vom Admin-Board landen Sie auf dem Mentoren-Board, von der Kandidatenliste bei Ihren eigenen Mentees. Seiten, die es nur für Admins gibt, führen stattdessen zum Mentoren-Dashboard.',
+      ],
+    },
+  },
+  {
     version: '0.36.0-beta',
     date: '2026-08-01',
     highlights: {


### PR DESCRIPTION
## What & why

Reported from the app: clicking a "No recent contact with …" notification as an admin flipped the whole shell — menu and all — into the mentor layout, with no explanation. That is not a bug: the mentor layout's role check has always accepted `ADMIN`, so `/mentor/*` was already reachable. What was missing is that **nothing in the UI led there, and nothing said you were there.**

And the maintainer wants that view: as an admin who also mentors, the org-wide admin pages are too dense for working your own mentees day to day. So this turns the accident into a deliberate, reversible control.

## The change

- **`ModeSwitcher`** — an `ADMIN`-only segmented `Admin | Mentor` control pinned above the account menu in *both* shells. The active half is an inert state marker (`aria-current="page"`), not a link back to the page you are already on; it is the "why does this look different" signal that was missing. Admin half is blue, mentor half green, matching the accent each shell already uses for its avatar.
- **`appMode.counterpartPath`** keeps your place across the switch:
  - 1:1 for sections in both shells — `board`, `projects`, `meetings`, `calendar`, `email`, `mentee-activity`, `analytics`
  - `candidates` / `mentorship` ⇄ `mentees`
  - no counterpart (`settings`, `availability`, `interactions`, …) → the target dashboard, rather than guessing
- Mentor view carries a one-line hint — *"only the mentees you mentor yourself"* — so the narrowed data is understood as scope, not as missing records.
- i18n: new `modeSwitch` block, EN/TR/DE (`check:i18n` green).

## Design note

**The mode is derived from the URL, never stored.** A persisted flag is precisely what would let the sidebar, the page and the address bar disagree the next time an inbound link drops an admin into the other shell — the situation this grew out of. No schema, session or API change: an admin in mentor view is just an admin on a `/mentor` route, under the same `where: { mentorId }` scoping every mentor page already applies. Nothing new is exposed.

Impersonation stays separate and does not overlap: an impersonated session carries the *target's* role (`token.role`, `src/lib/auth.ts`), so an admin impersonating a mentor gets the purple `ImpersonationBanner` as their way back and no mode switch.

## Verification

- `npx tsc --noEmit` clean; `npm run build` compiles; `npm run check:i18n` green — all re-run after the rebase.
- `counterpartPath` / `modeOf` exercised over 20 cases (shared sections, aliases, fallbacks, deep paths, same-mode, non-shell paths) — all pass.
- Visual check in light **and** dark against the project's real Tailwind build: active pill legible in both, no dark-on-dark on the tinted track (the `globals.css` retint hazard called out in CLAUDE.md).
- New `e2e/admin-mentor-mode.spec.ts`: round-trip admin → mentor → admin (`@smoke`), section-context mapping incl. the fallback, and a plain mentor never seeing the switch. Since the PR gate only runs `@smoke`, the two non-smoke specs were dispatched separately via `e2e.yml` with `grep='mode switch|admin and mentor views'` → [run 30698769078](https://github.com/21072026/Internship/actions/runs/30698769078).

No local MySQL or Docker on this machine, so CI is the first execution of the specs.

## Rebase note

Opened against an older `main`; rebased onto `4224009`. `main` had meanwhile shipped **0.36.0-beta** (global search for mentors, #976 — also touched `src/app/mentor/layout.tsx`, auto-merged cleanly and both now render). This PR is therefore renumbered **0.37.0-beta**, and the 0.36.0 changelog/release-note entries are preserved below the new ones.

## Not included

No `src/lib/features.ts` entry: the catalogue is public marketing copy for broad product capabilities, and an internal sidebar view toggle would dilute it. Happy to add one if you'd rather it be listed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)