### PR TITLE
test(e2e): put the six flaky specs on the shared sign-in helpers

### DIFF
--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -1913,3 +1913,19 @@ dışa aç, `signInAsFreshUser` onu çağırsın — guard'lar tek yerde kalır.
 **Süreç notu:** iki iş (kırmızı onarımı + flaky onarımı) ayrı PR'lara ayrıldı. Aynı dala
 yığmak, kırmızı düzeltmesinin merge'ünü flaky işinin CI'sine bağlardı; `git stash` + yeni
 dal (`git checkout -B <yeni> origin/main` + `stash pop`) bunu 10 saniyede ayırıyor.
+
+**Ek ders (aynı oturum, ilk denemem kırdı):** flaky'leri helper'a taşırken
+`submitSignInForm`'u "about:blank → sadece session cookie'sini sil → /auth/signin" olarak
+yazmak `two-factor.spec.ts`'i **deterministik olarak** bozdu (failed,failed) — parola alanı
+hiç gelmedi. Sebep: `/auth/signin` girişi tamamlarken `/api/auth/session`'ı yoklayıp
+`window.location.assign(roleHome)` yapıyor. `waitForURL()` dönüyor ama **terk edilen sayfa
+hâlâ session okuyor**; `clearCookies()`'ten sonra düşen bir yanıt cookie'yi geri yazıyor,
+sıradaki `/auth/signin` `authenticated` görüp dashboard'a `router.replace()` ediyor.
+Ekranda bunu söyleyen hiçbir şey yok — belirti sadece "parola alanı 15 sn'de gelmedi".
+Çözüm: cookie'yi düşürmeden **önce** çıkan sayfanın susmasını bekle (`networkidle`), form
+yine yoksa cookie'yi bir kez daha düşürüp yeniden yükle.
+
+İki genel kural: (1) blanket `clearCookies()`'i seçmeli silmeyle değiştirirken, o blanket
+silmenin **yan etkisiyle** neyi maskelediğini varsayma — doğrula; (2) grep'li dispatch
+koşusu bittikten sonra logu **oku**, "yaklaşım doğru" diye peşinen yeşil ilan etme. Bu
+oturumda 8 testten 7'si geçmişti; kalan 1'i sadece log gösterdi.

--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -1869,3 +1869,47 @@ Bu makinede yerel MySQL yok, yani paneli tıklayarak deneyemedim. Bunun yerine s
 yönü de ölçtü: mentee'nin değerlendirmesine `403` + satır duruyor, mentorun kendi
 kaydına `200` + satır gitti. Görsel doğrulama yapılamayan ortamda **kuralı** test etmek,
 "derlendi" demekten çok daha fazlasını veriyor — PR'a da bu logu yapıştır.
