### PR TITLE
docs(legal): commercial licence draft, in-app contributor-terms design, invoicing decision deferred

### DIFF
--- a/docs/legal/README.md
+++ b/docs/legal/README.md
@@ -10,12 +10,11 @@
 - **Hak sahipliği (IP):** Yazılımın tek hak sahibi **Mehmet Erşahin** (gerçek kişi) —
   bkz. `LICENSE` ve [cla-contributor-agreement.md](cla-contributor-agreement.md).
   Fikri mülkiyet hiçbir tüzel kişiye devredilmemiştir.
-- **Ticari yürütme (fatura/sözleşme):** Gelirin hangi tüzel kişi üzerinden
-  faturalandığı ayrı bir vergisel karardır; mevcut çalışma
-  [legal-tax-framework.md](legal-tax-framework.md) içinde Almanya merkezli
-  **bcsit GmbH**'yi varsayıyor (kurucu e-postası `@bcsit-gmbh.de`) ve **teyit
-  bekliyor**. Satış GmbH üzerinden yapılacaksa hak sahibinden GmbH'ye bir iç lisans
-  gerekir; şahıs üzerinden faturalanacaksa buna gerek yoktur.
+- **Ticari yürütme (fatura/sözleşme):** Gelirin hangi taraf üzerinden faturalandığı ayrı
+  bir vergisel karardır ve **ilk satışa kadar bilinçli olarak ertelendi**
+  ([legal-tax-framework.md](legal-tax-framework.md)). Adaylar: Almanya merkezli
+  **bcsit GmbH** veya hak sahibinin şahsı. GmbH seçilirse, fatura kesilmeden önce hak
+  sahibinden GmbH'ye yazılı bir ticari dağıtım lisansı gerekir.
 
 Story #523 (Epic #517) kapsamındaki kod-dışı ön koşullar. Her biri ayrı dosyada,
 somut bir **karar** ve gerekçesiyle.
@@ -24,7 +23,9 @@ somut bir **karar** ve gerekçesiyle.
 |------|-------|--------------|-------|
 | Lisans stratejisi | — | AGPL-3.0-or-later + ikili lisanslama korunur; marka hakkı saklı; premium katman ileride ayrı kapalı modülde | [licensing-strategy.md](licensing-strategy.md) |
 | Katkı sözleşmesi (CLA) | #548 | Tek hak sahibi **Mehmet Erşahin**; mentee katkıları hak talebi doğurmaz; gelecek katkılar PR şablonu + onboarding onayıyla yazılı hale gelir | [cla-contributor-agreement.md](cla-contributor-agreement.md) |
-| Hukuki/vergisel çerçeve | #549 | Faturalama tüzel kişisi teyit bekliyor (varsayım: **bcsit GmbH**); SaaS abonelik faturalaması (KDV/USt dahil); klasik success-fee'den kaçın (AÜG riski) | [legal-tax-framework.md](legal-tax-framework.md) |
+| Katkı şartları — uygulama içi onay | — | Elektronik onay geçerli; tek blanket onay değil **üç katmanlı** (platform + proje + PR) kurgu; şartlar veri olarak modellenir | [contributor-terms-in-app.md](contributor-terms-in-app.md) |
+| Ticari lisans sözleşmesi | — | Kullanıma hazır taslak + Annex A iskeleti; yıllık abonelik ya da süresiz lisans + %20 bakım | [commercial-license-template.md](commercial-license-template.md) |
+| Hukuki/vergisel çerçeve | #549 | Faturalayan taraf **ilk satışa ertelendi** (aday: **bcsit GmbH** veya şahıs); SaaS abonelik faturalaması (KDV/USt dahil); klasik success-fee'den kaçın (AÜG riski) | [legal-tax-framework.md](legal-tax-framework.md) |
 | Mentee görünürlük rızası | #551 | Yalnızca kamuya-açık alanlar (ad, üniversite, beceri, hedef pozisyon); e-posta/telefon asla; anında geri çekilebilir | [talent-pool-consent-policy.md](talent-pool-consent-policy.md) |
 | Ödeme altyapısı | #552 | Faz 1 manuel fatura; ölçeklenince Stripe Billing + webhook → entitlement | [payment-infrastructure.md](payment-infrastructure.md) |
 

