### PR TITLE
fix(impersonation): show the "return to your account" bar on shell-less screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.38.3-beta] - 2026-08-02
+
+### Fixed
+- **The impersonation banner disappeared on the screens that have no app shell.**
+  "You are viewing the app as …" + "Return to your account" was rendered by
+  `ResponsiveShell`, so it existed only on the role-scoped areas (/admin, /mentor,
+  /portal, /company, /source). Open Messages — or /account, /notifications,
+  /announcements, which render their own chrome — and the bar was simply gone: no
+  warning that the session belongs to someone else, and no way back except typing an
+  admin URL by hand. The banner now renders once app-wide in `Providers`, above every
+  page shell, as a sticky full-width strip (`data-testid="impersonation-banner"`), and
+  `ResponsiveShell` no longer renders its own copy.
+- The strip is in normal flow, which the viewport-sized chat frame (`MessagesShell`,
+  `100dvh`) cannot see, so it would have pushed the composer below the fold. New
+  `useTopBannerInset` hook publishes the strip's measured height as
+  `--top-banner-inset` (mirror of `--fixed-bottom-inset`/#935) and the frame subtracts
+  it from both its height and its `--visible-viewport-height` clamp.
+- `e2e/impersonation.spec.ts` now asserts the banner on /messages and /account and
+  returns to the admin account from a shell-less screen.
+
 ## [0.38.2-beta] - 2026-08-02
 
 ### Fixed

--- a/e2e/impersonation.spec.ts
+++ b/e2e/impersonation.spec.ts
@@ -73,7 +73,15 @@ test('admin can impersonate a user and return to their own account', async ({ pa
     });
     expect(started).not.toBeNull();
 
-    // Return to the admin account.
+    // …and on the screens that render their own chrome instead of the app shell:
+    // Messages used to drop the banner entirely, stranding the admin in the
+    // impersonated session with no visible way back.
+    await page.goto('/messages');
+    await expect(page.getByTestId('impersonation-banner')).toBeVisible({ timeout: 10_000 });
+    await page.goto('/account');
+    await expect(page.getByTestId('impersonation-banner')).toBeVisible({ timeout: 10_000 });
+
+    // Return to the admin account — from a shell-less screen, which is the point.
     await page.getByRole('button', { name: /Return to your account/ }).click();
     await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
     await expect(page.getByText(/viewing the app as/i)).toHaveCount(0);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.38.2-beta",
+  "version": "0.38.3-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "author": "Mehmet Erşahin",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13,6 +13,13 @@
      * end of a page scrollable above the bar instead of buried under it (#935).
      */
     --fixed-bottom-inset: 0px;
+    /*
+     * Height of the app-wide banner strip at the top of the document (the
+     * impersonation bar). It is in normal flow, so pages need no correction —
+     * only viewport-sized screens (the chat frame) subtract it. 0px when none
+     * is showing. Published by useTopBannerInset.
+     */
+    --top-banner-inset: 0px;
   }
 
   body {

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -4,6 +4,7 @@ import { SessionProvider } from 'next-auth/react';
 import { LocaleProvider } from '@/i18n/client';
 import { ToastProvider } from '@/components/ui/Toast';
 import { CookieConsent } from '@/components/CookieConsent';
+import { ImpersonationBanner } from '@/components/ImpersonationBanner';
 import { ActivityTracker } from '@/components/ActivityTracker';
 import { TimezoneSync } from '@/components/TimezoneSync';
 import type { Locale } from '@/i18n/config';
@@ -22,6 +23,10 @@ export function Providers({
     <SessionProvider>
       <LocaleProvider locale={locale} dict={dict}>
         <ToastProvider>
+          {/* App-wide, above every page shell: an impersonation session has to be
+              visible (and reversible) on screens that render their own chrome —
+              /messages, /account, /notifications — not just inside ResponsiveShell. */}
+          <ImpersonationBanner />
           {children}
           <CookieConsent />
           <ActivityTracker />

--- a/src/components/ImpersonationBanner.tsx
+++ b/src/components/ImpersonationBanner.tsx
@@ -1,21 +1,35 @@
 'use client';
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { signIn, useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { UserCog } from 'lucide-react';
 import { useT } from '@/i18n/client';
+import { useTopBannerInset } from '@/hooks/useTopBannerInset';
 
-// Persistent bar shown while an admin is impersonating another user, with a
-// one-click way back to their own account.
+/**
+ * Persistent bar shown while an admin is impersonating another user, with a
+ * one-click way back to their own account.
+ *
+ * Rendered once, app-wide (`Providers`), as the first thing in the document —
+ * not inside a page shell. It used to live in `ResponsiveShell`, which meant it
+ * simply did not exist on the screens that render their own chrome (/messages,
+ * /account, /notifications, /announcements): an admin who opened Messages while
+ * impersonating lost both the "you are someone else" warning and the way back.
+ * It is `sticky` so it stays on screen while a page scrolls, and publishes its
+ * height as `--top-banner-inset` for the viewport-sized chat frame.
+ */
 export function ImpersonationBanner() {
   const t = useT();
   const router = useRouter();
   const { data: session } = useSession();
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const ref = useRef<HTMLDivElement>(null);
+  const impersonating = Boolean(session?.user?.impersonatorName);
+  useTopBannerInset(ref, impersonating);
 
-  if (!session?.user?.impersonatorName) return null;
+  if (!impersonating) return null;
 
   const stop = async () => {
     setBusy(true);
@@ -39,15 +53,21 @@ export function ImpersonationBanner() {
   };
 
   return (
-    <div className="mb-4 flex flex-wrap items-center gap-x-3 gap-y-1 rounded-lg border border-purple-300 dark:border-purple-700 bg-purple-100 dark:bg-purple-900/40 px-4 py-3 text-sm text-purple-900 dark:text-purple-100">
-      <UserCog className="h-4 w-4 shrink-0" />
-      <span className="flex-1 min-w-0">
-        {t.impersonation.viewingAs.replace('{name}', session.user.name ?? '')}
-      </span>
-      {error && <span className="text-red-700 dark:text-red-300">{error}</span>}
-      <button onClick={stop} disabled={busy} className="font-semibold underline hover:no-underline disabled:opacity-50">
-        {t.impersonation.return}
-      </button>
+    <div
+      ref={ref}
+      data-testid="impersonation-banner"
+      className="no-print sticky top-0 z-50 border-b border-purple-300 dark:border-purple-700 bg-purple-100 dark:bg-purple-900/60 text-sm text-purple-900 dark:text-purple-100 pt-[env(safe-area-inset-top,0px)] pl-[env(safe-area-inset-left,0px)] pr-[env(safe-area-inset-right,0px)]"
+    >
+      <div className="mx-auto flex max-w-7xl flex-wrap items-center gap-x-3 gap-y-1 px-4 py-2.5">
+        <UserCog className="h-4 w-4 shrink-0" />
+        <span className="flex-1 min-w-0">
+          {t.impersonation.viewingAs.replace('{name}', session?.user?.name ?? '')}
+        </span>
+        {error && <span className="text-red-700 dark:text-red-300">{error}</span>}
+        <button onClick={stop} disabled={busy} className="font-semibold underline hover:no-underline disabled:opacity-50">
+          {t.impersonation.return}
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/components/MessagesShell.tsx
+++ b/src/components/MessagesShell.tsx
@@ -74,12 +74,15 @@ export function MessagesShell({
         they resolve to 0px everywhere else, so desktop is unchanged.
         `max()` rather than a sum: a fixed bottom bar pads itself past the inset
         already (CookieConsent), so subtracting both would leave a gap above it.
+        `--top-banner-inset` is the app-wide banner strip above the frame
+        (impersonation): it sits in normal flow, so the frame has to give back
+        exactly its height or the document overflows the viewport by that much.
         `--visible-viewport-height` (useVisibleViewportHeight) clamps the same thing
         from the other direction — as a max-height, so if both signals report the
         same hidden strip the smaller one simply wins instead of it being subtracted
         twice.
       */}
-      <div className="flex h-[calc(100dvh_-_max(var(--fixed-bottom-inset),env(safe-area-inset-bottom,0px)))] max-h-[var(--visible-viewport-height,100dvh)] flex-col overflow-hidden bg-gray-50 pl-[env(safe-area-inset-left,0px)] pr-[env(safe-area-inset-right,0px)] lg:h-auto lg:max-h-none lg:min-h-screen lg:overflow-visible lg:px-0" data-testid="messages-frame">
+      <div className="flex h-[calc(100dvh_-_var(--top-banner-inset,0px)_-_max(var(--fixed-bottom-inset),env(safe-area-inset-bottom,0px)))] max-h-[calc(var(--visible-viewport-height,100dvh)_-_var(--top-banner-inset,0px))] flex-col overflow-hidden bg-gray-50 pl-[env(safe-area-inset-left,0px)] pr-[env(safe-area-inset-right,0px)] lg:h-auto lg:max-h-none lg:min-h-screen lg:overflow-visible lg:px-0" data-testid="messages-frame">
         {/* `bg-white/95` is not the `bg-white` globals.css retints, so dark mode
             needs its own surface here. `viewport-fit=cover` also puts the status
             bar inside the viewport, hence the top inset on the header. */}

--- a/src/components/ResponsiveShell.tsx
+++ b/src/components/ResponsiveShell.tsx
@@ -3,7 +3,6 @@
 import { useState } from 'react';
 import { Menu, X } from 'lucide-react';
 import { EmailVerificationBanner } from '@/components/EmailVerificationBanner';
-import { ImpersonationBanner } from '@/components/ImpersonationBanner';
 import { NotificationBell } from '@/components/NotificationBell';
 import { MessagesButton } from '@/components/MessagesButton';
 import { BetaBadge } from '@/components/BetaBadge';
@@ -87,7 +86,8 @@ export function ResponsiveShell({
           <NotificationBell />
         </div>
         <div className="p-4 lg:p-8 lg:pt-2">
-          <ImpersonationBanner />
+          {/* The impersonation banner is rendered app-wide in Providers — it has to
+              show on the shell-less screens too (/messages, /account, ...). */}
           <EmailVerificationBanner />
           {children}
         </div>

--- a/src/hooks/useTopBannerInset.ts
+++ b/src/hooks/useTopBannerInset.ts
@@ -1,0 +1,37 @@
+'use client';
+
+import { useEffect, type RefObject } from 'react';
+
+/**
+ * Publishes the height of the app-wide banner strip that sits at the very top of
+ * the document as `--top-banner-inset` on `<html>` (0px when nothing is showing).
+ *
+ * The strip is in normal flow, so ordinary pages simply start below it. Screens
+ * that size themselves against the viewport (`100dvh` — the chat frame, #1006)
+ * cannot see it that way and would overflow the viewport by exactly the banner's
+ * height, so they subtract this variable instead.
+ *
+ * Mirror of `useFixedBottomInset` at the other edge; re-measured with a
+ * ResizeObserver because the banner reflows when its text wraps (locale, rotation).
+ */
+const CSS_VAR = '--top-banner-inset';
+
+export function useTopBannerInset(ref: RefObject<HTMLElement | null>, active = true) {
+  useEffect(() => {
+    const el = ref.current;
+    if (!active || !el) return;
+
+    const root = document.documentElement;
+    const measure = () => {
+      root.style.setProperty(CSS_VAR, `${Math.ceil(el.getBoundingClientRect().height)}px`);
+    };
+    measure();
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => {
+      observer.disconnect();
+      root.style.setProperty(CSS_VAR, '0px');
+    };
+  }, [ref, active]);
+}

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,21 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.38.3-beta',
+    date: '2026-08-02',
+    highlights: {
+      en: [
+        'The "You are viewing the app as …" bar now follows you everywhere. On Messages, Account, Notifications and Announcements it used to vanish, so an admin viewing someone else\'s account had no reminder of it — and no "Return to your account" link to get back. It is now a strip at the top of every screen that stays visible while you scroll.',
+      ],
+      tr: [
+        '"Uygulamayı … olarak görüntülüyorsun" çubuğu artık her ekranda görünüyor. Mesajlar, Hesap, Bildirimler ve Duyurular sayfalarında kayboluyordu; başkasının hesabını görüntüleyen bir yönetici bunu hatırlatan bir uyarıyı da, "Kendi hesabına dön" bağlantısını da göremiyordu. Çubuk artık her ekranın en üstünde ve sayfayı kaydırırken de görünür kalıyor.',
+      ],
+      de: [
+        'Die Leiste „Du siehst die App als …“ erscheint jetzt auf jedem Bildschirm. Unter Nachrichten, Konto, Benachrichtigungen und Ankündigungen verschwand sie bisher — eine Administratorin im Konto einer anderen Person sah weder den Hinweis noch den Link „Zu deinem Konto zurückkehren“. Die Leiste sitzt nun oben auf jedem Bildschirm und bleibt beim Scrollen sichtbar.',
+      ],
+    },
+  },
+  {
     version: '0.38.2-beta',
     date: '2026-08-02',
     highlights: {


### PR DESCRIPTION
## Problem

While impersonating (`Login as`), the purple **"Uygulamayı … olarak görüntülüyorsun / Kendi hesabına dön"** bar was rendered by `ResponsiveShell` — so it existed **only** in the role-scoped areas (`/admin`, `/mentor`, `/portal`, `/company`, `/source`).

Open **Mesajlar** (or `/account`, `/notifications`, `/announcements`), which render their own chrome, and the bar was simply gone: no reminder that the session belongs to someone else, and no way back short of typing an admin URL by hand.

## Fix

- The banner now renders **once, app-wide** in `Providers`, above every page shell, as a **sticky full-width strip** (`data-testid="impersonation-banner"`) that stays visible while a page scrolls. `ResponsiveShell` no longer renders its own copy.
- The strip is in normal flow, which the viewport-sized chat frame (`MessagesShell`, `100dvh`) can't see — it would have pushed the composer below the fold. New `useTopBannerInset` hook publishes the measured height as `--top-banner-inset` (mirror of `--fixed-bottom-inset`, #935) and the frame subtracts it from both its height and its `--visible-viewport-height` clamp.

## Verification

- `tsc --noEmit` clean, `npm run check:i18n` OK (no new keys — same three strings).
- Frame math checked headlessly at 375×812 with the exact CSS from the diff: banner 61px + frame 751px = 812px viewport, `docOverflow=0px`, composer visible, banner `top: 0` after scrolling the list.
- `e2e/impersonation.spec.ts` now asserts the banner on `/messages` and `/account`, and returns to the admin account **from a shell-less screen**.

Version bumped to `0.38.3-beta` with CHANGELOG + release-notes entries (EN/TR/DE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)