### PR TITLE
fix(email): meeting times render in the recipient's timezone, not the server's

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,12 @@ LOG_LEVEL="info"
 # App
 NEXT_PUBLIC_APP_URL="http://localhost:3000"
 
+# Fallback IANA timezone for server-rendered times (reminder/invite emails and
+# the stored text of in-app notifications) when the recipient has no timezone on
+# their profile. The container runs on UTC, so without this those times would be
+# printed on the UTC clock (#1030). Defaults to Europe/Istanbul.
+APP_TIMEZONE="Europe/Istanbul"
+
 # First admin (optional — used by: npx prisma db seed)
 # SEED_ADMIN_EMAIL="admin@example.com"
 # SEED_ADMIN_PASSWORD="ChangeMe123!"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.38.2-beta] - 2026-08-02
+
+### Fixed
+- **Meeting reminder emails printed the wrong time.** A meeting the app showed at
+  09:00 arrived as "07:00" in the reminder. The instant stored in the DB was right
+  the whole time; the *rendering* was not. Emails and the stored text of in-app
+  notifications are produced server-side, where `toLocaleString()` without a
+  `timeZone` falls back to the process zone — and the container runs on UTC. So
+  every recipient read every meeting time on the UTC clock while the browser
+  showed it on theirs. Server-rendered times now name an explicit zone
+  (`src/lib/timezone.ts`): the recipient's saved `User.timezone`, else
+  `APP_TIMEZONE`, else `Europe/Istanbul` — and carry a `(GMT+3)`-style suffix so a
+  time is never ambiguous across zones. Applies to the meeting reminder, the
+  meeting invite, the meeting request and the request-decision emails; the
+  reminder resolves the zone per participant, so a mentor and a mentee in
+  different zones each read their own clock.
+
+### Added
+- **The browser's timezone is captured for profiles that have none**
+  (`TimezoneSync` → `POST /api/profile/timezone`, once per browser session). Only
+  the mentee profile form exposes a zone picker, so mentors and admins had no zone
+  at all and would have kept reading times on the deployment default. The endpoint
+  fills the field **only when it is empty** — an explicitly chosen zone is never
+  overwritten — and ignores impersonated sessions.
+
 ## [0.38.1-beta] - 2026-08-01
 
 ### Fixed

