### PR TITLE
fix(availability): admin's added slot disappeared, making "Ekle" look dead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.38.1-beta] - 2026-08-01
+
+### Fixed
+- **Availability: the "Add" button did nothing for admins.** `POST /api/availability`
+  has always accepted ADMINs — they reach the mentor shell through the view switch
+  added in 0.37.0-beta — but `GET` only defaulted `mentorId` to the session user when
+  the role was `MENTOR`, and returned `{ slots: [] }` for everyone else. So an admin's
+  slot was created (201), the page reloaded the list, got nothing back, and stayed on
+  "Your slots (0)": a silent write with no visible effect. `GET` without `?mentorId=`
+  now means "my own slots" for any role, matching what `POST` writes. Regression test
+  drives the page through the UI (`e2e/calendar.spec.ts`) — the existing mentor test
+  hits the API only and passed the entire time this was broken.
+
 ## [0.38.0-beta] - 2026-08-01
 
 ### Added

--- a/e2e/calendar.spec.ts
+++ b/e2e/calendar.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { randomBytes } from 'crypto';
 import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { signInAndSettle } from './helpers/auth';
 
 test.afterAll(async () => {
   await prisma.$disconnect();
@@ -21,6 +22,32 @@ test('a mentor can add and list availability slots', async ({ page }) => {
     expect(await prisma.availabilitySlot.count({ where: { mentorId: mentor.id } })).toBeGreaterThan(0);
   } finally {
     await prisma.availabilitySlot.deleteMany({ where: { mentorId: mentor.id } });
+    await cleanupByEmail(email);
+  }
+});
+
+/**
+ * The admin path through the same page. POST has always accepted ADMINs (they
+ * reach the mentor shell through the view switch), but GET only defaulted to
+ * "my own slots" for MENTORs, so the list came back empty and the Add button
+ * looked dead. Driven through the UI because the API-level mentor test above
+ * passed the whole time this was broken.
+ */
+test('an admin sees the slot they just added on the availability page', async ({ page }) => {
+  const email = uniqueEmail('av-admin');
+  const admin = await seedUser(email, 'AdminPass123', 'ADMIN', 'Av Admin');
+  try {
+    await signInAndSettle(page, email, 'AdminPass123', '/admin');
+    await page.goto('/mentor/availability');
+
+    // The form ships with usable defaults (Monday, 09:00–10:00) — just submit.
+    const form = page.locator('form').filter({ has: page.locator('input[type="time"]') });
+    await form.locator('button[type="submit"]').click();
+
+    await expect(page.getByText('09:00–10:00')).toBeVisible();
+    expect(await prisma.availabilitySlot.count({ where: { mentorId: admin.id } })).toBe(1);
+  } finally {
+    await prisma.availabilitySlot.deleteMany({ where: { mentorId: admin.id } });
     await cleanupByEmail(email);
   }
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.38.0-beta",
+  "version": "0.38.1-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "author": "Mehmet Erşahin",

--- a/src/app/api/availability/route.ts
+++ b/src/app/api/availability/route.ts
@@ -6,13 +6,17 @@ import { z } from 'zod';
 
 const TIME = /^([01]\d|2[0-3]):[0-5]\d$/;
 
-// GET — availability slots. Mentors see their own; ?mentorId= returns a
-// mentor's slots (for booking).
+// GET — availability slots. Without a parameter you get your own; ?mentorId=
+// returns a mentor's slots (for booking).
+//
+// "Your own" deliberately includes ADMINs: POST lets an admin add slots (they
+// reach the mentor shell through the view switch to work their own mentees), so
+// a GET that only defaulted for MENTORs left the page permanently empty — every
+// added slot vanished and the Add button looked dead.
 export async function GET(request: Request) {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  const mentorId = new URL(request.url).searchParams.get('mentorId') || (session.user.role === 'MENTOR' ? session.user.id : null);
-  if (!mentorId) return NextResponse.json({ slots: [] });
+  const mentorId = new URL(request.url).searchParams.get('mentorId') || session.user.id;
   const slots = await prisma.availabilitySlot.findMany({ where: { mentorId }, orderBy: [{ weekday: 'asc' }, { startTime: 'asc' }] });
   return NextResponse.json({ slots });
 }

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,21 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.38.1-beta',
+    date: '2026-08-01',
+    highlights: {
+      en: [
+        'Availability: the "Add" button now works for admins too. Adding a slot did save it, but the list underneath kept showing "Your slots (0)", so it looked like nothing happened. Any slots you added earlier were never lost — they are all visible again.',
+      ],
+      tr: [
+        'Müsaitlik: "Ekle" düğmesi artık yöneticiler için de çalışıyor. Saat aslında kaydediliyordu, ama alttaki liste "Saatlerin (0)" göstermeye devam ettiği için hiçbir şey olmamış gibi görünüyordu. Daha önce eklediğiniz saatler kaybolmadı — hepsi yeniden görünüyor.',
+      ],
+      de: [
+        'Verfügbarkeit: Die Schaltfläche „Hinzufügen“ funktioniert jetzt auch für Admins. Das Zeitfenster wurde zwar gespeichert, die Liste darunter zeigte aber weiterhin „Deine Zeitfenster (0)“ — es sah also aus, als passiere nichts. Früher angelegte Zeitfenster gingen nie verloren und sind wieder sichtbar.',
+      ],
+    },
+  },
+  {
     version: '0.38.0-beta',
     date: '2026-08-01',
     highlights: {


### PR DESCRIPTION
## The bug

On **Müsaitlik** (`/mentor/availability`), pressing **Ekle** appeared to do
nothing: no error, no new row, the list stayed on `Saatlerin (0)`.

## Root cause

The write worked; the read didn't. `POST /api/availability` has always accepted
ADMINs — admins reach the mentor shell through the "View as" switch added in
0.37.0-beta — but `GET` defaulted `mentorId` to the session user **only when the
role was `MENTOR`**, and returned `{ slots: [] }` for everyone else:

```ts
const mentorId = searchParams.get('mentorId') || (session.user.role === 'MENTOR' ? session.user.id : null);
if (!mentorId) return NextResponse.json({ slots: [] });
```

So an admin got a `201`, the page reloaded the list, got an empty array back,
and rendered `(0)` again — a silent write with no visible effect. Mentors were
never affected.

## Fix

`GET` without `?mentorId=` now means "my own slots" for any role, matching what
`POST` writes. The `?mentorId=` branch (for booking) is unchanged.

## Test

`e2e/calendar.spec.ts` gets an admin test that drives the **page**, not the API:
sign in → `/mentor/availability` → submit the form → expect the slot to show up.
The existing mentor test only hits the API and passed the entire time this was
broken, which is why the UI path is the one asserted now.

- ✅ `tsc --noEmit` clean, `next lint` clean
- Version bumped to `0.38.1-beta` + CHANGELOG + release notes (EN/TR/DE)

No data was lost — slots added earlier were stored all along and are visible again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)