### PR TITLE
fix(e2e): repair the two specs the scheduled full run broke on

### DIFF
--- a/e2e/date-formatter-locale.spec.ts
+++ b/e2e/date-formatter-locale.spec.ts
@@ -24,7 +24,9 @@ test('dates on admin/activity follow the selected app language, not the browser 
     await page.goto('/admin/activity');
 
     // TR formatting uses dots (gg.aa.yyyy), never the en-US slash format.
-    const firstDate = page.locator('span.text-gray-400').first();
+    // Target the test id, not `span.text-gray-400` — the row also carries an
+    // IP chip in that colour (#881), and it comes first in the DOM.
+    const firstDate = page.getByTestId('activity-date').first();
     await expect(firstDate).toBeVisible();
     await expect(firstDate).toHaveText(/\d{2}\.\d{2}\.\d{4}/);
     await expect(firstDate).not.toHaveText(/\d{1,2}\/\d{1,2}\/\d{4}/);

--- a/e2e/inbound-email.spec.ts
+++ b/e2e/inbound-email.spec.ts
@@ -1,6 +1,13 @@
 import { test, expect } from '@playwright/test';
 import { createHmac } from 'crypto';
 import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { E2E_INBOUND_SECRET } from '../playwright.config';
+
+// The webhook's shared secret is mandatory outside development (#870), and CI
+// serves a production build — so every call here carries it. That is also the
+// production shape: the token gate below is the *second* factor, not the only
+// one.
+const authed = { 'x-inbound-secret': E2E_INBOUND_SECRET };
 
 test.afterAll(async () => {
   await prisma.$disconnect();
@@ -27,6 +34,7 @@ test('inbound email reply is routed to the thread (token + sender verified)', as
   try {
     // Valid: correct token + participant sender → message created, quoted text stripped.
     const ok = await request.post('/api/inbound-email', {
+      headers: authed,
       data: { to: `reply+${token}@crm.ersah.in`, from: `Inb Mentee <${menteeEmail}>`, text: 'Thanks, see you then!\n\nOn Mon someone wrote:\n> earlier message' },
     });
     expect(ok.status()).toBe(200);
@@ -35,8 +43,15 @@ test('inbound email reply is routed to the thread (token + sender verified)', as
     expect(msg?.body).toBe('Thanks, see you then!');
     await expect.poll(async () => prisma.notification.count({ where: { userId: mentor.id, type: 'message' } })).toBeGreaterThan(0);
 
+    // No shared secret → refused before the token is even looked at (#870).
+    const anon = await request.post('/api/inbound-email', {
+      data: { to: `reply+${token}@crm.ersah.in`, from: menteeEmail, text: 'no secret' },
+    });
+    expect(anon.status()).toBe(401);
+
     // Tampered token → rejected.
     const bad = await request.post('/api/inbound-email', {
+      headers: authed,
       data: { to: `reply+${rel.id}.deadbeefdeadbeefdeadbeefdeadbeef@crm.ersah.in`, from: menteeEmail, text: 'hack' },
     });
     expect(bad.status()).toBe(400);
@@ -44,6 +59,7 @@ test('inbound email reply is routed to the thread (token + sender verified)', as
     // Legacy token (no recipient) + sender is not a participant → rejected,
     // because nothing else identifies the writer.
     const stranger = await request.post('/api/inbound-email', {
+      headers: authed,
       data: { to: `reply+${token}@crm.ersah.in`, from: 'stranger@evil.com', text: 'spoof' },
     });
     expect(stranger.status()).toBe(403);
@@ -56,6 +72,7 @@ test('inbound email reply is routed to the thread (token + sender verified)', as
     const messageId = `<replay-${rel.id}@mail.example>`;
     for (const attempt of [1, 2]) {
       const res = await request.post('/api/inbound-email', {
+        headers: authed,
         data: { to: `reply+${token}@crm.ersah.in`, from: menteeEmail, text: 'Sent twice by the mail server', messageId },
       });
       expect(res.status()).toBe(200);
@@ -68,6 +85,7 @@ test('inbound email reply is routed to the thread (token + sender verified)', as
     // Quote attribution lines other than "On … wrote:" are trimmed too — this
     // exact shape arrived from a real client and used to leak into the thread.
     const quoted = await request.post('/api/inbound-email', {
+      headers: authed,
       data: {
         to: `reply+${token}@crm.ersah.in`,
         from: menteeEmail,
@@ -86,6 +104,7 @@ test('inbound email reply is routed to the thread (token + sender verified)', as
     const scoped = makeScopedToken(rel.id, mentee.id);
     const forwardedId = `<forwarded-${rel.id}@mail.example>`;
     const forwarded = await request.post('/api/inbound-email', {
+      headers: authed,
       data: {
         to: `reply+${scoped}@crm.ersah.in`,
         from: 'personal-address-not-on-file@gmail.com',
@@ -103,6 +122,7 @@ test('inbound email reply is routed to the thread (token + sender verified)', as
     const outsider = await seedUser(uniqueEmail('inb-outsider'), 'x', 'MENTEE', 'Inb Outsider');
     try {
       const spoof = await request.post('/api/inbound-email', {
+        headers: authed,
         data: {
           to: `reply+${makeScopedToken(rel.id, outsider.id)}@crm.ersah.in`,
           from: 'stranger@evil.com',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "internship-crm",
-  "version": "0.36.0-beta",
+  "version": "0.38.0-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "internship-crm",
-      "version": "0.36.0-beta",
+      "version": "0.38.0-beta",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {
@@ -4044,6 +4044,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6117,6 +6118,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,6 +14,12 @@ const PORT = 3000;
 const localURL = `http://localhost:${PORT}`;
 // Shared with e2e/health.spec.ts, which asserts both sides of the token gate.
 export const E2E_HEALTH_TOKEN = 'e2e-health-token';
+// Shared with e2e/inbound-email.spec.ts. CI serves a production build, and
+// since #870 the inbound webhook's fail-open is dev-only — so without this the
+// endpoint answers 401 to everything. Setting it also makes the spec exercise
+// the shape production actually runs (secret required AND supplied) instead of
+// the lenient path.
+export const E2E_INBOUND_SECRET = 'e2e-inbound-secret';
 
 export default defineConfig({
   testDir: './e2e',
@@ -52,6 +58,7 @@ export default defineConfig({
           // keeps its legacy fully-public response and health.spec.ts's
           // assertions about what an anonymous caller may see would be vacuous.
           HEALTH_TOKEN: E2E_HEALTH_TOKEN,
+          INBOUND_SECRET: E2E_INBOUND_SECRET,
         },
       },
 });

--- a/src/app/admin/activity/page.tsx
+++ b/src/app/admin/activity/page.tsx
@@ -98,7 +98,7 @@ export default function AdminActivityPage() {
                     {e.ip}
                   </span>
                 )}
-                <span className="text-xs text-gray-400 flex-shrink-0">{formatDateTime(e.createdAt, locale)}</span>
+                <span data-testid="activity-date" className="text-xs text-gray-400 flex-shrink-0">{formatDateTime(e.createdAt, locale)}</span>
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Why

Scheduled full run [30696957141](https://github.com/21072026/Internship/actions/runs/30696957141) went red on two specs. Both were `failed,failed` — no retry rescued either — so both are real breakage, not flakes. Both came from changes merged *after* the last green full run.

## 1. `inbound-email.spec.ts` — 401 instead of 200

#870 (cea7a06) removed the inbound webhook's fail-open outside development:

```ts
if (!expected) return process.env.NODE_ENV !== 'production';
```

CI serves a production build (`npm run start`), so `NODE_ENV=production`, `INBOUND_SECRET` is unset, and `/api/inbound-email` answered **401 to every call** in the suite. The endpoint is behaving exactly as intended — the test environment was relying on the fail-open that #870 deliberately closed.

Fix: give the Playwright web server an `INBOUND_SECRET` (alongside the existing `HEALTH_TOKEN`, same pattern) and send it from the spec. This is the better test anyway — it now exercises the shape production actually runs: shared secret **required and supplied**, with the HMAC reply token as the second factor rather than the only one. Added a case pinning the gate itself (no header → 401), which nothing covered before.

`cron-start.spec.ts` still passes: with the secret configured, `/api/inbound-email/poll` returns 401 for both a missing and a wrong header, and that spec accepts `[401, 503]`.

## 2. `date-formatter-locale.spec.ts` — got `"unknown"`, expected a date

#881 added an IP chip to each `/admin/activity` row:

```tsx
{e.ip && <span className="hidden sm:inline font-mono text-xs text-gray-400 …" title={e.userAgent}>{e.ip}</span>}
<span className="text-xs text-gray-400 …">{formatDateTime(e.createdAt, locale)}</span>
```

The spec's `span.text-gray-400.first()` now resolves to the IP chip, which comes first in the DOM. It read `"unknown"` — `clientIp()` returns that sentinel when there is no proxy header, and the e2e server deliberately runs with `TRUSTED_PROXY_COUNT=0`.

Fix: `data-testid="activity-date"` on the date span, and the spec targets it. This is the exact pitfall CLAUDE.md documents under "E2E locator pitfalls".

## Verification

`E2E Tests` dispatched on this branch with `grep` covering both specs (linked in a comment below), plus `tsc --noEmit` and `check:i18n` clean.

## Not in this PR

- **The 6 flakies** (`announcements`, `comms`, `mentee-detail-feedback`, `mentee-setpw`, `profile-activity`, `two-factor`) — all `failed,passed`, all the same sign-in/navigation race. Worth a dedicated fix in the shared sign-in helper; not bundled with a red-run repair.
- **No version bump.** The only `src/` change is a `data-testid` attribute; everything else is test and CI config. Per the CHANGELOG rule, non-user-visible changes don't get a bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)