+
+## 2026-08-01 — Zamanlanmış koşuda 2 kırmızı + 6 flaky: üçü de farklı sınıf
+
+Tek bir e2e raporundaki üç grup, üç ayrı iş çıkardı. Ayırt etme sırası şu:
+
+**1. `failed,failed` mi `failed,passed` mi?** Shard JSON'larını indirip retry desenine bak
+(yöntem bir önceki girdide). Bu koşuda 2 test retry'da da düştü → gerçek kırılma;
+6 test retry'da geçti → yarış koşulu. İkisine bakış açısı tamamen farklı: birincide
+"hangi commit bunu bozdu", ikincide "hangi bekleme eksik".
+
+**2. Kırmızıların ikisi de "test ortamı bir fail-open'a yaslanmış" sınıfındaydı.**
+`inbound-email` 401 veriyordu çünkü #870 webhook'un dev-dışı fail-open'ını kapattı ve CI
+production build (`next start`) servis ediyor — `NODE_ENV=production` + `INBOUND_SECRET`
+yok = 401. Endpoint doğru davranıyordu; **test ortamı, kapatılmış olan gevşek yola
+bağlıydı**. Doğru düzeltme testi gevşetmek değil, `playwright.config.ts`'in `webServer.env`
+bloğuna sırrı eklemek (`HEALTH_TOKEN` ile aynı desen) ve spec'ten göndermek — böylece test
+production'ın gerçek şeklini koşuyor. Bir güvenlik PR'ı bir fail-open'ı kapattığında,
+**o fail-open'a yaslanan e2e'ler o PR'da güncellenmeli**; yoksa fatura zamanlanmış koşuya
+kesiliyor.
+
+**3. Diğer kırmızı, CLAUDE.md'de zaten yazan locator tuzağının aynısı.** #881
+`/admin/activity` satırına bir IP çipi ekledi — o da `text-gray-400` ve DOM'da tarihten
+önce. `span.text-gray-400.first()` artık IP'yi yakalıyor ("unknown", çünkü e2e sunucusu
+bilerek `TRUSTED_PROXY_COUNT=0` ile koşuyor). Sınıf tabanlı locator, o sınıfı kullanan
+**yeni bir kardeş eklendiği gün** kırılır. `data-testid` ekle.
+
+**4. Altı flaky'nin hepsi, repoda zaten var olan yardımcıları kullanmıyordu.**
+`e2e/helpers/auth.ts` bu iki şekli önlemek için yazılmış ve doc comment'lerinde tam olarak
+bu hataları anlatıyor; spec'ler sadece geçmemişti. Yeni bir flake görünce **önce helper'ın
+var olup olmadığına bak** — muhtemelen problem çözülmüş, sadece uygulanmamış.
+İkinci şeklin sebebi blanket `clearCookies()`: `storageState`'ten gelen consent cookie'sini
+de siliyor *ve* terk edilen sayfanın uçuştaki `/api/auth/session` çağrısı session
+cookie'sini geri yazıyor, böylece `/auth/signin` test hâlâ yazarken eski dashboard'a
+`router.replace()` ediyor. `two-factor`'da submit, önceki sayfanın **disabled "Add note"**
+düğmesine çözünüp 15 sn boyunca onu denedi. Belirtisi hep aynı: hata mesajında
+"locator resolved to <...>" ile gelen element, o an bulunduğunu sandığın sayfaya ait değil.
+
+**Yardımcıyı bölerken:** 2FA açık hesap submit'ten sonra `/auth/signin`'de kalmalı, yani
+`signInAsFreshUser`'ın landing beklemesi orada yanlış. Gövdesini `submitSignInForm` olarak
+dışa aç, `signInAsFreshUser` onu çağırsın — guard'lar tek yerde kalır.
+
+**Süreç notu:** iki iş (kırmızı onarımı + flaky onarımı) ayrı PR'lara ayrıldı. Aynı dala
+yığmak, kırmızı düzeltmesinin merge'ünü flaky işinin CI'sine bağlardı; `git stash` + yeni
+dal (`git checkout -B <yeni> origin/main` + `stash pop`) bunu 10 saniyede ayırıyor.

