### PR TITLE
test(e2e): move the remaining mid-test user switches onto the shared sign-in helpers

### DIFF
--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -2168,3 +2168,44 @@ yardımcısını yazan başka spec'ler var (`grep -l "goto('/auth/signin')" e2e/
 `helpers/auth` import etmeyenleri kesiştir; ≥2 giriş yapanlar riskli). Şu an yeşiller, yani
 aynı yarış onlarda **uykuda**. Hepsini bu PR'da taşımak yeşil testleri riske atardı;
 ayrı bir süpürme işi.
+
+## 2026-08-02 — Uykudaki giriş yarışının süpürmesi (#1043): "≥2 giriş" değil, "aynı `page`'te ≥2 giriş"
+
+Bir önceki girdinin (`questions.spec.ts`) kapsam dışı bıraktığı iş. Başlangıç ölçütü —
+"`goto('/auth/signin')` içeren ama `helpers/auth` import etmeyen, ≥2 giriş yapan spec'ler" —
+doğru yere bakıyor ama **çok geniş**: 27 dosya eşleşiyor, gerçekte taşınması gereken **7**.
+
+**Eleyen soru "kaç giriş?" değil, "aynı oturum devrediliyor mu?".** Yarış ancak *aynı*
+`page` üstünde ikinci bir giriş yapılınca oluşuyor. Üç yaygın yanlış pozitif:
+
+1. **Girişler ayrı `test()` bloklarında.** Her test taze bir `page` fixture'ı alır; devreden
+   bir çerez yok. 27 adayın 18'i bu. (`account`, `evaluation`, `impersonation`, `projects`, …)
+2. **Her kullanıcıya kendi `browser.newContext()`'i.** Ayrı çerez kavanozu, yarış yok.
+   (`admin-support`, `free-core-regression`, `interaction-summary`, `sign-out-all`,
+   `support-attachments`, `talent-pool-early-access`, `mentorship-request`'in 3 testinden 2'si)
+3. **İkinci `goto('/auth/signin')` iddianın kendisi.** `redirect.spec.ts` bir kez giriyor;
+   ikinci gidiş "giriş yapmış kullanıcı buradan atılmalı" testi.
+
+Ayıklama grep'le değil, **test bloğu başına sayarak** yapılır: dosyayı satır satır gez,
+`test(` görünce sayacı sıfırla, `goto('/auth/signin')` *veya yerel giriş yardımcısının çağrısı*
+görünce artır. Yerel yardımcı adımı şart — `announcements-feed` gibi dosyalarda dosyada tek
+bir `goto` literali var ama yardımcı test başına iki kez çağrılıyor; sadece literal sayan bir
+tarama bunları **kaçırır**.
+
+**Aynı kullanıcıya yeniden giriş de bu sınıfa girebiliyor.** `email-verification` iki kez
+*aynı* hesapla giriyor, dolayısıyla "kullanıcı değişimi" filtresine takılmıyor — ama amacı
+bayat JWT'deki `emailVerified: false`'ı tazelemek. Eski oturumla sessizce `/mentor`'a
+dönmek `waitForURL`'i geçirir ve testi *yanlış sebeple* kırar (banner hâlâ ekranda).
+Ölçüt "farklı e-posta" değil, **"bu girişin gerçekten yeniden kimlik doğrulaması gerekiyor mu"**.
+
+**Girişin bir iniş sayfası yoksa `submitSignInForm`.** `admin-user-active`'de ikinci giriş
+devre dışı bırakılmış bir hesapla yapılıyor: doğru sonuç `/auth/signin`'de kalmak.
+`signInAsFreshUser` orada 20 sn bekleyip düşerdi. Aynı ayrım `two-factor.spec.ts`'te de var.
+
+**Yeşil testleri taşırken doğrulama CI'da yapılır, lokalde değil.** Bu yarış hızlı makinede
+tekrar üretilemiyor (bir önceki girdi), dolayısıyla "lokalde geçti" hiçbir şey söylemiyor.
+Kullanılan zincir: `gh workflow run e2e.yml --ref <branch> -f grep='<8 testi kapsayan regex>'`
+→ log'da **`Running 8 tests`** satırını doğrula (0 olsaydı regex tutmamış demektir, ve koşu
+yine de yeşil raporlardı — sessiz yanlış pozitif) → merge'den önce `e2e-full.yml` branch'te.
+`npx playwright test --list --grep '<regex>'` lokalde regex'i bedavaya doğruluyor; dispatch
+etmeden önce onu koştur.

