### PR TITLE
feat: localize notification emails by recipient language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.35.2-beta] - 2026-08-01
+
+### Changed
+- **The admin candidate list is now usable at 375px without horizontal page overflow.**
+  Mobile shows compact candidate cards with name, pipeline stage and mentor first, followed
+  by education, city and skills. The seven existing filters stay unchanged but are collapsed
+  behind a visible Filters control on small screens. The existing desktop candidate grid and
+  its actions remain unchanged.
+
 ## [0.35.1-beta] - 2026-08-01
 
 ### Changed

--- a/e2e/candidates-mobile.spec.ts
+++ b/e2e/candidates-mobile.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect } from '@playwright/test';
+import { cleanupByEmail, prisma, seedUser, uniqueEmail } from './helpers/db';
+import { signInAndSettle } from './helpers/auth';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('candidates are usable without horizontal overflow on mobile and keep the desktop list', async ({ page }) => {
+  const adminEmail = uniqueEmail('candidates-mobile-admin');
+  const mentorEmail = uniqueEmail('candidates-mobile-mentor');
+  const menteeEmail = uniqueEmail('candidates-mobile-mentee');
+  const password = 'AdminPass123';
+  await seedUser(adminEmail, password, 'ADMIN', 'Mobile Candidates Admin');
+  const mentor = await seedUser(mentorEmail, 'x', 'MENTOR', 'Mobile Candidate Mentor');
+  const mentee = await seedUser(menteeEmail, 'x', 'MENTEE', 'Mobile Candidate Name That Wraps Safely');
+
+  await prisma.user.update({
+    where: { id: mentee.id },
+    data: {
+      university: 'Mobile Test University With A Long Name',
+      department: 'Computer Science',
+      graduationYear: 2027,
+      city: 'A Long Mobile Test City',
+      skills: ['TypeScript', 'Responsive interface design'],
+    },
+  });
+  await prisma.mentorshipRelation.create({
+    data: { mentorId: mentor.id, menteeId: mentee.id, pipelineStatus: 'APPLICATION_100' },
+  });
+
+  try {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await signInAndSettle(page, adminEmail, password, '/admin');
+    await page.goto('/admin/candidates');
+
+    const search = page.getByTestId('candidates-search-input');
+    await page.getByTestId('candidates-mobile-filter-toggle').click();
+    await expect(search).toBeVisible();
+    await search.fill(menteeEmail);
+
+    const mobileList = page.getByTestId('candidates-mobile-list');
+    const mobileCard = page.getByTestId(`candidate-mobile-card-${mentee.id}`);
+    await expect(mobileList).toBeVisible({ timeout: 10_000 });
+    await expect(mobileCard).toBeVisible();
+    await expect(mobileCard.getByText(mentee.fullName)).toBeVisible();
+    await expect(mobileCard.getByTestId('candidate-mobile-stage')).toBeVisible();
+    await expect(mobileCard.getByText(/Mobile Candidate Mentor/)).toBeVisible();
+
+    for (const testId of [
+      'candidates-search-input',
+      'candidates-skill-filter',
+      'candidates-year-filter',
+      'candidates-city-filter',
+      'candidates-project-filter',
+      'candidates-source-filter',
+      'candidates-stage-filter',
+    ]) {
+      await expect(page.getByTestId(testId)).toBeVisible();
+    }
+
+    const hasHorizontalOverflow = await page.evaluate(() => {
+      const element = document.scrollingElement;
+      if (!element) return true;
+      return element.scrollWidth > element.clientWidth;
+    });
+    expect(hasHorizontalOverflow).toBe(false);
+
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await expect(page.getByTestId('candidates-desktop-list')).toBeVisible();
+    await expect(mobileList).toBeHidden();
+    await expect(page.getByTestId(`candidate-card-${mentee.id}`)).toBeVisible();
+  } finally {
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "internship-crm",
-  "version": "0.35.1-beta",
+  "version": "0.35.2-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "internship-crm",
-      "version": "0.35.1-beta",
+      "version": "0.35.2-beta",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.35.1-beta",
+  "version": "0.35.2-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "prisma": {

--- a/src/app/admin/candidates/page.tsx
+++ b/src/app/admin/candidates/page.tsx
@@ -66,6 +66,7 @@ export default function CandidatesPage() {
   const [error, setError] = useState('');
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [bulkBusy, setBulkBusy] = useState(false);
+  const [filtersOpen, setFiltersOpen] = useState(false);
   // Deactivated candidates are hidden by default and live in the archive view.
   const [archived, setArchived] = useState(false);
 
@@ -212,7 +213,7 @@ export default function CandidatesPage() {
 
   return (
     <div>
-      <div className="mb-8 flex items-start justify-between gap-4">
+      <div className="mb-8 flex flex-col items-start justify-between gap-4 sm:flex-row">
         <div>
         <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.candidates.title}</h1>
         <p className="text-gray-500 mt-1">{t.candidates.subtitle}</p>
@@ -233,7 +234,7 @@ export default function CandidatesPage() {
           </div>
         )}
         </div>
-        <div className="flex gap-2">
+        <div className="flex max-w-full flex-wrap gap-2">
           <Button variant="outline" onClick={exportCsv} disabled={candidates.length === 0}>
             <Download className="h-4 w-4" />
             {t.candidates.exportCsv}
@@ -253,48 +254,70 @@ export default function CandidatesPage() {
 
       {/* Filters */}
       <div className="bg-white rounded-xl border border-gray-200 p-4 mb-6">
-        <div className="flex items-center gap-2 mb-3">
+        <button
+          type="button"
+          data-testid="candidates-mobile-filter-toggle"
+          aria-expanded={filtersOpen}
+          aria-controls="candidate-filters"
+          onClick={() => setFiltersOpen((open) => !open)}
+          className="flex w-full items-center justify-between gap-2 text-left md:hidden"
+        >
+          <span className="flex items-center gap-2">
+            <Filter className="h-4 w-4 text-gray-500" />
+            <span className="text-sm font-medium text-gray-700 dark:text-gray-300">{t.candidates.filters}</span>
+          </span>
+          <span aria-hidden className="text-sm text-gray-500">{filtersOpen ? '−' : '+'}</span>
+        </button>
+        <div className="hidden items-center gap-2 mb-3 md:flex">
           <Filter className="h-4 w-4 text-gray-500" />
-          <span className="text-sm font-medium text-gray-700">{t.candidates.filters}</span>
+          <span className="text-sm font-medium text-gray-700 dark:text-gray-300">{t.candidates.filters}</span>
         </div>
+        <div id="candidate-filters" className={`${filtersOpen ? 'block mt-3' : 'hidden'} md:block md:mt-0`}>
         <div className="grid grid-cols-1 sm:grid-cols-4 gap-4">
           <div className="relative">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
             <input
               type="text"
               placeholder={t.candidates.searchPlaceholder}
+              data-testid="candidates-search-input"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               className="pl-10 w-full rounded-lg border border-gray-300 px-3.5 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-100 focus:border-blue-400"
             />
           </div>
           <Input
+            data-testid="candidates-skill-filter"
             placeholder={t.candidates.skillsPlaceholder}
             value={skillFilter}
             onChange={(e) => setSkillFilter(e.target.value)}
           />
           <Select
+            data-testid="candidates-year-filter"
             options={[{ value: '', label: t.candidates.allYears }, ...gradYears]}
             value={yearFilter}
             onChange={(e) => setYearFilter(e.target.value)}
             placeholder={t.candidates.allGradYears}
           />
           <Input
+            data-testid="candidates-city-filter"
             placeholder={t.candidates.cityPlaceholder}
             value={cityFilter}
             onChange={(e) => setCityFilter(e.target.value)}
           />
           <Input
+            data-testid="candidates-project-filter"
             placeholder={t.candidates.projectPlaceholder}
             value={projectFilter}
             onChange={(e) => setProjectFilter(e.target.value)}
           />
           <Select
+            data-testid="candidates-source-filter"
             options={[{ value: '', label: t.candidates.allSources }, ...sources.map((s) => ({ value: s.id, label: s.name }))]}
             value={sourceFilter}
             onChange={(e) => setSourceFilter(e.target.value)}
           />
           <Select
+            data-testid="candidates-stage-filter"
             aria-label={t.candidates.allStages}
             options={[{ value: '', label: t.candidates.allStages }, ...stages.map((s) => ({ value: s.key, label: s.label }))]}
             value={statusFilter}
@@ -332,6 +355,7 @@ export default function CandidatesPage() {
               setProjectFilter(f.projectFilter || '');
             }}
           />
+        </div>
         </div>
       </div>
 
@@ -410,7 +434,71 @@ export default function CandidatesPage() {
           )}
         </Card>
       ) : (
-        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
+        <>
+        <div data-testid="candidates-mobile-list" className="space-y-4 md:hidden">
+          {candidates.map((candidate) => {
+            const activeRelation = candidate.menteeRelations[0];
+
+            return (
+              <Card key={candidate.id} padding="sm" data-testid={`candidate-mobile-card-${candidate.id}`} className={!candidate.isActive ? 'opacity-60' : undefined}>
+                <div className="flex min-w-0 items-start gap-2">
+                  <input
+                    type="checkbox"
+                    className="mt-1 flex-shrink-0"
+                    checked={selected.has(candidate.id)}
+                    onChange={() => toggleSelect(candidate.id)}
+                    aria-label={t.candidates.selectOne}
+                  />
+                  <div className="min-w-0 flex-1">
+                    <Link
+                      href={`/admin/candidates/${candidate.id}`}
+                      className="block break-words font-semibold text-gray-900 dark:text-gray-100 hover:text-blue-700 dark:hover:text-blue-300 hover:underline"
+                    >
+                      {candidate.fullName}
+                    </Link>
+                    <p className="mt-1 min-w-0 break-words text-sm text-gray-600 dark:text-gray-300">
+                      {t.candidates.mentor}: {activeRelation?.mentor.fullName ?? t.candidates.unassigned}
+                    </p>
+                  </div>
+                  <Badge data-testid="candidate-mobile-stage" variant={activeRelation?.pipelineStatus ? 'info' : 'warning'} className="max-w-[9rem] flex-shrink-0 text-center whitespace-normal break-words">
+                    {activeRelation?.pipelineStatus ? label(activeRelation.pipelineStatus) : t.candidates.unassigned}
+                  </Badge>
+                </div>
+
+                {(candidate.university || candidate.department || candidate.graduationYear || candidate.city || candidate.skills.length > 0) && (
+                  <div className="mt-4 min-w-0 space-y-2 border-t border-gray-100 pt-3 text-sm text-gray-600 dark:border-gray-800 dark:text-gray-300">
+                    {(candidate.university || candidate.department) && (
+                      <p className="break-words">
+                        {[candidate.university, candidate.department].filter(Boolean).join(' · ')}
+                      </p>
+                    )}
+                    {candidate.graduationYear && <p>{t.candidates.classOf} {candidate.graduationYear}</p>}
+                    {candidate.city && <p className="break-words">{candidate.city}</p>}
+                    {candidate.skills.length > 0 && (
+                      <div className="flex min-w-0 flex-wrap gap-1">
+                        {candidate.skills.map((skill) => (
+                          <Badge key={skill} variant="info" className="max-w-full whitespace-normal break-words text-xs">{skill}</Badge>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {candidate.cvUrl && (
+                  <a href={candidate.cvUrl} target="_blank" rel="noopener noreferrer" className="mt-3 flex items-center gap-1 text-sm text-blue-600 dark:text-blue-300 hover:underline">
+                    <ExternalLink className="h-3 w-3" />
+                    {t.candidates.viewCv}
+                  </a>
+                )}
+
+                {!activeRelation && candidate.isActive && (
+                  <AssignMentorInline menteeId={candidate.id} mentors={mentors} meId={session?.user?.id} onAssigned={fetchCandidates} />
+                )}
+              </Card>
+            );
+          })}
+        </div>
+        <div data-testid="candidates-desktop-list" className="hidden md:grid md:grid-cols-2 xl:grid-cols-3 gap-6">
           {candidates.map((candidate) => {
             const activeRelation = candidate.menteeRelations[0];
 
@@ -500,6 +588,7 @@ export default function CandidatesPage() {
             );
           })}
         </div>
+        </>
       )}
 
       {!loading && totalPages > 1 && (

--- a/src/app/api/admin/announcements/route.ts
+++ b/src/app/api/admin/announcements/route.ts
@@ -9,6 +9,8 @@ import { sendEmail } from '@/services/emailService';
 import { logger } from '@/lib/logger';
 import { emailAllowed } from '@/lib/notificationPrefs';
 import { withTenantScope } from '@/lib/orgContext';
+import { defaultLocale, isLocale } from '@/i18n/config';
+import { getDictionary } from '@/i18n/dictionaries';
 import {
   validateAnnouncementImage,
   announcementImageUrl,
@@ -132,7 +134,7 @@ export async function POST(request: Request) {
 
   const users = await prisma.user.findMany({
     where: { isActive: true },
-    select: { id: true, email: true, emailNotifications: true, notificationPrefs: true },
+    select: { id: true, email: true, emailNotifications: true, notificationPrefs: true, preferredLanguage: true },
   });
 
   // Bulk-create the in-app notifications in one statement.
@@ -147,19 +149,22 @@ export async function POST(request: Request) {
     // <id>/image requires a session, so an <img src="https://…"> would render as
     // a broken image in every mail client.
     const imageHtml = imageData ? `<p><img src="cid:${IMAGE_CID}" alt="" style="max-width:100%;height:auto"></p>` : '';
-    const html = `<p>${safe.replace(/\n/g, '<br>')}</p>${imageHtml}${link ? `<p><a href="${link}">${link}</a></p>` : ''}`;
     const attachments = imageData && image
       ? [{ filename: emailImageFilename(image.type), content: imageData, contentType: image.type, cid: IMAGE_CID }]
       : undefined;
     await Promise.all(
       users
         .filter((u) => u.email && emailAllowed(u, 'announcements'))
-        .map((u) =>
-          sendEmail({ to: u.email, subject: 'Announcement', html, attachments }).then(
+        .map((u) => {
+          const preferredLanguage = u.preferredLanguage ?? undefined;
+          const locale = isLocale(preferredLanguage) ? preferredLanguage : defaultLocale;
+          const t = getDictionary(locale);
+          const html = `<h2>${t.announcements.emailSubject}</h2><p>${safe.replace(/\n/g, '<br>')}</p>${imageHtml}${link ? `<p><a href="${link}">${t.announcements.emailOpenLink}</a></p>` : ''}`;
+          return sendEmail({ to: u.email, subject: t.announcements.emailSubject, html, attachments }).then(
             () => { emailed++; },
             (e) => logger.error('Failed to send announcement email', { error: String(e) })
-          )
-        )
+          );
+        })
     );
   }
 

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -761,6 +761,11 @@ const en = {
       meeting_request: 'Meeting request',
       announcement: 'Announcement',
     },
+    deadlineEmail: {
+      subject: "Overdue: {mentee}'s stage deadline",
+      greeting: 'Hi {mentor},',
+      body: 'The stage deadline for {mentee} has passed. Please review their progress.',
+    },
   },
   announcementFeed: {
     cardTitle: 'Announcements',
@@ -1105,6 +1110,8 @@ const en = {
   },
   announcements: {
     title: 'Announcements',
+    emailSubject: 'Announcement',
+    emailOpenLink: 'Open announcement link',
     subtitle: 'Broadcast a message to every active user',
     newAnnouncement: 'New announcement',
     message: 'Message',
@@ -2414,6 +2421,11 @@ const tr: Dict = {
       meeting_request: 'Toplantı talebi',
       announcement: 'Duyuru',
     },
+    deadlineEmail: {
+      subject: 'Gecikmiş: {mentee} için aşama son tarihi',
+      greeting: 'Merhaba {mentor},',
+      body: '{mentee} için aşama son tarihi geçti. Lütfen ilerleme durumunu gözden geçirin.',
+    },
   },
   announcementFeed: {
     cardTitle: 'Duyurular',
@@ -2758,6 +2770,8 @@ const tr: Dict = {
   },
   announcements: {
     title: 'Duyurular',
+    emailSubject: 'Duyuru',
+    emailOpenLink: 'Duyuru bağlantısını aç',
     subtitle: 'Tüm aktif kullanıcılara bir mesaj yayınla',
     newAnnouncement: 'Yeni duyuru',
     message: 'Mesaj',
@@ -4065,6 +4079,11 @@ const de: Dict = {
       meeting_request: 'Meeting-Anfrage',
       announcement: 'Ankündigung',
     },
+    deadlineEmail: {
+      subject: 'Überfällig: Phasenfrist für {mentee}',
+      greeting: 'Hallo {mentor},',
+      body: 'Die Phasenfrist für {mentee} ist abgelaufen. Bitte prüfe den Fortschritt.',
+    },
   },
   announcementFeed: {
     cardTitle: 'Ankündigungen',
@@ -4409,6 +4428,8 @@ const de: Dict = {
   },
   announcements: {
     title: 'Ankündigungen',
+    emailSubject: 'Ankündigung',
+    emailOpenLink: 'Ankündigungslink öffnen',
     subtitle: 'Sende eine Nachricht an alle aktiven Benutzer',
     newAnnouncement: 'Neue Ankündigung',
     message: 'Nachricht',

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,21 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.35.2-beta',
+    date: '2026-08-01',
+    highlights: {
+      en: [
+        'The admin candidate list is now easier to use on a phone: each candidate appears in a compact card with their stage and mentor up front, while education, city and skills remain close at hand. Filters can be opened when needed, and the page no longer scrolls sideways at 375px.',
+      ],
+      tr: [
+        'Yönetici aday listesi artık telefonda daha rahat kullanılıyor: her aday, aşaması ve mentoru önde olacak şekilde kompakt bir kartta gösteriliyor; eğitim, şehir ve yetkinlik bilgileri de hemen altında yer alıyor. Filtreler gerektiğinde açılabiliyor ve sayfa 375px genişlikte artık yatay kaymıyor.',
+      ],
+      de: [
+        'Die Kandidatenliste für Admins ist jetzt auf dem Handy leichter nutzbar: Jede Person erscheint in einer kompakten Karte, in der Phase und Mentor zuerst sichtbar sind; Ausbildung, Ort und Skills stehen direkt darunter. Die Filter lassen sich bei Bedarf öffnen, und bei 375px scrollt die Seite nicht mehr seitwärts.',
+      ],
+    },
+  },
+  {
     version: '0.35.1-beta',
     date: '2026-08-01',
     highlights: {

--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -8,6 +8,8 @@ import { makeConsentRenewToken } from '@/lib/consentRenew';
 import { getRetentionMonths, RETENTION_GRACE_DAYS } from '@/lib/retention';
 import { getMentorMenteeActivity, getSystemMenteeActivity, formatDuration, type MenteeActivity } from '@/lib/activityReport';
 import { getOrgBranding } from '@/lib/orgBranding';
+import { defaultLocale, isLocale } from '@/i18n/config';
+import { getDictionary } from '@/i18n/dictionaries';
 
 // Resolved branding for a transactional email (#546). When no orgId is given
 // (single-tenant, or a caller without tenant context) this returns the product
@@ -699,16 +701,33 @@ export async function checkStageDeadlineReminders() {
       deadlineReminderSentAt: null,
       pipelineStatus: { notIn: [...TERMINAL] },
     },
-    include: { mentor: true, mentee: true },
+    include: {
+      mentor: {
+        select: {
+          email: true,
+          fullName: true,
+          emailNotifications: true,
+          notificationPrefs: true,
+          preferredLanguage: true,
+        },
+      },
+      mentee: { select: { fullName: true } },
+    },
   });
 
   for (const rel of overdue) {
     await notify(rel.mentorId, 'deadline', `Stage deadline passed for ${rel.mentee.fullName}.`, `/admin/candidates/${rel.menteeId}`);
     if (emailAllowed(rel.mentor, 'deadlines')) {
+      const preferredLanguage = rel.mentor.preferredLanguage ?? undefined;
+      const locale = isLocale(preferredLanguage) ? preferredLanguage : defaultLocale;
+      const emailText = getDictionary(locale).notifications.deadlineEmail;
+      const subject = emailText.subject.replace('{mentee}', rel.mentee.fullName);
+      const greeting = emailText.greeting.replace('{mentor}', rel.mentor.fullName);
+      const body = emailText.body.replace('{mentee}', `<strong>${rel.mentee.fullName}</strong>`);
       await sendEmail({
         to: rel.mentor.email,
-        subject: `Overdue: ${rel.mentee.fullName}'s stage deadline`,
-        html: `<p>Hi ${rel.mentor.fullName},</p><p>The stage deadline for <strong>${rel.mentee.fullName}</strong> has passed. Please review their progress.</p>`,
+        subject,
+        html: `<p>${greeting}</p><p>${body}</p>`,
       }).catch((error) => {
         console.error('checkStageDeadlineReminders email failed:', { relationId: rel.id, mentorId: rel.mentorId, error });
       });


### PR DESCRIPTION
 Amaç

Bildirim e-postalarının, alıcının hesap ayarlarında kayıtlı olan dil tercihine göre oluşturulmasını sağlamak.

Yapılan değişiklikler

- Admin duyuru e-postası alıcının `preferredLanguage` değerine göre yerelleştirildi.
- Duyuru e-postasının konusu, gövde başlığı ve bağlantı etiketi EN/TR/DE sözlüklerinden alınıyor.
- Admin tarafından yazılan asıl duyuru içeriği otomatik çevrilmiyor.
- Her alıcı için kendi diline göre ayrı subject ve HTML oluşturuluyor.
- `checkStageDeadlineReminders` cron e-postası yerelleştirildi.
- Cron e-postası dili cookie veya request context üzerinden değil, kalıcı `User.preferredLanguage` alanından okuyor.
- `preferredLanguage` boş veya desteklenmeyen bir değerse İngilizce fallback kullanılıyor.
- Mevcut escape, görsel CID, attachment, bağlantı, opt-out, bildirim ve hata loglama davranışları korundu.
- Prisma şema değişikliği gerekmedi; mevcut `preferredLanguage` alanı kullanıldı.

 Yerelleştirilen tetikleyiciler

- Admin announcement email
- Stage deadline reminder cron email

Doğrulamalar

- `npm run check:i18n` başarılı — 1617 anahtar × 3 locale
- `npm run build` başarılı
- `git diff --check` başarılı

Build sırasında görülen mevcut bağımsız React hook ve `<img>` uyarıları bu değişikliklerle ilgili değildir.

 Manuel test durumu

Yerel ortamda gerçek e-posta teslimatı manuel olarak doğrulanamadı. Localhost ortamındaki giriş hesabı ortak kullanılan `admin@example.com` test hesabıdır ve bu hesabın e-posta adresini kişisel bir adresle değiştirmek diğer geliştiricilerin kullandığı ortak test verisini etkileyebilir. Ayrıca yerel ortamın SMTP yapılandırması kişisel posta kutuma teslimat yapacak şekilde ayarlanmamıştır.

Bu nedenle gerçek inbox üzerinden teslimat testi yapılmadı. Dil seçimi, İngilizce fallback ve cron’un cookie olmadan `User.preferredLanguage` kullanması kod incelemesi ile; i18n bütünlüğü ve derlenebilirlik ise yukarıdaki otomatik kontrollerle doğrulandı.

Beklenen davranış

- `preferredLanguage = "tr"` → Türkçe subject ve şablon metinleri
- `preferredLanguage = "de"` → Almanca subject ve şablon metinleri
- `preferredLanguage = "en"` → İngilizce subject ve şablon metinleri
- `preferredLanguage = null` veya geçersiz değer → İngilizce fallback