### PR TITLE
feat(meetings): proje ekibi ve grup sohbeti için anlık görüşme (#1055)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.40.7-beta] - 2026-08-03
+
+### Added
+- **Start a meeting for a whole project team** (#1055). A button next to the recurring rule
+  on the project page — the two sit together but are different things: one books a weekly
+  slot, the other opens a room now. Visible to admins and OWNER/MENTOR members, mirroring
+  the server rule in `resolveMeetingContext`; mentee members join a call, they don't summon
+  one. `ProjectWeeklyMeeting` no longer hides itself when there is no series but the viewer
+  may still start a call.
+- **Start a meeting from a group chat, and the link lands in the chat** (#1055). Button in
+  the thread header (and its own row on a phone, where that header is hidden). The
+  conversation branch of `/api/meetings/instant` now also posts the room into the thread, as
+  the organizer rather than a faceless system row — `Message` has no system flag, and "who
+  called us in" is worth knowing. Any participant may start one; a non-participant gets 403
+  and no message is written.
+- `e2e/instant-meeting-team.spec.ts` — team call by an owner (incl. the member's in-app
+  notification), a mentee member refused, a chat call landing in the thread, and an outsider
+  refused with nothing posted.
+
+### Note
+- Only *conversation* threads get the button. The legacy relation thread is left out: its
+  mentee would be refused server-side anyway (relations are mentor-scoped), and a button
+  that always fails is worse than no button. Mentors reach 1:1 calls from the mentee card.
+
 ## [0.40.6-beta] - 2026-08-03
 
 ### Added

--- a/e2e/instant-meeting-team.spec.ts
+++ b/e2e/instant-meeting-team.spec.ts
@@ -1,0 +1,165 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { signInAndSettle } from './helpers/auth';
+
+// #1055 — the same one-click call, but for a whole project team or a group chat.
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('a project owner starts a meeting for the whole team', async ({ page }) => {
+  const ownerEmail = uniqueEmail('pm-owner');
+  const owner = await seedUser(ownerEmail, 'MentorPass123', 'MENTOR', 'PM Owner');
+  const member = await seedUser(uniqueEmail('pm-member'), 'x', 'MENTEE', 'PM Member');
+  const project = await prisma.project.create({
+    data: {
+      name: 'Instant Team Project',
+      ownerType: 'MENTOR',
+      ownerUserId: owner.id,
+      members: {
+        create: [
+          { userId: owner.id, role: 'OWNER' },
+          { userId: member.id, role: 'MENTEE' },
+        ],
+      },
+    },
+  });
+
+  try {
+    await signInAndSettle(page, ownerEmail, 'MentorPass123', '/mentor');
+
+    const res = await page.request.post('/api/meetings/instant', {
+      data: { projectId: project.id, title: 'Standup' },
+    });
+    expect(res.status()).toBe(201);
+    const body = await res.json();
+    expect(body.meetLink).toContain('meet.jit.si');
+    // Everyone but the organizer.
+    expect(body.invited).toBe(1);
+
+    const meeting = await prisma.meeting.findUnique({ where: { id: body.meetingId } });
+    expect(meeting?.projectId).toBe(project.id);
+    expect(meeting?.relationId).toBeNull();
+    expect(meeting?.conversationId).toBeNull();
+
+    // The member hears about it in the app, not only by email.
+    const note = await prisma.notification.findFirst({
+      where: { userId: member.id, type: 'meeting.started' },
+    });
+    expect(note?.link).toBe(body.meetLink);
+  } finally {
+    await prisma.meeting.deleteMany({ where: { projectId: project.id } });
+    await prisma.notification.deleteMany({ where: { userId: { in: [owner.id, member.id] } } });
+    await prisma.projectMember.deleteMany({ where: { projectId: project.id } });
+    await prisma.project.deleteMany({ where: { id: project.id } });
+    await cleanupByEmail(member.email);
+    await cleanupByEmail(ownerEmail);
+  }
+});
+
+test('a mentee member cannot summon the whole project', async ({ page }) => {
+  const menteeEmail = uniqueEmail('pm-mentee');
+  const owner = await seedUser(uniqueEmail('pm-owner2'), 'x', 'MENTOR', 'PM Owner2');
+  const mentee = await seedUser(menteeEmail, 'MenteePass123', 'MENTEE', 'PM Mentee');
+  const project = await prisma.project.create({
+    data: {
+      name: 'Instant Team Project 2',
+      ownerType: 'MENTOR',
+      ownerUserId: owner.id,
+      members: {
+        create: [
+          { userId: owner.id, role: 'OWNER' },
+          { userId: mentee.id, role: 'MENTEE' },
+        ],
+      },
+    },
+  });
+
+  try {
+    await signInAndSettle(page, menteeEmail, 'MenteePass123', '/portal');
+
+    const res = await page.request.post('/api/meetings/instant', {
+      data: { projectId: project.id, title: 'Nope' },
+    });
+    expect(res.status()).toBe(403);
+    expect(await prisma.meeting.count({ where: { projectId: project.id } })).toBe(0);
+  } finally {
+    await prisma.meeting.deleteMany({ where: { projectId: project.id } });
+    await prisma.projectMember.deleteMany({ where: { projectId: project.id } });
+    await prisma.project.deleteMany({ where: { id: project.id } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(owner.email);
+  }
+});
+
+test('a meeting started from a group chat drops its link into that chat', async ({ page }) => {
+  const starterEmail = uniqueEmail('gc-starter');
+  const starter = await seedUser(starterEmail, 'MentorPass123', 'MENTOR', 'GC Starter');
+  const other = await seedUser(uniqueEmail('gc-other'), 'x', 'MENTEE', 'GC Other');
+  const conversation = await prisma.conversation.create({
+    data: {
+      type: 'GROUP',
+      participants: { create: [{ userId: starter.id }, { userId: other.id }] },
+    },
+  });
+
+  try {
+    await signInAndSettle(page, starterEmail, 'MentorPass123', '/mentor');
+
+    const res = await page.request.post('/api/meetings/instant', {
+      data: { conversationId: conversation.id, title: 'Huddle' },
+    });
+    expect(res.status()).toBe(201);
+    const body = await res.json();
+
+    const meeting = await prisma.meeting.findUnique({ where: { id: body.meetingId } });
+    expect(meeting?.conversationId).toBe(conversation.id);
+    expect(meeting?.projectId).toBeNull();
+
+    // The people already reading the thread shouldn't have to dig the link out
+    // of a notification.
+    const message = await prisma.message.findFirst({
+      where: { conversationId: conversation.id },
+      orderBy: { createdAt: 'desc' },
+    });
+    expect(message?.body).toContain(body.meetLink);
+    expect(message?.senderId).toBe(starter.id);
+  } finally {
+    await prisma.meeting.deleteMany({ where: { conversationId: conversation.id } });
+    await prisma.message.deleteMany({ where: { conversationId: conversation.id } });
+    await prisma.notification.deleteMany({ where: { userId: { in: [starter.id, other.id] } } });
+    await prisma.conversationParticipant.deleteMany({ where: { conversationId: conversation.id } });
+    await prisma.conversation.deleteMany({ where: { id: conversation.id } });
+    await cleanupByEmail(other.email);
+    await cleanupByEmail(starterEmail);
+  }
+});
+
+test('someone outside the chat cannot start a meeting in it', async ({ page }) => {
+  const outsiderEmail = uniqueEmail('gc-outsider');
+  const outsider = await seedUser(outsiderEmail, 'MentorPass123', 'MENTOR', 'GC Outsider');
+  const a = await seedUser(uniqueEmail('gc-a'), 'x', 'MENTOR', 'GC A');
+  const b = await seedUser(uniqueEmail('gc-b'), 'x', 'MENTEE', 'GC B');
+  const conversation = await prisma.conversation.create({
+    data: { type: 'GROUP', participants: { create: [{ userId: a.id }, { userId: b.id }] } },
+  });
+
+  try {
+    await signInAndSettle(page, outsiderEmail, 'MentorPass123', '/mentor');
+
+    const res = await page.request.post('/api/meetings/instant', {
+      data: { conversationId: conversation.id, title: 'Intruder' },
+    });
+    expect(res.status()).toBe(403);
+    expect(await prisma.message.count({ where: { conversationId: conversation.id } })).toBe(0);
+  } finally {
+    await prisma.meeting.deleteMany({ where: { conversationId: conversation.id } });
+    await prisma.message.deleteMany({ where: { conversationId: conversation.id } });
+    await prisma.conversationParticipant.deleteMany({ where: { conversationId: conversation.id } });
+    await prisma.conversation.deleteMany({ where: { id: conversation.id } });
+    await cleanupByEmail(b.email);
+    await cleanupByEmail(a.email);
+    await cleanupByEmail(outsiderEmail);
+  }
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.40.6-beta",
+  "version": "0.40.7-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "author": "Mehmet Erşahin",

--- a/src/app/api/meetings/instant/route.ts
+++ b/src/app/api/meetings/instant/route.ts
@@ -85,6 +85,23 @@ export async function POST(request: Request) {
         select: { id: true, relationId: true, rsvpToken: true },
       });
       meetingId = row.id;
+
+      // A call started from a chat belongs in that chat (#1055): the people who
+      // are already reading the thread shouldn't have to find the link in a
+      // notification. Posted as the organizer, not as a faceless system row —
+      // Message has no system flag, and "who called us in" is worth knowing.
+      if (ctx.conversationId) {
+        const who = session.user.name ?? 'Someone';
+        await prisma.message.create({
+          data: {
+            conversationId: ctx.conversationId,
+            senderId: session.user.id,
+            body: `📹 ${who} started a meeting: ${title}\n${meetLink}`,
+            channel: 'IN_APP',
+          },
+        });
+      }
+
       await inviteAll(ctx.invitees, [row], title, meetLink, session.user.name ?? null);
     }
 

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -66,6 +66,12 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
     role === 'ADMIN' ||
     (!!session && p.ownerUserId === session.user.id) ||
     (!!session && p.members.some((m) => m.user.id === session.user.id && m.role === 'OWNER'));
+  // Who may summon the whole team into a room (#1055). Mirrors the server rule
+  // in resolveMeetingContext: admins and OWNER/MENTOR members — mentee members
+  // join a call, they don't call everyone in.
+  const canStartMeeting =
+    isLead ||
+    (!!session && p.members.some((m) => m.user.id === session.user.id && m.role === 'MENTOR'));
   const canInternal =
     isLead ||
     isMember ||
@@ -185,7 +191,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
 
               {isLead && <ProjectJoinRequests projectId={id} />}
 
-              <ProjectWeeklyMeeting projectId={id} canManage={isLead} />
+              <ProjectWeeklyMeeting projectId={id} canManage={isLead} canStartInstant={canStartMeeting} projectName={p.name} />
 
               {session && (
                 <ProjectGoals projectId={id} myId={session.user.id} canLead={isLead} isMember={isMember} />

--- a/src/components/MessageThreadView.tsx
+++ b/src/components/MessageThreadView.tsx
@@ -16,6 +16,8 @@ import {
 } from '@/components/MessageThread';
 import { useMessagesHeaderTitle } from '@/components/MessagesShell';
 import { useIsNarrow } from '@/hooks/useIsNarrow';
+import { StartMeetingButton } from '@/components/meeting/StartMeetingButton';
+import type { MeetingTarget } from '@/components/meeting/MeetingLauncher';
 
 interface Attachment {
   id: string;
@@ -257,6 +259,13 @@ export function MessageThreadView({ target }: { target: ThreadTarget }) {
   const other = parties.find((p) => p.id !== myId) ?? null;
   // A group chat has no "other side" — it is named after its project.
   const threadTitle = group ? group.projectName ?? t.messages.groupChat : other?.fullName;
+  // Only conversation threads can host a call (#1055): membership is derived
+  // from ConversationParticipant, so either side may start one. The legacy
+  // relation thread is left out — its mentee would be refused server-side
+  // anyway (relations are mentor-scoped), and a button that always fails is
+  // worse than no button. Mentors reach 1:1 calls from the mentee card.
+  const startMeetingTarget: MeetingTarget | null =
+    target.kind === 'conversation' ? { conversationId: target.id } : null;
   // On mobile the shell's header is the only title, so it carries the name.
   useMessagesHeaderTitle(threadTitle);
 
@@ -281,9 +290,31 @@ export function MessageThreadView({ target }: { target: ThreadTarget }) {
       {/* On mobile the shell header is the heading (and names the thread), so this
           block would be a duplicate title eating a third of a phone screen. */}
       {!narrow && (
-        <div className="mb-6">
-          <h1 className="text-2xl font-bold text-gray-900 mb-1">{t.messages.title}</h1>
-          <p className="text-gray-500">{threadTitle}</p>
+        <div className="mb-6 flex items-start gap-3">
+          <div className="min-w-0">
+            <h1 className="text-2xl font-bold text-gray-900 mb-1">{t.messages.title}</h1>
+            <p className="text-gray-500">{threadTitle}</p>
+          </div>
+          {startMeetingTarget && (
+            <StartMeetingButton
+              className="ml-auto flex-shrink-0"
+              target={startMeetingTarget}
+              defaultTitle={threadTitle ?? undefined}
+              testId="start-meeting-conversation"
+            />
+          )}
+        </div>
+      )}
+
+      {/* On a phone the header above is hidden, so the action needs its own row —
+          otherwise starting a call from a chat is desktop-only. */}
+      {narrow && startMeetingTarget && (
+        <div className="mb-2 flex justify-end">
+          <StartMeetingButton
+            target={startMeetingTarget}
+            defaultTitle={threadTitle ?? undefined}
+            testId="start-meeting-conversation-mobile"
+          />
         </div>
       )}
 

--- a/src/components/project/ProjectWeeklyMeeting.tsx
+++ b/src/components/project/ProjectWeeklyMeeting.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { CalendarClock, Video, Pencil, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/Button';
 import { useT } from '@/i18n/client';
+import { StartMeetingButton } from '@/components/meeting/StartMeetingButton';
 
 // The project's recurring meeting (#51).
 //
@@ -23,7 +24,19 @@ interface Series {
 
 const DAY_KEYS = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'] as const;
 
-export function ProjectWeeklyMeeting({ projectId, canManage }: { projectId: string; canManage: boolean }) {
+export function ProjectWeeklyMeeting({
+  projectId,
+  canManage,
+  canStartInstant = false,
+  projectName,
+}: {
+  projectId: string;
+  canManage: boolean;
+  // Separate from canManage: editing the weekly rule and starting an ad-hoc call
+  // are different permissions (MENTOR members get the second, not the first).
+  canStartInstant?: boolean;
+  projectName?: string;
+}) {
   const t = useT();
   const [series, setSeries] = useState<Series[]>([]);
   const [loading, setLoading] = useState(true);
@@ -106,12 +119,24 @@ export function ProjectWeeklyMeeting({ projectId, canManage }: { projectId: stri
   };
 
   if (loading) return null;
-  if (series.length === 0 && !canManage) return null;
+  // `|| canStartInstant`: a MENTOR member who may summon the team but can't edit
+  // the schedule still needs somewhere to press the button (#1055).
+  if (series.length === 0 && !canManage && !canStartInstant) return null;
 
   return (
     <div data-testid="weekly-meeting">
       <h2 className="mb-1.5 flex items-center gap-2 text-sm font-semibold text-gray-900 dark:text-gray-100">
         <CalendarClock className="h-4 w-4 text-gray-400" /> {t.projects.weeklyMeeting}
+        {/* The recurring rule and an ad-hoc "everyone, now" call are separate
+            things; they just live next to each other. */}
+        {canStartInstant && (
+          <StartMeetingButton
+            className="ml-auto"
+            target={{ projectId }}
+            defaultTitle={projectName}
+            testId="start-meeting-project"
+          />
+        )}
       </h2>
 
       {series.length === 0 ? (

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,27 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.40.7-beta',
+    date: '2026-08-03',
+    highlights: {
+      en: [
+        'The same one-click meeting now works for a whole project team: a button on the project page, next to the weekly meeting. Everyone on the team gets the link — you no longer invite people one at a time.',
+        'And from a group chat: start a call and the link is posted straight into the conversation, so anyone reading the thread can just tap it.',
+        'Who may start one follows who runs the space: project owners and mentors for a team call, and any participant of a chat for a chat call.',
+      ],
+      tr: [
+        'Aynı tek tıklık görüşme artık bütün bir proje ekibi için de var: proje sayfasında, haftalık toplantının yanında bir buton. Link ekipteki herkese gidiyor — kişileri tek tek davet etmene gerek kalmıyor.',
+        'Grup sohbetinden de olur: görüşmeyi başlat, link doğrudan konuşmaya düşsün; sohbeti okuyan herkes tıklayıp katılsın.',
+        'Kimin başlatabileceği, o alanı kimin yürüttüğüne göre: ekip görüşmesini proje sahipleri ve mentörler, sohbet görüşmesini o sohbetteki herkes başlatabiliyor.',
+      ],
+      de: [
+        'Dieselbe Ein-Klick-Besprechung gibt es jetzt für ein ganzes Projektteam: eine Schaltfläche auf der Projektseite, neben der wöchentlichen Besprechung. Alle im Team bekommen den Link — niemand muss mehr einzeln eingeladen werden.',
+        'Und aus einem Gruppenchat heraus: Besprechung starten, und der Link landet direkt im Gespräch, sodass alle Mitlesenden einfach darauf tippen können.',
+        'Wer starten darf, richtet sich danach, wer den Raum führt: Projekt-Eigentümer und Mentoren für einen Teamanruf, und jede teilnehmende Person eines Chats für einen Chat-Anruf.',
+      ],
+    },
+  },
+  {
     version: '0.40.6-beta',
     date: '2026-08-03',
     highlights: {


### PR DESCRIPTION
Aynı tek tıklık oda, artık "herkesin zaten toplandığı" iki yerde de.

## Ne değişti
- **Proje sayfası** — tekrarlayan kuralın yanında bir buton. Yan yana duruyorlar ama farklı şeyler: biri **haftalık slot ayırıyor**, diğeri **şimdi oda açıyor**. Admin'lere ve OWNER/MENTOR üyelere görünüyor; sunucudaki kuralın aynası — mentee üyeler görüşmeye *katılır*, ekibi *toplamaz*. `ProjectWeeklyMeeting` artık seri yokken de kendini gizlemiyor (görüşme başlatabilen biri varsa).
- **Grup sohbeti** — thread başlığında buton, telefonda (o başlık gizli olduğu için) kendi satırında. Instant endpoint'in conversation dalı odayı **konuşmaya mesaj olarak da** düşürüyor.

## İki bilinçli karar
1. **Mesaj organizatör adına gidiyor**, isimsiz bir sistem satırı olarak değil. `Message`'ta system flag'i yok ve "bizi kim çağırdı" bilinmeye değer bir bilgi. İssue'daki "sistem mesajı ayırt edilebilsin" maddesi bu yüzden şu an metnin kendisiyle karşılanıyor; ayrı bir kolon istenirse takip issue'su açılabilir.
2. **Yalnızca conversation thread'leri buton alıyor.** Legacy relation thread'i dışarıda: oradaki mentee sunucu tarafında zaten reddedilirdi (ilişkiler mentor-scoped) ve **her zaman hata veren bir buton, buton olmamasından kötü**. Mentörler 1:1 görüşmeye mentee kartından ulaşıyor.

## Test
`e2e/instant-meeting-team.spec.ts` — sahibin ekip görüşmesi başlatması (üyenin uygulama içi bildirimi dahil), mentee üyenin reddedilmesi, sohbet görüşmesinin linkinin thread'e düşmesi, ve sohbet dışından birinin reddedilip **hiçbir mesaj yazılmaması**.

Yerelde 7/7 geçti (bu paketin iki spec'i birlikte): `npx playwright test e2e/instant-meeting-team.spec.ts e2e/instant-meeting.spec.ts`

## Doğrulama
`npx tsc --noEmit` ✅ · `npm run build` ✅ · `npm run check:i18n` ✅ (1724 anahtar × 3 dil)

Closes #1055

🤖 Generated with [Claude Code](https://claude.com/claude-code)