### PR TITLE
fix(meetings): store the wall clock the organizer picked, not the server's UTC reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,35 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.40.4-beta] - 2026-08-03
+
+### Fixed
+- **Scheduled meetings landed at the wrong time for any organizer outside UTC** (#1061).
+  The scheduler's split Date + Time inputs produce a bare wall clock
+  (`"2026-08-03T16:30"`) with no zone, and it was POSTed as-is and read with
+  `new Date()` on a server that runs UTC — so the string was taken to mean 16:30 **UTC**.
+  An organizer in Germany (CEST, GMT+2) who picked 16:30 got a meeting stored at
+  `16:30Z`, which the app and the reminder email then correctly rendered in their zone
+  as **18:30**: every meeting silently jumped forward by the organizer's offset, and the
+  invitees were told the wrong time. Fixed on both sides — `MeetingsManager` and
+  `MeetingSchedulerPanel` now send a zone-qualified instant built from the viewer's own
+  clock (`wallClockToInstantISO`), and `/api/meetings` + `/api/meeting-requests` no longer
+  hand a bare wall clock to `new Date()`: `parseUserDateTime` anchors it to the
+  organizer's saved `User.timezone` (→ `APP_TIMEZONE` → Europe/Istanbul), so API clients
+  and browsers on a cached bundle are covered too. New `parseWallClockInZone` resolves the
+  offset through `Intl`, iteratively, so DST is handled per date rather than assumed.
+- As a side effect, **date-only meetings** (no clock time) are now stored at local midnight
+  instead of UTC midnight, so they no longer show up on the previous day on the calendar for
+  viewers west of UTC.
+- Note: `Meeting` rows created *before* this fix keep their shifted `scheduledAt` — there is
+  no reschedule/cancel path to correct them in place, and a blanket backfill can't tell a
+  form-created row from a correctly-stored one (series occurrences and accepted meeting
+  requests always were correct).
+
+### Added
+- `e2e/meeting-timezone.spec.ts` — schedules 16:30 in a `Europe/Berlin` browser and asserts
+  the **stored instant** is `14:30Z`. Verified to fail (`16:30Z`) against the pre-fix code.
+
 ## [0.40.3-beta] - 2026-08-03
 
 ### Fixed

--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -2311,3 +2311,69 @@ Kullanılan zincir: `gh workflow run e2e.yml --ref <branch> -f grep='<8 testi ka
 yine de yeşil raporlardı — sessiz yanlış pozitif) → merge'den önce `e2e-full.yml` branch'te.
 `npx playwright test --list --grep '<regex>'` lokalde regex'i bedavaya doğruluyor; dispatch
 etmeden önce onu koştur.
+
+## 2026-08-03 — Aynı hatanın diğer yarısı: *giriş* yönü (#1061, 0.40.4-beta)
+
+#1030 (bir gün önce, hemen yukarıda) tarih/saatin **çıkış** yönünü düzeltmişti: sunucuda
+`timeZone` vermeden formatlamak. Bugün gelen bildirim neredeyse aynı görünüyordu — "16:30
+seçtim, 18:30 oldu", yine tam **2 saat**, yine Berlin/UTC — ama kök neden **karşı yönde**
+idi: bu kez format değil, **parse**.
+
+**Ayırt edici soru: yanlış olan gösterim mi, saklanan veri mi?** #1030'da DB doğruydu,
+e-posta yanlış render ediyordu. Burada e-posta *doğru* render ediyordu ("18:30 (GMT+2)" —
+saklanan an gerçekten 18:30 Berlin'di); bozuk olan `scheduledAt`'in kendisiydi. Ekran
+görüntülerinden bunu ayırmanın yolu: **ilan edilen ofset etiketiyle** tutarlı mı? "18:30
+(GMT+2)" iç tutarlı bir cümle, dolayısıyla formatlayıcı suçlu değil. Tutarlıysa yukarı,
+yazma yoluna bak.
+
+**Kural:** `<input type="date">` + `<input type="time">` (ve `datetime-local`) **saat dilimi
+taşımayan** bir duvar saati üretir (`"2026-08-03T16:30"`). ECMAScript'e göre belirteçsiz bir
+tarih-saat dizesi **çalışma zamanının yerel diliminde** yorumlanır — tarayıcıda kullanıcının
+dilimi, sunucuda ise UTC. Yani aynı dize iki uçta **iki farklı an** demek. Bu dize asla ham
+hâlde POST edilmemeli; `new Date(bareString)` sunucuda her zaman bir hatadır.
+
+**Neden hem istemci hem sunucu düzeltildi:** istemci tarafı yetkili çözüm (kullanıcının
+dilimini yalnızca tarayıcı bilir), ama sunucu tarafı `new Date()` çağrısı bırakılırsa
+önbellekteki eski paketle gelen tarayıcı ve API tüketicileri hatayı yaşamaya devam eder.
+Sunucuda "diliminden emin değilsen" fallback'i organizatörün `User.timezone`'u → `APP_TIMEZONE`
+→ Europe/Istanbul; UTC varsaymaktan her koşulda daha iyi (ama #1030'un tuzağı burada da
+geçerli: bu alan mentor/adminlerde boş olabilir, o yüzden istemci düzeltmesi asıl olan).
+
+**IANA duvar saati → an dönüşümü, kütüphanesiz:** aradığın ofset, çözmeye çalıştığın anın
+kendisine bağlıdır (DST). Yineleyerek çöz — duvar saatini UTC varsay, oradaki ofsetle
+düzelt, bir kez daha düzelt. İki geçiş, ofseti ~1 saatten az kayan her dilim için tam
+sonuç veriyor. Ofseti `Intl.DateTimeFormat(...).formatToParts` ile geri okumak, kendi ofset
+tablonu tutmaktan iyidir. `hour12: false` bazı ICU sürümlerinde gece yarısını **"24"**
+döndürür — `% 24` şart.
+
+**Regex tuzağı — "saat dilimi belirteci var mı":** naif `/(?:Z|[+-]\d{2}:?\d{2})$/` deseni
+yalnızca-tarih olan `"2026-08-03"`'ü de **eşleştirir** (`-08-03` bir "-08:03" ofseti gibi
+okunur) ve dizeyi "zaten dilimli" sayıp UTC gece yarısına çevirir. Belirteci **bir saatin
+ardından** aramak gerekiyor; `.000Z` için kesirli saniyeyi de kapsa.
+
+**Düzeltmenin gerçekten çalıştığını kanıtlama — testi eski kodda kırmızı gör.** Yeni e2e
+`git stash push -- src/` ile düzeltme geri alınıp koşuldu: `Received: 16:30Z` (bildirilen
+hatanın tam kendisi), düzeltmeyle `14:30Z`. Yeşil bir test tek başına hiçbir şey kanıtlamaz;
+Playwright'ta `test.use({ timezoneId: 'Europe/Berlin' })` bu tür hataları görünür kılan tek
+satırdır — **UTC tarayıcıda bu hata görünmez**, yani varsayılan dilimle yazılmış bir test
+sessizce yeşil kalırdı. Ayrıca iddia **saklanan anı** (`prisma.meeting.findFirst` →
+`scheduledAt.toISOString()`) kontrol etmeli; ekranda okunan metin hem doğru hem yanlış
+veriyle "16:30" gösterebilir.
+
+**Formattan bağımsız iddia yaz:** ekrandaki saati doğrulayan satır ilk denemede kırıldı,
+çünkü liste `Intl`'i tarayıcının **locale**'iyle çalıştırıyor ve `en-US` 12 saatlik
+("4:30 PM") biçim veriyor. `/(16:30|4:30\s*PM)/` gibi iki biçimi de kabul et — yoksa test
+saat dilimini değil locale'i test eder.
+
+**Geriye dönük veri:** düzeltmeden önce oluşmuş satırlar kayık kalıyor ve toptan bir
+backfill **yapılmadı** — form kaynaklı satırı doğru saklanmış satırdan (seri tekrarları,
+kabul edilmiş toplantı istekleri) ayırt edecek bir işaret yok, `createdById` üzerinden ofset
+tahmini doğru satırları bozardı. Yerinde düzeltme için bir yeniden planlama/iptal yolu da
+yok (`/api/meetings` yalnızca GET+POST). Bunu kullanıcıya **açıkça söyle**; "düzelttim"
+demek yeni kayıtlar için doğru, mevcut kayıt için değil.
+
+**Ortam:** yerel MariaDB + `.env` + `db push` playbook'taki gibi sorunsuz kuruldu. Playwright
+runner'ı için `executablePath` override'ı ayrı bir config dosyasına yazılıyor ve bu dosya
+**repo kökünde** olmalı — `playwright.config.ts` içindeki `globalSetup: './e2e/global-setup.ts'`
+gibi göreli yollar config'in bulunduğu dizine göre çözülüyor, scratchpad'e koyunca
+`MODULE_NOT_FOUND` veriyor. Commit'ten önce silmeyi unutma.

--- a/e2e/meeting-timezone.spec.ts
+++ b/e2e/meeting-timezone.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// #1061: the Date + Time inputs produce a bare wall clock ("2026-08-03T16:30")
+// with no zone. That used to be POSTed as-is and read with `new Date()` on a
+// server running UTC, so an organizer in Germany who picked 16:30 got a meeting
+// stored at 16:30Z — 18:30 on their own clock, which is what the reminder email
+// then told them. The picked wall clock must survive the round trip whatever
+// zone the browser is in, so this asserts the stored instant, not the rendering.
+test.describe('meeting times are stored in the organizer’s zone', () => {
+  // CEST in August, so 16:30 local is 14:30Z. A zone with a non-zero offset is
+  // the whole point — under UTC the bug is invisible.
+  test.use({ timezoneId: 'Europe/Berlin' });
+
+  test('16:30 picked in Europe/Berlin is stored as 14:30Z, not 16:30Z', async ({ page }) => {
+    const mentorEmail = uniqueEmail('tz-mentor');
+    const menteeEmail = uniqueEmail('tz-mentee');
+    const mentor = await seedUser(mentorEmail, 'Pass1234!', 'MENTOR', 'TZ Mentor');
+    const mentee = await seedUser(menteeEmail, 'Pass1234!', 'MENTEE', 'TZ Mentee');
+    const relation = await prisma.mentorshipRelation.create({
+      data: { mentorId: mentor.id, menteeId: mentee.id, status: 'ACTIVE' },
+    });
+
+    try {
+      await page.goto('/auth/signin');
+      await page.fill('input[type="email"], input[name="email"]', mentorEmail);
+      await page.fill('input[type="password"]', 'Pass1234!');
+      await page.click('button[type="submit"]');
+      await page.waitForURL((u) => !u.pathname.includes('/auth/signin'), { timeout: 20_000 });
+
+      await page.goto('/mentor/meetings');
+      await page.getByRole('checkbox').first().check();
+      await page.getByLabel('Title').fill('Timezone check-in');
+      await page.getByLabel('Date', { exact: true }).fill('2026-08-03');
+      await page.getByLabel('Time', { exact: true }).fill('16:30');
+      await page.getByRole('button', { name: /send invite/i }).click();
+      await expect(page.getByText(/invite sent to 1/i)).toBeVisible({ timeout: 10_000 });
+
+      const meeting = await prisma.meeting.findFirst({
+        where: { relationId: relation.id, title: 'Timezone check-in' },
+      });
+      expect(meeting?.scheduledAt?.toISOString()).toBe('2026-08-03T14:30:00.000Z');
+
+      // …and the mentor reads back the clock time they picked. The list renders
+      // via Intl in the browser's locale, so accept either 24h or 12h form.
+      await expect(page.getByText(/(16:30|4:30\s*PM)/i).first()).toBeVisible();
+    } finally {
+      await cleanupByEmail(mentorEmail);
+      await cleanupByEmail(menteeEmail);
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.40.3-beta",
+  "version": "0.40.4-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "author": "Mehmet Erşahin",

--- a/src/app/api/meeting-requests/route.ts
+++ b/src/app/api/meeting-requests/route.ts
@@ -7,6 +7,7 @@ import { getThreadIfAllowed, otherParticipant } from '@/lib/messaging';
 import { notify } from '@/lib/notify';
 import { emailAllowed } from '@/lib/notificationPrefs';
 import { sendMeetingRequestEmail } from '@/services/emailService';
+import { hasTimeZoneDesignator, parseUserDateTime } from '@/lib/timezone';
 
 // GET ?relationId= — meeting requests for a thread (participants/admin).
 export async function GET(request: Request) {
@@ -36,12 +37,20 @@ export async function POST(request: Request) {
   const rel = await getThreadIfAllowed(session.user, parsed.data.relationId);
   if (!rel) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
 
+  // The panel sends a zone-qualified instant; a bare wall clock is anchored to
+  // the requester's zone rather than the container's UTC (#1061).
+  const requester = hasTimeZoneDesignator(parsed.data.proposedAt)
+    ? null
+    : await prisma.user.findUnique({ where: { id: session.user.id }, select: { timezone: true } });
+  const proposedAt = parseUserDateTime(parsed.data.proposedAt, requester?.timezone);
+  if (!proposedAt) return NextResponse.json({ error: 'Validation failed' }, { status: 400 });
+
   const req = await prisma.meetingRequest.create({
     data: {
       relationId: rel.id,
       requestedById: session.user.id,
       topic: parsed.data.topic,
-      proposedAt: new Date(parsed.data.proposedAt),
+      proposedAt,
     },
   });
 

--- a/src/app/api/meetings/route.ts
+++ b/src/app/api/meetings/route.ts
@@ -7,6 +7,7 @@ import { randomBytes } from 'crypto';
 import { sendMeetingInviteEmail } from '@/services/emailService';
 import { dispatchWebhook } from '@/lib/webhooks';
 import { withTenantScope } from '@/lib/orgContext';
+import { hasTimeZoneDesignator, parseUserDateTime } from '@/lib/timezone';
 
 const schema = z.object({
   relationIds: z.array(z.string().min(1)).min(1),
@@ -47,7 +48,25 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 });
     }
     const { relationIds, title, scheduledAt, meetLink } = parsed.data;
-    const when = scheduledAt ? new Date(scheduledAt) : null;
+
+    // `scheduledAt` normally arrives zone-qualified from the browser. A bare wall
+    // clock ("2026-08-03T16:30") still has to be honoured for API clients and for
+    // browsers on a cached bundle — and must NOT go through `new Date()`, which
+    // reads it in the container's zone (UTC) and so shifts the meeting by the
+    // organizer's offset (#1061). Anchor it to the organizer's own zone instead.
+    let when: Date | null = null;
+    if (scheduledAt) {
+      const organizer = hasTimeZoneDesignator(scheduledAt)
+        ? null
+        : await prisma.user.findUnique({
+            where: { id: session.user.id },
+            select: { timezone: true },
+          });
+      when = parseUserDateTime(scheduledAt, organizer?.timezone);
+      if (!when) {
+        return NextResponse.json({ error: 'Validation failed', details: { scheduledAt: 'Invalid date/time' } }, { status: 400 });
+      }
+    }
 
     const where =
       session.user.role === 'ADMIN'

--- a/src/components/MeetingSchedulerPanel.tsx
+++ b/src/components/MeetingSchedulerPanel.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/Button';
 import { Copy, Check, Video } from 'lucide-react';
 import { useT, useLocale } from '@/i18n/client';
 import { formatDateTime } from '@/lib/relativeTime';
+import { wallClockToInstantISO } from '@/lib/timezone';
 
 interface Meeting {
   id: string;
@@ -31,8 +32,8 @@ export function MeetingSchedulerPanel({ relationId }: { relationId: string }) {
   const [busy, setBusy] = useState(false);
   const [copiedId, setCopiedId] = useState<string | null>(null);
   // Time optional: a date gives the meeting a time (+ RSVP); no date → no-time
-  // meeting (just a link).
-  const scheduledAt = date ? `${date}T${time || '00:00'}` : '';
+  // meeting (just a link). Sent zone-qualified — see MeetingsManager (#1061).
+  const scheduledAt = date ? wallClockToInstantISO(date, time || '00:00') : '';
 
   const load = useCallback(async () => {
     const r = await fetch('/api/meetings');

--- a/src/components/MeetingsManager.tsx
+++ b/src/components/MeetingsManager.tsx
@@ -8,6 +8,7 @@ import { Badge } from '@/components/ui/Badge';
 import { Copy, Check } from 'lucide-react';
 import { useT, useLocale } from '@/i18n/client';
 import { formatDateTime } from '@/lib/relativeTime';
+import { wallClockToInstantISO } from '@/lib/timezone';
 
 interface Relation {
   id: string;
@@ -42,7 +43,11 @@ export function MeetingsManager() {
   // Time is optional. With a date the meeting has a time (defaulting to
   // midnight if no clock time) and expects an RSVP; with no date it's a
   // no-time meeting (just a link, no RSVP).
-  const scheduledAt = date ? `${date}T${time || '00:00'}` : '';
+  //
+  // Sent as a zone-qualified instant, not the bare "2026-08-03T16:30" the inputs
+  // produce: the server runs UTC and would have read that wall clock as UTC,
+  // pushing the meeting forward by the organizer's offset (#1061).
+  const scheduledAt = date ? wallClockToInstantISO(date, time || '00:00') : '';
   const [busy, setBusy] = useState(false);
   const [result, setResult] = useState<string | null>(null);
   const [copiedId, setCopiedId] = useState<string | null>(null);

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,27 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.40.4-beta',
+    date: '2026-08-03',
+    highlights: {
+      en: [
+        'Important fix: a meeting you scheduled was saved at the wrong time unless your clock happened to match UTC. Picking 16:30 in Germany created an 18:30 meeting — the time jumped forward by your own time-zone offset, and that wrong time is what the invitation and the reminder email told everyone. The time you pick is now the time that gets saved, wherever you are, summer time included.',
+        'Meetings you give a date but no time to now sit on that date on the calendar for everyone, instead of slipping to the day before for anyone west of London.',
+        'Meetings created before this fix keep their shifted time — please check any upcoming meeting you scheduled earlier and set it up again if the time is off.',
+      ],
+      tr: [
+        'Önemli düzeltme: planladığın toplantı, saatin UTC ile aynı olmadığı her durumda yanlış saatte kaydediliyordu. Almanya\'da 16:30 seçmek 18:30\'luk bir toplantı oluşturuyordu — saat kendi saat dilimi farkın kadar ileri kayıyordu ve davet ile hatırlatma e-postası herkese bu yanlış saati söylüyordu. Artık seçtiğin saat, nerede olursan ol (yaz saati dahil) kaydedilen saat.',
+        'Tarih verip saat vermediğin toplantılar artık takvimde herkes için o tarihte duruyor; Londra\'nın batısındakiler için bir gün öncesine kaymıyor.',
+        'Bu düzeltmeden önce oluşturulan toplantıların saati kayık kalıyor — daha önce planladığın yaklaşan toplantıları kontrol et ve saati yanlışsa yeniden oluştur.',
+      ],
+      de: [
+        'Wichtige Korrektur: Ein von dir geplantes Meeting wurde zur falschen Zeit gespeichert, sofern deine Uhr nicht ohnehin UTC entsprach. Wer in Deutschland 16:30 wählte, bekam ein Meeting um 18:30 — die Zeit sprang um deinen eigenen Zeitzonen-Versatz nach vorn, und genau diese falsche Zeit stand in der Einladung und in der Erinnerungs-E-Mail. Jetzt wird die Zeit gespeichert, die du auswählst — überall, Sommerzeit inklusive.',
+        'Meetings mit Datum, aber ohne Uhrzeit liegen im Kalender nun für alle an diesem Datum, statt für alle westlich von London auf den Vortag zu rutschen.',
+        'Vor dieser Korrektur erstellte Meetings behalten ihre verschobene Zeit — prüfe bitte deine bereits geplanten kommenden Meetings und lege sie bei falscher Zeit neu an.',
+      ],
+    },
+  },
+  {
     version: '0.40.3-beta',
     date: '2026-08-03',
     highlights: {

--- a/src/lib/timezone.ts
+++ b/src/lib/timezone.ts
@@ -1,5 +1,6 @@
-// Server-side date/time rendering for anything a user reads *outside* the
-// browser — emails and the stored text of in-app notifications.
+// Timezone handling for date/times that cross the browser ↔ server boundary,
+// in both directions: rendering an instant *out* (emails, stored notification
+// text) and parsing a user-entered wall clock *in*.
 //
 // The browser picks the viewer's zone on its own (see lib/relativeTime.ts), but
 // the server has no such context: the container runs on UTC, so a plain
@@ -57,4 +58,93 @@ export function formatInTimeZone(
   }).format(date);
   const label = zoneLabel(date, timeZone);
   return label ? `${formatted} (${label})` : formatted;
+}
+
+// ---------------------------------------------------------------------------
+// The other direction: a *wall clock* the user typed → the instant they meant.
+// ---------------------------------------------------------------------------
+
+// `<input type="date">` + `<input type="time">` (and `datetime-local`) yield a
+// bare wall clock with no zone: "2026-08-03T16:30". `new Date()` reads that in
+// the *runtime's* local zone, so the same string means different instants in the
+// browser and on the server — and our server runs UTC. An organizer in Germany
+// picking 16:30 got a meeting stored at 16:30Z, i.e. 18:30 on their own clock
+// (#1061). Anything sent to the server therefore has to carry a zone.
+// The time is optional so a date on its own means local midnight in the zone,
+// rather than the UTC midnight `new Date('2026-08-03')` would give.
+const WALL_CLOCK = /^(\d{4})-(\d{2})-(\d{2})(?:[T ](\d{2}):(\d{2})(?::(\d{2}))?)?$/;
+
+// Does the string already pin an instant ("…Z", "…+02:00")? Only these are safe
+// to hand to `new Date()` directly. The designator has to follow a *time* — a
+// plain "2026-08-03" ends in digits preceded by "-" and would otherwise read as
+// a "-08:03" offset.
+const ZONED = /[T ]\d{2}:\d{2}(?::\d{2})?(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})$/i;
+
+export function hasTimeZoneDesignator(value: string): boolean {
+  return ZONED.test(value.trim());
+}
+
+// What is `timeZone` offset from UTC at this instant, in ms? Positive east of
+// Greenwich. Derived from Intl so the IANA database (and its DST rules) is the
+// single source of truth — no offset tables of our own to keep current.
+function offsetAt(date: Date, timeZone: string): number {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    hour12: false,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  }).formatToParts(date);
+  const at = (type: string) => Number(parts.find((p) => p.type === type)?.value);
+  // `hour12: false` renders midnight as "24" in some ICU versions.
+  const hour = at('hour') % 24;
+  const wall = Date.UTC(at('year'), at('month') - 1, at('day'), hour, at('minute'), at('second'));
+  return wall - date.getTime();
+}
+
+// Read a bare wall clock as an instant in `tz` (falling back to the deployment
+// default). Returns null if the string isn't a wall clock we recognise.
+//
+// The offset we need depends on the very instant we're solving for (DST), so
+// resolve it iteratively: guess the wall clock is UTC, correct by the offset
+// there, then correct once more. Two passes are exact for every zone whose
+// offset shifts by less than the ~1h we're already within after the first pass.
+export function parseWallClockInZone(value: string, tz?: string | null): Date | null {
+  const m = WALL_CLOCK.exec(value.trim());
+  if (!m) return null;
+  const [, year, month, day, hour, minute, second] = m;
+  const asUtc = Date.UTC(+year, +month - 1, +day, hour ? +hour : 0, minute ? +minute : 0, second ? +second : 0);
+  const timeZone = resolveTimeZone(tz);
+  let ts = asUtc;
+  for (let pass = 0; pass < 2; pass++) ts = asUtc - offsetAt(new Date(ts), timeZone);
+  const date = new Date(ts);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+// Accepts either form and always returns a real instant: zone-qualified input is
+// taken at face value, a bare wall clock is anchored to `tz`. Use this wherever
+// an API takes a user-entered date/time.
+export function parseUserDateTime(value: string, tz?: string | null): Date | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (hasTimeZoneDesignator(trimmed)) {
+    const date = new Date(trimmed);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+  return parseWallClockInZone(trimmed, tz);
+}
+
+// Browser-side counterpart: turn the two form fields into a zone-qualified
+// instant, read in the *viewer's* own zone — which is the clock they picked the
+// time on. Safe to call in a client component; `new Date(y, m, …)` is local by
+// definition, so no Intl round-trip is needed here.
+export function wallClockToInstantISO(date: string, time: string): string {
+  const m = WALL_CLOCK.exec(`${date}T${time}`);
+  if (!m) return '';
+  const [, year, month, day, hour, minute, second] = m;
+  const local = new Date(+year, +month - 1, +day, hour ? +hour : 0, minute ? +minute : 0, second ? +second : 0, 0);
+  return Number.isNaN(local.getTime()) ? '' : local.toISOString();
 }


### PR DESCRIPTION
## Summary

Scheduling a meeting saved it at the **wrong time for every organizer outside UTC**. Picking **16:30** in Germany (CEST, GMT+2) created a meeting stored at `16:30Z` — genuinely **18:30** on the organizer's own clock — and that wrong time is what the app and the reminder email then faithfully reported to the invitees.

The scheduler's split Date + Time inputs produce a bare wall clock (`"2026-08-03T16:30"`) carrying **no timezone**. It was POSTed as-is and read with `new Date()` on a server that runs UTC; per ECMAScript a date-time string without a designator is interpreted in the **runtime's** local zone, so the same string means one instant in the browser and a different one on the server. The stored data itself was wrong — this was not a rendering bug.

#1030 fixed the *rendering* direction of this same family (formatting server-side without an explicit zone). This is the *parsing* direction.

Closes #1061

## Changes

- **Client** — `MeetingsManager` and `MeetingSchedulerPanel` build a zone-qualified instant from the viewer's own clock (`wallClockToInstantISO`) instead of sending the raw input value. This is the authoritative fix: only the browser knows the user's zone.
- **Server** — `/api/meetings` and `/api/meeting-requests` no longer hand a bare wall clock to `new Date()`. `parseUserDateTime` takes zone-qualified input at face value and anchors a bare one to the organizer's saved `User.timezone` (→ `APP_TIMEZONE` → Europe/Istanbul), covering API clients and browsers on a cached bundle. Unparseable input now 400s instead of silently becoming `Invalid Date`.
- **`src/lib/timezone.ts`** — the module now owns both directions (render out / parse in). `parseWallClockInZone` resolves the offset via `Intl.formatToParts` **iteratively**, so DST is handled per date rather than assumed. The "already zone-qualified?" test deliberately requires the designator to follow a *time*: a naive anchor matches plain `"2026-08-03"` as a `-08:03` offset. `hour12: false` can render midnight as `"24"` in some ICU versions, hence the `% 24`.
- **Side effect (an improvement)** — date-only meetings are now stored at local rather than UTC midnight, so they stop landing on the previous day on the calendar for viewers west of UTC.
- Version bump `0.40.4-beta` + `CHANGELOG.md` + `src/lib/releaseNotes.ts` (EN/TR/DE), and a retrospective entry in `docs/agent-experience.md`.

## Verification

- [x] `npm run lint` + `npx tsc --noEmit` clean (only pre-existing warnings); `npm run check:i18n` OK — 1710 keys × 3 locales
- [x] `npm run test:e2e` — all 8 meeting specs green against a local MySQL, including the new one
- [x] Added `e2e/meeting-timezone.spec.ts`

**The new test was proved to catch the bug**, not merely to pass — re-run with the fix stashed:

| | stored `scheduledAt` | shown in Germany |
|---|---|---|
| pre-fix code | `2026-08-03T16:30:00.000Z` | **18:30** ← the reported bug |
| this PR | `2026-08-03T14:30:00.000Z` | **16:30** ✅ |

It asserts the **stored instant** (`prisma.meeting.findFirst`), not the rendered text, and runs under `test.use({ timezoneId: 'Europe/Berlin' })` — under a UTC browser this class of bug is invisible, so a default-zone test would have stayed silently green.

Also verified out-of-band on a UTC runtime: exact round-trips for half- and quarter-hour zones (`Asia/Kolkata`, `Australia/Eucla`, `Pacific/Chatham`) and across both European DST transitions (48/48).

**Smoke-suite failures were attributed, not assumed:** 8 red locally — 6 were this container lacking seed data (green after `prisma db seed` + `seed:demo`), and the remaining 2 (`pipeline.spec.ts:8`, `smoke.spec.ts:53`) fail identically on `origin/main` with these changes stashed, so they are pre-existing and unrelated.

## ⚠️ Pre-existing rows are not corrected

`Meeting` rows created before this fix keep their shifted `scheduledAt`. No backfill is included, deliberately:

- There is **no reschedule/cancel path** to correct one in place — `/api/meetings` is GET + POST only.
- A blanket backfill **cannot** tell a form-created row from a correctly-stored one; series occurrences and accepted meeting requests always were correct, so shifting by the creator's offset would corrupt them.

Any already-scheduled upcoming meeting therefore needs to be re-created after this ships. Adding meeting edit/cancel is follow-up work.

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WQjiAwXFcVygA8ZCgqvUE4


---
_Generated by [Claude Code](https://claude.ai/code/session_01WQjiAwXFcVygA8ZCgqvUE4)_