### PR TITLE
docs: 2026-08-01 oturumunun dersleri (kesilen pull_request, releaseNotes çakışması, grep'li e2e dispatch)

### DIFF
--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -1831,3 +1831,41 @@ ilgili değil; `npm run build` ve CI'ya güven.
 `announcements/route.ts`, `src/lib/activity.ts`) ~18 hayalet TS hatası. `npm install &&
 npx prisma generate` temizliyor. CLAUDE.md bunu söylüyor ama *belirti* şekli — "hiç
 açmadığım dosyalar kırmızı" — teşhisi tek bakışta veriyor.
+
+---
+
+## 2026-08-01 — Değerlendirme silme (#1013, 0.38.0-beta)
+
+**Kesilen `pull_request` olayı bu kez ilk push'ta oldu — ve rebase force-push'u
+tetikledi.** PR açıldı, `gh pr checks` "no checks reported" dedi,
+`gh api repos/O/R/commits/<sha>/check-runs` → `total_count: 0`. 20 dakika bekledim,
+hiçbir şey gelmedi. Sonra main'e rebase edip `git push --force-with-lease` yapınca beş
+workflow da 8 saniye içinde koştu. Yani #992'de işe yaramayan boş commit'in aksine
+**gerçek bir yeni head SHA** (rebase) olayı geri getiriyor. Önceki oturumun önerdiği
+`gh workflow run` yolunu denemeye gerek kalmadı. Pratik sıra: PR açtıktan ~1 dk sonra
+`check-runs` sayısına bak; 0 ise beklemeden dalı main'e rebase edip force-push et —
+sürüm çakışmasını da aynı anda çözüyorsun.
+
+**`releaseNotes.ts` çakışmasında "benimkini al" karşı tarafın notunu siler.** Sürüm
+çakışması bu oturumda üçüncü kez yaşandı (main 0.35.3 → 0.37.0 ilerlemişti) ama asıl
+tuzak çözümdeydi: `RELEASE_NOTES` dizisinde çakışma **en üstteki girdinin *içine*** düşüyor
+— `<<<<<<<` HEAD'in sürüm numarası + `=======` senin metnin şeklinde. Blok olarak
+"benimkini al" dersen karşı tarafın sürüm numarası kalır, **kullanıcıya görünen notu
+kaybolur**. Doğrusu: HEAD tarafını olduğu gibi bırak, kendi girdini dizinin başına *yeni*
+bir eleman olarak ekle. Aynı hata `CHANGELOG.md`'de daha görünür (başlık kaybolur), ama
+release notes'ta sessiz. Çözdükten sonra `grep -n "version: '0\." src/lib/releaseNotes.ts`
+ile sürümlerin azalan sırada ve tekrarsız olduğunu doğrula.
+
+**`@smoke` olmayan yeni bir spec'i doğrulamanın ucuz yolu `e2e-full` değil.**
+`e2e.yml` workflow_dispatch bir `grep` girdisi alıyor:
+`gh workflow run e2e.yml --ref <dal> -f grep="testin başlığından bir parça"`. Tek test,
+~1 dakika, 4-shard suite'i ve zorunlu özet e-postasını hiç uyandırmadan. Sonucu körlemesine
+"success" diye okuma — `gh run view <id> --log | grep -E "Running [0-9]+ test|passed"` ile
+testin **gerçekten koştuğunu** teyit et (`Running 1 test` + `1 passed`), yoksa hiçbir şeyle
+eşleşmeyen bir grep de yeşil görünebilir.
+
+**Yetki matrisi olan bir endpoint'te e2e, tarayıcı doğrulamasının yerine geçebiliyor.**
+Bu makinede yerel MySQL yok, yani paneli tıklayarak deneyemedim. Bunun yerine spec iki
+yönü de ölçtü: mentee'nin değerlendirmesine `403` + satır duruyor, mentorun kendi
+kaydına `200` + satır gitti. Görsel doğrulama yapılamayan ortamda **kuralı** test etmek,
+"derlendi" demekten çok daha fazlasını veriyor — PR'a da bu logu yapıştır.


### PR DESCRIPTION
End-of-session retrospective for #1013 (evaluation delete, 0.38.0-beta). Four reusable lessons:

- **The dropped `pull_request` event hit on the very first push this time** — zero check-runs on the head commit. A rebase + `--force-with-lease` re-triggered all five workflows within seconds, unlike the empty commit that failed in #992. Practical order: check `check-runs` count a minute after opening, and if it's 0, rebase onto `main` immediately (which also settles the version collision).
- **Resolving a `releaseNotes.ts` conflict by "taking mine" silently deletes the other session's user-facing note** — the conflict lands *inside* the top array element, so the other version number survives while its highlights don't. Keep HEAD intact and prepend your own entry as a new element.
- **`e2e.yml` workflow_dispatch takes a `grep` input** — the cheap way to verify a non-`@smoke` spec (one test, ~1 min) instead of the 4-shard `e2e-full`. Confirm from the log that the test actually ran; a grep matching nothing can still look green.
- **Where no browser verification is possible (no local MySQL), an e2e spec over the authorization matrix is the substitute** that beats "it compiles".

Docs only — no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)