### PR TITLE
feat(meetings): instant meeting endpoint + project/conversation context (#1051, #1052)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.40.5-beta] - 2026-08-03
+
+### Added
+- **`POST /api/meetings/instant` — start a meeting now and get the room back in the
+  response** (#1052). `POST /api/meetings` answers `{ created }`, so a UI that wants to
+  show or open the link has to re-fetch the list; that round trip is what makes "call this
+  person" feel slow. The new endpoint always creates a time-less room (no RSVP, no
+  reminder) and returns `{ meetingId, meetLink, invited }`. Invitees get an in-app
+  notification unconditionally and an email when `emailAllowed(user, 'meetingReminders')`.
+  Rate-limited to 10/min per IP — each call fans out invitations. The existing
+  `POST /api/meetings` contract is untouched.
+- **`Meeting` can hang off a project or a conversation, not only a mentorship** (#1051).
+  `relationId` is now nullable and joined by `projectId` / `conversationId`. MySQL can't
+  express "exactly one of three" as a CHECK, so the rule and the membership authorization
+  live in `src/lib/meetingContext.ts` (`resolveMeetingContext`) and every write path goes
+  through it: project meetings need an OWNER/MENTOR membership (or admin), conversation
+  meetings need participation, relation meetings keep the mentor-scoped rule. The project
+  lookup goes through `prisma.project` first because `Project` is a `TENANT_MODEL` and
+  `ProjectMember` is not — querying members directly would reach across tenants.
+
+### Changed
+- Jitsi room generation moved out of the route into `generateMeetingLink()` so the two
+  endpoints can't drift; `isEmbeddableMeetingLink()` joins it for the upcoming side panel.
+- `GET /api/meetings`, `/api/calendar-events` and the meeting-reminder cron now filter on
+  `relationId: { not: null }`, keeping their shape and behaviour identical now that the
+  column is nullable.
+
 ## [0.40.4-beta] - 2026-08-03
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.40.4-beta",
+  "version": "0.40.5-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "author": "Mehmet Erşahin",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -358,6 +358,7 @@ model Conversation {
   project      Project?                  @relation(fields: [projectId], references: [id], onDelete: SetNull)
   participants ConversationParticipant[]
   messages     Message[]
+  meetings     Meeting[]
 
   // MySQL permits multiple NULL values, so DIRECT conversations remain
   // unaffected while each project can have only one GROUP conversation.
@@ -850,6 +851,7 @@ model Project {
   members       ProjectMember[]
   conversations Conversation[]
   meetingSeries MeetingSeries[]
+  meetings      Meeting[]
   taskTemplates ProjectTaskTemplate[]
   joinRequests  ProjectJoinRequest[]
 
@@ -1219,11 +1221,22 @@ enum RsvpStatus {
   DECLINED
 }
 
-// A scheduled meeting between a mentor and a mentee, with a Google Meet link
-// and an emailed RSVP (responded to via a public token link).
+// A scheduled meeting, with a video link and an emailed RSVP (responded to via
+// a public token link).
+//
+// A meeting hangs off exactly ONE context (#1051):
+//   relationId     — the original mentor ↔ mentee meeting (one row per invitee,
+//                    each with its own rsvpToken; the shared room is meetLink)
+//   projectId      — an ad-hoc meeting for a whole project team
+//   conversationId — an ad-hoc meeting for a group chat
+// MySQL can't express "exactly one of three" as a CHECK, so the rule lives in
+// src/lib/meetingContext.ts and every write path goes through it.
 model Meeting {
   id             String     @id @default(cuid())
-  relationId     String
+  // Nullable since #1051: project/conversation meetings have no relation.
+  relationId     String?
+  projectId      String?
+  conversationId String?
   title          String
   // Optional: a meeting with a set time expects an RSVP and gets reminders; a
   // meeting with no time (null) is just a shared link — no RSVP, no reminder.
@@ -1237,10 +1250,14 @@ model Meeting {
   // Null for manually scheduled meetings; set for auto-generated series instances.
   seriesId       String?
 
-  relation MentorshipRelation @relation(fields: [relationId], references: [id], onDelete: Cascade)
-  series   MeetingSeries?     @relation(fields: [seriesId], references: [id], onDelete: SetNull)
+  relation     MentorshipRelation? @relation(fields: [relationId], references: [id], onDelete: Cascade)
+  project      Project?            @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  conversation Conversation?       @relation(fields: [conversationId], references: [id], onDelete: Cascade)
+  series       MeetingSeries?      @relation(fields: [seriesId], references: [id], onDelete: SetNull)
 
   @@index([relationId])
+  @@index([projectId])
+  @@index([conversationId])
   @@index([seriesId])
 }
 

--- a/src/app/api/calendar-events/route.ts
+++ b/src/app/api/calendar-events/route.ts
@@ -21,7 +21,11 @@ export async function GET() {
 
   const [meetings, relations, loggedMeetings] = await Promise.all([
     prisma.meeting.findMany({
-      where: { relation: relWhere },
+      // `relationId: { not: null }` — since #1051 a meeting may instead hang off
+      // a project or a conversation. Those are always time-less (instant rooms),
+      // so they'd be dropped by the scheduledAt filter below anyway; excluding
+      // them here keeps `relation` non-null for the mapping.
+      where: { relationId: { not: null }, relation: relWhere },
       include: { relation: { include: { mentee: { select: { fullName: true } } } } },
       orderBy: { scheduledAt: 'asc' },
     }),
@@ -41,11 +45,11 @@ export async function GET() {
 
   const events = [
     // No-time meetings (nullable scheduledAt) don't belong on a calendar.
-    ...meetings.filter((m) => m.scheduledAt).map((m) => ({
+    ...meetings.filter((m) => m.scheduledAt && m.relation).map((m) => ({
       id: `meeting-${m.id}`,
       type: 'meeting' as const,
       title: m.title,
-      who: m.relation.mentee.fullName,
+      who: m.relation!.mentee.fullName,
       date: m.scheduledAt!.toISOString(),
       link: m.meetLink ?? null,
     })),

--- a/src/app/api/meetings/instant/route.ts
+++ b/src/app/api/meetings/instant/route.ts
@@ -1,0 +1,140 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { z } from 'zod';
+import { randomBytes } from 'crypto';
+import { sendMeetingInviteEmail } from '@/services/emailService';
+import { dispatchWebhook } from '@/lib/webhooks';
+import { withTenantScope } from '@/lib/orgContext';
+import { enforceRateLimit } from '@/lib/rateLimit';
+import { emailAllowed } from '@/lib/notificationPrefs';
+import { notify } from '@/lib/notify';
+import { generateMeetingLink, resolveMeetingContext, type Invitee } from '@/lib/meetingContext';
+
+// "Start a meeting now" (#1052).
+//
+// The difference from POST /api/meetings is not the scheduling — it is that the
+// caller gets the room back in the response. The planner endpoint answers with
+// `{ created }` only, so a UI wanting to show or open the link has to re-fetch
+// the list; that round trip is exactly what makes "start a call with this
+// person" feel slow. Here the room is always time-less (no RSVP, no reminder)
+// and the link comes straight back.
+//
+// POST /api/meetings is untouched — its contract has other callers.
+const schema = z.object({
+  title: z.string().min(1).max(200),
+  relationIds: z.array(z.string().min(1)).optional(),
+  projectId: z.string().min(1).optional(),
+  conversationId: z.string().min(1).optional(),
+});
+
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  // Each call fans out invite emails, so it is worth a cap of its own.
+  const limited = enforceRateLimit(request, 'meeting-instant', { limit: 10, windowMs: 60_000 });
+  if (limited) return limited;
+
+  return await withTenantScope(session, async () => {
+    const parsed = schema.safeParse(await request.json().catch(() => null));
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 });
+    }
+    const { title, relationIds, projectId, conversationId } = parsed.data;
+
+    const ctx = await resolveMeetingContext(session.user, { relationIds, projectId, conversationId });
+    if (!ctx.ok) return NextResponse.json({ error: ctx.error }, { status: ctx.status });
+
+    const meetLink = generateMeetingLink();
+
+    // RELATION keeps the established shape — one row (and one RSVP token) per
+    // relation, all sharing the room. PROJECT/CONVERSATION are a single row: the
+    // invitee list is derived from membership, not from N relations.
+    let meetingId: string;
+    if (ctx.kind === 'RELATION') {
+      const rows = await Promise.all(
+        ctx.relationIds.map((relationId) =>
+          prisma.meeting.create({
+            data: {
+              relationId,
+              title,
+              scheduledAt: null,
+              meetLink,
+              rsvpToken: randomBytes(24).toString('hex'),
+              createdById: session.user.id,
+            },
+            select: { id: true, relationId: true, rsvpToken: true },
+          })
+        )
+      );
+      meetingId = rows[0].id;
+      await inviteAll(ctx.invitees, rows, title, meetLink, session.user.name ?? null);
+    } else {
+      const row = await prisma.meeting.create({
+        data: {
+          projectId: ctx.projectId,
+          conversationId: ctx.conversationId,
+          title,
+          scheduledAt: null,
+          meetLink,
+          rsvpToken: randomBytes(24).toString('hex'),
+          createdById: session.user.id,
+        },
+        select: { id: true, relationId: true, rsvpToken: true },
+      });
+      meetingId = row.id;
+      await inviteAll(ctx.invitees, [row], title, meetLink, session.user.name ?? null);
+    }
+
+    await dispatchWebhook('meeting.scheduled', {
+      title,
+      scheduledAt: null,
+      count: ctx.invitees.length,
+      instant: true,
+    });
+
+    return NextResponse.json({ meetingId, meetLink, invited: ctx.invitees.length }, { status: 201 });
+  });
+}
+
+type Row = { id: string; relationId: string | null; rsvpToken: string };
+
+// Notify every invitee: always in-app, email only when they haven't opted out.
+// A failure for one recipient must not sink the meeting that was already created.
+async function inviteAll(
+  invitees: Invitee[],
+  rows: Row[],
+  title: string,
+  meetLink: string,
+  organizer: string | null
+) {
+  // English, like every other notify() call site; notification i18n is its own
+  // epic (#857) and this text should move with the rest, not ahead of it.
+  const text = organizer ? `${organizer} started a meeting: ${title}` : `A meeting started: ${title}`;
+  await Promise.all(
+    invitees.map(async (inv) => {
+      // In-app first — it's the channel that always works.
+      await notify(inv.userId, 'meeting.started', text, meetLink);
+      if (!emailAllowed(inv, 'meetingReminders')) return;
+      // For a relation invite, use that relation's own token; otherwise any row
+      // works (a project/chat meeting has exactly one).
+      const row = inv.relationId ? rows.find((r) => r.relationId === inv.relationId) : rows[0];
+      if (!row) return;
+      try {
+        await sendMeetingInviteEmail({
+          to: inv.email,
+          fullName: inv.fullName,
+          title,
+          scheduledAt: null,
+          meetLink,
+          rsvpToken: row.rsvpToken,
+          timeZone: inv.timezone,
+        });
+      } catch (e) {
+        console.error('Instant meeting invite email failed:', e);
+      }
+    })
+  );
+}

--- a/src/app/api/meetings/route.ts
+++ b/src/app/api/meetings/route.ts
@@ -8,6 +8,7 @@ import { sendMeetingInviteEmail } from '@/services/emailService';
 import { dispatchWebhook } from '@/lib/webhooks';
 import { withTenantScope } from '@/lib/orgContext';
 import { hasTimeZoneDesignator, parseUserDateTime } from '@/lib/timezone';
+import { generateMeetingLink } from '@/lib/meetingContext';
 
 const schema = z.object({
   relationIds: z.array(z.string().min(1)).min(1),
@@ -23,8 +24,14 @@ export async function GET() {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
   return await withTenantScope(session, async () => {
+    // `relationId: { not: null }` keeps this endpoint's shape after #1051 made
+    // the column nullable: every consumer (MeetingsManager, MeetingSchedulerPanel)
+    // reads `m.relation.mentee.fullName`, and an admin's unfiltered query would
+    // otherwise start returning project/conversation rows with a null relation.
     const where =
-      session.user.role === 'ADMIN' ? {} : { relation: { mentorId: session.user.id } };
+      session.user.role === 'ADMIN'
+        ? { relationId: { not: null } }
+        : { relationId: { not: null }, relation: { mentorId: session.user.id } };
     const meetings = await prisma.meeting.findMany({
       where,
       include: { relation: { include: { mentee: { select: { fullName: true } } } } },
@@ -81,7 +88,7 @@ export async function POST(request: Request) {
     // same room, so the video link is generated once (Jitsi, no account needed)
     // when the organizer didn't paste one. The per-person RSVP token stays
     // unique — each participant confirms attendance individually.
-    const link = meetLink || `https://meet.jit.si/InternshipCRM-${randomBytes(8).toString('hex')}`;
+    const link = meetLink || generateMeetingLink();
 
     let created = 0;
     for (const rel of relations) {

--- a/src/lib/meetingContext.ts
+++ b/src/lib/meetingContext.ts
@@ -1,0 +1,176 @@
+import { randomBytes } from 'crypto';
+import { prisma } from '@/lib/prisma';
+
+// A meeting hangs off exactly one context (#1051). MySQL can't express
+// "exactly one of three columns is set" as a CHECK constraint, so the rule is
+// enforced here and every write path goes through `resolveMeetingContext`.
+
+export type MeetingContextKind = 'RELATION' | 'PROJECT' | 'CONVERSATION';
+
+export interface MeetingContextInput {
+  relationIds?: string[];
+  projectId?: string;
+  conversationId?: string;
+}
+
+export interface Invitee {
+  userId: string;
+  email: string;
+  fullName: string | null;
+  timezone?: string | null;
+  emailNotifications?: boolean | null;
+  notificationPrefs?: unknown;
+  // Set only for RELATION context: the relation this invitee is reached through,
+  // so the caller can keep writing one Meeting row (and one RSVP token) per
+  // relation, exactly as /api/meetings always has.
+  relationId?: string;
+}
+
+export type ResolvedMeetingContext =
+  | { ok: true; kind: MeetingContextKind; relationIds: string[]; projectId: string | null; conversationId: string | null; invitees: Invitee[] }
+  | { ok: false; status: 400 | 403 | 404; error: string };
+
+interface SessionUser {
+  id: string;
+  role: string;
+  companyId?: string | null;
+}
+
+// How many context keys the input sets. Anything but 1 is a client bug.
+export function countContexts(input: MeetingContextInput): number {
+  let n = 0;
+  if (input.relationIds && input.relationIds.length > 0) n++;
+  if (input.projectId) n++;
+  if (input.conversationId) n++;
+  return n;
+}
+
+// The shared video room. Jitsi needs no account and — unlike Meet/Zoom — allows
+// being embedded in an iframe, which is what the in-app side panel relies on.
+export function generateMeetingLink(): string {
+  return `https://meet.jit.si/InternshipCRM-${randomBytes(8).toString('hex')}`;
+}
+
+// True when the link can safely be embedded in an iframe. Meet/Zoom/Teams all
+// send X-Frame-Options and would render an empty box, so the UI must offer
+// "open in a new tab" for anything else.
+export function isEmbeddableMeetingLink(link: string | null | undefined): boolean {
+  if (!link) return false;
+  try {
+    const host = new URL(link).hostname.toLowerCase();
+    return host === 'meet.jit.si' || host.endsWith('.jit.si');
+  } catch {
+    return false;
+  }
+}
+
+const INVITEE_SELECT = {
+  id: true,
+  email: true,
+  fullName: true,
+  timezone: true,
+  emailNotifications: true,
+  notificationPrefs: true,
+} as const;
+
+// Validate the context and resolve who gets invited — always server-side:
+// hiding a button is not authorization.
+export async function resolveMeetingContext(
+  user: SessionUser,
+  input: MeetingContextInput
+): Promise<ResolvedMeetingContext> {
+  const contexts = countContexts(input);
+  if (contexts !== 1) {
+    return { ok: false, status: 400, error: 'Exactly one of relationIds, projectId or conversationId is required' };
+  }
+
+  if (input.projectId) {
+    // Read the project first: Project is a TENANT_MODEL (src/lib/orgContext.ts)
+    // so this lookup is org-scoped, while ProjectMember is not — querying
+    // members directly would reach across tenants.
+    const project = await prisma.project.findUnique({
+      where: { id: input.projectId },
+      select: { id: true },
+    });
+    if (!project) return { ok: false, status: 404, error: 'Project not found' };
+
+    const members = await prisma.projectMember.findMany({
+      where: { projectId: input.projectId },
+      select: { userId: true, role: true, user: { select: INVITEE_SELECT } },
+    });
+    if (members.length === 0) {
+      // Either the project doesn't exist or it has no members — same answer, so
+      // a probe can't tell the two apart.
+      return { ok: false, status: 404, error: 'Project not found' };
+    }
+    const me = members.find((m) => m.userId === user.id);
+    // Admins reach every project; otherwise only OWNER/MENTOR members may start
+    // a meeting for the whole team (mentee members join, they don't summon).
+    if (user.role !== 'ADMIN' && (!me || me.role === 'MENTEE')) {
+      return { ok: false, status: 403, error: 'Forbidden' };
+    }
+    return {
+      ok: true,
+      kind: 'PROJECT',
+      relationIds: [],
+      projectId: input.projectId,
+      conversationId: null,
+      invitees: members
+        .filter((m) => m.userId !== user.id)
+        .map((m) => ({ userId: m.userId, ...m.user, email: m.user.email })),
+    };
+  }
+
+  if (input.conversationId) {
+    const participants = await prisma.conversationParticipant.findMany({
+      where: { conversationId: input.conversationId },
+      select: { userId: true, user: { select: INVITEE_SELECT } },
+    });
+    if (participants.length === 0) {
+      return { ok: false, status: 404, error: 'Conversation not found' };
+    }
+    // Every participant of a chat may start a call in it; a non-participant may
+    // not, admin or otherwise — reading someone else's thread is not the point.
+    if (!participants.some((p) => p.userId === user.id)) {
+      return { ok: false, status: 403, error: 'Forbidden' };
+    }
+    return {
+      ok: true,
+      kind: 'CONVERSATION',
+      relationIds: [],
+      projectId: null,
+      conversationId: input.conversationId,
+      invitees: participants
+        .filter((p) => p.userId !== user.id)
+        .map((p) => ({ userId: p.userId, ...p.user, email: p.user.email })),
+    };
+  }
+
+  const relationIds = input.relationIds ?? [];
+  // Same scoping rule as /api/meetings: an admin schedules for any relation, a
+  // mentor only for their own.
+  const where =
+    user.role === 'ADMIN'
+      ? { id: { in: relationIds } }
+      : { id: { in: relationIds }, mentorId: user.id };
+  const relations = await prisma.mentorshipRelation.findMany({
+    where,
+    select: { id: true, mentee: { select: INVITEE_SELECT } },
+  });
+  if (relations.length === 0) {
+    return { ok: false, status: 404, error: 'No accessible relations' };
+  }
+  return {
+    ok: true,
+    kind: 'RELATION',
+    relationIds: relations.map((r) => r.id),
+    projectId: null,
+    conversationId: null,
+    invitees: relations.map((r) => ({
+      userId: r.mentee.id,
+      ...r.mentee,
+      email: r.mentee.email,
+      relationId: r.id,
+    })),
+  };
+}

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,21 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.40.5-beta',
+    date: '2026-08-03',
+    highlights: {
+      en: [
+        'Groundwork for starting a meeting on the spot: the server can now open a room and hand back the link in one step, instead of making the page look it up afterwards. A meeting can also belong to a whole project or a group chat, not just to one mentorship. Nothing new on screen yet — the buttons come next.',
+      ],
+      tr: [
+        'Anında görüşme başlatmanın altyapısı: sunucu artık odayı açıp linki tek adımda geri veriyor, sayfanın sonradan aramasına gerek kalmıyor. Bir görüşme artık tek bir mentorluğa değil, bütün bir projeye ya da grup sohbetine de ait olabiliyor. Ekranda henüz yeni bir şey yok — butonlar sırada.',
+      ],
+      de: [
+        'Grundlage für das sofortige Starten einer Besprechung: Der Server öffnet den Raum jetzt und gibt den Link in einem Schritt zurück, statt die Seite ihn nachträglich suchen zu lassen. Eine Besprechung kann außerdem zu einem ganzen Projekt oder einem Gruppenchat gehören, nicht nur zu einer Mentorschaft. Auf dem Bildschirm ist noch nichts Neues zu sehen — die Schaltflächen folgen.',
+      ],
+    },
+  },
+  {
     version: '0.40.4-beta',
     date: '2026-08-03',
     highlights: {

--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -807,7 +807,15 @@ export async function sendMeetingReminders() {
     // rather than only the two sides of a relation. Without this exclusion the
     // people who have both a relation and a membership got the hour-before
     // reminder twice (#51).
-    where: { scheduledAt: { gt: now, lte: horizon }, reminderSentAt: null, seriesId: null },
+    // `relationId: { not: null }` — a project/conversation meeting (#1051) has
+    // no two-sided relation to remind; those rooms are instant and time-less,
+    // so they never match the scheduledAt window either.
+    where: {
+      scheduledAt: { gt: now, lte: horizon },
+      reminderSentAt: null,
+      seriesId: null,
+      relationId: { not: null },
+    },
     include: {
       relation: {
         include: {
@@ -824,6 +832,8 @@ export async function sendMeetingReminders() {
   let emailed = 0;
 
   for (const m of meetings) {
+    // Guaranteed by the query above; the guard is what tells TypeScript so.
+    if (!m.relation) continue;
     // Claim it first — see the idempotency note above.
     const claim = await prisma.meeting.updateMany({
       where: { id: m.id, reminderSentAt: null },


### PR DESCRIPTION
Paketin ilk adımı: "kişiyi seç, konuyu yaz, linki gör" akışının sunucu tarafı.

## Neden
`POST /api/meetings` yanıtta sadece `{ created }` dönüyordu, üretilen odayı geri vermiyordu — UI linki ancak listeyi yeniden çekerek öğrenebiliyordu. "Şu kişiyle şimdi konuşalım" niyeti için bu tur fazladan.

## Ne değişti
- **`POST /api/meetings/instant`** — her zaman saatsiz oda (RSVP yok, hatırlatma yok), yanıt `{ meetingId, meetLink, invited }`. Uygulama içi bildirim koşulsuz, e-posta `emailAllowed(user, 'meetingReminders')` ile. IP başına 10/dk (her çağrı davet e-postası saçıyor).
- **`Meeting` artık üç bağlamdan birine bağlanıyor** — `relationId` nullable oldu, yanına `projectId` / `conversationId` geldi. MySQL "üçünden tam biri"ni CHECK ile ifade edemediği için kural ve üyelik yetkilendirmesi `src/lib/meetingContext.ts` içinde; bütün yazma yolları oradan geçiyor.
- Jitsi oda üretimi `generateMeetingLink()`e taşındı (iki endpoint ayrışmasın); `isEmbeddableMeetingLink()` bir sonraki adımdaki yan panel için burada.
- `GET /api/meetings`, `/api/calendar-events` ve hatırlatma cron'u `relationId: { not: null }` ile süzüyor — şekilleri ve davranışları birebir aynı kaldı.

`POST /api/meetings` sözleşmesine dokunulmadı.

## Güvenlik notu
Proje dalı önce `prisma.project`'i okuyor: `Project` bir `TENANT_MODEL`, `ProjectMember` değil — üyeleri doğrudan sorgulamak kiracılar arası sızıntı olurdu. Proje toplantısı OWNER/MENTOR üyelik (ya da admin), sohbet toplantısı katılımcılık istiyor; ikisi de sunucu tarafında.

## Doğrulama
- `npx prisma validate` ✅ · `npx tsc --noEmit` ✅ · `npm run build` ✅ · `npm run check:i18n` ✅ (1710 anahtar × 3 dil)

Closes #1051
Closes #1052

🤖 Generated with [Claude Code](https://claude.com/claude-code)