### PR TITLE
feat(projects): personal goals move to the profile + starter template pool; fix(cv): view instead of download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.41.5-beta] - 2026-08-04
+
+### Fixed
+- **"View CV" downloaded the file instead of showing it** — on a phone that reads as a dead
+  link: the tab opens blank and the file lands in Downloads. `GET /api/cv/[userId]` has answered
+  `Content-Disposition: attachment` for everything since #890; it now accepts `?inline=1` and
+  honours it for `application/pdf` only (upload accepts PDF and Word, and the bytes are verified
+  against the declared type in #888, so an inline PDF here really is a PDF and renders in the
+  browser's own viewer rather than as a page on our origin). Word CVs still download — no browser
+  renders them. Every "view CV" link now goes through `cvViewHref()` (`src/lib/cvLink.ts`):
+  mentee detail, admin candidates list and detail (`CvManager`), company candidate detail. An
+  external `cvUrl` (a Drive link a mentee typed in) is untouched.
+- **A long e-mail broke the mentee detail header on mobile** (`/mentor/mentees/[id]`). Name +
+  e-mail and the stage select shared one flex row with a `min-w-[240px]` right column, so a long
+  address ran under the select and pushed the status badge off the right edge of the screen. The
+  header now stacks below `sm`, and the text column is `min-w-0 break-words` so a long address
+  wraps instead of widening the row. Same `break-words` on the admin candidate detail header,
+  which had the identical text.
+
 ## [0.41.4-beta] - 2026-08-04
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.41.4-beta] - 2026-08-04
+
+### Changed
+- **A project goal assigned to someone now lives on that person's profile, not on the project
+  page.** `ProjectGoals` used to list "my goals" and "the team's goals" next to the unassigned
+  pool, so every member read everyone's personal checklist. The project page now keeps only the
+  unassigned goals anyone may claim, plus a count of how many are assigned; the goals themselves
+  are rendered by the new `PersonProjectGoals` panel on `/portal/profile` (your own),
+  `/mentor/mentees/[id]` and `/admin/candidates/[id]`.
+- New `GET /api/project-goals[?userId=]` — one person's assigned goals across all their projects,
+  grouped by project. Readable by the person themselves, an ADMIN, or their mentor; each goal
+  carries `canEdit` mirroring the tick rules of `PATCH /api/project-tasks/[taskId]` (your own
+  goals, or any goal if you lead the project). "Release" (hand a goal back to the open pool)
+  moved along with the goal, so nothing that was possible on the project page was lost.
+- Notifications about a new goal now link to where the goal actually is
+  (`src/lib/projectGoalLink.ts`: `/portal/profile` for a mentee, the project otherwise) instead
+  of a project page that no longer shows it.
+
+### Added
+- **A shared starter pool of 20 project-goal templates** (`prisma/seed-goal-templates.mjs`,
+  wired into `infra/deploy-prod.sh` next to `seed-templates`). Every project's template pool is
+  "its own templates + the shared ones", and the shared half was empty, so the "send the starter
+  goals" button had nothing to offer until a mentor had typed the set by hand. Idempotent: only
+  missing titles are inserted (MySQL does not enforce the `@@unique([projectId, title])` key
+  across NULL `projectId`s, so existence is checked in the script).
+
 ## [0.41.3-beta] - 2026-08-04
 
 ### Changed

