### PR TITLE
docs(legal): sole rights holder is Mehmet Erşahin; licensing strategy + contributor terms

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,3 +13,10 @@ Closes #
 - [ ] `npm run lint` + `npx tsc --noEmit` clean
 - [ ] `npm run test:e2e` passing (or CI green)
 - [ ] Tested the change manually / added an e2e test
+
+## Contributor terms
+
+- [ ] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
+      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
+      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
+      it is my own work, and I make no claim over the application.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,12 @@ workaround, #636, and it compiled on every PR push).
 - **Work is tracked on a GitHub Project board** (Epics #5–#11, stories #12+). Move the issue
   to the matching column as you work.
 - Co-author trailer on commits: `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+- **Licensing & IP**: the project is `AGPL-3.0-or-later` with **dual licensing**, and the
+  **sole rights holder is Mehmet Erşahin (a natural person — not bcsit GmbH)**. Don't name a
+  company as the IP owner in docs or license texts; the invoicing entity is a *separate*,
+  still-open question (`docs/legal/legal-tax-framework.md`). Contributor terms live in
+  `CONTRIBUTING.md` (§ Contributor terms (IP)) and are confirmed via the PR template;
+  rationale in [`docs/legal/licensing-strategy.md`](docs/legal/licensing-strategy.md).
 - **Feature catalogue**: when a user-visible feature ships, add/update its entry in
   `src/lib/features.ts` (+ `featureCatalog` i18n block) — the landing cards and the `/features`
   page are both fed from that single source. Same discipline as CHANGELOG/releaseNotes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,34 @@ By taking part you agree to the [Code of Conduct](CODE_OF_CONDUCT.md)
 ([Türkçe](docs/code-of-conduct.tr.md), [Deutsch](docs/code-of-conduct.de.md)).
 Report unacceptable behaviour to **ersahin@bcsit-gmbh.de**.
 
+## Contributor terms (IP)
+
+Read this before your first pull request. Opening a PR means you accept these terms —
+the PR template asks you to confirm it.
+
+- **Sole rights holder.** All rights in Internship CRM are held by **Mehmet Erşahin**
+  (a natural person, not a company). Only the rights holder may license the software.
+- **Your contribution.** You license your contribution under **AGPL-3.0-or-later** and
+  grant the rights holder an **exclusive, perpetual, worldwide, sub-licensable right to
+  use it** (assignment of economic rights where the law permits; under German copyright
+  law the copyright itself cannot be transferred, § 29 UrhG, so the mechanism is an
+  exclusive exploitation right, § 31 (3) UrhG).
+- **Dual licensing.** You agree the rights holder may also offer your contribution under
+  a separate **commercial license**, without AGPL obligations.
+- **No claims.** Contributions are made within the mentorship, without additional
+  remuneration, and give rise to **no copyright, license, fee, partnership, or equity
+  claim** over the application.
+- **Portfolio grant-back.** You keep the right to present your own contributions in a
+  personal portfolio or for educational purposes (non-commercial).
+- **Originality.** You confirm your contribution is your own work and does not infringe
+  third-party rights. Don't paste in code you don't have the right to contribute.
+- **Beyond the mentorship.** Paid, external, or corporate contributors sign a short
+  written agreement instead of relying on the PR confirmation — see
+  [docs/legal/cla-contributor-agreement.md](docs/legal/cla-contributor-agreement.md).
+
+Trademarks are **not** covered by the AGPL: the "Internship CRM" name, logo, and the
+`crm.ersah.in` domain stay with the rights holder (see [README](README.md#trademarks)).
+
 ## Workflow
 
 1. **Branch** off `main`: `feat/<issue>-slug`, `fix/<issue>-slug`, `docs/...`, `test/...`.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,11 @@
 Internship CRM
 Copyright (C) 2026 Mehmet Erşahin
 
+Mehmet Erşahin is the sole rights holder of this software. Contributions by
+others are made under the contributor terms in CONTRIBUTING.md, which grant the
+rights holder an exclusive right to use them; no contributor holds a licensing
+claim over the software.
+
 This program is free software: you can redistribute it and/or modify it under
 the terms of the GNU Affero General Public License as published by the Free
 Software Foundation, either version 3 of the License, or (at your option) any
@@ -15,6 +20,11 @@ with this program. If not, see <https://www.gnu.org/licenses/>.
 
 A commercial license (without AGPL obligations) is also available — see the
 "Commercial licensing & hosting" section of README.md.
+
+This license covers the source code only. The name "Internship CRM", the project
+logo and the crm.ersah.in domain are trademarks / identifiers of the rights
+holder and are NOT licensed under the AGPL; forks and derivative services must
+use their own name and branding.
 
 The complete text of the GNU Affero General Public License v3.0 follows.
 ================================================================================

--- a/README.md
+++ b/README.md
@@ -162,10 +162,19 @@ prisma/         # schema.prisma + seed
 
 ## License
 
+Copyright © 2026 **Mehmet Erşahin**, the project's sole rights holder.
+
 Licensed under the **GNU Affero General Public License v3.0 or later** (AGPL-3.0-or-later) —
 see [LICENSE](LICENSE). You are free to use, study, modify, and self-host this software. If
 you run a modified version as a network service, the AGPL requires you to make your modified
 source available to its users.
+
+### Trademarks
+
+The AGPL covers the **code only**. The name "Internship CRM", the project's logo and the
+`crm.ersah.in` domain are **not** licensed with it — forks and derivative services must use
+their own name and branding, and may not imply endorsement by or affiliation with the rights
+holder.
 
 ## Commercial licensing & hosting
 
@@ -175,10 +184,12 @@ paths exist for organizations:
 - **Hosted service** — use the maintained deployment at https://crm.ersah.in (support,
   updates, backups included) instead of running it yourself.
 - **Commercial license** — if AGPL's source-sharing obligations don't fit your product (e.g.
-  embedding in a closed-source offering), a separate commercial license is available.
+  embedding in a closed-source offering), a separate commercial license is available. Because
+  all rights are held by a single person, such a license can be granted directly.
 
 For hosting, a commercial license, custom deployment, or support, contact
-**ersahin@bcsit-gmbh.de**.
+**ersahin@bcsit-gmbh.de**. Strategy and rationale:
+[docs/legal/licensing-strategy.md](docs/legal/licensing-strategy.md).
 
 ## Contributing
 
@@ -190,5 +201,9 @@ Everyone taking part — contributors, mentors, mentees, admins — is expected 
 [Code of Conduct](CODE_OF_CONDUCT.md)
 ([Türkçe](docs/code-of-conduct.tr.md), [Deutsch](docs/code-of-conduct.de.md)).
 
-By contributing you agree that your contributions are licensed under AGPL-3.0-or-later, and
-that the maintainer may also offer them under a commercial license (dual licensing).
+**Contributor terms.** By opening a pull request you agree that your contribution is
+licensed under AGPL-3.0-or-later; that the exclusive right to use it passes to the rights
+holder (Mehmet Erşahin), who may also offer it under a separate commercial license (dual
+licensing); and that you make no copyright, license, fee, or equity claim over the
+application. You keep the right to show your own contributions in a personal portfolio. Full
+wording: [CONTRIBUTING.md → Contributor terms (IP)](CONTRIBUTING.md#contributor-terms-ip).

--- a/docs/legal/README.md
+++ b/docs/legal/README.md
@@ -3,18 +3,30 @@
 > **Uyarı:** Bu klasördeki metinler hukuki tavsiye değildir; ürünü ticarileştirmeden
 > önceki belirsizliği azaltmak için hazırlanmış **karar dokümanları ve taslaklardır**.
 > İlk premium satıştan / ilk imzadan önce bir avukat ve mali müşavir tarafından
-> gözden geçirilmelidir. Bağlam: ürün, Almanya merkezli **bcsit GmbH** üzerinden
-> yürütülüyor (kurucu e-postası `@bcsit-gmbh.de`); kararlar bu yapıya göre verildi.
+> gözden geçirilmelidir.
+
+**İki ayrı kavramı karıştırmayın:**
+
+- **Hak sahipliği (IP):** Yazılımın tek hak sahibi **Mehmet Erşahin** (gerçek kişi) —
+  bkz. `LICENSE` ve [cla-contributor-agreement.md](cla-contributor-agreement.md).
+  Fikri mülkiyet hiçbir tüzel kişiye devredilmemiştir.
+- **Ticari yürütme (fatura/sözleşme):** Gelirin hangi tüzel kişi üzerinden
+  faturalandığı ayrı bir vergisel karardır; mevcut çalışma
+  [legal-tax-framework.md](legal-tax-framework.md) içinde Almanya merkezli
+  **bcsit GmbH**'yi varsayıyor (kurucu e-postası `@bcsit-gmbh.de`) ve **teyit
+  bekliyor**. Satış GmbH üzerinden yapılacaksa hak sahibinden GmbH'ye bir iç lisans
+  gerekir; şahıs üzerinden faturalanacaksa buna gerek yoktur.
 
 Story #523 (Epic #517) kapsamındaki kod-dışı ön koşullar. Her biri ayrı dosyada,
 somut bir **karar** ve gerekçesiyle.
 
 | Konu | Issue | Karar (özet) | Dosya |
 |------|-------|--------------|-------|
-| Katkı sözleşmesi (CLA) | #548 | Kısa yazılı IP-devri; tüm mevcut+gelecek katkıcı mentee'lere imzalatılır, onboarding'e eklenir | [cla-contributor-agreement.md](cla-contributor-agreement.md) |
-| Hukuki/vergisel çerçeve | #549 | Mevcut **bcsit GmbH** üzerinden; SaaS abonelik faturalaması (KDV/USt dahil); klasik success-fee'den kaçın (AÜG riski) | [legal-tax-framework.md](legal-tax-framework.md) |
+| Lisans stratejisi | — | AGPL-3.0-or-later + ikili lisanslama korunur; marka hakkı saklı; premium katman ileride ayrı kapalı modülde | [licensing-strategy.md](licensing-strategy.md) |
+| Katkı sözleşmesi (CLA) | #548 | Tek hak sahibi **Mehmet Erşahin**; mentee katkıları hak talebi doğurmaz; gelecek katkılar PR şablonu + onboarding onayıyla yazılı hale gelir | [cla-contributor-agreement.md](cla-contributor-agreement.md) |
+| Hukuki/vergisel çerçeve | #549 | Faturalama tüzel kişisi teyit bekliyor (varsayım: **bcsit GmbH**); SaaS abonelik faturalaması (KDV/USt dahil); klasik success-fee'den kaçın (AÜG riski) | [legal-tax-framework.md](legal-tax-framework.md) |
 | Mentee görünürlük rızası | #551 | Yalnızca kamuya-açık alanlar (ad, üniversite, beceri, hedef pozisyon); e-posta/telefon asla; anında geri çekilebilir | [talent-pool-consent-policy.md](talent-pool-consent-policy.md) |
-| Ödeme altyapısı | #552 | Faz 1 manuel fatura (GmbH); ölçeklenince Stripe Billing + webhook → entitlement | [payment-infrastructure.md](payment-infrastructure.md) |
+| Ödeme altyapısı | #552 | Faz 1 manuel fatura; ölçeklenince Stripe Billing + webhook → entitlement | [payment-infrastructure.md](payment-infrastructure.md) |
 
 ## Veri erişim kuralı (#523 kalemi — zaten uygulandı)
 Katkı veren mentee'ler gerçek/preview PII'ye erişmez; geliştirme sentetik seed ile

--- a/docs/legal/cla-contributor-agreement.md
+++ b/docs/legal/cla-contributor-agreement.md
@@ -1,55 +1,89 @@
-# Katkı Sözleşmesi (CLA) — mevcut & gelecek mentee'ler (#548)
+# Katkı Sözleşmesi (CLA) — hak sahipliği ve gelecek katkılar (#548)
 
-> Hukuki tavsiye değildir; imzadan önce avukat gözden geçirmesi gerekir.
+> Hukuki tavsiye değildir; imzadan / ilk ticari lisans satışından önce avukat
+> gözden geçirmesi gerekir.
 
 ## Karar
-Mentee'ler mentorluk anlaşması gereği projeye emek/kod katkısı veriyor. Ticarileşme
-anında bu katkıların fikri mülkiyetinin **bcsit GmbH**'ye ait olduğu **yazılı** olmalı;
-sözlü anlaşma yeterli değildir ve geriye dönük toplanamaz.
 
-**Uygulanacak model:** Kısa bir **fikri hak devri + katkı lisansı** sözleşmesi (CLA
-benzeri). Tüm **mevcut** katkıcılara imzalatılır; **yeni** katılımcılar için
-onboarding'in zorunlu adımı yapılır. İmza durumu basit bir kayıtla (aşağıda opsiyonel
-şema önerisi) izlenir.
+**Projenin tek hak sahibi Mehmet Erşahin'dir** (gerçek kişi). Ürünün fikri
+mülkiyeti bir tüzel kişiye (bcsit GmbH dahil) devredilmemiştir; telif
+`LICENSE` dosyasında da bu şekilde kayıtlıdır (`Copyright (C) 2026 Mehmet
+Erşahin`). İkili lisanslama (AGPL-3.0-or-later + ayrıca ticari lisans) yetkisi
+yalnızca hak sahibine aittir.
 
-**Neden devir (assignment) + geri-lisans, yalnız lisans değil:** Ürün tek elden
-ticarileştirileceği ve yatırımcı/Enterprise müşteri "IP kimde?" diye soracağı için
-net sahiplik gerekir. Katkıcıya, kendi katkısını portföyünde kullanabilmesi için
-geniş bir geri-lisans verilir (adil ve motive edici).
+Katkı veren geliştiriciler, hak sahibinin **mentorluk verdiği mentee'lerdir**;
+katkı, mentorluk ilişkisinin karşılığı olarak verilir (piyasa tecrübesi ↔ emek)
+ve **bu uygulama üzerinde lisans/telif hakkı talebi doğurmaz**. Mentee'ler bu
+çerçeveyi bilerek ve onaylayarak katkı veriyor.
+
+### Geçmiş katkılar
+Mevcut katkıcılarla bu çerçeve **sözlü olarak mutabık** kalınmıştır; katkıcılar
+uygulama üzerinde hak talep etmeyeceklerini teyit etmiştir. Maintainer kararı:
+geçmiş katkılar için geriye dönük imza toplanmayacak; bu doküman kaydın kendisi
+sayılacaktır. (Bir yatırımcı ya da Enterprise müşteri due-diligence sırasında
+yazılı teyit isterse, aşağıdaki taslak "hak talebinde bulunmuyorum" beyanı olarak
+o an da imzalatılabilir.)
+
+### Gelecek katkılar — uygulanacak model
+Yeni katkılarda hak sahipliği **en baştan yazılı** hale gelir:
+
+1. **PR'da onay** — her PR, şablondaki katkı şartları maddesi işaretlenerek
+   açılır (`.github/PULL_REQUEST_TEMPLATE.md`). Şartların tanımı
+   [CONTRIBUTING.md → Contributor terms (IP)](../../CONTRIBUTING.md#contributor-terms-ip).
+2. **Onboarding'de bilgilendirme** — mentorluk başlangıcında katkı şartları
+   anlatılır; mentee kabul ettiğini beyan eder.
+3. **Mentorluk dışı katkıcı** (ücretli çalışan, harici geliştirici, ajans, kurumsal
+   katkı) için aşağıdaki **yazılı sözleşme imzalatılır** — bu durumda zorunludur,
+   PR onayı yeterli sayılmaz.
+
+**Neden münhasır kullanım hakkı + geri-lisans:** Ürün tek elden ticarileştirileceği
+ve müşteri/yatırımcı "haklar kimde?" diye soracağı için net sahiplik gerekir.
+Katkıcıya, kendi katkısını portföyünde gösterebilmesi için geniş bir geri-lisans
+verilir (adil ve motive edici; mentorluk modelinin özü).
 
 ## Sözleşme taslağı (TR)
 
-**KATKI VE FİKRİ HAK DEVRİ SÖZLEŞMESİ**
+**KATKI VE FİKRİ HAK SÖZLEŞMESİ**
 
-1. **Taraflar.** bcsit GmbH ("Şirket") ve aşağıda imzası bulunan katkı veren
-   ("Katkıcı").
+1. **Taraflar.** Mehmet Erşahin ("Hak Sahibi") ve aşağıda imzası bulunan katkı
+   veren ("Katkıcı").
 2. **Kapsam.** Katkıcı'nın "Internship CRM" projesine sağladığı tüm kod, tasarım,
    doküman ve diğer eserler ("Katkılar").
-3. **Devir.** Katkıcı, Katkılar üzerindeki tüm dünya çapındaki fikri mülkiyet
-   haklarını, mevzuatın izin verdiği azami ölçüde, süresiz ve bedelsiz olarak
-   Şirket'e devreder. Almanya telif hukukunda eserin kendisi devredilemediğinden
-   (§ 29 UrhG), Katkıcı Şirket'e **münhasır, süresiz, dünya çapında, alt-lisans
-   verilebilir kullanım hakkı** (ausschließliches Nutzungsrecht) tanır.
-4. **Geri-lisans.** Şirket, Katkıcı'ya kendi Katkılarını kişisel portföy/eğitim
+3. **Hak devri / kullanım hakkı.** Katkıcı, Katkılar üzerindeki tüm dünya çapındaki
+   mali hakları, mevzuatın izin verdiği azami ölçüde, süresiz ve bedelsiz olarak Hak
+   Sahibi'ne devreder. Alman telif hukukunda telif hakkının kendisi devredilemediği
+   için (§ 29 UrhG), Katkıcı Hak Sahibi'ne **münhasır, süresiz, dünya çapında,
+   alt-lisans verilebilir kullanım hakkı** (ausschließliches Nutzungsrecht,
+   § 31 Abs. 3 UrhG) tanır.
+4. **İkili lisanslama yetkisi.** Katkıcı, Hak Sahibi'nin Katkıları hem
+   AGPL-3.0-or-later altında hem de ayrı bir **ticari lisans** altında sunmasına
+   açıkça onay verir.
+5. **Hak talebinde bulunmama.** Katkıcı, Katkılar nedeniyle uygulama üzerinde
+   telif, lisans, ücret, ortaklık veya pay talebinde bulunmayacağını kabul eder.
+6. **Geri-lisans.** Hak Sahibi, Katkıcı'ya kendi Katkılarını kişisel portföy/eğitim
    amacıyla ticari olmayan biçimde sergileme hakkı tanır.
-5. **Taahhütler.** Katkıcı, Katkıların özgün olduğunu ve üçüncü kişi haklarını
-   ihlal etmediğini beyan eder.
-6. **Ücret.** Katkılar mentorluk ilişkisi kapsamında karşılıksız verilmiştir;
-   ek ücret doğurmaz.
-7. **Uygulanacak hukuk.** Alman hukuku; yetkili mahkeme Şirket'in merkezi.
+7. **Taahhütler.** Katkıcı, Katkıların özgün olduğunu ve üçüncü kişi haklarını ihlal
+   etmediğini beyan eder.
+8. **Ücret.** Katkılar mentorluk ilişkisi kapsamında karşılıksız verilmiştir; ek
+   ücret doğurmaz.
+9. **Uygulanacak hukuk.** Alman hukuku; yetkili mahkeme Hak Sahibi'nin yerleşim yeri.
 
 İmza / Tarih / Ad-Soyad.
 
-## Contribution & IP Assignment Agreement (EN, short form)
-The Contributor grants bcsit GmbH an exclusive, perpetual, worldwide,
-sub-licensable right to use all contributions to the "Internship CRM" project
-(assignment where permitted; exclusive exploitation right under German © law,
-§ 31 UrhG), with a non-exclusive grant-back to the Contributor for
-non-commercial portfolio use. Contributions are made without additional
-remuneration within the mentorship. Governed by German law.
+## Contribution & IP Agreement (EN, short form)
 
-## Opsiyonel: imza takibi (ileride, gerekirse)
-Zorunlu değil (kağıt/DocuSign yeterli). İstenirse basit bir model:
+The Contributor grants Mehmet Erşahin ("Rights Holder") an exclusive, perpetual,
+worldwide, sub-licensable right to use all contributions to the "Internship CRM"
+project (assignment of economic rights where permitted; exclusive exploitation right
+under German copyright law, § 31 (3) UrhG), and consents to those contributions being
+offered both under AGPL-3.0-or-later **and** under a separate commercial licence. The
+Contributor makes no copyright, licence, fee, or equity claim over the application,
+and receives a non-exclusive grant-back for non-commercial portfolio use.
+Contributions are made without additional remuneration within the mentorship.
+Governed by German law.
+
+## Opsiyonel: uygulama içi kabul takibi (ileride, gerekirse)
+Zorunlu değil (PR onayı + kağıt/e-imza yeterli). İstenirse basit bir model:
 
 ```prisma
 model ContributorAgreement {
@@ -60,9 +94,13 @@ model ContributorAgreement {
   ipHash    String?  // imza anındaki IP (kanıt)
 }
 ```
-Onboarding akışına "sözleşmeyi okudum ve kabul ediyorum" adımı eklenebilir.
+Onboarding akışına "katkı şartlarını okudum ve kabul ediyorum" adımı eklenebilir
+(kod işi; ayrı issue).
 
 ## Aksiyon listesi
-- [ ] Metni avukata onaylat (özellikle § 31/29 UrhG ifadeleri).
-- [ ] Mevcut katkıcı mentee'lere imzalat (kağıt/e-imza).
-- [ ] Onboarding'e imza adımı ekle (kod işi; ayrı issue açılabilir).
+- [x] Hak sahibini tek isimde sabitle (Mehmet Erşahin) — `LICENSE`, `README.md`,
+      `package.json` ve bu doküman.
+- [x] Gelecek katkılar için PR şablonuna katkı şartları onayı ekle.
+- [ ] Metni avukata onaylat (özellikle § 29 / § 31 UrhG ifadeleri ve madde 5).
+- [ ] Mentorluk dışı (ücretli/harici) bir katkıcı gelirse yazılı sözleşme imzalat.
+- [ ] İstenirse onboarding'e uygulama içi kabul adımı ekle (ayrı issue).

--- a/docs/legal/legal-tax-framework.md
+++ b/docs/legal/legal-tax-framework.md
@@ -2,13 +2,30 @@
 
 > Hukuki/mali tavsiye değildir; mali müşavir (Steuerberater) ve avukat onayı gerekir.
 
-## Karar
-Ticarileşme **mevcut bcsit GmbH** (Almanya) üzerinden yürütülür. Yeni bir tüzel yapı
-kurulmaz — GmbH zaten var, sınırlı sorumluluk sağlıyor ve B2B SaaS faturalaması için
-uygun.
+## Önce netleştirilmesi gereken ayrım — IP ≠ faturalayan taraf
+
+**Yazılımın hak sahibi Mehmet Erşahin'dir (gerçek kişi)**; fikri mülkiyet hiçbir
+tüzel kişiye devredilmemiştir (bkz. `LICENSE`,
+[cla-contributor-agreement.md](cla-contributor-agreement.md)). Bu doküman yalnızca
+**gelirin hangi taraf üzerinden faturalandığını** ele alır — bu ayrı bir vergisel
+karardır ve hak sahipliğini değiştirmez.
+
+## Karar (teyit bekliyor)
+Ticarileşmenin **mevcut bcsit GmbH** (Almanya) üzerinden yürütülmesi öneriliyor. Yeni
+bir tüzel yapı kurulmaz — GmbH zaten var, sınırlı sorumluluk sağlıyor ve B2B SaaS
+faturalaması için uygun.
+
+> ⚠️ **Açık karar:** Faturalamanın GmbH üzerinden mi, hak sahibinin şahsı üzerinden mi
+> yapılacağı maintainer tarafından teyit edilmeli. GmbH seçilirse, hak sahibinden
+> GmbH'ye **yazılı bir kullanım/dağıtım lisansı** (ör. münhasır olmayan, alt-lisans
+> verilebilir ticari dağıtım hakkı) gerekir — aksi halde GmbH, hakkı kendisinde olmayan
+> bir yazılımı satmış olur. Şahıs üzerinden faturalanırsa bu iç lisansa gerek kalmaz,
+> ancak sınırlı sorumluluk avantajı da kaybedilir; Enterprise müşteriler genelde tüzel
+> kişiyle sözleşme yapmayı tercih eder.
 
 ### 1. Tüzel yapı
-- **Yürütücü:** bcsit GmbH (Almanya). Gelir, sözleşmeler ve faturalar GmbH üzerinden.
+- **Yürütücü (varsayım):** bcsit GmbH (Almanya). Gelir, sözleşmeler ve faturalar GmbH
+  üzerinden; yazılımın hakları hak sahibinde kalır, GmbH iç lisansla satar.
 - Gerekçe: hazır yapı, sınırlı sorumluluk, kurumsal müşterinin (Enterprise) sözleşme
   yapmak isteyeceği tüzel kişilik.
 
@@ -40,6 +57,8 @@ uygun.
 - **Kullanım Şartları + Gizlilik** (mevcut `/terms`, `/privacy` ile uyumlu).
 
 ## Aksiyon listesi
+- [ ] **Faturalayan tarafı teyit et** (bcsit GmbH mi, hak sahibinin şahsı mı).
+- [ ] GmbH seçilirse: hak sahibi → GmbH ticari dağıtım lisansını yazılı hale getir.
 - [ ] Steuerberater ile KDV/reverse-charge faturalama akışını netleştir.
 - [ ] Avukatla B2B SaaS sözleşme + DPA şablonları hazırlat.
 - [ ] Success-fee kullanılacaksa AÜG/SGB III değerlendirmesi (ayrı, ertelenebilir).

--- a/docs/legal/licensing-strategy.md
+++ b/docs/legal/licensing-strategy.md
@@ -1,0 +1,85 @@
+# Lisans stratejisi kararı
+
+> Hukuki tavsiye değildir; ilk ticari lisans satışından önce avukat gözden geçirmesi
+> gerekir.
+
+## Karar
+
+**Mevcut kurgu korunur: `AGPL-3.0-or-later` + ikili lisanslama (dual licensing).**
+Repo public kalır; AGPL dışı kullanım isteyen taraflara ayrıca **ticari lisans**
+satılır. Bu, GitLab / Grafana / Mattermost / Metabase gibi ürünlerin kullandığı
+standart modeldir ve bu projenin hedefine (açık staj projesi + ileride ticari gelir)
+uyar.
+
+**Tek hak sahibi: Mehmet Erşahin** (gerçek kişi). İkili lisanslama ancak hakların tek
+elde olmasıyla mümkündür; bu koşul sağlanmış durumda (bkz.
+[cla-contributor-agreement.md](cla-contributor-agreement.md)).
+
+## Gerekçe
+
+### AGPL ne sağlıyor
+- Kimse kodu **kapalı kaynak** bir ürüne gömemez. Kurumsal bir kullanıcı bunu kendi
+  ürününe entegre etmek isterse ya tüm değişikliklerini yayınlamak (kurumsal alıcıların
+  neredeyse hiç kabul etmediği bir şey) ya da **ticari lisans satın almak** zorunda.
+  AGPL'in işlevi teknik bir kilit değil, **satın almaya iten ticari kaldıraçtır**.
+- "Network use = distribution" maddesi sayesinde, MIT/Apache'nin aksine, kodu servis
+  olarak sunan taraf da değişikliklerini yayınlamak zorundadır.
+- **Hak sahibi AGPL'e bağlı değildir.** Kendi SaaS'ı (crm.ersah.in), kapalı premium
+  modüller, white-label sürümü istediği gibi lisanslanabilir. AGPL yalnızca üçüncü
+  tarafları bağlar.
+
+### AGPL ne sağlamıyor (bilinçli kabul edilen risk)
+- **Rakip olmayı engellemez:** biri repo'yu fork'layıp kendi sunucusunda barındırıp
+  satabilir; tek yükümlülüğü değişikliklerini yayınlamaktır.
+- **Premium kapıları korumaz:** `src/lib/entitlements.ts`, `planGate.ts`, `orgPlans.ts`
+  public repo'da; bir fork bu kapıları kaldırabilir.
+
+**Neden bu risk kabul edilebilir:** Bu üründe değerin kaynağı kod değil — doğrulanmış
+aday havuzu (`Evaluation`, `InteractionLog`, `Project` geçmişi), mentor ağı, operasyonun
+kendisi ve marka güveni. Fork bunları kopyalayamaz; sıfır veri, sıfır mentor, sıfır
+referansla başlar. B2B alıcı da kaynak kodu değil **sorumluluk alan bir muhatap** satın
+alır (SLA, DPA, destek, fatura) — fork bunu sunamaz.
+
+## Değerlendirilen alternatifler
+
+| Seçenek | Rakip koruması | Topluluk/portföy değeri | Karar |
+|---|---|---|---|
+| MIT / Apache-2.0 | Yok | En yüksek | ✗ ticari plan varsa yanlış |
+| **AGPL-3.0-or-later + ikili lisans** | Orta-yüksek | Yüksek | ✅ **seçilen** |
+| Open-core (çekirdek AGPL + premium modüller kapalı) | Yüksek | Yüksek | ↗ doğal sonraki adım |
+| BSL / FSL (kaynak-açık, N yıl sonra açılır) | En yüksek | Düşer | ⏸ ancak gerçek rakip belirirse |
+| Tamamen kapalı | Tam | Yok | ✗ mentorluk/portföy modelini öldürür |
+
+Şu aşamada AGPL'den ayrılmanın maliyeti var, faydası yok: repo public ve mentee'lerin
+portföy hikâyesi bunun üzerine kurulu. Ayrıca lisans **geriye dönük daraltılamaz** —
+yayınlanmış her sürüm sonsuza dek AGPL kalır; yalnızca gelecek sürümler değiştirilebilir.
+
+## Premium katmanın kod sınırı (Faz 3'e girmeden karar verilecek)
+
+Çekirdek AGPL'de kalır. `docs/premium-model-calismasi.md` Faz 3 kalemleri (SSO/SAML,
+beyaz etiket, ATS entegrasyonları, gelişmiş rapor ihracı) istenirse **ayrı bir özel
+repo'da tescilli lisansla** geliştirilebilir → "açık çekirdek + kapalı kurumsal katman".
+Bu sınır **kod yazılmadan önce** çizilmeli; sonradan iç içe geçmiş kodu ayırmak pahalıdır.
+Bugün ücretsiz olan hiçbir özellik ücretli katmana taşınmaz (bkz. premium doküman § 0).
+
+## Marka hakkı
+
+AGPL **marka hakkı vermez**. "Internship CRM" adı, logosu ve `crm.ersah.in` alan adı
+lisans kapsamı dışındadır; fork'lar farklı isim/marka kullanmak zorundadır. Bu, rakip
+fork'ları caydırmanın en ucuz ve en etkili yoludur (`README.md` → *Trademarks*).
+
+## AGPL uyumu — kendi tarafımız
+
+Hak sahibi kendi lisansına bağlı olmasa da, hosted sürümü AGPL kodunu çalıştırdığı
+sürece kullanıcılara kaynak erişimi sunmak iyi pratiktir (ve Enterprise satışında
+sorulur). Repo public olduğu için ek yük yok; ürün içinde bir "kaynak kodu" bağlantısı
+bulundurmak yeterlidir.
+
+## Aksiyon listesi
+- [x] Tek hak sahibini her yerde sabitle (`LICENSE`, `README.md`, `package.json`, CLA).
+- [x] Marka hakkı notunu ekle (`README.md`, `LICENSE` başlığı).
+- [x] Katkı şartlarını gelecek katkılar için yazılı hale getir (CONTRIBUTING + PR şablonu).
+- [ ] Bir sayfalık **ticari lisans şablonu** hazırlat (kapsam, süre, destek, sorumluluk
+      sınırı, fiyat) — ilk talep gelmeden önce hazır olsun.
+- [ ] Premium/kapalı modül sınırını Faz 3'e girmeden yazılı olarak belirle.
+- [ ] Ürün içine "kaynak kodu" bağlantısı ekle (küçük UI işi; ayrı issue).

--- a/docs/legal/payment-infrastructure.md
+++ b/docs/legal/payment-infrastructure.md
@@ -5,7 +5,8 @@ Erken karmaşıklık eklemeden gelir doğrulaması için:
 
 ### Faz 1 — Manuel faturalama (kod gerekmez) ✅ şimdi
 - Entitlement (`hasFeature` / premium Setting) **elle** açılır (admin).
-- Fatura bcsit GmbH tarafından elle kesilir (bkz. [legal-tax-framework.md](legal-tax-framework.md)).
+- Fatura, faturalayan taraf tarafından elle kesilir — hangi tüzel kişi/şahıs olduğu
+  [legal-tax-framework.md](legal-tax-framework.md) içinde (teyit bekliyor).
 - Uygun çünkü: ilk müşteri sayısı az; amaç ödeme akışını değil **değeri** doğrulamak.
 - Gereken: yok (mevcut entitlement katmanı yeterli).
 

--- a/docs/premium-model-calismasi.md
+++ b/docs/premium-model-calismasi.md
@@ -28,9 +28,12 @@ Bunun premium modele üç doğrudan etkisi var:
 
 **Dikkat edilmesi gereken iki nokta:**
 
-- **Fikri haklar**: sözlü anlaşma yeterli değil; her katkı verenle "katkılar işverene
-  aittir" maddesi içeren kısa yazılı bir katkı sözleşmesi (CLA benzeri) imzalanmalı.
-  Ticarileşme anında geriye dönük hak iddiasını en baştan kapatır.
+- **Fikri haklar** (karara bağlandı): tek hak sahibi **Mehmet Erşahin**; mentee
+  katkıları mentorluk kapsamında verilir ve uygulama üzerinde hak talebi doğurmaz.
+  Gelecek katkılar PR şablonundaki katkı şartları onayıyla yazılı hale gelir; mentorluk
+  dışı katkıcılar ayrıca sözleşme imzalar. Bkz.
+  [legal/cla-contributor-agreement.md](legal/cla-contributor-agreement.md) ve
+  [legal/licensing-strategy.md](legal/licensing-strategy.md).
 - **Veri erişimi**: katkı veren mentee'ler kod tabanında çalışırken **gerçek kullanıcı
   verisine** (paylaşılan preview DB dahil) erişmemeli. Ticarileşme öncesi, geliştirme
   ortamlarının seed/sahte veriyle çalışması kural haline getirilmeli — hem GDPR gereği
@@ -176,9 +179,12 @@ bölünebilir — ürün yol haritası ile mentorluk müfredatı bilinçli olara
 
 ## 6. Açık sorular
 
-- Ürünün hukuki/vergisel çerçevesi (şahıs mı, şirket mi; hangi ülke?) success-fee
-  ve abonelik faturalamasını etkiler. Ticarileşmeden önce netleşmeli.
-- Katkı sözleşmeleri: mevcut mentee'lerle yazılı IP devri var mı? Yoksa ilk iş bu.
+- Ürünün hukuki/vergisel çerçevesi: **hak sahipliği çözüldü** (Mehmet Erşahin, gerçek
+  kişi); **faturalayan taraf hâlâ açık** (şahıs mı, bcsit GmbH mi) — success-fee ve
+  abonelik faturalamasını etkiler, ilk satıştan önce netleşmeli. Bkz.
+  [legal/legal-tax-framework.md](legal/legal-tax-framework.md).
+- Katkı şartları: **çözüldü** — mentee katkıları hak talebi doğurmaz, gelecek katkılar
+  PR onayıyla yazılı. Bkz. [legal/cla-contributor-agreement.md](legal/cla-contributor-agreement.md).
 - Yetenek havuzu görünürlüğü **mentee'nin açık rızasına** bağlanmalı (mevcut
   `publicProfile` + `UserConsent` deseni genişletilerek) — hem GDPR gereği hem güven.
 - Katkı veren mentee'lerin gerçek kullanıcı verisine erişimi nasıl sınırlanacak?

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.38.0-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
+  "author": "Mehmet Erşahin",
   "prisma": {
     "seed": "node prisma/seed.mjs"
   },


### PR DESCRIPTION
## Summary

Corrects the IP-ownership record and writes down the licensing strategy. The earlier legal
drafts assigned contributions to **bcsit GmbH**; per the maintainer that is wrong — the
**sole rights holder is Mehmet Erşahin (a natural person)**. IP ownership and the invoicing
entity are now treated as two separate questions.

No retroactive CLA collection: existing contributors are mentees who contribute within the
mentorship and have confirmed they make no claim over the application. Going forward the
terms are written down and confirmed on every PR.

Docs-only — no version bump (per the CLAUDE.md exemption for pure docs).

## Changes

- **`docs/legal/cla-contributor-agreement.md`** — rights holder is Mehmet Erşahin; records
  that mentee contributions give rise to no claim and that the past is not chased
  retroactively; future contributions are covered by the PR-template confirmation plus
  onboarding, with a signed agreement required for non-mentorship (paid/external)
  contributors; draft gains dual-licensing consent and a no-claims clause.
- **`docs/legal/licensing-strategy.md`** (new) — decision to keep `AGPL-3.0-or-later` +
  dual licensing; what AGPL does and does not protect; why the fork/competitor risk is
  acceptable (value sits in data, mentor network, operations, brand — not the code);
  comparison against MIT/Apache, open-core, BSL/FSL and closed source; trademark reservation;
  where the premium/closed module boundary should be drawn before Phase 3.
- **`docs/legal/legal-tax-framework.md`** — adds the IP ≠ invoicing-party distinction; the
  invoicing entity is now explicitly an open decision, and if the GmbH invoices, a written
  rights-holder → GmbH commercial distribution licence is required.
- **`LICENSE` / `README.md`** — sole-rights-holder note, trademark section (name, logo and
  `crm.ersah.in` are not licensed under the AGPL), contributor-terms summary, link to the
  strategy doc.
- **`CONTRIBUTING.md`** — new "Contributor terms (IP)" section: AGPL licence + exclusive
  exploitation right (§ 31 (3) UrhG), dual-licensing consent, no-claims, portfolio
  grant-back, originality.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — contributor-terms confirmation checkbox.
- **`docs/legal/README.md`**, **`docs/premium-model-calismasi.md`** — cross-references and
  resolved/open status updated.
- **`package.json`** — `author` field; **`CLAUDE.md`** — licensing/IP convention so the
  GmbH-as-owner wording isn't reintroduced.

## Verification

- [x] `node -e JSON.parse(package.json)` clean; documentation-only otherwise (no `src/`,
      schema or i18n changes, so lint/tsc/e2e surface is unaffected)
- [ ] Legal wording still needs maintainer review + a lawyer's pass before the first
      commercial licence is sold (§ 29 / § 31 UrhG phrasing, no-claims clause)

## Contributor terms

- [x] Authored on behalf of the rights holder; no third-party code introduced.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GZzCHgHX9SraP5un6BgMPb)_