### PR TITLE
test(e2e): fix the consistently-red questions spec (second sign-in raced the old session)

### DIFF
--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -2116,3 +2116,55 @@ yaz, sonra ara.
 e2e-full.yml --ref <branch>`) merge ettikten *sonra* fark ettim; bu turda tam suite main'de
 koşup 349/349 geçti, ama doğru sıra branch'te koşturmak. `docs/agent-experience.md`'yi
 oturumun *başında* okumanın nedeni bu — sonunda yazmak yetmiyor.
+
+## 2026-08-02 — `questions.spec.ts`: "sorular UI'ı değişmiş" değildi, *ikinci* giriş yarışıydı
+
+Zamanlanmış tam koşuda (shard 4/4) sürekli kırmızı olan tek test. Bildirimdeki tahmin
+"sorular ekranı değişti, spec geride kaldı" idi — **yanlış**. Spec, sorular UI'ına hiç
+dokunmuyor: üç `page.request` çağrısıyla `/api/questions`'ı sürüyor. `page.fill` /
+`page.click` yalnızca kendi yazdığı `signIn()` yardımcısının içinde geçiyor. Yığın izi
+zaten bunu söylüyordu (`at signIn (…:12:14)` ← `…:31:5`, yani **mentor** girişi).
+
+**Kural: hata satırını değil, hatanın geçtiği fonksiyonu oku.** "Timeout on `page.fill`"
+görüp özellik ekranını aramak, yığın izinin ilk satırını atlamaktır. Testin adı ("mentee
+asks a question") nerede kırıldığını söylemez.
+
+**Kesin kanıt, teoriden ucuzdu.** `gh run download <run-id> -R 21072026/Internship -n
+playwright-report-full-shard-4` ile inen rapordaki `data/*.png`, hata anında ekranda
+**önceki kullanıcının portal panosunu** ("Welcome, QA Mentee!", sol altta mentee çipi)
+gösteriyor — `/auth/signin` değil. Bu tek kare tüm tartışmayı bitirdi: `router.replace()`
+testi mentee portalına geri atmış, parola alanı hiç var olmamış. Retry #1'de aynı sebep
+başka yüzle geldi: `button[type="submit"]` **5 elemana** çözündü ve ilki portalın
+*disabled* "Add" düğmesiydi. Zamanlanmış koşuda bir spec kırıldığında **önce artifact'ı
+indir**; log'daki "locator resolved to <…>" satırı ve ekran görüntüsü, hangi sayfada
+olduğunu tahmin etmekten hızlıdır.
+
+**Sebep, repoda zaten yazılı ve zaten çözülmüştü.** `e2e/helpers/auth.ts`'in doc
+comment'leri bu iki belirtiyi (kaybolan parola alanı + disabled "Add" düğmesi) birebir
+anlatıyor; #965/#969/#1018 altı spec'i bu yardımcılara taşıdı. `questions.spec.ts`
+o süpürmelerde **atlanmış** — #342'den beri hiç dokunulmamış. Düzeltme tek satır:
+kendi `signIn()`'ini sil, `signInAsFreshUser` kullan. Bir önceki girdinin kuralı bir kez
+daha geçerli: *yeni bir flake görünce önce helper'ın var olup olmadığına bak.*
+
+**Bu Mac'te yarış tekrar üretilemiyor — ve bunu dürüstçe söylemek gerekiyor.** Lokal DB
+kuruldu (`brew install mariadb`; `mariadbd-safe --datadir=/usr/local/var/mysql &`, root
+socket-auth olduğu için `mariadb -u <os-kullanıcısı>` ile bağlanıp `crm`/`crm` kullanıcısı
+açıldı — playbook'un `apt` tarifi macOS'ta geçmiyor, Docker daemon da kapalı). Spec hem
+dev sunucuda hem `CI=1` + production build ile **geçti** (2.8 s). `/api/auth/session`'ı
+2.5 sn geciktirip yavaş runner'ı taklit etmek de yarışı tetiklemedi. Yani "lokalde geçiyor"
+bu sınıf için **kanıt değil**; yarış GitHub runner'ının yavaşlığına bağlı. Doğrulama
+zinciri: artifact (ne olduğu) + helper'ın doc comment'i (neden) + zamanlanmış koşu (düzeldi mi).
+
+**`@smoke` kararı: hayır, dışarıda kalıyor.** Gerekçe: (1) smoke seti şu an **31** test,
+CLAUDE.md'nin hedefi ~15-20 — her "bu da önemli" eklemesi tam olarak bu aşımı üretti;
+(2) bu spec üç API iddiası için **iki tam UI girişi** ödüyor (CI'da ~16 sn), gate ~3,5 dk;
+(3) konusu olan rol-aşırı yetkilendirme smoke'ta zaten `authz-matrix` + `role-scoping` ile
+temsil ediliyor; (4) kırılma bir ürün regresyonu değildi, ortak yardımcıya geçmemiş bir
+spec'ti — ve artık geçti. Tespit mekanizması da çalıştı: bunu zamanlanmış koşunun özet
+e-postası yakaladı. Smoke'a terfi, PR'da görünürlük isteyen **ürün** yollarına saklanmalı.
+
+**Açık kalan (kapsam dışı bırakıldı):** kullanıcı **değiştiren** ve hâlâ kendi giriş
+yardımcısını yazan başka spec'ler var (`grep -l "goto('/auth/signin')" e2e/*.spec.ts` ile
+`helpers/auth` import etmeyenleri kesiştir; ≥2 giriş yapanlar riskli). Şu an yeşiller, yani
+aynı yarış onlarda **uykuda**. Hepsini bu PR'da taşımak yeşil testleri riske atardı;
+ayrı bir süpürme işi.

--- a/e2e/questions.spec.ts
+++ b/e2e/questions.spec.ts
@@ -1,18 +1,10 @@
 import { test, expect } from '@playwright/test';
 import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { signInAsFreshUser } from './helpers/auth';
 
 test.afterAll(async () => {
   await prisma.$disconnect();
 });
-
-async function signIn(page: import('@playwright/test').Page, email: string, password: string, home: string) {
-  await page.context().clearCookies();
-  await page.goto('/auth/signin');
-  await page.fill('input[type="email"], input[name="email"]', email);
-  await page.fill('input[type="password"]', password);
-  await page.click('button[type="submit"]');
-  await page.waitForURL((u) => u.pathname.startsWith(home), { timeout: 20_000 });
-}
 
 test('mentee asks a question and the mentor answers it', async ({ page }) => {
   const mentorEmail = uniqueEmail('qa-mentor');
@@ -23,12 +15,12 @@ test('mentee asks a question and the mentor answers it', async ({ page }) => {
   let qId = '';
 
   try {
-    await signIn(page, menteeEmail, 'MenteePass123', '/portal');
+    await signInAsFreshUser(page, menteeEmail, 'MenteePass123', '/portal');
     const asked = await page.request.post('/api/questions', { data: { relationId: rel.id, question: 'How do I prep for the interview?' } });
     expect(asked.status()).toBe(201);
     qId = (await asked.json()).question.id;
 
-    await signIn(page, mentorEmail, 'MentorPass123', '/mentor');
+    await signInAsFreshUser(page, mentorEmail, 'MentorPass123', '/mentor');
     const answered = await page.request.patch(`/api/questions/${qId}`, { data: { answer: 'Practice system design.' } });
     expect(answered.ok()).toBeTruthy();
     expect((await answered.json()).question.answer).toContain('system design');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "internship-crm",
-  "version": "0.38.0-beta",
+  "version": "0.39.0-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "internship-crm",
-      "version": "0.38.0-beta",
+      "version": "0.39.0-beta",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {


### PR DESCRIPTION
## What was failing

`e2e/questions.spec.ts:17` failed on **both attempts** in every scheduled full run —
run [30734938839](https://github.com/21072026/Internship/actions/runs/30734938839) (03:00 UTC, shard 4/4)
and the manual dispatch [30740979060](https://github.com/21072026/Internship/actions/runs/30740979060).
Not tagged `@smoke`, so the PR gate never ran it.

## It was not a questions-UI regression

The spec never touches the questions UI — it drives `/api/questions` through three
`page.request` calls. The timing-out `page.fill` / `page.click` exist **only** inside the
spec's own `signIn()` helper, and the stack trace points at the *second* call:

```
at signIn (e2e/questions.spec.ts:12:14)
at e2e/questions.spec.ts:31:5      ← the mentor sign-in
```

The failure screenshot in `playwright-report-full-shard-4` settles it: at the moment of the
timeout the browser was on the **mentee's portal dashboard** ("Welcome, QA Mentee!"), not
`/auth/signin`. So the password field genuinely did not exist.

## Root cause

A blanket `clearCookies()` immediately before `goto('/auth/signin')` is not enough. The
outgoing page's in-flight `/api/auth/session` read re-issues the session cookie;
`/auth/signin` then sees `status === 'authenticated'` and `router.replace()`s to the
previous user's dashboard while the test is still typing. On retry the submit locator
resolved to five elements, the first being the portal's **disabled "Add"** button — which
it then retried for the full 15s action timeout.

`e2e/helpers/auth.ts` exists for exactly this and documents both symptoms verbatim;
#965 / #969 / #1018 migrated six specs onto it. `questions.spec.ts` was simply **missed** —
untouched since #342.

## Fix

Drop the bespoke `signIn()`, use the shared `signInAsFreshUser`.

## Verification

- Local MariaDB + `prisma db push`; spec passes on the dev server **and** under `CI=1`
  with a production build (`next start`), 2.8s.
- **Honest caveat:** the race does **not** reproduce on this machine — not even with
  `/api/auth/session` delayed 2.5s to imitate a loaded runner. It is specific to the
  GitHub runner's timing, so "passes locally" is not the evidence here. The evidence is
  the CI artifact + the helper's own documented mechanism + the next scheduled full run.

## `@smoke`: deliberately left out

Reasoning recorded in `docs/agent-experience.md`:
1. The set is already **31** tests against CLAUDE.md's ~15-20 target.
2. This spec pays **two full UI sign-ins** for three API assertions (~16s in CI, on a ~3.5min gate).
3. Its cross-role authorization subject is already represented in smoke by `authz-matrix` + `role-scoping`.
4. The break was never a product regression — it was a spec that missed a helper migration.
   The detection mechanism worked: the scheduled run's summary email caught it.

## Noted, not fixed (out of scope)

Other specs that **switch users** still roll their own sign-in. They are green today, so
the same race is dormant there; migrating them all here would put green tests at risk.
Flagged in the doc entry as a separate sweep.

## Versioning

Test + docs only, no app code — no version/changelog/release-notes entry per CLAUDE.md's
non-user-facing carve-out. The `package-lock.json` version line is unrelated pre-existing
drift (`package.json` was already `0.39.0-beta`) that `npm install` corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)