--- a/docs/legal/cla-contributor-agreement.md
+++ b/docs/legal/cla-contributor-agreement.md
@@ -82,25 +82,22 @@ and receives a non-exclusive grant-back for non-commercial portfolio use.
 Contributions are made without additional remuneration within the mentorship.
 Governed by German law.
 
-## Opsiyonel: uygulama içi kabul takibi (ileride, gerekirse)
-Zorunlu değil (PR onayı + kağıt/e-imza yeterli). İstenirse basit bir model:
+## Uygulama içi kabul (planlandı)
 
-```prisma
-model ContributorAgreement {
-  id        String   @id @default(cuid())
-  userId    String   @unique
-  version   String   // sözleşme metni sürümü
-  signedAt  DateTime @default(now())
-  ipHash    String?  // imza anındaki IP (kanıt)
-}
-```
-Onboarding akışına "katkı şartlarını okudum ve kabul ediyorum" adımı eklenebilir
-(kod işi; ayrı issue).
+Maintainer kararı: geliştiriciler zaten platforma kaydolduğu için onay **uygulama içine**
+alınacak — kayıt/onboarding'de platform şartları, bir projeye eklenirken o projenin
+şartları. Elektronik onay hukuken geçerlidir; ancak tek bir "gelecekteki tüm katkılarım"
+onayı yerine kapsamı belirli, tekrarlanan bir onay zinciri kurulur (§ 40 UrhG).
+Tasarım, şema ve uygulama dilimleri: **[contributor-terms-in-app.md](contributor-terms-in-app.md)**.
+
+Kağıt/e-imza yalnızca **mentorluk dışı** katkıcılar (ücretli, harici, ajans, kurumsal) için
+gerekli kalır.
 
 ## Aksiyon listesi
 - [x] Hak sahibini tek isimde sabitle (Mehmet Erşahin) — `LICENSE`, `README.md`,
       `package.json` ve bu doküman.
 - [x] Gelecek katkılar için PR şablonuna katkı şartları onayı ekle.
-- [ ] Metni avukata onaylat (özellikle § 29 / § 31 UrhG ifadeleri ve madde 5).
+- [x] Uygulama içi kabul akışını tasarla — [contributor-terms-in-app.md](contributor-terms-in-app.md).
+- [ ] Metni avukata onaylat (özellikle § 29 / § 31 / § 40 UrhG ifadeleri ve madde 5).
 - [ ] Mentorluk dışı (ücretli/harici) bir katkıcı gelirse yazılı sözleşme imzalat.
