### PR TITLE
docs: 2026-08-02 dersi — guard eklerken endpoint'in bütün arayüz yüzeylerini bul (#1039)

### DIFF
--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -2075,3 +2075,44 @@ yeni `impersonation` vakası) gerçekten koşup geçtiği böyle görüldü. Sha
 kırmızı `e2e/questions.spec.ts:17` idi ve **aynı test main'in 03:00 UTC koşusunda da
 kırmızıydı** — yani mevcut bir sorun. Bir shard kırmızı olduğunda önce aynı testin son
 main koşusundaki durumuna bak; "benim değişikliğim mi" sorusunu 30 saniyede kapatıyor.
+
+## 2026-08-02 — Guard'ı yazmak kolay, endpoint'in *bütün* yüzeylerini bulmak asıl iş (#1039, 0.39.1-beta)
+
+`/api/account/2fa` impersonation guard'ı olmayan tek hesap endpoint'iydi: "Kullanıcı olarak
+gir" ile giren admin, sahibinin elinde olmayan bir authenticator'ı hesaba bağlayabiliyor
+(30 dakikalık impersonation penceresinden sonra da yaşayan kalıcı bir ikinci kimlik
+bilgisi) ya da sahibi koruyan faktörü söküp atabiliyordu.
+
+**Aynı endpoint'in ikinci bir arayüz yüzeyi vardı.** `/account` kartı bariz olanıydı;
+`/security-setup` (org 2FA zorunluluk kapısı) aynı endpoint'e POST ediyor. Rol layout'ları
+bu kapıyı impersonation'da zaten atlıyor, yani oraya ancak URL elle yazılarak ulaşılıyor —
+ama guard eklendikten sonra orası da "gönderilince 400 dönen form" olacaktı, yani bir
+önceki dersin (#1036) tuzağının aynısı. **Kural:** guard eklerken `grep -rn
+"api/<endpoint>" src/` çalıştır ve çıkan her çağrı noktasını ayrı ayrı karara bağla; kartı
+gizlemek "arayüz tarafı bitti" demek değil.
+
+**Engellemeden önce alternatif yolun var mı diye bak.** `sign-out-all`'ı da kapattım, ama
+önce admin'in bir kullanıcıyı kilitleme yolu olup olmadığını kontrol ettim:
+`POST /api/admin/users/[id]/reset-password` var ve **admin'in kendi id'siyle** loglanıyor.
+Olmasaydı doğru hamle "engelle" değil, "engelle + admin tarafı eşdeğerini ekle" olurdu —
+yoksa guard bir yeteneği karşılıksız siler.
+
+**Denetim kaydı tek başına guard gerekçesidir.** `logActivity` bu rotalarda
+`actorId: session.user.id` yazıyor; impersonation'da bu, işlemi yapan admin değil
+*kullanıcı* demek. İşleme izin verilseydi bile kayıt yanlış kişiyi gösterecekti. Bir
+eylemin impersonation'da serbest olup olmayacağını tartışırken "kim yaptı diye sorulursa
+kayıt ne diyor?" sorusu, "zararlı mı?" sorusundan daha hızlı sonuç veriyor.
+
+**GET'i engelleme.** Salt-okunur durum sorgusunu da 400'lemek arayüzün mount'ta yaptığı
+`fetch`'i kırar, karşılığında hiçbir şey kazandırmaz. Guard mutasyona konur.
+
+**`gh run view --job X --log | grep` sessizce boş dönebiliyor.** Dört shard'da da yeni
+testin adını aradım, dördü de `0` eşleşme verdi — test koşmamış gibi göründü. Aynı log'u
+önce dosyaya yazıp (`> s$j.log`) grep'leyince eşleşmeler çıktı (shard 2, `✓
+impersonation.spec.ts:136`). **Log'da bir şey bulamamak "yok" demek değil**: önce dosyaya
+yaz, sonra ara.
+
+**Ve merge'den önce koştur.** Bir önceki dersin tam da bunu söylediğini (`gh workflow run
+e2e-full.yml --ref <branch>`) merge ettikten *sonra* fark ettim; bu turda tam suite main'de
+koşup 349/349 geçti, ama doğru sıra branch'te koşturmak. `docs/agent-experience.md`'yi
+oturumun *başında* okumanın nedeni bu — sonunda yazmak yetmiyor.


### PR DESCRIPTION
Session retrospective for #1039 / #1040, per the standing end-of-session instruction in CLAUDE.md.

Lessons recorded:
- An impersonation guard has to be reconciled with *every* UI surface that calls the endpoint — `/account` was the obvious one, `/security-setup` was the second.
- Check for an admin-side equivalent before blocking a capability (here: `reset-password`), so the guard doesn't delete a capability outright.
- `actorId` misattribution is on its own sufficient grounds for a guard.
- Don't guard read-only GETs.
- `gh run view --job X --log | grep` returned 0 matches on all four shards for a test that had in fact run and passed; writing the log to a file first found it. Absence of a grep hit is not absence of the test.
- Dispatch `e2e-full.yml` on the *branch* before merging, not on main after — a lesson the previous entry already recorded and I applied late.

Docs-only, so no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)