--- a/e2e/announcements.spec.ts
+++ b/e2e/announcements.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { signInAndSettle, gotoSettled } from './helpers/auth';
 
 test.afterAll(async () => {
   await prisma.$disconnect();
@@ -11,13 +12,9 @@ test('sending an announcement persists it and shows up in the history list', asy
   const uniqueText = `E2E announcement ${Date.now().toString(36)}`;
 
   try {
-    await page.goto('/auth/signin');
-    await page.fill('input[type="email"], input[name="email"]', adminEmail);
-    await page.fill('input[type="password"]', 'AdminPass123');
-    await page.click('button[type="submit"]');
-    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+    await signInAndSettle(page, adminEmail, 'AdminPass123', '/admin');
 
-    await page.goto('/admin/announcements');
+    await gotoSettled(page, '/admin/announcements');
     await page.fill('textarea', uniqueText);
 
     const postDone = page.waitForResponse(

--- a/e2e/comms.spec.ts
+++ b/e2e/comms.spec.ts
@@ -1,20 +1,13 @@
 import { test, expect } from '@playwright/test';
 import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+// This spec hops between three sessions, so every sign-in is a user switch —
+// see signInAsFreshUser for why a blanket clearCookies() is not enough (it also
+// drops the seeded consent cookie, putting the banner back over the form).
+import { signInAsFreshUser } from './helpers/auth';
 
 test.afterAll(async () => {
   await prisma.$disconnect();
 });
-
-async function signIn(page: import('@playwright/test').Page, email: string, password: string, home: string) {
-  // Drop any existing session so the sign-in form is shown (an authenticated
-  // visit to /auth/signin would just redirect to the role home).
-  await page.context().clearCookies();
-  await page.goto('/auth/signin');
-  await page.fill('input[type="email"], input[name="email"]', email);
-  await page.fill('input[type="password"]', password);
-  await page.click('button[type="submit"]');
-  await page.waitForURL((u) => u.pathname.startsWith(home), { timeout: 20_000 });
-}
 
 test('messages track read/unread and the sender sees a read receipt', async ({ page }) => {
   const mentorEmail = uniqueEmail('cm-mentor');
@@ -25,12 +18,12 @@ test('messages track read/unread and the sender sees a read receipt', async ({ p
 
   try {
     // Mentor posts a message.
-    await signIn(page, mentorEmail, 'MentorPass123', '/mentor');
+    await signInAsFreshUser(page, mentorEmail, 'MentorPass123', '/mentor');
     const posted = await page.request.post('/api/messages', { data: { relationId: rel.id, body: 'Hello mentee' } });
     expect(posted.status()).toBe(201);
 
     // Mentee has one unread message until they open the thread.
-    await signIn(page, menteeEmail, 'MenteePass123', '/portal');
+    await signInAsFreshUser(page, menteeEmail, 'MenteePass123', '/portal');
     let unread = await (await page.request.get('/api/messages/unread')).json();
     expect(unread.count).toBe(1);
     await page.request.get(`/api/messages?relationId=${rel.id}`); // opening marks it read
@@ -38,7 +31,7 @@ test('messages track read/unread and the sender sees a read receipt', async ({ p
     expect(unread.count).toBe(0);
 
     // Back as mentor, the message now carries a readAt timestamp.
-    await signIn(page, mentorEmail, 'MentorPass123', '/mentor');
+    await signInAsFreshUser(page, mentorEmail, 'MentorPass123', '/mentor');
     const thread = await (await page.request.get(`/api/messages?relationId=${rel.id}`)).json();
     expect(thread.messages[0].readAt).toBeTruthy();
   } finally {
@@ -57,20 +50,20 @@ test('admin broadcasts an announcement to all users and toggles email preference
 
   try {
     // A user opts out of email notifications via their profile API.
-    await signIn(page, userEmail, 'UserPass123', '/portal');
+    await signInAsFreshUser(page, userEmail, 'UserPass123', '/portal');
     const pref = await page.request.put('/api/profile', { data: { emailNotifications: false } });
     expect(pref.ok()).toBeTruthy();
     const me = await (await page.request.get('/api/profile')).json();
     expect(me.user.emailNotifications).toBe(false);
 
     // Admin broadcasts an announcement.
-    await signIn(page, adminEmail, 'AdminPass123', '/admin');
+    await signInAsFreshUser(page, adminEmail, 'AdminPass123', '/admin');
     const sent = await page.request.post('/api/admin/announcements', { data: { text: 'Welcome to the platform!' } });
     expect(sent.status()).toBe(201);
     expect((await sent.json()).recipients).toBeGreaterThan(0);
 
     // The user received it as an in-app notification.
-    await signIn(page, userEmail, 'UserPass123', '/portal');
+    await signInAsFreshUser(page, userEmail, 'UserPass123', '/portal');
     const notifs = await (await page.request.get('/api/notifications')).json();
     expect(notifs.items.some((n: { text: string }) => n.text === 'Welcome to the platform!')).toBeTruthy();
   } finally {

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -49,6 +49,22 @@ export async function signInAndSettle(page: Page, email: string, password: strin
  * the consent banner back over the form.
  */
 export async function signInAsFreshUser(page: Page, email: string, password: string, landing: string) {
+  await submitSignInForm(page, email, password);
+  await page.waitForURL((u) => u.pathname.startsWith(landing), { timeout: 20_000 });
+}
+
+/**
+ * The guards of `signInAsFreshUser` without the landing wait, for accounts that
+ * are *supposed* to stay on `/auth/signin` after submitting — a 2FA-enabled user
+ * gets the authenticator field instead of a redirect.
+ *
+ * Everything in the doc comment above applies here; the landing wait is the only
+ * difference. Rolling this by hand is what made two-factor.spec.ts flaky: with a
+ * blanket `clearCookies()` and an unscoped `button[type="submit"]`, a submit
+ * issued before `/auth/signin` had rendered resolved against the *previous*
+ * page and sat on its disabled "Add note" button until the action timeout.
+ */
+export async function submitSignInForm(page: Page, email: string, password: string) {
   await page.goto('about:blank');
   await page.context().clearCookies({ name: /next-auth\.session-token/ });
   await page.goto('/auth/signin');
@@ -56,7 +72,6 @@ export async function signInAsFreshUser(page: Page, email: string, password: str
   await form.locator('input[type="email"], input[name="email"]').fill(email);
   await form.locator('input[type="password"]').fill(password);
   await form.locator('button[type="submit"]').click();
-  await page.waitForURL((u) => u.pathname.startsWith(landing), { timeout: 20_000 });
 }
 
 /**

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -63,15 +63,36 @@ export async function signInAsFreshUser(page: Page, email: string, password: str
  * blanket `clearCookies()` and an unscoped `button[type="submit"]`, a submit
  * issued before `/auth/signin` had rendered resolved against the *previous*
  * page and sat on its disabled "Add note" button until the action timeout.
+ *
+ * The session teardown is deliberately belt-and-braces. `/auth/signin` signs in
+ * by polling `/api/auth/session` and then doing a full-page
+ * `window.location.assign(roleHome)`, so `waitForURL()` returns while the old
+ * page is still reading the session — and a read landing after `clearCookies()`
+ * re-issues the cookie. `/auth/signin` then sees `authenticated` and
+ * `router.replace()`s to the dashboard, leaving no form to fill: the failure is
+ * a timeout on the password input, with no obvious culprit on screen. So: let
+ * the outgoing page go quiet first, and if the form still isn't there, drop the
+ * cookie again and reload once.
  */
 export async function submitSignInForm(page: Page, email: string, password: string) {
-  await page.goto('about:blank');
-  await page.context().clearCookies({ name: /next-auth\.session-token/ });
-  await page.goto('/auth/signin');
   const form = page.locator('form', { has: page.locator('input[type="password"]') });
+
+  await page.waitForLoadState('networkidle', { timeout: 10_000 }).catch(() => {});
+  await dropSessionAndOpenSignIn(page);
+  if (!(await form.isVisible().catch(() => false))) {
+    await dropSessionAndOpenSignIn(page);
+  }
+
   await form.locator('input[type="email"], input[name="email"]').fill(email);
   await form.locator('input[type="password"]').fill(password);
   await form.locator('button[type="submit"]').click();
+}
+
+async function dropSessionAndOpenSignIn(page: Page) {
+  await page.goto('about:blank');
+  await page.context().clearCookies({ name: /next-auth\.session-token/ });
+  await page.goto('/auth/signin');
+  await page.waitForLoadState('networkidle', { timeout: 10_000 }).catch(() => {});
 }
 
 /**

--- a/e2e/mentee-detail-feedback.spec.ts
+++ b/e2e/mentee-detail-feedback.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { signInAndSettle, gotoSettled } from './helpers/auth';
 
 test.afterAll(async () => {
   await prisma.$disconnect();
@@ -15,13 +16,9 @@ test('mentee detail: empty interaction log shows an example card, and logging on
   const rel = await prisma.mentorshipRelation.create({ data: { mentorId: mentor.id, menteeId: mentee.id } });
 
   try {
-    await page.goto('/auth/signin');
-    await page.fill('input[type="email"], input[name="email"]', mentorEmail);
-    await page.fill('input[type="password"]', 'MentorPass123');
-    await page.click('button[type="submit"]');
-    await page.waitForURL((u) => u.pathname.startsWith('/mentor'), { timeout: 20_000 });
+    await signInAndSettle(page, mentorEmail, 'MentorPass123', '/mentor');
 
-    await page.goto(`/mentor/mentees/${rel.id}`);
+    await gotoSettled(page, `/mentor/mentees/${rel.id}`);
     await expect(page.getByText('No interactions logged yet')).toBeVisible({ timeout: 10_000 });
     // The illustrative example card is shown alongside the empty message.
     await expect(page.getByText('Example')).toBeVisible();

--- a/e2e/mentee-setpw.spec.ts
+++ b/e2e/mentee-setpw.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { signInAndSettle, signInAsFreshUser, gotoSettled } from './helpers/auth';
 
 test.afterAll(async () => {
   await prisma.$disconnect();
@@ -16,14 +17,10 @@ test('adding a mentee with an email yields a set-password link the mentee can us
 
   try {
     // Sign in as the mentor.
-    await page.goto('/auth/signin');
-    await page.fill('input[type="email"], input[name="email"]', mentorEmail);
-    await page.fill('input[type="password"]', mentorPw);
-    await page.click('button[type="submit"]');
-    await page.waitForURL((u) => u.pathname.startsWith('/mentor'), { timeout: 20_000 });
+    await signInAndSettle(page, mentorEmail, mentorPw, '/mentor');
 
     // Create a mentee WITH an email.
-    await page.goto('/mentor/mentees/new');
+    await gotoSettled(page, '/mentor/mentees/new');
     await page.getByLabel(/Full Name/).fill('New Mentee Person');
     await page.getByLabel(/Email/).fill(menteeEmail);
     const created = page.waitForResponse(
@@ -50,16 +47,10 @@ test('adding a mentee with an email yields a set-password link the mentee can us
     await done;
     await page.waitForURL((u) => u.pathname.startsWith('/auth/signin'), { timeout: 20_000 });
 
-    // Drop the mentor's still-active session before signing in as the mentee,
-    // otherwise /auth/signin redirects the authenticated mentor away.
-    await page.context().clearCookies();
-
     // Mentee can now sign in with their chosen password → lands on the portal.
-    await page.goto('/auth/signin');
-    await page.fill('input[type="email"], input[name="email"]', menteeEmail);
-    await page.fill('input[type="password"]', menteePw);
-    await page.click('button[type="submit"]');
-    await page.waitForURL((u) => u.pathname.startsWith('/portal'), { timeout: 20_000 });
+    // The mentor's session is still live, so this is a user switch: the helper
+    // drops it without taking the seeded consent cookie with it.
+    await signInAsFreshUser(page, menteeEmail, menteePw, '/portal');
   } finally {
     await cleanupByEmail(menteeEmail);
     await cleanupByEmail(mentorEmail);

--- a/e2e/profile-activity.spec.ts
+++ b/e2e/profile-activity.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { signInAndSettle, signInAsFreshUser } from './helpers/auth';
 
 test.afterAll(async () => {
   await prisma.$disconnect();
@@ -19,31 +20,17 @@ test('a user\'s activity is visible to admin and to their mentor, but not to str
 
   try {
     // Admin can read it.
-    await page.goto('/auth/signin');
-    await page.fill('input[type="email"], input[name="email"]', adminEmail);
-    await page.fill('input[type="password"]', 'AdminPass123');
-    await page.click('button[type="submit"]');
-    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+    await signInAndSettle(page, adminEmail, 'AdminPass123', '/admin');
     const asAdmin = await (await page.request.get(`/api/users/${mentee.id}/activity`)).json();
     expect(asAdmin.items.some((i: { action: string }) => i.action === 'auth.login')).toBeTruthy();
 
     // The mentee's mentor can read it.
-    await page.context().clearCookies();
-    await page.goto('/auth/signin');
-    await page.fill('input[type="email"], input[name="email"]', mentorEmail);
-    await page.fill('input[type="password"]', 'MentorPass123');
-    await page.click('button[type="submit"]');
-    await page.waitForURL((u) => u.pathname.startsWith('/mentor'), { timeout: 20_000 });
+    await signInAsFreshUser(page, mentorEmail, 'MentorPass123', '/mentor');
     const asMentor = await page.request.get(`/api/users/${mentee.id}/activity`);
     expect(asMentor.ok()).toBeTruthy();
 
     // An unrelated mentor cannot.
-    await page.context().clearCookies();
-    await page.goto('/auth/signin');
-    await page.fill('input[type="email"], input[name="email"]', strangerEmail);
-    await page.fill('input[type="password"]', 'StrangerPass123');
-    await page.click('button[type="submit"]');
-    await page.waitForURL((u) => u.pathname.startsWith('/mentor'), { timeout: 20_000 });
+    await signInAsFreshUser(page, strangerEmail, 'StrangerPass123', '/mentor');
     const asStranger = await page.request.get(`/api/users/${mentee.id}/activity`);
     expect(asStranger.status()).toBe(403);
   } finally {

--- a/e2e/two-factor.spec.ts
+++ b/e2e/two-factor.spec.ts
@@ -1,18 +1,15 @@
 import { test, expect } from '@playwright/test';
 import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
 import { totp } from '../src/lib/totp';
+import { submitSignInForm } from './helpers/auth';
 
 test.afterAll(async () => {
   await prisma.$disconnect();
 });
 
-async function fillLogin(page: import('@playwright/test').Page, email: string, password: string) {
-  await page.context().clearCookies();
-  await page.goto('/auth/signin');
-  await page.fill('input[type="email"], input[name="email"]', email);
-  await page.fill('input[type="password"]', password);
-  await page.click('button[type="submit"]');
-}
+// Submits without waiting for a landing page: once 2FA is on, the expected
+// outcome is staying on /auth/signin with the authenticator field.
+const fillLogin = submitSignInForm;
 
 test('a user enables TOTP 2FA and must provide a code at sign-in', async ({ page }) => {
   const email = uniqueEmail('tfa-user');


### PR DESCRIPTION
## Why

The six flakies in scheduled run [30696957141](https://github.com/21072026/Internship/actions/runs/30696957141) (`failed,passed` — green on retry) are two known shapes, and [e2e/helpers/auth.ts](e2e/helpers/auth.ts) already exists to prevent both. These specs simply never adopted it. The same race also showed up in the previous scheduled run, so it isn't settling on its own.

| shape | specs |
|---|---|
| `Navigation to /X is interrupted by another navigation to /admin` | `announcements`, `mentee-detail-feedback`, `mentee-setpw` |
| action times out on an element belonging to the **previous** page | `comms`, `profile-activity`, `two-factor` |

The second shape is the blanket-`clearCookies()` trap already documented on `signInAsFreshUser`: it also drops the consent cookie seeded via `storageState`, and the page being left keeps calling `/api/auth/session`, which re-issues the session cookie — so `/auth/signin` sees `authenticated` and `router.replace()`s to the old dashboard while the test is still typing. Concretely, `two-factor`'s submit resolved against the previous page's **disabled "Add note" button** and retried it until the 15s action timeout:

```
locator resolved to <button disabled type="submit" …>Add note</button>
```

`comms` sat on a password field that was about to be replaced.

## What changed

- `signInAndSettle` + `gotoSettled` for the deep-link cases.
- `signInAsFreshUser` for the user switches.
- `two-factor` needs those guards **without** the landing wait — a 2FA account is *supposed* to stay on `/auth/signin` and show the authenticator field. The body of `signInAsFreshUser` is now exported as `submitSignInForm`, and both share it.

No product code changes.

## Verification

`E2E Tests` dispatched on this branch with `grep` covering all eight affected tests (linked in a comment below). `tsc --noEmit` clean.

## Not in this PR

16 other specs still call blanket `clearCookies()`. Some do it deliberately (`legal-consent`, `cookie-consent-categories` need the consent cookie gone), so a blind sweep would break them. Worth a follow-up pass that goes file by file — this PR fixes the ones that actually flaked.

## No version bump

Test-only change, no user-visible behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)