-- [ ] İstenirse onboarding'e uygulama içi kabul adımı ekle (ayrı issue).
+- [ ] Uygulama içi kabul akışını kodla (3 dilim — tasarım dokümanındaki issue'lar).

--- a/docs/legal/commercial-license-template.md
+++ b/docs/legal/commercial-license-template.md
@@ -1,0 +1,188 @@
+# Ticari lisans sözleşmesi — taslak
+
+> **Hukuki tavsiye değildir.** Bu, ilk talep geldiğinde sıfırdan yazmak zorunda kalmamak
+> için hazırlanmış **çalışma taslağıdır**. İlk imzadan önce Alman hukukuna aşina bir
+> avukat tarafından gözden geçirilmelidir — özellikle sorumluluk sınırlaması (§ 305 vd.,
+> § 309 BGB: genel işlem koşullarında ağır kusur için sorumluluk sınırlanamaz), garanti
+> ve kabul (Abnahme) maddeleri.
+
+## Ne zaman kullanılır
+
+AGPL-3.0-or-later herkese yeterlidir; ticari lisans **yalnızca** AGPL yükümlülüklerini
+kabul edemeyen taraf için gerekir:
+
+| Durum | Gereken |
+|---|---|
+| Kendi sunucusunda kurup kullanmak, değişiklikleri yayınlamak | AGPL — lisans satışı **yok** |
+| Hosted sürümü (crm.ersah.in) kullanmak | Abonelik sözleşmesi (SaaS) — bu doküman değil |
+| Yazılımı **kapalı kaynak** bir ürüne gömmek / OEM olarak dağıtmak | **Ticari lisans** |
+| Değiştirilmiş sürümü müşterilerine servis olarak sunup kaynağı **açmak istememek** | **Ticari lisans** |
+
+Fiyat, AGPL'den kaçınmanın alıcıya sağladığı değere göre belirlenir (maliyet artı değil).
+Pratik iskelet: **yıllık abonelik** (kapsam metriğine bağlı) veya **süresiz lisans + %20
+yıllık bakım**. İlk müşterilerde yıllık abonelik daha güvenli — hem gelir öngörülebilir
+hem yazılım gelişmeye devam ediyor.
+
+---
+
+## TASLAK — Commercial Software Licence Agreement
+
+**Parties**
+
+**Licensor:** Mehmet Erşahin, [address], Germany — sole rights holder of the Software.
+**Licensee:** [company, legal form, address, register no., VAT-ID].
+
+**1. Definitions**
+
+1.1 **"Software"** — the "Internship CRM" application authored by the Licensor, in source
+and object form, including its documentation.
+1.2 **"Licensed Version"** — the release(s) delivered under this Agreement, as identified
+in Annex A (version / commit).
+1.3 **"Public Version"** — the Software as published under AGPL-3.0-or-later at
+https://github.com/21072026/internship.
+1.4 **"Modifications"** — changes the Licensee makes to the Software.
+1.5 **"Permitted Scope"** — the use case, metric and volume set out in Annex A.
+
+**2. Grant of licence**
+
+2.1 The Licensor grants the Licensee a **non-exclusive, non-transferable, worldwide** right,
+for the Term, to use, reproduce, modify and internally distribute the Licensed Version
+within the Permitted Scope.
+2.2 **Relief from AGPL obligations.** The Licensed Version is provided under this Agreement
+**instead of** AGPL-3.0-or-later. Within the Permitted Scope the Licensee is therefore not
+subject to the AGPL's copyleft or source-disclosure obligations (including AGPL § 13,
+network use), and may combine the Software with proprietary code.
+2.3 Depending on Annex A, the grant includes the right to (a) operate the Software as a
+service for the Licensee's own end users, and/or (b) distribute it in object form as an
+integrated component of the Licensee's own product (OEM). Sub-licensing is limited to what
+is technically necessary for (a)/(b); end users receive no rights beyond use of the
+Licensee's product.
+2.4 Affiliates: [included / excluded — if included, define "Affiliate" and make the Licensee
+liable for their compliance].
+2.5 The Public Version remains available to the Licensee under AGPL; this Agreement does not
+restrict rights the Licensee has under the AGPL.
+
+**3. Restrictions**
+
+The Licensee shall not: (a) exceed the Permitted Scope; (b) resell, rent or transfer this
+licence as such; (c) remove or alter copyright, licence or attribution notices in the source;
+(d) use the Licensor's trademarks, the name "Internship CRM", its logo or the domain
+`crm.ersah.in` (see § 9); (e) publish the Licensed Version's source code publicly (this would
+defeat the purpose of the commercial licence, and § 2.2 relief does not extend to it).
+
+**4. Delivery, updates**
+
+4.1 Delivery is electronic: access to the source repository and/or container images, within
+[N] business days of the first payment.
+4.2 During the Term the Licensee receives all maintenance and feature releases the Licensor
+publishes for the Software. Custom development is not included and is agreed separately.
+4.3 Installation, migration and configuration are not included unless stated in Annex B.
+
+**5. Support**
+
+No support is owed unless Annex B (support / SLA) is agreed. Absent Annex B, the Licensor
+answers questions on a best-effort basis and the security-reporting process in `SECURITY.md`
+applies.
+
+**6. Fees, term, termination**
+
+6.1 Fees, metric and billing cycle: **Annex A**. Prices are net; VAT / reverse charge is
+added as applicable. Payment within [14] days of invoice.
+6.2 Term: [12] months from the Effective Date, renewing automatically for further [12] month
+periods unless terminated in writing [3] months before the end of a period.
+6.3 Either party may terminate for cause. The Licensor may terminate on the Licensee's
+material breach (in particular §§ 3, 6.1) or payment default after written notice and a
+[14] day cure period.
+6.4 **Effect of termination.** *Subscription model:* the rights under § 2 end; the Licensee
+must stop using the Licensed Version outside the AGPL (it may continue under AGPL, with the
+AGPL's obligations). *Perpetual model (if agreed in Annex A):* the § 2 rights for the
+delivered Licensed Version survive; only updates and support end.
+
+**7. Warranty**
+
+7.1 The Licensor warrants that it holds the rights necessary to grant this licence.
+7.2 The Software contains third-party open-source components; their licences apply to those
+components. A current list is available on request (`package.json` / lock file).
+7.3 The Licensor warrants that the Licensed Version substantially conforms to its
+documentation at delivery. Beyond that the Software is provided **without further warranty**
+as to fitness for a particular purpose. Claims for defects lapse [12] months after delivery.
+7.4 The warranty does not cover defects caused by the Licensee's Modifications, its
+environment, or unsupported third-party components.
+
+**8. Liability**
+
+8.1 The Licensor is liable without limitation for intent, gross negligence, injury to life,
+body or health, and under mandatory statutory liability.
+8.2 For simple negligence the Licensor is liable only for breach of a material contractual
+obligation, limited to foreseeable, typical damage, and in total capped at the fees paid in
+the **12 months** preceding the event.
+8.3 Liability for lost profits, loss of data (beyond the cost of restoring properly kept
+backups) and indirect damage is excluded within the limits of § 8.1.
+8.4 The Licensee is responsible for backups and for the lawfulness of the data it processes.
+
+**9. Intellectual property, trademarks**
+
+9.1 All rights in the Software remain with the Licensor. This Agreement grants a licence, not
+a transfer of rights.
+9.2 The Licensee owns its own Modifications but acquires no rights in the Software itself.
+Modifications may not be published in a way that discloses the Licensed Version's source
+(§ 3(e)).
+9.3 Trademarks and the name/logo/domain are **not** licensed. Factual reference ("built on
+Internship CRM") is permitted; implying endorsement or partnership is not.
+9.4 Optional contribution-back: if the Licensee offers Modifications to the Licensor, the
+contributor terms in `CONTRIBUTING.md` apply. This is voluntary.
+
+**10. Confidentiality**
+
+Each party keeps the other's non-public information confidential for the Term and [3] years
+thereafter. The existence of this Agreement is not confidential; naming the Licensee as a
+reference requires its prior written consent.
+
+**11. Data protection**
+
+If the Licensor processes personal data on the Licensee's behalf (e.g. hosting, support
+access to production data), the parties conclude a **data processing agreement**
+(Art. 28 GDPR / AVV) as **Annex C** before such processing begins. Where the Licensee
+self-hosts and the Licensor has no access, no DPA is required.
+
+**12. Final provisions**
+
+12.1 Written form (including qualified electronic signature) is required for amendments.
+12.2 Assignment requires the other party's consent; the Licensor may assign to a legal entity
+it controls, having notified the Licensee.
+12.3 Severability: an invalid provision is replaced by what the parties would have reasonably
+agreed.
+12.4 **Governing law: German law**, excluding the CISG. Venue: the Licensor's domicile, as far
+as legally permissible.
+
+**Annexes** — A: Permitted Scope, metric, fees, model (subscription / perpetual) ·
+B: Support & SLA (optional) · C: DPA (if applicable).
+
+Place, date — Licensor / Licensee signatures.
+
+---
+
+## Annex A iskeleti (doldurulacak alanlar)
+
+| Alan | Örnek / seçenek |
+|---|---|
+| Kullanım tipi | Dahili kullanım · kendi müşterilerine SaaS · OEM/gömülü dağıtım |
+| Metrik | Aktif mentee sayısı · kiracı (tenant) sayısı · kurulum (instance) sayısı · şirket koltuğu |
+| Hacim / üst sınır | ör. 500 aktif mentee, 3 kurulum |
+| Model | Yıllık abonelik · süresiz lisans + %20 yıllık bakım |
+| Ücret | [tutar] / yıl, net |
+| Lisanslı sürüm | ör. `v1.4.x` hattı / commit `abc123` |
+| İştirakler | dahil / değil |
+| Ek modüller | white-label, SSO, API/entegrasyon paketi (varsa) |
+
+## Kontrol listesi — imzadan önce
+
+- [ ] Avukat gözden geçirmesi (özellikle §§ 7, 8 ve alıcı Almanya'daysa AGB kontrolü).
+- [ ] Faturalayan taraf netleşti mi? Tüzel kişi üzerinden satılacaksa hak sahibinden o
+      tüzel kişiye **iç lisans** gerekir (bkz. [legal-tax-framework.md](legal-tax-framework.md)).
+- [ ] KDV/reverse-charge doğru mu (AB içi B2B → alıcının VAT-ID'si + § 13b UStG notu).
+- [ ] Kişisel veri işlenecekse Annex C (DPA) hazır mı?
+- [ ] Üçüncü taraf açık kaynak bileşen listesi güncel mi (lisans uyumu: AGPL çekirdek +
+      bağımlılıklar)?
+- [ ] Alıcı Almanca sözleşme isterse: DE çeviri avukat tarafından hazırlanmalı (İngilizce
+      metin Almanya'da geçerlidir, ancak kurumsal alıcılar DE ister).

--- a/docs/legal/contributor-terms-in-app.md
+++ b/docs/legal/contributor-terms-in-app.md
@@ -1,0 +1,119 @@
+# Katkı şartlarının uygulama içinde onaylanması — tasarım
+
+> Hukuki tavsiye değildir; uygulanmadan önce (özellikle § 40 UrhG kısmı) avukat
+> gözden geçirmesi gerekir. Bağlam:
+> [cla-contributor-agreement.md](cla-contributor-agreement.md).
+
+## Soru
+
+Yeni geliştiriciler zaten bu platforma kaydoluyor. **Kayıt sırasında onayladıkları metne
+katkı şartlarını koymak yeterli mi?** Yoksa bir projeye eklenirken ayrıca onay almalı mıyız?
+
+## Cevap: elektronik onay yeterlidir — ama tek bir "ömür boyu" onay değil
+
+**Elektronik kabul (click-wrap) hukuken geçerlidir.** Alman hukukunda kullanım hakkı
+tanınması (Nutzungsrechtseinräumung, § 31 UrhG) kural olarak **yazılı şekle tabi değildir**;
+tıklayarak verilen onay da bağlayıcıdır. Geçerli olması için gereken pratik koşullar:
+
+1. **Metin onaydan önce görünür** olmalı (link değil, okunabilir içerik; link ise metin tek
+   tıkla ve giriş yapmadan erişilebilir olmalı).
+2. **İşaretsiz kutu** — önceden işaretli gelmemeli; kabul, kullanıcının aktif eylemi olmalı.
+3. **Sürümlü metin** — hangi sürümün kabul edildiği kayıtlı olmalı; metin değişince
+   **yeniden onay** istenmeli (eski onay yeni metni kapsamaz).
+4. **Kanıt kaydı** — kim, hangi sürümü, ne zaman, hangi IP'den kabul etti.
+5. **Kalıcı kopya** — kullanıcı kabul ettiği metni sonradan görebilmeli/indirebilmeli.
+
+**Ama iki hukuki sınır var** ve tasarımı bunlar belirliyor:
+
+- **§ 40 UrhG** — henüz yaratılmamış, yalnızca "türüyle" tanımlanmış **gelecek eserler**
+  üzerine yapılan sözleşmeler **yazılı şekil** gerektirir ve 5 yıl sonra feshedilebilir.
+  Yani "bundan sonraki tüm katkılarım şimdiden devredilmiştir" tarzı **tek ve süresiz bir
+  blanket onay zayıftır**.
+- **§ 31a UrhG** — bilinmeyen kullanım türleri için de yazılı şekil gerekir.
+
+**Tasarım sonucu:** onayı *geleceğe dönük tek bir taahhüt* olarak değil, **kapsamı belirli
+ve tekrarlanan** bir onay zinciri olarak kur:
+
+| Katman | Nerede | Neyi kapsar |
+|---|---|---|
+| **Platform onayı** | Kayıt / onboarding | Genel katkı şartları — bu kullanıcının bu platformdaki katkılarına uygulanacak kurallar |
+| **Proje onayı** | Kullanıcı bir projeye eklendiğinde | O projenin şartları (varsayılan veya projeye özel), kapsamı somut hale getirir |
+| **Katkı onayı** | Her PR (mevcut şablon kutusu) | O somut katkı — hukuken en güçlü halka, çünkü eser artık mevcut ve belirli |
+
+Üçü birlikte, tek bir blanket onaydan çok daha sağlam. **Bu yüzden "projeye eklenirken onay
+alalım" fikri doğru** — sadece ek bir tıklama değil, kapsamı belirlediği için hukuken
+anlamlı. Kağıt/e-imza yalnızca **mentorluk dışı** (ücretli çalışan, harici geliştirici,
+ajans, kurumsal katkı) durumlarda gerekli kalır.
+
+## Genel tasarım (çok projeli düşünülmüş)
+
+İleride başka projeler olacağı ve her projenin IP kuralı farklı olabileceği için şartlar
+**veri** olarak modellenir, koda gömülmez.
+
+```prisma
+model ContributorTerms {
+  id            String   @id @default(cuid())
+  key           String   // 'default' | 'project-x' ...
+  version       String   // '1.0' — değişince yeni satır, eski satır saklanır
+  locale        String   // 'en' | 'tr' | 'de' (biri "asıl metin" işaretlenir)
+  body          String   @db.Text  // markdown
+  isAuthoritative Boolean @default(false)
+  effectiveFrom DateTime
+  createdAt     DateTime @default(now())
+  @@unique([key, version, locale])
+}
+
+model ContributorTermsAcceptance {
+  id        String   @id @default(cuid())
+  userId    String
+  termsKey  String
+  version   String
+  projectId String?  // null = platform seviyesi onay
+  acceptedAt DateTime @default(now())
+  ipHash    String?  // kanıt (ham IP değil, hash — mevcut clientIp deseni)
+  uaHash    String?
+  @@unique([userId, termsKey, version, projectId])
+}
+```
+
+`Project` tarafında iki alan yeter:
+
+```prisma
+// model Project
+contributorTermsKey      String?  // null → platform varsayılanı
+contributorTermsRequired Boolean  @default(true)
+```
+
+**Akış:**
+1. Onboarding'e bir adım: metin gösterilir, işaretsiz kutu, kabul → `Acceptance` (platform).
+2. Bir kullanıcı projeye eklendiğinde: proje şartları kabul edilmemişse proje sayfası
+   **gate**'lenir (görev listesi görünmez, "şartları oku ve kabul et" ekranı çıkar).
+   Aynı desen `planGate`/`consent` katmanında mevcut — yeni bir mimari gerekmez.
+3. Metin sürümü değişirse: bir sonraki girişte yeniden onay istenir (mevcut
+   `consentRenew.ts` deseni birebir uygun).
+4. `/contributor-terms` sayfası: yürürlükteki metin + kullanıcının kabul geçmişi, indirilebilir.
+5. Admin: üye başına "kabul edildi mi / hangi sürüm / ne zaman" raporu + CSV/Excel ihracı
+   (due-diligence'ta istenecek olan tam olarak bu; `src/lib/excel.ts` mevcut).
+
+**Not:** Onay ekranı bir **hak talebinden feragat** de içerdiği için (bkz. CLA § 5), metnin
+sade dille yazılması ve tıklamadan önce tam görünmesi önemli — gizlenmiş bir feragat maddesi
+sürpriz madde (überraschende Klausel) sayılıp geçersiz olabilir.
+
+## Kapsam dışı bırakılanlar (bilinçli)
+
+- **Kimlik doğrulama/e-imza değil.** Nitelikli elektronik imza (QES) yalnızca § 40 UrhG
+  kapsamına giren blanket gelecek-eser sözleşmesi için gerekli olurdu; yukarıdaki üç
+  katmanlı kurgu o ihtiyacı ortadan kaldırıyor.
+- **Mevcut katkıcılara geriye dönük uygulama yok** — maintainer kararı (CLA dokümanı).
+  Sistem canlıya alındığında mevcut kullanıcılardan da bir kez onay istenebilir; bu
+  ileriye dönük netlik sağlar, geçmişi değiştirmez.
+
+## Uygulama dilimleri (issue'lara bölünmüş)
+
+1. **Şema + platform onayı** — `ContributorTerms`, `ContributorTermsAcceptance`,
+   `hasAcceptedContributorTerms()` helper'ı, onboarding adımı, `/contributor-terms` sayfası.
+2. **Proje seviyesi onay** — `Project.contributorTermsKey/Required`, projeye eklenince gate,
+   sürüm değişince yeniden onay.
+3. **Admin raporu + ihracat** — üye başına kabul durumu, filtre, Excel/CSV.
+
+Her dilim tek başına değer üretir ve junior-dostudur; 1. dilim olmadan 2 ve 3 anlamsızdır.

--- a/docs/legal/legal-tax-framework.md
+++ b/docs/legal/legal-tax-framework.md
@@ -10,24 +10,37 @@ tüzel kişiye devredilmemiştir (bkz. `LICENSE`,
 **gelirin hangi taraf üzerinden faturalandığını** ele alır — bu ayrı bir vergisel
 karardır ve hak sahipliğini değiştirmez.
 
-## Karar (teyit bekliyor)
-Ticarileşmenin **mevcut bcsit GmbH** (Almanya) üzerinden yürütülmesi öneriliyor. Yeni
-bir tüzel yapı kurulmaz — GmbH zaten var, sınırlı sorumluluk sağlıyor ve B2B SaaS
-faturalaması için uygun.
+## Karar: faturalayan taraf **ilk satışa kadar ertelendi** (maintainer, 2026-08-01)
 
-> ⚠️ **Açık karar:** Faturalamanın GmbH üzerinden mi, hak sahibinin şahsı üzerinden mi
-> yapılacağı maintainer tarafından teyit edilmeli. GmbH seçilirse, hak sahibinden
-> GmbH'ye **yazılı bir kullanım/dağıtım lisansı** (ör. münhasır olmayan, alt-lisans
-> verilebilir ticari dağıtım hakkı) gerekir — aksi halde GmbH, hakkı kendisinde olmayan
-> bir yazılımı satmış olur. Şahıs üzerinden faturalanırsa bu iç lisansa gerek kalmaz,
-> ancak sınırlı sorumluluk avantajı da kaybedilir; Enterprise müşteriler genelde tüzel
-> kişiyle sözleşme yapmayı tercih eder.
+Faturalamanın bcsit GmbH üzerinden mi, hak sahibinin şahsı üzerinden mi yapılacağı
+**şimdi karara bağlanmıyor**; ilk gerçek satış/talep geldiğinde karara bağlanacak. Bu
+bilinçli bir erteleme ve güvenlidir, çünkü:
+
+- Hak sahipliği **zaten net** (Mehmet Erşahin) — erteleyen karar yalnızca faturayı kimin
+  kestiği; bu, yazılımın hakları üzerinde hiçbir etki doğurmaz.
+- Karar, ilk müşterinin kim olduğuna göre değişebilir (kurumsal alıcı tüzel kişi ister,
+  küçük müşteri şahıs faturasını sorun etmez) — şimdi verilecek karar erken olur.
+- Geriye dönük düzeltilemeyen tek şey **fatura kesildikten sonrası**dır; imzadan önce
+  seçmek yeterli.
+
+> ⚠️ **İlk satıştan/imzadan önce yapılması gerekenler** (ertelemenin şartı):
+> 1. Faturalayan tarafı seç.
+> 2. **GmbH seçilirse**, hak sahibinden GmbH'ye **yazılı bir ticari dağıtım lisansı**
+>    (münhasır olmayan, alt-lisans verilebilir) imzalanmalı — aksi halde GmbH, hakkı
+>    kendisinde olmayan bir yazılımı satmış olur. Tek sayfalık bir metin yeterli, ama
+>    **fatura tarihinden önce** tarihli olmalı.
+> 3. Şahıs seçilirse iç lisansa gerek yok; ancak sınırlı sorumluluk avantajı olmaz ve
+>    Enterprise alıcılar genelde tüzel kişiyle sözleşme yapmak ister.
+>
+> Bunlar yapılmadan sözleşme imzalanmamalı/fatura kesilmemeli.
 
 ### 1. Tüzel yapı
-- **Yürütücü (varsayım):** bcsit GmbH (Almanya). Gelir, sözleşmeler ve faturalar GmbH
+- **Aday (henüz seçilmedi):** bcsit GmbH (Almanya) — gelir, sözleşmeler ve faturalar GmbH
   üzerinden; yazılımın hakları hak sahibinde kalır, GmbH iç lisansla satar.
 - Gerekçe: hazır yapı, sınırlı sorumluluk, kurumsal müşterinin (Enterprise) sözleşme
   yapmak isteyeceği tüzel kişilik.
+- **Alternatif:** hak sahibinin şahsı üzerinden faturalama (iç lisans gerekmez, kurulum
+  maliyeti sıfır; sınırlı sorumluluk yok).
 
 ### 2. Vergi / faturalama
 - **KDV (Umsatzsteuer):** GmbH KDV mükellefi; faturalarda %19 USt gösterilir.
@@ -57,8 +70,9 @@ faturalaması için uygun.
 - **Kullanım Şartları + Gizlilik** (mevcut `/terms`, `/privacy` ile uyumlu).
 
 ## Aksiyon listesi
-- [ ] **Faturalayan tarafı teyit et** (bcsit GmbH mi, hak sahibinin şahsı mı).
-- [ ] GmbH seçilirse: hak sahibi → GmbH ticari dağıtım lisansını yazılı hale getir.
+- [x] Kararı ilk satışa ertele (yukarıdaki şartlarla) — 2026-08-01.
+- [ ] **İlk talep geldiğinde:** faturalayan tarafı seç (bcsit GmbH mi, şahıs mı).
+- [ ] GmbH seçilirse: hak sahibi → GmbH ticari dağıtım lisansını **fatura öncesi** imzala.
 - [ ] Steuerberater ile KDV/reverse-charge faturalama akışını netleştir.
 - [ ] Avukatla B2B SaaS sözleşme + DPA şablonları hazırlat.
 - [ ] Success-fee kullanılacaksa AÜG/SGB III değerlendirmesi (ayrı, ertelenebilir).

--- a/docs/legal/licensing-strategy.md
+++ b/docs/legal/licensing-strategy.md
@@ -79,7 +79,7 @@ bulundurmak yeterlidir.
 - [x] Tek hak sahibini her yerde sabitle (`LICENSE`, `README.md`, `package.json`, CLA).
 - [x] Marka hakkı notunu ekle (`README.md`, `LICENSE` başlığı).
 - [x] Katkı şartlarını gelecek katkılar için yazılı hale getir (CONTRIBUTING + PR şablonu).
-- [ ] Bir sayfalık **ticari lisans şablonu** hazırlat (kapsam, süre, destek, sorumluluk
-      sınırı, fiyat) — ilk talep gelmeden önce hazır olsun.
+- [x] **Ticari lisans şablonu** taslağı hazır —
+      [commercial-license-template.md](commercial-license-template.md) (avukat turu bekliyor).
 - [ ] Premium/kapalı modül sınırını Faz 3'e girmeden yazılı olarak belirle.
 - [ ] Ürün içine "kaynak kodu" bağlantısı ekle (küçük UI işi; ayrı issue).


### PR DESCRIPTION
## Summary

Follow-up to #1019, covering the maintainer's three decisions.

**1. Invoicing party — deferred until the first sale (recorded as a decision, not an open
item).** Safe to defer: rights ownership is already settled, and the only thing that cannot
be fixed retroactively is invoicing after the fact. The doc now states the *conditions* of
the deferral: choose before signing, and if the GmbH invoices, a written rights-holder →
GmbH commercial distribution licence must be dated before the first invoice.

**2. Commercial licence template — drafted.** A usable working draft rather than a stub, so
nothing has to be written from scratch when the first request arrives.

**3. In-app contributor terms.** Registration-time acceptance is legally valid, but a single
blanket "all my future contributions" consent is weak under § 40 UrhG (contracts over
unspecified future works require written form and are terminable after 5 years). The design
therefore uses three scoped layers instead: platform acceptance at onboarding, project
acceptance when a user joins a project, and the existing per-PR confirmation as the
per-contribution anchor. Terms are modelled as *data* so future projects can define their
own IP rules.

Docs-only — no version bump (CLAUDE.md pure-docs exemption).

## Changes

- **`docs/legal/commercial-license-template.md`** (new) — when a commercial licence is
  actually needed (decision table); full draft agreement: AGPL-relief clause, scope options
  (internal / SaaS / OEM), delivery & updates, term and the different termination effects for
  subscription vs perpetual, warranty, liability cap with the § 309 BGB caveat, IP and
  trademark carve-out, confidentiality, Art. 28 GDPR annex, German law; Annex A skeleton
  (metric/volume/model/price) and a pre-signature checklist.
- **`docs/legal/contributor-terms-in-app.md`** (new) — validity conditions for click-wrap
  (text shown up front, unticked box, versioning, evidence record, durable copy), the
  § 40 / § 31a UrhG limits, the three-layer acceptance model, Prisma sketch
  (`ContributorTerms`, `ContributorTermsAcceptance`, `Project.contributorTermsKey/Required`),
  gate/re-acceptance flow reusing the existing `consent` / `planGate` patterns, admin
  acceptance report, and three independently-shippable implementation slices.
- **`docs/legal/legal-tax-framework.md`** — the deferral decision and its conditions.
- **`docs/legal/README.md`**, **`licensing-strategy.md`**, **`cla-contributor-agreement.md`**
  — index rows, cross-references, action lists.

## Verification

- [x] Documentation only — no `src/`, schema, i18n or workflow changes
- [ ] Legal texts still need a lawyer's pass before first use (§§ 7–8 of the licence draft,
      § 40 UrhG reasoning in the terms design)

## Contributor terms

- [x] Authored on behalf of the rights holder; no third-party code introduced.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GZzCHgHX9SraP5un6BgMPb)_