--- a/e2e/admin-user-active.spec.ts
+++ b/e2e/admin-user-active.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { signInAsFreshUser, submitSignInForm } from './helpers/auth';
 
 test.afterAll(async () => {
   await prisma.$disconnect();
@@ -14,11 +15,7 @@ test('admin deactivates a user and that user can no longer sign in', async ({ pa
 
   try {
     // Admin signs in and opens the Users page.
-    await page.goto('/auth/signin');
-    await page.fill('input[type="email"], input[name="email"]', adminEmail);
-    await page.fill('input[type="password"]', 'AdminPass123!');
-    await page.click('button[type="submit"]');
-    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+    await signInAsFreshUser(page, adminEmail, 'AdminPass123!', '/admin');
 
     await page.goto('/admin/users');
     // Deactivate the seeded mentor via its row.
@@ -34,11 +31,9 @@ test('admin deactivates a user and that user can no longer sign in', async ({ pa
     expect(updated!.isActive).toBe(false);
 
     // The deactivated mentor cannot sign in.
-    await page.context().clearCookies();
-    await page.goto('/auth/signin');
-    await page.fill('input[type="email"], input[name="email"]', mentorEmail);
-    await page.fill('input[type="password"]', mentorPw);
-    await page.click('button[type="submit"]');
+    // submitSignInForm, not signInAsFreshUser: a deactivated account is *supposed*
+    // to stay on /auth/signin, so there is no landing page to wait for.
+    await submitSignInForm(page, mentorEmail, mentorPw);
     await expect(page.getByText(/deactivated/i)).toBeVisible({ timeout: 15_000 });
     expect(new URL(page.url()).pathname).toContain('/auth/signin');
   } finally {

--- a/e2e/announcements-feed.spec.ts
+++ b/e2e/announcements-feed.spec.ts
@@ -1,17 +1,10 @@
 import { test, expect } from '@playwright/test';
 import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { signInAsFreshUser } from './helpers/auth';
 
 test.afterAll(async () => {
   await prisma.$disconnect();
 });
-
-async function signIn(page: import('@playwright/test').Page, email: string, pw: string, home: string) {
-  await page.goto('/auth/signin');
-  await page.fill('input[type="email"], input[name="email"]', email);
-  await page.fill('input[type="password"]', pw);
-  await page.click('button[type="submit"]');
-  await page.waitForURL((u) => u.pathname.startsWith(home), { timeout: 20_000 });
-}
 
 // #920: admin broadcasts fan out to every active user (see POST
 // /api/admin/announcements — there's no per-role/org targeting), so a mentee
@@ -26,12 +19,11 @@ test('an admin announcement shows up in the mentee dashboard card and the shared
   const uniqueText = `Feed announcement ${Date.now().toString(36)}`;
 
   try {
-    await signIn(page, adminEmail, 'AdminPass123', '/admin');
+    await signInAsFreshUser(page, adminEmail, 'AdminPass123', '/admin');
     const res = await page.request.post('/api/admin/announcements', { data: { text: uniqueText } });
     expect(res.ok()).toBeTruthy();
 
-    await page.context().clearCookies();
-    await signIn(page, menteeEmail, 'MenteePass123', '/portal');
+    await signInAsFreshUser(page, menteeEmail, 'MenteePass123', '/portal');
 
     // Dashboard card (client-fetched — wait for it to leave the loading state).
     await expect(page.getByText(uniqueText)).toBeVisible({ timeout: 10_000 });
@@ -54,12 +46,11 @@ test('an admin announcement is also visible to mentors, via the same shared feed
   const uniqueText = `Mentor feed announcement ${Date.now().toString(36)}`;
 
   try {
-    await signIn(page, adminEmail, 'AdminPass123', '/admin');
+    await signInAsFreshUser(page, adminEmail, 'AdminPass123', '/admin');
     const res = await page.request.post('/api/admin/announcements', { data: { text: uniqueText } });
     expect(res.ok()).toBeTruthy();
 
-    await page.context().clearCookies();
-    await signIn(page, mentorEmail, 'MentorPass123', '/mentor');
+    await signInAsFreshUser(page, mentorEmail, 'MentorPass123', '/mentor');
 
     await expect(page.getByText(uniqueText)).toBeVisible({ timeout: 10_000 });
   } finally {

--- a/e2e/email-verification.spec.ts
+++ b/e2e/email-verification.spec.ts
@@ -2,18 +2,11 @@ import { test, expect } from '@playwright/test';
 import bcrypt from 'bcryptjs';
 import { randomBytes } from 'crypto';
 import { prisma, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { signInAsFreshUser } from './helpers/auth';
 
 test.afterAll(async () => {
   await prisma.$disconnect();
 });
-
-async function signIn(page: import('@playwright/test').Page, email: string, password: string) {
-  await page.goto('/auth/signin');
-  await page.fill('input[type="email"], input[name="email"]', email);
-  await page.fill('input[type="password"]', password);
-  await page.click('button[type="submit"]');
-  await page.waitForURL((u) => u.pathname.startsWith('/mentor'), { timeout: 20_000 });
-}
 
 test('unverified user is read-only until they confirm their email', async ({ page }) => {
   const email = uniqueEmail('unverified');
@@ -25,7 +18,7 @@ test('unverified user is read-only until they confirm their email', async ({ pag
 
   try {
     // Signed in but unverified → the read-only banner is shown.
-    await signIn(page, email, password);
+    await signInAsFreshUser(page, email, password, '/mentor');
     await expect(page.getByText(/read-only until you confirm/i)).toBeVisible();
 
     // A write is rejected by middleware with 403.
@@ -45,8 +38,9 @@ test('unverified user is read-only until they confirm their email', async ({ pag
     expect(refreshed!.emailVerified).toBe(true);
 
     // Re-sign-in to pick up the verified flag in the session, then a write works.
-    await page.context().clearCookies();
-    await signIn(page, email, password);
+    // Same user, but the stale JWT still carries emailVerified: false — the sign-in
+    // has to actually happen, so it needs the same session teardown as a user switch.
+    await signInAsFreshUser(page, email, password, '/mentor');
     await expect(page.getByText(/read-only until you confirm/i)).toHaveCount(0);
     const allowed = await page.request.post('/api/mentor/mentees', {
       data: { fullName: 'Now Allowed Mentee' },

--- a/e2e/mentorship-request.spec.ts
+++ b/e2e/mentorship-request.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test';
 import { readFileSync } from 'fs';
 import path from 'path';
 import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { signInAsFreshUser } from './helpers/auth';
 
 test.afterAll(async () => {
   await prisma.$disconnect();
@@ -213,22 +214,13 @@ test('admin rejects a mentorship request and the mentee is notified with no rela
 
   let requestId = '';
   try {
-    await page.goto('/auth/signin');
-    await page.fill('input[type="email"], input[name="email"]', menteeEmail);
-    await page.fill('input[type="password"]', pw);
-    await page.click('button[type="submit"]');
-    await page.waitForURL((u) => u.pathname.startsWith('/portal'), { timeout: 20_000 });
+    await signInAsFreshUser(page, menteeEmail, pw, '/portal');
 
     const created = await page.request.post('/api/mentorship-requests', { data: {} });
     expect(created.status()).toBe(201);
     requestId = (await created.json()).request.id;
 
-    await page.context().clearCookies();
-    await page.goto('/auth/signin');
-    await page.fill('input[type="email"], input[name="email"]', adminEmail);
-    await page.fill('input[type="password"]', pw);
-    await page.click('button[type="submit"]');
-    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+    await signInAsFreshUser(page, adminEmail, pw, '/admin');
 
     const reject = await page.request.put('/api/admin/mentorship-requests', {
       data: { requestId, action: 'reject' },

--- a/e2e/pipeline-deadline.spec.ts
+++ b/e2e/pipeline-deadline.spec.ts
@@ -1,18 +1,10 @@
 import { test, expect } from '@playwright/test';
 import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { signInAsFreshUser } from './helpers/auth';
 
 test.afterAll(async () => {
   await prisma.$disconnect();
 });
-
-async function signIn(page: import('@playwright/test').Page, email: string, password: string, home: string) {
-  await page.context().clearCookies();
-  await page.goto('/auth/signin');
-  await page.fill('input[type="email"], input[name="email"]', email);
-  await page.fill('input[type="password"]', password);
-  await page.click('button[type="submit"]');
-  await page.waitForURL((u) => u.pathname.startsWith(home), { timeout: 20_000 });
-}
 
 test('stage deadlines flag overdue, surface on the calendar, and trigger reminders', async ({ page }) => {
   const adminEmail = uniqueEmail('dl-admin');
@@ -25,7 +17,7 @@ test('stage deadlines flag overdue, surface on the calendar, and trigger reminde
 
   try {
     // Admin sets a stage deadline in the past.
-    await signIn(page, adminEmail, 'AdminPass123', '/admin');
+    await signInAsFreshUser(page, adminEmail, 'AdminPass123', '/admin');
     const put = await page.request.put(`/api/mentorship/${rel.id}`, { data: { stageDeadline: '2020-01-01' } });
     expect(put.ok()).toBeTruthy();
 
@@ -42,7 +34,7 @@ test('stage deadlines flag overdue, surface on the calendar, and trigger reminde
     expect(after?.deadlineReminderSentAt).toBeTruthy();
 
     // The mentor received an in-app deadline notification.
-    await signIn(page, mentorEmail, 'MentorPass123', '/mentor');
+    await signInAsFreshUser(page, mentorEmail, 'MentorPass123', '/mentor');
     const notifs = await (await page.request.get('/api/notifications')).json();
     expect(notifs.items.some((n: { type: string }) => n.type === 'deadline')).toBeTruthy();
   } finally {

--- a/e2e/relation-notes.spec.ts
+++ b/e2e/relation-notes.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { signInAsFreshUser } from './helpers/auth';
 
 test.afterAll(async () => {
   await prisma.$disconnect();
@@ -16,11 +17,7 @@ test('mentor can add a private note on a mentee; the note stays mentor-only', as
 
   try {
     // Mentor adds a private note.
-    await page.goto('/auth/signin');
-    await page.fill('input[type="email"], input[name="email"]', mentorEmail);
-    await page.fill('input[type="password"]', 'MentorPass123');
-    await page.click('button[type="submit"]');
-    await page.waitForURL((u) => u.pathname.startsWith('/mentor'), { timeout: 20_000 });
+    await signInAsFreshUser(page, mentorEmail, 'MentorPass123', '/mentor');
 
     await page.goto(`/mentor/mentees/${rel.id}`);
     const panel = page.getByTestId('relation-notes-panel');
@@ -32,22 +29,12 @@ test('mentor can add a private note on a mentee; the note stays mentor-only', as
     await expect(panel.getByText('Strong technical fit, a bit shy in meetings — check in 1:1.')).toBeVisible({ timeout: 10_000 });
 
     // IDOR: an unrelated mentor cannot read notes on this relation.
-    await page.context().clearCookies();
-    await page.goto('/auth/signin');
-    await page.fill('input[type="email"], input[name="email"]', outsiderMentorEmail);
-    await page.fill('input[type="password"]', 'x');
-    await page.click('button[type="submit"]');
-    await page.waitForURL((u) => u.pathname.startsWith('/mentor'), { timeout: 20_000 });
+    await signInAsFreshUser(page, outsiderMentorEmail, 'x', '/mentor');
     const outsiderRes = await page.request.get(`/api/relation-notes?relationId=${rel.id}`);
     expect(outsiderRes.status()).toBe(403);
 
     // The mentee is never exposed to the note, even via the API directly.
-    await page.context().clearCookies();
-    await page.goto('/auth/signin');
-    await page.fill('input[type="email"], input[name="email"]', menteeEmail);
-    await page.fill('input[type="password"]', 'MenteePass123');
-    await page.click('button[type="submit"]');
-    await page.waitForURL((u) => u.pathname.startsWith('/portal'), { timeout: 20_000 });
+    await signInAsFreshUser(page, menteeEmail, 'MenteePass123', '/portal');
     const menteeApiRes = await page.request.get(`/api/relation-notes?relationId=${rel.id}`);
     expect(menteeApiRes.status()).toBe(403);
   } finally {

--- a/e2e/source-portal.spec.ts
+++ b/e2e/source-portal.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { signInAsFreshUser } from './helpers/auth';
 
 test.afterAll(async () => {
   await prisma.$disconnect();
@@ -16,11 +17,7 @@ test('a source user can log in and submit mentees that show up for the admin', a
 
   try {
     // Source signs in and lands on the source portal.
-    await page.goto('/auth/signin');
-    await page.fill('input[type="email"], input[name="email"]', sourceUserEmail);
-    await page.fill('input[type="password"]', 'SourcePass123');
-    await page.click('button[type="submit"]');
-    await page.waitForURL((u) => u.pathname.startsWith('/source'), { timeout: 20_000 });
+    await signInAsFreshUser(page, sourceUserEmail, 'SourcePass123', '/source');
 
     // Submit a mentee.
     const res = await page.request.post('/api/source/mentees', {
@@ -40,12 +37,7 @@ test('a source user can log in and submit mentees that show up for the admin', a
     expect(mentee?.sourceId).toBe(source.id);
 
     // Admin can filter candidates by this source and find the mentee.
-    await page.context().clearCookies();
-    await page.goto('/auth/signin');
-    await page.fill('input[type="email"], input[name="email"]', adminEmail);
-    await page.fill('input[type="password"]', 'AdminPass123');
-    await page.click('button[type="submit"]');
-    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+    await signInAsFreshUser(page, adminEmail, 'AdminPass123', '/admin');
     const cands = await (await page.request.get(`/api/candidates?source=${source.id}`)).json();
     expect(cands.candidates.some((c: { id: string }) => c.id === mentee!.id)).toBeTruthy();
   } finally {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "internship-crm",
-  "version": "0.39.0-beta",
+  "version": "0.39.1-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "internship-crm",
-      "version": "0.39.0-beta",
+      "version": "0.39.1-beta",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {


### PR DESCRIPTION
Follow-up to #1041 (and #965 / #969 / #1018). Those PRs fixed specs that were *already* failing; this one sweeps the rest of the same hazard before it goes red on its own schedule.

## The hazard

A spec that signs in as a **second user on the same `page`** cannot roll its own sign-in. The outgoing page's in-flight `/api/auth/session` read re-issues the session cookie after a blanket `clearCookies()`; `/auth/signin` then sees `status === 'authenticated'` and `router.replace()`s to the *previous* user's dashboard while the test is still typing. Symptoms: a `page.fill` timeout on `input[type="password"]`, or a `button[type="submit"]` click resolving against a disabled button on the old dashboard. A blanket `clearCookies()` also drops the cookie-consent state seeded via `storageState`, bringing the consent banner back over the form.

`e2e/helpers/auth.ts` already handles all of it, and its doc comments describe both symptoms.

## Migrated — 8 tests across 7 files

| Spec | Switch |
|---|---|
| `admin-user-active` | admin → the just-deactivated mentor |
| `announcements-feed` | admin → mentee, and admin → mentor (both tests) |
| `email-verification` | same user twice, to refresh a stale JWT |
| `mentorship-request` | reject test only: mentee → admin |
| `pipeline-deadline` | admin → mentor |
| `relation-notes` | mentor → outsider mentor → mentee |
| `source-portal` | source user → admin |

Two notes on the non-obvious ones:

- **`admin-user-active`** uses `submitSignInForm`, not `signInAsFreshUser` — the whole point of that sign-in is that it does *not* land anywhere, so there is no landing page to wait for.
- **`email-verification`** re-signs in as the *same* user, which looks like it doesn't need this. It does: the stale JWT still carries `emailVerified: false`, so a silent redirect back to `/mentor` on the old session would leave the read-only banner up and fail the assertion.

## Deliberately not touched

- Specs whose several sign-ins live in **different `test()` blocks** — each gets a fresh `page` fixture, so nothing is carried over: `account`, `admin-mentor-mode`, `api-validation-documents-notifications`, `auth`, `auto-meet-link`, `candidate-erasure`, `cohorts-sources-search`, `dup-guard-transliteration`, `evaluation`, `goals-archive-sort`, `google-calendar-status`, `impersonation`, `impersonation-governance`, `lifecycle`, `notif-prefs`, `program-benchmark`, `projects`, `verify-email-resend`.
- Specs that give each user its own `browser.newContext()` — isolated cookie jars, no race: `admin-support`, `ai-gate`, `free-core-regression`, `interaction-summary`, `sign-out-all`, `support-attachments`, `talent-pool-early-access`, and the other two `mentorship-request` tests.
- `redirect.spec.ts` — it signs in once; the second `goto('/auth/signin')` *is* the assertion (a signed-in user must be redirected away).
- Blanket `clearCookies()` calls that exist for other reasons (consent, locale, anonymous/IDOR probes).

## Verification

These specs are green today, so the risk here is regressing working tests — and the race does not reproduce on a fast local machine. Verified on CI instead: a targeted `e2e.yml` dispatch with a `--grep` covering all 8 migrated tests (checking the `Running N tests` line is 8, not 0), plus a full `e2e-full.yml` run on the branch.

Test-only change → no version / changelog / release-notes entry. The `package-lock.json` version bump is pre-existing drift that `npm install` corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)