--- a/e2e/cron-jobs.spec.ts
+++ b/e2e/cron-jobs.spec.ts
@@ -13,14 +13,20 @@ test('admin cron run sends meeting reminders and stamps reminderSentAt', async (
   await seedUser(adminEmail, 'AdminPass123', 'ADMIN', 'Cron Admin');
   const mentor = await seedUser(mentorEmail, 'x', 'MENTOR', 'Cron Mentor');
   const mentee = await seedUser(menteeEmail, 'x', 'MENTEE', 'Cron Mentee');
+  // Two participants, two clocks — each reminder must be rendered in the
+  // recipient's own zone, never the server's (#1030).
+  const ZONES: Record<string, string> = { [mentor.id]: 'Europe/Istanbul', [mentee.id]: 'Pacific/Honolulu' };
+  await prisma.user.update({ where: { id: mentor.id }, data: { timezone: ZONES[mentor.id] } });
+  await prisma.user.update({ where: { id: mentee.id }, data: { timezone: ZONES[mentee.id] } });
   const rel = await prisma.mentorshipRelation.create({ data: { mentorId: mentor.id, menteeId: mentee.id } });
+  const scheduledAt = new Date(Date.now() + 30 * 60 * 1000);
   const meeting = await prisma.meeting.create({
     data: {
       relationId: rel.id,
       title: 'Soon Meeting',
       // Inside the 60-minute reminder window (#777) — a meeting further out is
       // deliberately NOT reminded yet.
-      scheduledAt: new Date(Date.now() + 30 * 60 * 1000),
+      scheduledAt,
       rsvpToken: randomBytes(12).toString('hex'),
       createdById: mentor.id,
     },
@@ -59,6 +65,14 @@ test('admin cron run sends meeting reminders and stamps reminderSentAt', async (
       const notes = await prisma.notification.findMany({ where: { userId, type: 'meeting_reminder' } });
       expect(notes.length).toBe(1);
       expect(notes[0].text).toContain('Soon Meeting');
+      // …and the time reads on the recipient's clock, not the server's.
+      const timeZone = ZONES[userId];
+      const expectedTime = new Intl.DateTimeFormat('en-GB', { timeStyle: 'short', timeZone }).format(scheduledAt);
+      const expectedZone = new Intl.DateTimeFormat('en-GB', { timeZone, timeZoneName: 'shortOffset' })
+        .formatToParts(scheduledAt)
+        .find((p) => p.type === 'timeZoneName')!.value;
+      expect(notes[0].text).toContain(expectedTime);
+      expect(notes[0].text).toContain(`(${expectedZone})`);
     }
 
     // Idempotent: a second run must not produce a second reminder.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.38.1-beta",
+  "version": "0.38.2-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "author": "Mehmet Erşahin",

--- a/src/app/api/meeting-requests/[id]/route.ts
+++ b/src/app/api/meeting-requests/[id]/route.ts
@@ -19,11 +19,11 @@ async function emailDecision(
 ) {
   const user = await prisma.user.findUnique({
     where: { id: requestedById },
-    select: { fullName: true, email: true, orgId: true, emailNotifications: true, notificationPrefs: true },
+    select: { fullName: true, email: true, orgId: true, emailNotifications: true, notificationPrefs: true, timezone: true },
   });
   if (!user?.email || !emailAllowed(user, 'meetingReminders')) return;
   try {
-    await sendMeetingRequestDecisionEmail({ to: user.email, fullName: user.fullName, orgId: user.orgId, ...args });
+    await sendMeetingRequestDecisionEmail({ to: user.email, fullName: user.fullName, orgId: user.orgId, timeZone: user.timezone, ...args });
   } catch (e) {
     console.error('Meeting request decision email failed:', e);
   }

--- a/src/app/api/meeting-requests/route.ts
+++ b/src/app/api/meeting-requests/route.ts
@@ -55,7 +55,7 @@ export async function POST(request: Request) {
     // never gets answered. Opt-out respected, failures logged.
     const rcpt = await prisma.user.findUnique({
       where: { id: recipient },
-      select: { fullName: true, email: true, orgId: true, emailNotifications: true, notificationPrefs: true },
+      select: { fullName: true, email: true, orgId: true, emailNotifications: true, notificationPrefs: true, timezone: true },
     });
     if (rcpt?.email && emailAllowed(rcpt, 'meetingReminders')) {
       try {
@@ -67,6 +67,7 @@ export async function POST(request: Request) {
           proposedAt: req.proposedAt,
           link,
           orgId: rcpt.orgId,
+          timeZone: rcpt.timezone,
         });
       } catch (e) {
         console.error('Meeting request email failed:', e);

--- a/src/app/api/meeting-series/route.ts
+++ b/src/app/api/meeting-series/route.ts
@@ -94,7 +94,7 @@ async function generateForSeries(series: {
       ...(role === 'MENTOR' ? { mentorId: sessionUserId } : {}),
       ...(menteeIds.length > 0 ? { menteeId: { in: menteeIds } } : {}),
     },
-    include: { mentee: { select: { email: true, fullName: true } } },
+    include: { mentee: { select: { email: true, fullName: true, timezone: true } } },
   });
   if (relations.length === 0) return { created: 0, fixedLink: series.fixedLink };
 
@@ -143,6 +143,7 @@ async function generateForSeries(series: {
           scheduledAt: when,
           meetLink: fixedLink,
           rsvpToken,
+          timeZone: rel.mentee.timezone,
         });
       } catch (e) {
         console.error('Meeting series invite email failed:', e);

--- a/src/app/api/meetings/route.ts
+++ b/src/app/api/meetings/route.ts
@@ -55,7 +55,7 @@ export async function POST(request: Request) {
         : { id: { in: relationIds }, mentorId: session.user.id };
     const relations = await prisma.mentorshipRelation.findMany({
       where,
-      include: { mentee: { select: { email: true, fullName: true } } },
+      include: { mentee: { select: { email: true, fullName: true, timezone: true } } },
     });
 
     // Bulk scheduling creates ONE shared meeting: everyone selected joins the
@@ -85,6 +85,7 @@ export async function POST(request: Request) {
           scheduledAt: when,
           meetLink: link,
           rsvpToken,
+          timeZone: rel.mentee.timezone,
         });
       } catch (e) {
         console.error('Meeting invite email failed:', e);

--- a/src/app/api/profile/timezone/route.ts
+++ b/src/app/api/profile/timezone/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { z } from 'zod';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { isValidTimeZone } from '@/lib/timezone';
+import { withTenantScope } from '@/lib/orgContext';
+
+const bodySchema = z.object({
+  timezone: z.string().max(80).refine(isValidTimeZone, { message: 'Invalid IANA timezone' }),
+});
+
+// POST — record the zone the browser reports, but ONLY for a profile that has
+// none yet. Emails and stored notification texts are rendered server-side in the
+// recipient's zone (#1030); without this, everyone who never opened the profile
+// form would read meeting times on the deployment's default clock instead of
+// their own. An explicitly chosen zone is never overwritten — that is the whole
+// point of the `timezone: null` guard below, and why this is a separate endpoint
+// rather than a PUT /api/profile with a `timezone` field.
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) return new NextResponse(null, { status: 204 });
+  // Not the real user's browser — don't write their profile from it.
+  if (session.user.impersonatorId) return new NextResponse(null, { status: 204 });
+
+  return await withTenantScope(session, async () => {
+    const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+    if (!parsed.success) return new NextResponse(null, { status: 204 });
+
+    try {
+      const res = await prisma.user.updateMany({
+        where: { id: session.user.id, OR: [{ timezone: null }, { timezone: '' }] },
+        data: { timezone: parsed.data.timezone },
+      });
+      return NextResponse.json({ saved: res.count > 0 });
+    } catch {
+      // A best-effort convenience write must never break the page.
+      return new NextResponse(null, { status: 204 });
+    }
+  });
+}

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -5,6 +5,7 @@ import { LocaleProvider } from '@/i18n/client';
 import { ToastProvider } from '@/components/ui/Toast';
 import { CookieConsent } from '@/components/CookieConsent';
 import { ActivityTracker } from '@/components/ActivityTracker';
+import { TimezoneSync } from '@/components/TimezoneSync';
 import type { Locale } from '@/i18n/config';
 import type { ClientDictionary } from '@/i18n/dictionaries';
 
@@ -24,6 +25,7 @@ export function Providers({
           {children}
           <CookieConsent />
           <ActivityTracker />
+          <TimezoneSync />
         </ToastProvider>
       </LocaleProvider>
     </SessionProvider>

--- a/src/components/TimezoneSync.tsx
+++ b/src/components/TimezoneSync.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useSession } from 'next-auth/react';
+
+// Reminder emails render meeting times in the recipient's saved zone
+// (lib/timezone.ts). Only the mentee profile form exposes a zone picker, so most
+// users never save one and would read every time on the deployment's default
+// clock. This reports the browser's zone once per browser session; the server
+// stores it only when the profile has none (#1030).
+//
+// Mounted once globally in Providers; self-gates on an authenticated session.
+const SENT_KEY = 'tzSynced';
+
+export function TimezoneSync() {
+  const { status } = useSession();
+
+  useEffect(() => {
+    if (status !== 'authenticated') return;
+    let tz: string | undefined;
+    try {
+      if (sessionStorage.getItem(SENT_KEY)) return;
+      tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    } catch {
+      return; // storage blocked or no Intl data — nothing to do
+    }
+    if (!tz) return;
+    fetch('/api/profile/timezone', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ timezone: tz }),
+    })
+      .then(() => {
+        try {
+          sessionStorage.setItem(SENT_KEY, '1');
+        } catch {
+          /* ignore */
+        }
+      })
+      .catch(() => {});
+  }, [status]);
+
+  return null;
+}

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,24 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.38.2-beta',
+    date: '2026-08-02',
+    highlights: {
+      en: [
+        'Meeting reminder emails now show the right time. A meeting at 09:00 in the app arrived as "07:00" in the email, because the times were written on the server\'s clock. Emails and notifications now use your own timezone and spell it out, e.g. "2 Aug 2026, 09:00 (GMT+2)". Nothing was ever scheduled at the wrong time — only the reminder text was misleading.',
+        'Your timezone is picked up from your browser automatically if you never set one. Mentees can still choose it by hand under Profile, and a zone you chose yourself is never overwritten.',
+      ],
+      tr: [
+        'Toplantı hatırlatma e-postalarındaki saat artık doğru. Uygulamada 09:00 görünen bir toplantı e-postada "07:00" olarak geliyordu, çünkü saatler sunucunun saatiyle yazılıyordu. E-postalar ve bildirimler artık sizin saat diliminizi kullanıyor ve bunu açıkça yazıyor: örneğin "2 Aug 2026, 09:00 (GMT+2)". Toplantılar hiçbir zaman yanlış saate kurulmadı — yalnızca hatırlatma metni yanıltıcıydı.',
+        'Hiç seçmediyseniz saat diliminiz tarayıcınızdan otomatik olarak alınır. Mentee’ler Profil sayfasından elle de seçebilir; kendi seçtiğiniz saat dilimi hiçbir zaman üzerine yazılmaz.',
+      ],
+      de: [
+        'Erinnerungs-E-Mails zu Terminen zeigen jetzt die richtige Uhrzeit. Ein Termin, den die App um 09:00 anzeigte, kam in der E-Mail als „07:00“ an, weil die Zeiten auf der Uhr des Servers geschrieben wurden. E-Mails und Benachrichtigungen verwenden nun Ihre eigene Zeitzone und nennen sie ausdrücklich, z. B. „2 Aug 2026, 09:00 (GMT+2)“. Kein Termin lag jemals falsch — nur der Erinnerungstext war irreführend.',
+        'Ihre Zeitzone wird automatisch aus dem Browser übernommen, falls Sie nie eine gesetzt haben. Mentees können sie im Profil weiterhin selbst wählen; eine selbst gewählte Zone wird nie überschrieben.',
+      ],
+    },
+  },
+  {
     version: '0.38.1-beta',
     date: '2026-08-01',
     highlights: {

--- a/src/lib/timezone.ts
+++ b/src/lib/timezone.ts
@@ -1,0 +1,60 @@
+// Server-side date/time rendering for anything a user reads *outside* the
+// browser — emails and the stored text of in-app notifications.
+//
+// The browser picks the viewer's zone on its own (see lib/relativeTime.ts), but
+// the server has no such context: the container runs on UTC, so a plain
+// `toLocaleString()` rendered a 09:00 Europe/Berlin meeting as "07:00" in the
+// reminder email while the app showed 09:00 (#1030). Every server-rendered
+// timestamp therefore has to name an explicit zone.
+//
+// Resolution order: the recipient's saved `User.timezone` → the deployment
+// default (`APP_TIMEZONE`) → Europe/Istanbul.
+
+export const FALLBACK_TIMEZONE = 'Europe/Istanbul';
+
+export function isValidTimeZone(tz?: string | null): tz is string {
+  if (!tz) return false;
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Deployment-wide default for recipients who never saved a zone.
+export function appTimeZone(): string {
+  const configured = process.env.APP_TIMEZONE;
+  return isValidTimeZone(configured) ? configured : FALLBACK_TIMEZONE;
+}
+
+export function resolveTimeZone(tz?: string | null): string {
+  return isValidTimeZone(tz) ? tz : appTimeZone();
+}
+
+// "GMT+3" — appended to every rendered time so a recipient in another zone can
+// see which clock the time refers to instead of guessing.
+function zoneLabel(date: Date, timeZone: string): string {
+  const parts = new Intl.DateTimeFormat('en-GB', { timeZone, timeZoneName: 'shortOffset' }).formatToParts(date);
+  return parts.find((p) => p.type === 'timeZoneName')?.value ?? '';
+}
+
+// Absolute date+time in the recipient's zone, e.g. "2 Aug 2026, 09:00 (GMT+3)".
+// `options` overrides the date/time style; note Intl forbids mixing
+// dateStyle/timeStyle with individual component options, which is why the zone
+// is appended as text rather than passed as `timeZoneName`.
+export function formatInTimeZone(
+  date: Date,
+  tz?: string | null,
+  options?: Intl.DateTimeFormatOptions
+): string {
+  const timeZone = resolveTimeZone(tz);
+  const formatted = new Intl.DateTimeFormat('en-GB', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+    ...options,
+    timeZone,
+  }).format(date);
+  const label = zoneLabel(date, timeZone);
+  return label ? `${formatted} (${label})` : formatted;
+}

--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -8,6 +8,7 @@ import { makeConsentRenewToken } from '@/lib/consentRenew';
 import { getRetentionMonths, RETENTION_GRACE_DAYS } from '@/lib/retention';
 import { getMentorMenteeActivity, getSystemMenteeActivity, formatDuration, type MenteeActivity } from '@/lib/activityReport';
 import { getOrgBranding } from '@/lib/orgBranding';
+import { formatInTimeZone } from '@/lib/timezone';
 
 // Resolved branding for a transactional email (#546). When no orgId is given
 // (single-tenant, or a caller without tenant context) this returns the product
@@ -272,6 +273,7 @@ export async function sendMeetingInviteEmail({
   scheduledAt,
   meetLink,
   rsvpToken,
+  timeZone,
 }: {
   to: string;
   fullName?: string | null;
@@ -279,13 +281,15 @@ export async function sendMeetingInviteEmail({
   scheduledAt: Date | null;
   meetLink?: string | null;
   rsvpToken: string;
+  // The recipient's saved IANA zone; falls back to the deployment default.
+  timeZone?: string | null;
 }) {
   const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
   const yes = `${appUrl}/rsvp/${rsvpToken}?r=yes`;
   const no = `${appUrl}/rsvp/${rsvpToken}?r=no`;
   // A meeting with no set time is just a shared link — skip the "when" line and
   // the RSVP ask entirely.
-  const when = scheduledAt ? scheduledAt.toLocaleString('en-GB', { dateStyle: 'full', timeStyle: 'short' }) : null;
+  const when = scheduledAt ? formatInTimeZone(scheduledAt, timeZone, { dateStyle: 'full', timeStyle: 'short' }) : null;
 
   await sendEmail({
     to,
@@ -460,6 +464,7 @@ export async function sendMeetingRequestEmail({
   proposedAt,
   link,
   orgId,
+  timeZone,
 }: {
   to: string;
   fullName?: string | null;
@@ -468,9 +473,10 @@ export async function sendMeetingRequestEmail({
   proposedAt: Date | null;
   link: string;
   orgId?: string | null;
+  timeZone?: string | null;
 }) {
   const brand = await emailBrand(orgId);
-  const when = proposedAt ? proposedAt.toLocaleString('en-GB', { dateStyle: 'full', timeStyle: 'short' }) : null;
+  const when = proposedAt ? formatInTimeZone(proposedAt, timeZone, { dateStyle: 'full', timeStyle: 'short' }) : null;
   await sendEmail({
     to,
     fromName: brand.name,
@@ -496,6 +502,7 @@ export async function sendMeetingRequestDecisionEmail({
   meetLink,
   link,
   orgId,
+  timeZone,
 }: {
   to: string;
   fullName?: string | null;
@@ -505,9 +512,10 @@ export async function sendMeetingRequestDecisionEmail({
   meetLink?: string | null;
   link: string;
   orgId?: string | null;
+  timeZone?: string | null;
 }) {
   const brand = await emailBrand(orgId);
-  const when = scheduledAt ? scheduledAt.toLocaleString('en-GB', { dateStyle: 'full', timeStyle: 'short' }) : null;
+  const when = scheduledAt ? formatInTimeZone(scheduledAt, timeZone, { dateStyle: 'full', timeStyle: 'short' }) : null;
   await sendEmail({
     to,
     fromName: brand.name,
@@ -747,6 +755,7 @@ export async function sendMeetingReminders() {
     orgId: true,
     emailNotifications: true,
     notificationPrefs: true,
+    timezone: true,
   } as const;
 
   const meetings = await prisma.meeting.findMany({
@@ -775,7 +784,6 @@ export async function sendMeetingReminders() {
     if (claim.count === 0) continue;
     reminded++;
 
-    const when = m.scheduledAt!.toLocaleString('en-GB', { dateStyle: 'medium', timeStyle: 'short' });
     const minutes = Math.max(1, Math.round((m.scheduledAt!.getTime() - Date.now()) / 60000));
 
     // Both sides of the relation are participants. Series-generated meetings
@@ -786,6 +794,9 @@ export async function sendMeetingReminders() {
 
     for (const user of participants) {
       const link = user.role === 'MENTEE' ? '/portal' : '/mentor/meetings';
+      // Per participant: the two sides of a relation can sit in different zones,
+      // and each must read the time on their own clock (#1030).
+      const when = formatInTimeZone(m.scheduledAt!, user.timezone);
       // In-app: unconditional (notify() never throws).
       await notify(
         user.id,


### PR DESCRIPTION
Closes #1030

## The bug

A meeting the app showed at **09:00** arrived as **"07:00"** in the reminder email.

The instant in the DB was correct the whole time — the *rendering* was not.
Emails and the stored text of in-app notifications are produced server-side,
where `Date.toLocaleString('en-GB', …)` **without a `timeZone`** falls back to
the Node process zone. The container runs on UTC, so every recipient read every
meeting time on the UTC clock while the browser showed it on theirs. The 2-hour
gap in the report is exactly the reporter's GMT+2 offset.

## The fix

`src/lib/timezone.ts` — one resolver for every server-rendered time:

| step | source |
|---|---|
| 1 | the recipient's saved `User.timezone` |
| 2 | `APP_TIMEZONE` (new, documented in `.env.example`) |
| 3 | `Europe/Istanbul` |

Rendered times now carry the zone: `2 Aug 2026, 09:00 (GMT+2)`. Applied to the
meeting **reminder**, **invite**, **request** and **request-decision** templates,
with the recipient's zone threaded in from the four calling routes. The reminder
resolves the zone **per participant** — a mentor and a mentee need not share one
— which also fixes the in-app notification text, previously computed once per
meeting.

## Why the extra endpoint

Only the mentee profile form exposes a zone picker, so mentors and admins had
**no** zone stored and would have kept reading times on the deployment default.
`TimezoneSync` (mounted in `Providers`, self-gating on an authenticated session)
reports the browser's zone once per browser session; `POST /api/profile/timezone`
writes it **only when the field is empty**, so a zone the user chose by hand is
never overwritten. Impersonated sessions are ignored — that isn't the user's own
browser.

## Verification

- `npx tsc --noEmit`, `npm run lint`, `npm run check:i18n`, `next build` — all clean.
- Formatter exercised under `TZ=UTC` with the exact instant from the report
  (`2026-08-02T07:00:00Z`): Berlin recipient → `2 Aug 2026, 09:00 (GMT+2)` (what the
  app shows), Istanbul → `10:00 (GMT+3)`, unset/invalid zone → the app default.
- `e2e/cron-jobs.spec.ts` now seeds the two participants in **Europe/Istanbul** and
  **Pacific/Honolulu** and asserts each reminder carries that participant's own
  clock and offset label — the old code produced one shared UTC string and would
  fail this.

## Out of scope (spotted, not fixed)

`meeting-series` interprets a recurring `timeOfDay` as **UTC** (`buildScheduledAt`
uses `Date.UTC`), so a series set to "09:00" is scheduled at 09:00 UTC rather than
09:00 local. That is a scheduling bug rather than a rendering one; filed
separately rather than folded into this fix.

## Versioning

`0.38.2-beta` — `package.json`, `CHANGELOG.md`, `src/lib/releaseNotes.ts` (EN/TR/DE).