### PR TITLE
fix(e2e): stable locators for the controls the new selects collide with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.40.3-beta] - 2026-08-03
+
+### Fixed
+- **Three scheduled full-suite failures caused by the new selects** (#51 follow-up). The
+  candidate page gained a "who referred them" picker and the project page gained the member
+  pickers, and an `<option>` is text like any other: `getByText('Detail Mentor')` and
+  `getByTestId('project-internal').getByText('Detail Member')` became strict-mode violations,
+  while `locator('select').first()` on the candidate page stopped resolving to the stage
+  dropdown (the profile card above it now has a select of its own). Fixed at the source
+  rather than in the assertions alone — `data-testid="stage-select"`,
+  `data-testid="referred-by-select"` and `data-testid="mentorship-mentor"` on the candidate
+  page — and the three specs target those (the project one scopes to `project-team`).
+
 ## [0.40.2-beta] - 2026-08-02
 
 ### Fixed

--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -10,6 +10,54 @@ Newest entries on top.
 
 ---
 
+## 2026-08-02 — #51'in kullanıcı geri bildirim turları (0.40.1/0.40.2-beta)
+
+Aynı oturumda özellik canlıya gitmeden önce üç tur geri bildirim geldi; hepsi
+"kod doğru ama davranış yanlış" cinsindendi.
+
+**Bir e-posta göndericisi döngünün içindeyse kaç kez çağrıldığını say.**
+`generateForSeries`, `sendMeetingInviteEmail`'i `tekrar × ilişki` döngüsünün
+içinde çağırıyordu: 6 mentee × 7 hafta = tek tıkla 42 e-posta. Kod #774'ten beri
+böyleydi ama UI olmadığı için kimse tetiklemiyordu — **var olan bir backend'e UI
+eklemek, o backend'in maliyetini de senin devraldığın anlamına geliyor.** Ölçüt:
+"bir kullanıcı eylemi kaç e-posta üretiyor?" sorusunu UI'ı yazmadan önce sor.
+
+**İki cron aynı satırı hedefliyorsa çift bildirim gider.** Yeni proje-bazlı
+hatırlatma ile mevcut ilişki-bazlı `sendMeetingReminders` aynı seri
+`Meeting` satırlarını eşleştiriyordu; hem ilişkisi hem üyeliği olan kişi 1 saat
+önce iki e-posta alıyordu. Yeni bir bildirim yolu eklerken **eski yolun aynı
+kaydı görüp görmediğini** kontrol et (`seriesId: null` ile dışladım) — ve dışlama
+yaptığında eski yolun kapsadığı kişileri yeni yolun da kapsadığından emin ol
+(`loadProjectTeam`, yalnız `ProjectMember` değil).
+
+**App shell'in dışındaki route mobilde başlıksız kalır.** `/projects/[id]` public
+ziyaretçi okuyabilsin diye admin/mentor layout'unun dışında; sonuç: projeyi açınca
+header tamamen kayboluyor, telefonda sidebar da olmadığı için ne başlık ne çıkış
+yolu kalıyor. Layout dışına sayfa koyarken kendi bar'ını da koy.
+
+**Responsive'i akıl yürütmeyle değil ekran görüntüsüyle doğrula — ama panelleri
+bekle.** 390px'te `page.screenshot()` aldığımda client panelleri boş çıktı; dev
+server route'u derlerken `networkidle` yetmiyor. `locator(...).waitFor()` ile
+beklemek gerçek durumu gösterdi. Kalıcı kontrol için mekanik denetim yazdım
+(yatay taşma yok + 120px altı metin alanı yok, açılır formlar açık halde):
+`e2e/mobile-responsive.spec.ts`. 20 ekranlık süpürme temiz çıktı, yani sorun
+uygulamanın genelinde değil tek bir kartta.
+
+**`signInAsFreshUser` sonrası `page.goto` yerine `gotoSettled` kullan.**
+Helper URL eşleşince dönüyor, landing push'u hâlâ uçuşta: "Navigation … is
+interrupted by another navigation" alıyorsun. `helpers/auth.ts` bunu zaten
+belgeliyor, yeni spec yazarken atlamak kolay.
+
+**Bu container'da MariaDB uzun koşular arasında kendi kendine düşüyor.** Testte
+"Can't reach database server at 127.0.0.1:3306" görünce ilk iş
+`service mariadb start` — değişikliğini suçlamadan önce.
+
+**Deploy beklemek için foreground `sleep` bloklu.** `until curl … | grep -q
+'"sha":"<sha>'; do sleep 15; done` komutunu `run_in_background: true` ile başlat;
+prod `/api/health` sha'yı flip ettiğinde bildirim geliyor.
+
+---
+
 ## 2026-08-02 — Proje ekipleri, hedefler, katılma talepleri, davet/referans (#51, 0.40.0-beta)
 
 **"Yanlış isim görünüyor" şikâyeti neredeyse hep iki kaynaklı veridir.** Proje kartı

--- a/e2e/admin-mentee.spec.ts
+++ b/e2e/admin-mentee.spec.ts
@@ -28,7 +28,9 @@ test('admin can open a mentee detail page with profile + mentorship', async ({ p
     await page.goto(`/admin/candidates/${mentee.id}`);
     await expect(page.getByRole('heading', { name: 'Detail Mentee' })).toBeVisible();
     await expect(page.getByText('Köln')).toBeVisible();
-    await expect(page.getByText('Detail Mentor')).toBeVisible();
+    // Scoped to the mentorship card: the page also carries a "who referred them"
+    // picker whose <option> list contains every mentor's name (#51).
+    await expect(page.getByTestId('mentorship-mentor')).toHaveText('Detail Mentor');
     await expect(page.getByText('450 · Internship in progress').first()).toBeVisible();
   } finally {
     await cleanupByEmail(mentorEmail);

--- a/e2e/candidate-change-toast.spec.ts
+++ b/e2e/candidate-change-toast.spec.ts
@@ -27,8 +27,10 @@ test('changing a candidate\'s stage shows a confirmation toast', async ({ page }
     await page.waitForURL((u) => !u.pathname.includes('/auth/signin'), { timeout: 20_000 });
 
     await page.goto(`/admin/candidates/${mentee.id}`);
-    // The stage dropdown is the first <select> in the mentorship card.
-    await page.locator('select').first().selectOption('INTERVIEW_PENDING_250');
+    // By test id, not `select.first()`: the profile card above the mentorship card
+    // now has a select of its own ("who referred them", #51), so positional
+    // matching picked the wrong control.
+    await page.getByTestId('stage-select').selectOption('INTERVIEW_PENDING_250');
 
     // A success toast confirms the save.
     await expect(page.getByRole('status').filter({ hasText: /saved|kaydedildi|gespeichert/i })).toBeVisible({ timeout: 10_000 });

--- a/e2e/project-detail.spec.ts
+++ b/e2e/project-detail.spec.ts
@@ -44,7 +44,9 @@ test('project detail: internal section for the admin, PII-free public view, 404 
     await expect(adminPage.getByRole('heading', { name: 'Private Detail Project' })).toBeVisible({ timeout: 10_000 });
     const internal = adminPage.getByTestId('project-internal');
     await expect(internal).toBeVisible();
-    await expect(internal.getByText('Detail Member')).toBeVisible();
+    // Scoped to the roster: the internal section also holds the member pickers,
+    // whose <option> lists repeat every candidate's name (#51).
+    await expect(internal.getByTestId('project-team').getByText('Detail Member')).toBeVisible();
     await expect(internal.getByText('Ship the detail view')).toBeVisible();
     await expect(internal.getByText('Open task')).toBeVisible();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "internship-crm",
-  "version": "0.40.2-beta",
+  "version": "0.40.3-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "internship-crm",
-      "version": "0.40.2-beta",
+      "version": "0.40.3-beta",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.40.2-beta",
+  "version": "0.40.3-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "author": "Mehmet Erşahin",

--- a/src/app/admin/candidates/[id]/page.tsx
+++ b/src/app/admin/candidates/[id]/page.tsx
@@ -339,6 +339,7 @@ export default function AdminMenteeDetailPage() {
                 can be the source; invite/referral links set it automatically. */}
             <Select
               label={t.referral.sourcePerson}
+              data-testid="referred-by-select"
               disabled={saving}
               value={user.referredById ?? ''}
               onChange={(e) => changeReferredBy(e.target.value)}
@@ -359,13 +360,14 @@ export default function AdminMenteeDetailPage() {
           ) : (
             <div className="space-y-4">
               <div className="flex flex-wrap gap-x-6 gap-y-2 text-sm">
-                <div><span className="text-gray-500">{t.candidateDetail.mentor}:</span> <span className="font-medium">{rel.mentor.fullName}</span></div>
+                <div><span className="text-gray-500">{t.candidateDetail.mentor}:</span> <span className="font-medium" data-testid="mentorship-mentor">{rel.mentor.fullName}</span></div>
                 {rel.company && <div><span className="text-gray-500">{t.candidateDetail.company}:</span> <span className="font-medium">{rel.company.name}</span></div>}
               </div>
 
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 max-w-lg">
                 <Select
                   label={t.candidateDetail.stage}
+                  data-testid="stage-select"
                   options={stages.map((s) => ({ value: s.key, label: s.label }))}
                   value={rel.pipelineStatus}
                   disabled={saving}

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,21 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.40.3-beta',
+    date: '2026-08-03',
+    highlights: {
+      en: [
+        'Maintenance only: the new "who referred them" and project member pickers made three automated tests ambiguous, because an option in a dropdown is text like any other. Nothing changed on screen.',
+      ],
+      tr: [
+        'Yalnızca bakım: yeni "getiren kişi" ve proje üye seçicileri, üç otomatik testi belirsiz hale getirmişti — açılır listedeki bir seçenek de sonuçta metin. Ekranda değişen bir şey yok.',
+      ],
+      de: [
+        'Nur Wartung: Die neuen Auswahlfelder „wer hat sie geworben“ und für Projektmitglieder machten drei automatisierte Tests mehrdeutig — eine Option in einem Dropdown ist auch nur Text. Auf dem Bildschirm ändert sich nichts.',
+      ],
+    },
+  },
+  {
     version: '0.40.2-beta',
     date: '2026-08-02',
     highlights: {


### PR DESCRIPTION
## Summary

The scheduled full run (`e2e-full`, 356/359) went red on three specs, all for the same reason: **an `<option>` is text like any other.** The candidate page gained a "who referred them" picker and the project page gained the member pickers (#51, merged in #1044), so:

- `getByText('Detail Mentor')` on `/admin/candidates/[id]` → strict-mode violation (the mentorship card's span *and* an option in the referral picker);
- `getByTestId('project-internal').getByText('Detail Member')` → three matches (the roster span plus two picker options);
- `locator('select').first()` on the candidate page stopped resolving to the stage dropdown, because the profile card *above* the mentorship card now has a select of its own.

Fixed at the source rather than only in the assertions, so the next spec on these screens doesn't step on the same rake.

Also carries the end-of-session retrospective for the #51 work (`docs/agent-experience.md`), per the standing convention in `CLAUDE.md`.

## Changes

- `src/app/admin/candidates/[id]/page.tsx`: `data-testid="stage-select"`, `data-testid="referred-by-select"`, `data-testid="mentorship-mentor"`.
- `e2e/admin-mentee.spec.ts`: asserts on `mentorship-mentor` instead of a page-wide text match.
- `e2e/candidate-change-toast.spec.ts`: targets `stage-select` instead of `select.first()`.
- `e2e/project-detail.spec.ts`: scopes the roster assertion to `project-team`.
- `docs/agent-experience.md`: dated retrospective entry — an email sender inside a nested loop, two crons matching the same row, a route outside the app shell losing its header on mobile, plus the container quirks that cost time.
- Version `0.40.3-beta` + CHANGELOG + release notes (the note says plainly that nothing changed on screen).

## Verification

- [x] `npm run lint` + `npx tsc --noEmit` clean
- [x] `npm run test:e2e` passing (or CI green) — the three previously failing specs pass locally, plus the other seven specs that drive `/admin/candidates/[id]` (`matching`, `admin-bulk-candidates`, `admin-status`, `candidate-erasure`, `dashboard-links`, `admin-history-edit`, `admin-reset-password`): 11/11.
- [x] Tested the change manually / added an e2e test — the fix *is* the test change; no new behaviour to exercise.

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WEZDe3yyaQD5eBqUkLf2Fj