--- a/e2e/mentee-detail-mobile-cv.spec.ts
+++ b/e2e/mentee-detail-mobile-cv.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { signInAndSettle, gotoSettled } from './helpers/auth';
+
+/**
+ * The mentee detail page on a phone, and the "view CV" link.
+ *
+ * Two regressions this locks down:
+ *   - the header put the name/e-mail and the stage select in one row, so a long
+ *     e-mail ran into the select and pushed the status badge off the screen;
+ *   - since #890 the CV route answers `attachment` for everything, so "view CV"
+ *     downloaded the file instead of showing it — a dead link on mobile.
+ */
+
+const password = 'CvPass123!';
+// Enough of a PDF for the browser to recognise; the route only reads the bytes back.
+const PDF = Buffer.from('%PDF-1.4\n1 0 obj<</Type/Catalog>>endobj\ntrailer<</Root 1 0 R>>\n%%EOF\n', 'utf8');
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('a long e-mail does not break the mentee header, and the CV opens instead of downloading', async ({ page }) => {
+  const mentorEmail = uniqueEmail('cvview-mentor');
+  // The kind of address that broke the header.
+  const menteeEmail = uniqueEmail('cvview-mentee-with-a-really-long-address-that-wraps');
+  const mentor = await seedUser(mentorEmail, password, 'MENTOR', 'CvView Mentor');
+  const mentee = await seedUser(menteeEmail, password, 'MENTEE', 'CvView Mentee');
+  const rel = await prisma.mentorshipRelation.create({ data: { mentorId: mentor.id, menteeId: mentee.id } });
+  await prisma.cvFile.create({
+    data: { userId: mentee.id, filename: 'cv.pdf', contentType: 'application/pdf', size: PDF.length, data: PDF },
+  });
+  await prisma.user.update({ where: { id: mentee.id }, data: { cvUrl: `/api/cv/${mentee.id}` } });
+
+  try {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await signInAndSettle(page, mentorEmail, password, '/mentor');
+    await gotoSettled(page, `/mentor/mentees/${rel.id}`);
+
+    // The header stacks: both the badge and the stage select are on screen and
+    // the page does not scroll sideways.
+    await expect(page.getByText(menteeEmail)).toBeVisible({ timeout: 15_000 });
+    const stageSelect = page.getByLabel(/Pipeline/i);
+    await expect(stageSelect).toBeVisible();
+
+    // Nothing in the header sticks out past the right edge — that is what the
+    // long e-mail used to cause (the status badge was clipped away).
+    const viewport = page.viewportSize()!.width;
+    for (const box of [
+      await stageSelect.boundingBox(),
+      await page.getByText(menteeEmail).boundingBox(),
+    ]) {
+      expect(box).not.toBeNull();
+      expect(box!.x + box!.width).toBeLessThanOrEqual(viewport + 1);
+    }
+    const overflows = await page.evaluate(() => {
+      const el = document.scrollingElement;
+      return el ? el.scrollWidth - el.clientWidth : 999;
+    });
+    expect(overflows).toBeLessThanOrEqual(1);
+
+    // "View CV" asks for the inline rendering, not a download.
+    const cvLink = page.locator(`a[href*="/api/cv/${mentee.id}"]`).first();
+    await expect(cvLink).toHaveAttribute('href', `/api/cv/${mentee.id}?inline=1`);
+
+    // …and the route honours it for a PDF, while the bare URL still downloads.
+    const inline = await page.request.get(`/api/cv/${mentee.id}?inline=1`);
+    expect(inline.ok()).toBeTruthy();
+    expect(inline.headers()['content-disposition']).toContain('inline');
+    expect(inline.headers()['content-type']).toContain('application/pdf');
+
+    const download = await page.request.get(`/api/cv/${mentee.id}`);
+    expect(download.headers()['content-disposition']).toContain('attachment');
+  } finally {
+    await prisma.cvFile.deleteMany({ where: { userId: mentee.id } });
+    await prisma.mentorshipRelation.deleteMany({ where: { id: rel.id } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+  }
+});

--- a/e2e/project-team-and-goals.spec.ts
+++ b/e2e/project-team-and-goals.spec.ts
@@ -17,7 +17,7 @@ test.afterAll(async () => {
   await prisma.$disconnect();
 });
 
-test('a mentee member sees the roster and their own goals on their project', { tag: '@smoke' }, async ({ page }) => {
+test('a mentee member sees the roster on their project and their goals on their profile', { tag: '@smoke' }, async ({ page }) => {
   // Two sign-ins plus five navigations: ~50s on an idle machine, over the 60s
   // default when the suite is loaded. Nothing here is waiting on a timeout.
   test.slow();
@@ -58,21 +58,30 @@ test('a mentee member sees the roster and their own goals on their project', { t
     expect(created.ok()).toBeTruthy();
 
     // The mentee opens the project: roster visible (private project, member
-    // access), and the goal is theirs to tick off.
+    // access). A goal that belongs to a person is NOT listed here — it moved to
+    // that person's profile, so the whole team no longer reads it.
     await signInAsFreshUser(page, menteeEmail, password, '/portal');
     await gotoSettled(page, `/projects/${project.id}`);
     await expect(page.locator('[data-testid="project-team"]')).toContainText('Team Mentor');
     await expect(page.locator('[data-testid="project-team"]')).toContainText('Team Mentee');
-    await expect(page.locator('[data-testid="project-goals"]')).toContainText('Read the project and understand it');
+    await expect(page.locator('[data-testid="project-goals"]')).not.toContainText(
+      'Read the project and understand it'
+    );
     // Shortcuts to the owner and the group chat are right there.
     await expect(page.locator('[data-testid="open-group-chat"]')).toBeVisible();
     await expect(page.locator('[data-testid="message-owner"]')).toBeVisible();
 
+    // Their own profile is where the goal lives, and where they tick it off.
     const task = await prisma.projectTask.findFirst({ where: { projectId: project.id } });
-    await page.locator(`[data-testid="goal-${task!.id}"] button`).first().click();
+    await gotoSettled(page, '/portal/profile');
+    const goalRow = page.locator(`[data-testid="project-goal-${task!.id}"]`);
+    await expect(goalRow).toContainText('Read the project and understand it');
+    await goalRow.locator('button').first().click();
     await expect
       .poll(async () => (await prisma.projectTask.findUnique({ where: { id: task!.id } }))?.done, { timeout: 10_000 })
       .toBe(true);
+
+    await gotoSettled(page, `/projects/${project.id}`);
 
     // The group chat says who is in the room, with each person's project role.
     await page.locator('[data-testid="open-group-chat"]').click();

--- a/infra/deploy-prod.sh
+++ b/infra/deploy-prod.sh
@@ -14,7 +14,7 @@
 #      GitHub-hosted runner so this server never compiles) or build it locally
 #      from source, stamping GIT_SHA
 #   3. prisma db push --accept-data-loss  (schema sync, same as CI)
-#   4. seed-templates + backfill-project-members  (idempotent)
+#   4. seed-templates + seed-goal-templates + backfill-project-members (idempotent)
 #   5. swap the internship-crm container (host networking, port 3200, restart
 #      unless-stopped) — byte-for-byte the flags deploy.yml uses
 #   6. health-check http://127.0.0.1:3200 and prune old images
@@ -231,6 +231,9 @@ run_tool npx prisma db push --accept-data-loss
 # ── 4. Idempotent seeds / backfills ──────────────────────────────────────────
 log "seed-templates + project-member backfill (idempotent)"
 run_tool node prisma/seed-templates.mjs || true
+# The shared project-goal template pool (#51) — every project sees these on top
+# of its own. Only ever adds missing titles.
+run_tool node prisma/seed-goal-templates.mjs || true
 run_tool node prisma/backfill-project-members.mjs || true
 run_tool node prisma/backfill-organization.mjs || true
 # One-shot: baseline the scheduled-job backlog so the first cron tick doesn't

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "internship-crm",
-  "version": "0.41.3-beta",
+  "version": "0.41.4-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "internship-crm",
-      "version": "0.41.3-beta",
+      "version": "0.41.4-beta",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "internship-crm",
-  "version": "0.41.4-beta",
+  "version": "0.41.5-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "internship-crm",
-      "version": "0.41.4-beta",
+      "version": "0.41.5-beta",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.41.3-beta",
+  "version": "0.41.4-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "author": "Mehmet Erşahin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.41.4-beta",
+  "version": "0.41.5-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "author": "Mehmet Erşahin",

--- a/prisma/seed-goal-templates.mjs
+++ b/prisma/seed-goal-templates.mjs
@@ -1,0 +1,75 @@
+// Idempotent seed of the shared project-goal template pool (#51).
+//
+// A project's template pool is "its own templates + the shared ones"
+// (`ProjectTaskTemplate.projectId = null`, see
+// src/app/api/projects/[id]/task-templates/route.ts), and until now the shared
+// half was empty: every mentor had to type the same starter goals for their
+// first mentee before the pool was worth anything. This seeds that shared half
+// with a standard internship starter set, so a fresh project can hand a new
+// member a sensible list on day one.
+//
+// Safe to run on every deploy. MySQL does not enforce the
+// @@unique([projectId, title]) key across NULL projectIds, so uniqueness is
+// checked here instead of relying on skipDuplicates.
+//
+// Titles are Turkish: that is the language the goals are handed out in (the
+// pipeline stages are Turkish too), and a template is free text shown as-is —
+// there is no per-locale variant of a pool entry. A mentor can rename or delete
+// project-scoped copies; these shared ones stay.
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+// The first-week set from the onboarding wizard's own description — read the
+// project, find a bug, find a feature — plus the rest of a typical internship
+// arc: getting set up, working in the open, and closing out.
+const GOALS = [
+  // Getting set up
+  'Projeyi yerelde çalıştır: depoyu klonla, kur ve ayağa kaldır',
+  'README’i oku; eksik veya yanlış bulduğun bir yeri düzelt',
+  'Projenin veri modelini incele ve aklına takılan 3 soruyu yaz',
+  'Bir özelliği baştan sona takip et ve nasıl çalıştığını kısaca anlat',
+  // Working on it
+  'Bir hata (bug) bul ve nasıl tekrar edildiğini adım adım yaz',
+  'Bulduğun hatayı düzelt ve pull request aç',
+  'Küçük bir özellik öner; neden gerektiğini bir paragrafla anlat',
+  'Önerdiğin küçük özelliği geliştir ve pull request aç',
+  'Yazdığın koda test ekle',
+  'İlk pull request’ini incelemeden geçir ve gelen yorumları uygula',
+  'Bir başkasının pull request’ini incele ve en az bir yapıcı yorum yaz',
+  // Working in the open
+  'Kendini tanıtan kısa bir mesajı grup sohbetine gönder',
+  'Tanışma toplantısına katıl ve notlarını çıkar',
+  'Haftalık ilerleme notunu yaz ve mentoruna gönder',
+  'Takıldığın bir konuyu sormadan önce 30 dakika kendin araştır, sonra sor',
+  // Career side
+  'CV’ni güncelle ve mentorundan geri bildirim al',
+  'LinkedIn profilini güncelle: başlık, özet ve projeler',
+  // Closing out
+  'Kullandığınız teknolojilerden birini seç ve 10 dakikalık mini sunum yap',
+  'Öğrendiklerini kısa bir dokümana dök',
+  'Staj sonu raporunun ana hatlarını çıkar',
+];
+
+async function main() {
+  const existing = await prisma.projectTaskTemplate.findMany({
+    where: { projectId: null },
+    select: { title: true },
+  });
+  const known = new Set(existing.map((t) => t.title));
+  const missing = GOALS.filter((title) => !known.has(title));
+
+  if (missing.length === 0) {
+    console.log(`[seed-goal-templates] all ${GOALS.length} shared goal templates already present.`);
+    return;
+  }
+
+  await prisma.projectTaskTemplate.createMany({
+    data: missing.map((title) => ({ projectId: null, title })),
+  });
+  console.log(`[seed-goal-templates] created ${missing.length} of ${GOALS.length} shared goal templates.`);
+}
+
+main()
+  .catch((e) => { console.error('[seed-goal-templates] error:', e); process.exitCode = 1; })
+  .finally(() => prisma.$disconnect());

--- a/src/app/admin/candidates/[id]/page.tsx
+++ b/src/app/admin/candidates/[id]/page.tsx
@@ -285,8 +285,8 @@ export default function AdminMenteeDetailPage() {
         </Link>
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div className="min-w-0">
-            <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{user.fullName}</h1>
-            <p className="text-gray-500">{user.email}</p>
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 break-words">{user.fullName}</h1>
+            <p className="text-gray-500 break-words">{user.email}</p>
           </div>
           <div className="flex flex-wrap items-center gap-2 sm:gap-3">
             {rel && <Badge variant="info">{label(rel.pipelineStatus)}</Badge>}

--- a/src/app/admin/candidates/[id]/page.tsx
+++ b/src/app/admin/candidates/[id]/page.tsx
@@ -15,6 +15,7 @@ import { CvManager } from '@/components/CvManager';
 import { nextAction } from '@/lib/matching';
 import { EvaluationPanel } from '@/components/EvaluationPanel';
 import { GoalsPanel } from '@/components/GoalsPanel';
+import { PersonProjectGoals } from '@/components/PersonProjectGoals';
 import { MeetingSchedulerPanel } from '@/components/MeetingSchedulerPanel';
 import { DocumentsManager } from '@/components/DocumentsManager';
 import { UserActivityPanel } from '@/components/UserActivityPanel';
@@ -494,6 +495,7 @@ export default function AdminMenteeDetailPage() {
         {rel && <MeetingSchedulerPanel relationId={rel.id} menteeName={user.fullName} />}
         {rel && <EvaluationPanel relationId={rel.id} />}
         {rel && <GoalsPanel relationId={rel.id} />}
+        <PersonProjectGoals userId={id} />
         <DocumentsManager targetUserId={id} />
         <UserActivityPanel userId={id} />
         {user && <CandidateEraseDangerZone userId={id} fullName={user.fullName} onAnonymized={load} />}

--- a/src/app/admin/candidates/page.tsx
+++ b/src/app/admin/candidates/page.tsx
@@ -8,6 +8,7 @@ import { EmptyState } from '@/components/EmptyState';
 import Link from "next/link";
 import { useT } from "@/i18n/client";
 import { useResolvedStages, useStageLabel } from '@/lib/pipelineStagesClient';
+import { cvViewHref } from '@/lib/cvLink';
 import { Card } from '@/components/ui/Card';
 import { SkeletonRows } from '@/components/ui/Skeleton';
 import { Badge } from '@/components/ui/Badge';
@@ -485,7 +486,7 @@ export default function CandidatesPage() {
                 )}
 
                 {candidate.cvUrl && (
-                  <a href={candidate.cvUrl} target="_blank" rel="noopener noreferrer" className="mt-3 flex items-center gap-1 text-sm text-blue-600 dark:text-blue-300 hover:underline">
+                  <a href={cvViewHref(candidate.cvUrl)} target="_blank" rel="noopener noreferrer" className="mt-3 flex items-center gap-1 text-sm text-blue-600 dark:text-blue-300 hover:underline">
                     <ExternalLink className="h-3 w-3" />
                     {t.candidates.viewCv}
                   </a>
@@ -566,7 +567,7 @@ export default function CandidatesPage() {
 
                 {candidate.cvUrl && (
                   <a
-                    href={candidate.cvUrl}
+                    href={cvViewHref(candidate.cvUrl)}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="flex items-center gap-1 text-sm text-blue-600 hover:underline"

--- a/src/app/api/cv/[userId]/route.ts
+++ b/src/app/api/cv/[userId]/route.ts
@@ -6,8 +6,16 @@ import { withTenantScope } from '@/lib/orgContext';
 import { canAccessCv } from '@/lib/cvAccess';
 import { downloadHeaders } from '@/lib/download';
 
-// GET — download a user's CV (access-controlled).
-export async function GET(_request: Request, { params }: { params: Promise<{ userId: string }> }) {
+// A CV the browser can safely render on our own origin. Upload only accepts PDF
+// and Word (see POST /api/cv), and the bytes are verified against the declared
+// type (#888) — so a PDF here really is a PDF, and the browser's own viewer
+// displays it without any of our HTML/script context. Word is not renderable by
+// any browser, so it keeps downloading.
+const INLINE_TYPES = new Set(['application/pdf']);
+
+// GET — a user's CV (access-controlled). Downloads by default; `?inline=1`
+// displays it in the browser when the type allows (see INLINE_TYPES).
+export async function GET(request: Request, { params }: { params: Promise<{ userId: string }> }) {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
@@ -20,10 +28,13 @@ export async function GET(_request: Request, { params }: { params: Promise<{ use
   const cv = await prisma.cvFile.findUnique({ where: { userId } });
   if (!cv) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 
-  // Downloaded, not rendered in place: a stored document must not run as a
-  // page on our own origin (#890).
+  // Rendered in place only when asked for and only for a type that cannot run
+  // as a page on our own origin (#890) — everything else downloads.
+  const wantsInline = new URL(request.url).searchParams.get('inline') === '1';
+  const inline = wantsInline && INLINE_TYPES.has(cv.contentType);
+
   return new NextResponse(Buffer.from(cv.data), {
-    headers: downloadHeaders({ filename: cv.filename, contentType: cv.contentType, size: cv.size }),
+    headers: downloadHeaders({ filename: cv.filename, contentType: cv.contentType, size: cv.size, inline }),
   });
   });
 }

--- a/src/app/api/project-goals/route.ts
+++ b/src/app/api/project-goals/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { withTenantScope } from '@/lib/orgContext';
+
+// One person's project goals, across every project they are on.
+//
+// A goal assigned to someone is *their* goal, so it belongs on their profile
+// rather than in the project's list where the whole team reads it (the project
+// page keeps only the unassigned, claimable ones). This is the read side of that
+// move: GET ?userId= — omit it for your own.
+//
+// Who may read whose:
+//   - your own, always
+//   - an ADMIN, anyone's
+//   - a MENTOR, their own mentees' (an active or past mentorship is enough)
+// Everything else is a 403, including "a colleague on the same project".
+
+export async function GET(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  return await withTenantScope(session, async () => {
+    const viewerId = session.user.id;
+    const userId = new URL(request.url).searchParams.get('userId') || viewerId;
+
+    if (userId !== viewerId && session.user.role !== 'ADMIN') {
+      const mentorship = await prisma.mentorshipRelation.findFirst({
+        where: { mentorId: viewerId, menteeId: userId },
+        select: { id: true },
+      });
+      if (!mentorship) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const [tasks, memberships] = await Promise.all([
+      prisma.projectTask.findMany({
+        where: { assigneeId: userId },
+        orderBy: [{ done: 'asc' }, { order: 'asc' }],
+        select: {
+          id: true,
+          title: true,
+          done: true,
+          doneAt: true,
+          project: { select: { id: true, name: true, ownerUserId: true } },
+        },
+      }),
+      // The viewer's own memberships decide whether they may tick a goal off —
+      // mirroring PATCH /api/project-tasks/[taskId], which needs membership
+      // plus either ownership of the goal or lead of the project.
+      prisma.projectMember.findMany({
+        where: { userId: viewerId },
+        select: { projectId: true, role: true },
+      }),
+    ]);
+
+    const memberOf = new Map(memberships.map((m) => [m.projectId, m.role]));
+    const goals = tasks.map((task) => {
+      const role = memberOf.get(task.project.id);
+      const lead =
+        session.user.role === 'ADMIN' || role === 'OWNER' || task.project.ownerUserId === viewerId;
+      const canEdit = (lead || role !== undefined) && (lead || userId === viewerId);
+      return {
+        id: task.id,
+        title: task.title,
+        done: task.done,
+        doneAt: task.doneAt,
+        project: { id: task.project.id, name: task.project.name },
+        canEdit,
+      };
+    });
+
+    // Whether the viewer is looking at their own goals — the client offers
+    // "release" (hand an unwanted goal back to the project) only there, the way
+    // the project page used to for your own row.
+    return NextResponse.json({ goals, viewerIsOwner: userId === viewerId });
+  });
+}

--- a/src/app/api/project-tasks/[taskId]/route.ts
+++ b/src/app/api/project-tasks/[taskId]/route.ts
@@ -5,6 +5,7 @@ import { prisma } from '@/lib/prisma';
 import { z } from 'zod';
 import { canManageProject, isProjectMember, isProjectOwner } from '@/lib/projectAccess';
 import { notify } from '@/lib/notify';
+import { goalLinkFor } from '@/lib/projectGoalLink';
 
 async function taskIfManageable(userId: string, role: string, companyId: string | null | undefined, taskId: string) {
   const task = await prisma.projectTask.findUnique({ where: { id: taskId }, include: { project: true } });
@@ -86,7 +87,7 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ ta
   });
 
   if (assigneeId && assigneeId !== session.user.id) {
-    await notify(assigneeId, 'project', `You were given a goal: ${updated.title}`, `/projects/${task.projectId}`);
+    await notify(assigneeId, 'project', `You were given a goal: ${updated.title}`, await goalLinkFor(assigneeId, task.projectId));
   }
   return NextResponse.json({ task: updated });
 }

--- a/src/app/api/projects/[id]/tasks/route.ts
+++ b/src/app/api/projects/[id]/tasks/route.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import { canManageProject, isProjectMember } from '@/lib/projectAccess';
 import { notify } from '@/lib/notify';
 import { withTenantScope } from '@/lib/orgContext';
+import { goalLinkFor } from '@/lib/projectGoalLink';
 
 // A task may be created from free text (`title`) or from the template pool
 // (`templateIds`) — the latter is the "send the standard goals to the person who
@@ -99,7 +100,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
         created.length === 1
           ? `New goal on "${project.name}": ${created[0].title}`
           : `${created.length} new goals on "${project.name}".`,
-        `/projects/${id}`
+        await goalLinkFor(assigneeId, id)
       );
     }
 

--- a/src/app/company/candidates/[id]/page.tsx
+++ b/src/app/company/candidates/[id]/page.tsx
@@ -11,6 +11,7 @@ import { useStageLabel } from '@/lib/pipelineStagesClient';
 import { useT } from '@/i18n/client';
 import { Textarea } from '@/components/ui/Textarea';
 import { TEXT_LIMITS } from '@/lib/textLimits';
+import { cvViewHref } from '@/lib/cvLink';
 
 type InterestStatus = 'INTERESTED' | 'SHORTLISTED' | 'PASS';
 interface Interest { status: InterestStatus; note?: string | null }
@@ -222,7 +223,7 @@ export default function CompanyCandidateDetailPage() {
 
         <div className="flex flex-wrap items-center gap-2 pt-3 border-t border-gray-100 dark:border-gray-800">
           {candidate.cvUrl && (
-            <a href={candidate.cvUrl} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 text-sm text-blue-600 dark:text-blue-400 hover:underline">
+            <a href={cvViewHref(candidate.cvUrl)} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 text-sm text-blue-600 dark:text-blue-400 hover:underline">
               <FileText className="h-4 w-4" /> {t.cv.view}
             </a>
           )}

--- a/src/app/mentor/mentees/[id]/page.tsx
+++ b/src/app/mentor/mentees/[id]/page.tsx
@@ -15,6 +15,7 @@ import { useResolvedStages, useStageLabel } from '@/lib/pipelineStagesClient';
 import { useT, useLocale } from '@/i18n/client';
 import { EvaluationPanel } from '@/components/EvaluationPanel';
 import { GoalsPanel } from '@/components/GoalsPanel';
+import { PersonProjectGoals } from '@/components/PersonProjectGoals';
 import { MeetingRequestsPanel } from '@/components/MeetingRequestsPanel';
 import { QuestionsPanel } from '@/components/QuestionsPanel';
 import { RelationNotesPanel } from '@/components/RelationNotesPanel';
@@ -426,6 +427,12 @@ export default function MenteeDetailPage() {
 
         <div className="lg:col-span-2">
           <GoalsPanel relationId={id} />
+        </div>
+
+        {/* Goals handed to this mentee inside a project live here now, not on the
+            project page in front of the whole team. */}
+        <div className="lg:col-span-2">
+          <PersonProjectGoals userId={relation.mentee.id} />
         </div>
 
         <div className="lg:col-span-2">

--- a/src/app/mentor/mentees/[id]/page.tsx
+++ b/src/app/mentor/mentees/[id]/page.tsx
@@ -26,6 +26,7 @@ import { useToast } from '@/components/ui/Toast';
 import { formatDate, formatDateTime } from '@/lib/relativeTime';
 import { Textarea } from '@/components/ui/Textarea';
 import { TEXT_LIMITS } from '@/lib/textLimits';
+import { cvViewHref } from '@/lib/cvLink';
 
 interface InteractionLog {
   id: string;
@@ -169,12 +170,16 @@ export default function MenteeDetailPage() {
           <ArrowLeft className="h-4 w-4" />
           {t.mentor.backToMentees}
         </Link>
-        <div className="flex items-center justify-between">
-          <div>
-            <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{relation.mentee.fullName}</h1>
-            <p className="text-gray-500">{relation.mentee.email}</p>
+        {/* Stacked on a phone: side by side, a long e-mail ran under the stage
+            select and pushed the status badge off the right edge. `min-w-0` +
+            `break-words` keep a long address inside its own column instead of
+            widening the row. */}
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="min-w-0">
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 break-words">{relation.mentee.fullName}</h1>
+            <p className="text-gray-500 break-words">{relation.mentee.email}</p>
           </div>
-          <div className="flex flex-col items-end gap-2 min-w-[240px]">
+          <div className="flex w-full flex-col items-start gap-2 sm:w-auto sm:min-w-[240px] sm:items-end">
             <StatusBadge status={relation.status} />
             <div className="w-full">
               <Select
@@ -266,7 +271,7 @@ export default function MenteeDetailPage() {
             )}
             {relation.mentee.cvUrl && (
               <a
-                href={relation.mentee.cvUrl}
+                href={cvViewHref(relation.mentee.cvUrl)}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="flex items-center gap-1 text-sm text-blue-600 hover:underline"

--- a/src/app/portal/profile/page.tsx
+++ b/src/app/portal/profile/page.tsx
@@ -16,6 +16,7 @@ import { SkillRating } from '@/components/SkillRating';
 import { AvatarManager } from '@/components/AvatarManager';
 import { DocumentsManager } from '@/components/DocumentsManager';
 import { TemplatesLibrary } from '@/components/TemplatesLibrary';
+import { PersonProjectGoals } from '@/components/PersonProjectGoals';
 import { useToast } from '@/components/ui/Toast';
 import { Textarea } from '@/components/ui/Textarea';
 import { TEXT_LIMITS } from '@/lib/textLimits';
@@ -441,6 +442,12 @@ export default function ProfilePage() {
           </div>
         </form>
       </Card>
+
+      {/* Goals your mentor handed you inside a project (#51 follow-up): they are
+          yours, so they live here rather than on the project page. */}
+      <div className="max-w-4xl mt-6">
+        <PersonProjectGoals />
+      </div>
 
       {userId && (
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 max-w-4xl mt-6">

--- a/src/components/CvManager.tsx
+++ b/src/components/CvManager.tsx
@@ -4,6 +4,7 @@ import { useRef, useState } from 'react';
 import { FileText, Trash2, Upload } from 'lucide-react';
 import { Button } from '@/components/ui/Button';
 import { useT } from '@/i18n/client';
+import { cvViewHref } from '@/lib/cvLink';
 
 // Upload / view / replace / delete a CV. Used by the mentee (self) on the
 // portal profile and by mentor/admin on a mentee's detail page.
@@ -57,7 +58,7 @@ export function CvManager({ targetUserId, initialCvUrl, onChange }: { targetUser
       <div className="flex flex-wrap items-center gap-2">
         {cvUrl ? (
           <a
-            href={cvUrl}
+            href={cvViewHref(cvUrl)}
             target="_blank"
             rel="noopener noreferrer"
             className="inline-flex items-center gap-1 text-sm text-blue-600 hover:underline"

--- a/src/components/PersonProjectGoals.tsx
+++ b/src/components/PersonProjectGoals.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { CheckCircle2, Circle } from 'lucide-react';
+import { Card, CardHeader, CardTitle, CardDescription } from '@/components/ui/Card';
+import { useT, useLocale } from '@/i18n/client';
+import { formatDate } from '@/lib/relativeTime';
+
+// The project goals that belong to one person, grouped by project.
+//
+// A goal handed to someone is theirs, so this is where it lives: their own
+// profile (and, for a mentor or admin, the profile they are looking at). The
+// project page shows only the unassigned goals anyone may claim — before this,
+// every personal goal was listed there for the whole team to read.
+//
+// Ticking follows PATCH /api/project-tasks/[taskId]: your own goals are yours to
+// tick, a project lead may tick anyone's, everyone else reads.
+
+interface Goal {
+  id: string;
+  title: string;
+  done: boolean;
+  doneAt: string | null;
+  project: { id: string; name: string };
+  canEdit: boolean;
+}
+
+export function PersonProjectGoals({ userId, className }: { userId?: string; className?: string }) {
+  const t = useT();
+  const locale = useLocale();
+  const [goals, setGoals] = useState<Goal[]>([]);
+  const [isOwner, setIsOwner] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [busy, setBusy] = useState('');
+
+  const load = useCallback(async () => {
+    const res = await fetch(`/api/project-goals${userId ? `?userId=${encodeURIComponent(userId)}` : ''}`);
+    if (res.ok) {
+      const d = await res.json();
+      setGoals(d.goals ?? []);
+      setIsOwner(Boolean(d.viewerIsOwner));
+    }
+    setLoaded(true);
+  }, [userId]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const patch = async (goal: Goal, body: Record<string, unknown>) => {
+    setBusy(goal.id);
+    try {
+      await fetch(`/api/project-tasks/${goal.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      await load();
+    } finally {
+      setBusy('');
+    }
+  };
+
+  const toggle = (goal: Goal) => patch(goal, { done: !goal.done });
+  // Hand a goal back to the project's open pool — the project page offered this
+  // on your own row before personal goals moved here.
+  const release = (goal: Goal) => patch(goal, { assigneeId: null });
+
+  const byProject = useMemo(() => {
+    const groups = new Map<string, { name: string; goals: Goal[] }>();
+    for (const goal of goals) {
+      const group = groups.get(goal.project.id) ?? { name: goal.project.name, goals: [] };
+      group.goals.push(goal);
+      groups.set(goal.project.id, group);
+    }
+    return [...groups.entries()];
+  }, [goals]);
+
+  // Nothing assigned and nothing loading: stay out of the way instead of
+  // adding an empty card to a page that already has plenty.
+  if (!loaded || goals.length === 0) return null;
+
+  const doneCount = goals.filter((g) => g.done).length;
+
+  return (
+    <Card className={className} data-testid="person-project-goals">
+      <CardHeader>
+        <CardTitle>{t.projectGoals.title}</CardTitle>
+        <CardDescription>
+          {t.projectGoals.progress.replace('{done}', String(doneCount)).replace('{total}', String(goals.length))}
+        </CardDescription>
+      </CardHeader>
+      <div className="space-y-4">
+        {byProject.map(([projectId, group]) => (
+          <div key={projectId}>
+            <Link
+              href={`/projects/${projectId}`}
+              className="text-xs font-semibold uppercase tracking-wide text-gray-500 hover:text-blue-600"
+            >
+              {group.name}
+            </Link>
+            <ul className="mt-1.5 space-y-1">
+              {group.goals.map((goal) => (
+                <li key={goal.id} className="flex items-start gap-2 text-sm" data-testid={`project-goal-${goal.id}`}>
+                  {goal.canEdit ? (
+                    <button
+                      type="button"
+                      onClick={() => toggle(goal)}
+                      disabled={busy === goal.id}
+                      aria-label={goal.done ? t.goals.markOpen : t.goals.markDone}
+                      className="mt-0.5 shrink-0"
+                    >
+                      {goal.done ? (
+                        <CheckCircle2 className="h-4 w-4 text-green-500" />
+                      ) : (
+                        <Circle className="h-4 w-4 text-gray-300" />
+                      )}
+                    </button>
+                  ) : goal.done ? (
+                    <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-green-500" />
+                  ) : (
+                    <Circle className="mt-0.5 h-4 w-4 shrink-0 text-gray-300" />
+                  )}
+                  <span className={`min-w-0 break-words ${goal.done ? 'text-gray-400 line-through' : 'text-gray-700 dark:text-gray-200'}`}>
+                    {goal.title}
+                    {goal.done && goal.doneAt && (
+                      <span className="ml-1.5 whitespace-nowrap text-xs text-gray-400">
+                        {formatDate(goal.doneAt, locale)}
+                      </span>
+                    )}
+                  </span>
+                  {isOwner && goal.canEdit && !goal.done && (
+                    <button
+                      type="button"
+                      onClick={() => release(goal)}
+                      disabled={busy === goal.id}
+                      className="ml-auto shrink-0 text-xs text-gray-400 hover:text-gray-600"
+                    >
+                      {t.projects.releaseGoal}
+                    </button>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+}

--- a/src/components/project/ProjectGoals.tsx
+++ b/src/components/project/ProjectGoals.tsx
@@ -96,9 +96,8 @@ export function ProjectGoals({
     }
   };
 
-  const mine = useMemo(() => tasks.filter((tk) => tk.assigneeId === myId), [tasks, myId]);
   const unassigned = useMemo(() => tasks.filter((tk) => !tk.assigneeId), [tasks]);
-  const others = useMemo(() => tasks.filter((tk) => tk.assigneeId && tk.assigneeId !== myId), [tasks, myId]);
+  const assigned = useMemo(() => tasks.filter((tk) => tk.assigneeId), [tasks]);
   const assignable = useMemo(() => team.filter((m) => m.role === 'MENTEE'), [team]);
 
   const toggle = (task: Task) =>
@@ -184,13 +183,6 @@ export function ProjectGoals({
         </div>
       </div>
 
-      {mine.length > 0 && (
-        <div>
-          <h3 className="mb-1.5 text-sm font-semibold text-gray-900 dark:text-gray-100">{t.projects.myGoals}</h3>
-          <ul className="space-y-1">{mine.map((tk) => row(tk, { canTick: true, canRelease: !canLead }))}</ul>
-        </div>
-      )}
-
       {unassigned.length > 0 && (
         <div>
           <h3 className="mb-1.5 text-sm font-semibold text-gray-900 dark:text-gray-100">{t.projects.openGoals}</h3>
@@ -201,17 +193,20 @@ export function ProjectGoals({
         </div>
       )}
 
-      {others.length > 0 && (
-        <div>
-          <h3 className="mb-1.5 text-sm font-semibold text-gray-900 dark:text-gray-100">{t.projects.teamGoals}</h3>
-          <ul className="space-y-1">{others.map((tk) => row(tk, { canTick: canLead }))}</ul>
-        </div>
+      {/* A personal goal belongs to the person, so it is listed on their profile
+          (PersonProjectGoals) instead of here in front of the whole team. Only
+          the count stays, so a lead can see the project is not idle. */}
+      {assigned.length > 0 && (
+        <p className="text-xs text-gray-400" data-testid="assigned-goals-count">
+          {t.projects.assignedGoalsCount.replace('{n}', String(assigned.length))}
+        </p>
       )}
 
       {tasks.length === 0 && <p className="text-sm text-gray-400">{t.projects.noGoals}</p>}
 
       {canLead && (
         <div className="space-y-3 border-t border-gray-100 pt-3 dark:border-gray-800">
+          <p className="text-xs text-gray-400">{t.projects.assignedGoalsHint}</p>
           {/* Stacked below sm: an input sharing a row with a select and a button
               collapses to a few characters wide on a phone (#51 follow-up). */}
           <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
@@ -226,6 +221,7 @@ export function ProjectGoals({
             <select
               value={draftAssignee}
               onChange={(e) => setDraftAssignee(e.target.value)}
+              title={t.projects.assignedGoalsHint}
               data-testid="goal-assignee"
               className="w-full min-w-0 rounded-lg border border-gray-300 bg-white px-2.5 py-1.5 text-sm dark:border-gray-700 dark:bg-gray-900 sm:w-auto"
             >

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -933,6 +933,12 @@ const en = {
     selectMember: 'Choose a member',
     selectAll: 'Select all',
     sendGoals: 'Send the goals',
+    assignedGoalsHint: 'A goal you hand to someone shows up on their own profile, not here.',
+    assignedGoalsCount: '{n} goal(s) assigned to team members',
+  },
+  projectGoals: {
+    title: 'Project goals',
+    progress: '{done} of {total} done',
   },
   upcomingMeeting: {
     inProgress: 'Meeting in progress',
@@ -2727,6 +2733,12 @@ const tr: Dict = {
     selectMember: 'Üye seç',
     selectAll: 'Tümünü seç',
     sendGoals: 'Hedefleri gönder',
+    assignedGoalsHint: 'Birine verdiğin hedef burada değil, o kişinin kendi profilinde görünür.',
+    assignedGoalsCount: 'Ekip üyelerine atanmış {n} hedef',
+  },
+  projectGoals: {
+    title: 'Proje hedefleri',
+    progress: '{total} hedefin {done} tanesi tamam',
   },
   upcomingMeeting: {
     inProgress: 'Toplantı devam ediyor',
@@ -4519,6 +4531,12 @@ const de: Dict = {
     selectMember: 'Mitglied wählen',
     selectAll: 'Alle auswählen',
     sendGoals: 'Ziele senden',
+    assignedGoalsHint: 'Ein Ziel, das du jemandem gibst, erscheint in dessen Profil — nicht hier.',
+    assignedGoalsCount: '{n} Ziel(e) an Teammitglieder vergeben',
+  },
+  projectGoals: {
+    title: 'Projektziele',
+    progress: '{done} von {total} erledigt',
   },
   upcomingMeeting: {
     inProgress: 'Treffen läuft',

--- a/src/lib/cvLink.ts
+++ b/src/lib/cvLink.ts
@@ -1,0 +1,17 @@
+/**
+ * The href behind a "view CV" link.
+ *
+ * A stored CV lives at `/api/cv/<userId>`, and since #890 that route answers
+ * with `Content-Disposition: attachment` — so "view CV" downloaded the file
+ * instead of showing it. On a phone that reads as a dead link: the tab opens
+ * blank and the file lands in Downloads.
+ *
+ * `?inline=1` asks the route to render it in place instead. The route only
+ * honours it for a PDF (see the comment there); a Word CV downloads either way,
+ * which is all a browser can do with it. An external `cvUrl` (a Drive link a
+ * mentee typed in) is returned untouched.
+ */
+export function cvViewHref(cvUrl: string): string {
+  if (!cvUrl.startsWith('/api/cv/')) return cvUrl;
+  return `${cvUrl}${cvUrl.includes('?') ? '&' : '?'}inline=1`;
+}

--- a/src/lib/projectGoalLink.ts
+++ b/src/lib/projectGoalLink.ts
@@ -1,0 +1,15 @@
+import { prisma } from '@/lib/prisma';
+
+/**
+ * Where a person reads a project goal that was just assigned to them.
+ *
+ * A personal goal is no longer listed on the project page — it lives on the
+ * assignee's own profile — so a notification pointing at `/projects/<id>` would
+ * send them somewhere the goal is not. Mentees read theirs in the portal; anyone
+ * else (a mentor or admin who ended up with a goal) still manages the project
+ * itself, so the project page is the useful destination for them.
+ */
+export async function goalLinkFor(assigneeId: string, projectId: string): Promise<string> {
+  const user = await prisma.user.findUnique({ where: { id: assigneeId }, select: { role: true } });
+  return user?.role === 'MENTEE' ? '/portal/profile' : `/projects/${projectId}`;
+}

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,24 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.41.5-beta',
+    date: '2026-08-04',
+    highlights: {
+      en: [
+        'Fixed: "View CV" now opens the CV instead of quietly downloading it — a PDF opens in the browser’s viewer, which is what the link looked like it did all along. Word CVs still download, because no browser can show them.',
+        'Fixed: on a phone, a long e-mail address no longer breaks the top of a mentee’s page — the name, the address and the stage selector stack instead of colliding, and the status badge stays on screen.',
+      ],
+      tr: [
+        'Düzeltildi: "CV’yi gör" artık CV’yi açıyor, sessizce indirmiyor — PDF tarayıcının görüntüleyicisinde açılıyor, linkin baştan beri yaptığını sandığın şey. Word CV’leri indirilmeye devam ediyor, çünkü tarayıcılar onları gösteremiyor.',
+        'Düzeltildi: telefonda uzun bir e-posta adresi mentee sayfasının üst kısmını bozmuyor — isim, adres ve aşama seçimi çakışmak yerine alt alta diziliyor, durum etiketi de ekranda kalıyor.',
+      ],
+      de: [
+        'Behoben: „CV ansehen“ öffnet den Lebenslauf jetzt, statt ihn still herunterzuladen — ein PDF erscheint im Viewer des Browsers, so wie der Link es immer schon versprochen hat. Word-Dateien werden weiterhin heruntergeladen, weil kein Browser sie anzeigen kann.',
+        'Behoben: Auf dem Handy zerlegt eine lange E-Mail-Adresse nicht mehr den Kopfbereich der Mentee-Seite — Name, Adresse und Phasen-Auswahl stapeln sich statt sich zu überlagern, und das Status-Label bleibt sichtbar.',
+      ],
+    },
+  },
+  {
     version: '0.41.4-beta',
     date: '2026-08-04',
     highlights: {

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,24 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.41.4-beta',
+    date: '2026-08-04',
+    highlights: {
+      en: [
+        'A goal you give someone in a project is now shown on their profile instead of on the project page: they see it (and tick it off) on their own profile, and you see it on their page. The project page keeps the open goals anyone may claim.',
+        'The goal template pool starts full: 20 ready-made internship goals — get the project running, find a bug, fix it, open a pull request, weekly progress note, update your CV, and so on — so you can hand a new mentee a sensible starter list on day one.',
+      ],
+      tr: [
+        'Projede birine verdiğin hedef artık proje sayfasında değil, o kişinin profilinde görünüyor: kişi kendi profilinden görüp işaretliyor, sen de onun sayfasından takip ediyorsun. Proje sayfasında herkesin üstlenebileceği açık hedefler kalıyor.',
+        'Hedef şablon havuzu artık dolu geliyor: 20 hazır staj hedefi — projeyi çalıştır, bir hata bul, düzelt, pull request aç, haftalık ilerleme notu, CV’ni güncelle gibi — yeni bir mentee’ye ilk günden mantıklı bir liste verebilirsin.',
+      ],
+      de: [
+        'Ein Ziel, das du jemandem im Projekt gibst, erscheint jetzt in dessen Profil statt auf der Projektseite: die Person sieht und hakt es im eigenen Profil ab, du verfolgst es auf ihrer Seite. Auf der Projektseite bleiben die offenen Ziele, die sich jeder nehmen kann.',
+        'Der Zielvorlagen-Pool ist von Anfang an gefüllt: 20 fertige Praktikumsziele — Projekt zum Laufen bringen, einen Bug finden, beheben, Pull Request öffnen, Wochenbericht, Lebenslauf aktualisieren und mehr — damit ein neues Mentee am ersten Tag eine sinnvolle Liste bekommt.',
+      ],
+    },
+  },
+  {
     version: '0.41.3-beta',
     date: '2026-08-04',
     highlights: {


### PR DESCRIPTION
## Summary

Three things reported from the phone, in two commits.

**A goal assigned to someone belongs to them, not to the project page.** `ProjectGoals` listed
"my goals" and "the team's goals" beside the unassigned pool, so every member read everyone
else's personal checklist and the page grew with each new member. The project page now keeps
only the goals anyone may claim (plus a count of the assigned ones, so a lead can see it is not
idle); the goals themselves render on the person's profile.

**The shared goal-template pool was empty.** A project's pool is "its own templates + the shared
ones", so "send the starter goals" had nothing to offer until a mentor had typed the set by
hand. Seeded with 20 starter internship goals.

**"View CV" downloaded the file instead of showing it** — since #890 every CV response is an
`attachment`, which on a phone reads as a dead link (blank tab, file in Downloads). And a long
e-mail address broke the top of `/mentor/mentees/[id]` on mobile: it ran under the stage select
and pushed the status badge off the screen.

## Changes

**Goals on the profile**
- New `GET /api/project-goals[?userId=]` — one person's assigned goals across all their projects,
  grouped by project. Readable by that person, an ADMIN, or their mentor; each goal carries
  `canEdit` mirroring the tick rules of `PATCH /api/project-tasks/[taskId]` (your own goals, or
  any goal if you lead the project).
- New `PersonProjectGoals` panel, mounted on `/portal/profile` (your own), `/mentor/mentees/[id]`
  and `/admin/candidates/[id]`. Renders nothing when the person has no goals. "Release" (hand a
  goal back to the open pool) moved along with the goal, so nothing possible before was lost.
- `ProjectGoals`: assigned sections dropped, count + hint added.
- `src/lib/projectGoalLink.ts`: a new-goal notification now links to where the goal actually is
  (`/portal/profile` for a mentee, the project otherwise).

**Template pool**
- `prisma/seed-goal-templates.mjs` — 20 shared (`projectId: null`) templates, wired into
  `infra/deploy-prod.sh` beside `seed-templates`. Idempotent by title: MySQL does not enforce
  `@@unique([projectId, title])` across NULL `projectId`s, so existence is checked in the script.
  Titles are Turkish, matching the language goals are handed out in.

**CV + mobile header**
- `GET /api/cv/[userId]` accepts `?inline=1`, honoured for `application/pdf` only. Upload accepts
  PDF and Word and verifies bytes against the declared type (#888), so an inline PDF really is a
  PDF and renders in the browser's own viewer rather than as a page on our origin — the #890
  concern is unchanged for everything else, and Word still downloads.
- `src/lib/cvLink.ts` (`cvViewHref`) used by every "view CV" link: mentee detail, admin candidates
  list, `CvManager`, company candidate detail. External `cvUrl` values are untouched.
- `/mentor/mentees/[id]` header stacks below `sm`; text column `min-w-0 break-words`. Same
  `break-words` on the admin candidate header.

**Tests**
- `e2e/project-team-and-goals.spec.ts` (@smoke) updated: the goal is *not* on the project page and
  *is* ticked from `/portal/profile`.
- New `e2e/mentee-detail-mobile-cv.spec.ts`: 375px header has nothing past the right edge, the CV
  link carries `?inline=1`, the route answers `inline` for a PDF and `attachment` without it.

## Verification

- [x] `npm run lint` + `npx tsc --noEmit` clean (lint unchanged: the three pre-existing warnings)
- [x] `npm run build` clean, `npm run check:i18n` OK (1757 keys × 3 locales)
- [x] Updated the affected smoke spec and added an e2e test — no DB in this container, so both run
      in CI
- Versions 0.41.4-beta and 0.41.5-beta + CHANGELOG + release notes.

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

---
_Generated by [Claude Code](https://claude.ai/code/session_013rB78Da9fXS9NfzNfvZo1L)_