### PR TITLE
test: fix the 5 specs failing in the scheduled full e2e suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [Unreleased]
+
+### Fixed
+- **The five specs failing in the scheduled full e2e suite** (run 31051715943). Both causes were
+  test defects, not product bugs. Since #1008 gave `/admin/candidates` a separate `md:hidden`
+  mobile list, every candidate is in the DOM twice, so the unscoped `getByText('<name>')`
+  assertions in `admin-bulk-candidates`, `dashboard-links`, `export-filter` and `export` became
+  strict-mode violations — they now scope to `candidates-desktop-list` (the list the Desktop
+  Chrome viewport actually renders). `security-headers` still asserted the pre-Jitsi
+  `camera=()`; it now checks that camera/microphone/display-capture are delegated to
+  `self "https://meet.jit.si"` only, that `geolocation=()` stays denied and that no directive
+  opens up to `*`. No version bump — tests only.
+
 ## [0.42.1-beta] - 2026-08-05
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,6 +225,13 @@ workaround, #636, and it compiled on every PR push).
   box; add a `data-testid` to any new search input and target that. `getByText('X')` does
   substring matching, so a seeded name like "RB Company" also matches `getByText('Company')`
   — use `{ exact: true }` or scope to a container (`page.locator('table').getByText(...)`).
+  **Responsive dual lists**: `/admin/candidates` renders every candidate *twice* — once in the
+  `md:hidden` mobile list (`candidates-mobile-list`, cards `candidate-mobile-card-<id>`) and
+  once in the desktop grid (`candidates-desktop-list`, cards `candidate-card-<id>`). Strict mode
+  counts matched elements regardless of CSS visibility, so any unscoped name locator there
+  resolves to 2 and throws; scope to `getByTestId('candidates-desktop-list')` (what the Desktop
+  Chrome viewport shows) or to a specific card testid. Assume the same for any future
+  mobile/desktop split.
 - **Known pre-existing CI flakes**: `e2e/account-self-service.spec.ts:52` and
   `e2e/sign-out-all.spec.ts:24` fail intermittently in the Playwright smoke job (usually
   preceded by a `[WebServer] TypeError: Cannot read properties of null (reading 'user')`

--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -2443,3 +2443,46 @@ için CI'a giden tek kırmızı, bu kurulumdan *önceki* PR'dı.
 **Dev sunucusu eski Prisma client'ıyla kalır.** `prisma generate` sonrası `next dev`'i
 yeniden başlatmazsan yeni kolona yazan endpoint 500 döner ve hata testin değil sunucunun
 olur. Şema değişince sunucuyu yeniden başlat.
+
+## 2026-08-06 — Zamanlanmış tam koşunun 5 kırmızısı: ikisi de "ürün değişti, test değişmedi"
+
+**Duyarlı (responsive) ikinci liste, strict mode'u sessizce silahlandırıyor.** #1008
+`/admin/candidates`'e `md:hidden` bir mobil kart listesi ekledi; masaüstü grid'i zaten
+duruyordu. Artık **her aday DOM'da iki kez** var. Playwright'ın strict mode'u *görünür*
+eşleşmeyi değil **eşleşen düğüm sayısını** sayar, dolayısıyla `md:hidden` olması hiçbir şeyi
+kurtarmaz: `getByText('<isim>')` 2 döner ve `toBeVisible()` daha görünürlüğe bakmadan patlar.
+Dört spec (`admin-bulk-candidates`, `dashboard-links`, `export-filter`, `export`) tam bu yüzden
+düştü — hepsi `candidates-desktop-list` kapsamına alındı. Aynı sayfanın testid ile çalışan
+assertion'ları (`candidate-card-<id>`) hiç etkilenmedi; ders bu: **isimle değil kapsamla/testid
+ile hedefle.** `toHaveCount(0)` yazan yokluk assertion'ları kırmızıya düşmediği için bu ikizleme
+PR gate'inde de gizli kaldı (bu 4 spec `@smoke` değil).
+
+**"Yokluk" assertion'ı, bozulmuş bir locator'ı maskeler.** `getByText(x)).toHaveCount(0)` hem
+"öğe yok" hem "locator artık yanlış" durumunda yeşil. Bir sayfanın DOM'u ikizlendiğinde önce
+*varlık* assertion'ları düşer; yokluk olanlar aynı yanlışlığı taşıdıkları halde susar. İkizleme
+düzeltilirken ikisini birlikte kapsamla.
+
+**`dashboard-links`'te ikinci bir bomba ilk hatanın arkasında bekliyordu:** `getByRole('link',
+{ name: 'ZZ InStage Mentee' })` de 2 eşleşiyordu. İlk `getByText` düzeltilse ve o satır
+bırakılsa, spec bir sonraki koşuda aynı yerden yine düşerdi. Aynı sayfadaki **bütün** isim
+tabanlı locator'ları tek seferde tara.
+
+**Header testi, ürün kararının fotoğrafını çekmişti.** `security-headers` hâlâ Jitsi öncesi
+`camera=()`'yi arıyordu; gömülü görüşme için `Permissions-Policy` bilerek
+`camera=(self "https://meet.jit.si")`'ye genişletilmişti. Doğru düzeltme sabiti güncellemek
+değil, **niyeti** test etmek: yetkiler tek host'a delege edilmiş mi, `geolocation=()` kapalı mı,
+ve hiçbir direktif `*`'a açılmış mı. Böylesi bir gevşetme bir daha sessizce geçmez.
+
+**Yerel `.env` paylaşılan preview DB'sine bakıyor — e2e'yi ona karşı koşmak veri yazmak demek.**
+Doğru yol: `DATABASE_URL`'i komut satırında geçersiz kılmak. `process.env`, `.env`'i ezdiği için
+`DATABASE_URL='mysql://...' npx playwright test ...` yeterli, dosyaya dokunmak gerekmiyor.
+
+**MariaDB'ye parola üretmeden bağlanmanın yolu unix socket.** Önceki notta TCP'li bir `e2e`
+kullanıcısı açılmış ama parolası oturumla birlikte gitmiş. `root` sudo istiyor. Prisma socket'i
+destekliyor: `mysql://<oturum-kullanıcısı>@localhost/<db>?socket=/tmp/mysql.sock` — `unix_socket`
+plugin'i sayesinde parolasız geçiyor, yeni kullanıcı/parola kurmaya gerek yok.
+
+**Playwright tarayıcısı pinlenen sürümü istiyorsa, indirmeden önce cache'e bak.**
+`~/Library/Caches/ms-playwright/` içinde komşu build'lar (1234) varken eksik olan yalnızca
+beklenen sürüm dizini (1228) olabilir; `chromium-1228 -> chromium-1234` ve aynısı
+`chromium_headless_shell` için symlink, ~150MB indirmeden koşmayı açıyor.

--- a/e2e/admin-bulk-candidates.spec.ts
+++ b/e2e/admin-bulk-candidates.spec.ts
@@ -21,7 +21,10 @@ test('admin can bulk-deactivate and bulk-reactivate selected candidates', async 
     await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
 
     await page.goto('/admin/candidates');
-    await expect(page.getByText('Bulk Candidate A')).toBeVisible({ timeout: 10_000 });
+    // Every candidate is rendered twice — md:hidden mobile list + desktop grid —
+    // so name locators have to be scoped to one list to stay strict-mode safe.
+    const desktopList = page.getByTestId('candidates-desktop-list');
+    await expect(desktopList.getByText('Bulk Candidate A')).toBeVisible({ timeout: 10_000 });
 
     await page.getByTestId(`candidate-card-${menteeA.id}`).getByRole('checkbox').check();
     await page.getByTestId(`candidate-card-${menteeB.id}`).getByRole('checkbox').check();
@@ -38,7 +41,7 @@ test('admin can bulk-deactivate and bulk-reactivate selected candidates', async 
 
     // Deactivated candidates leave the default (active) view and move to the
     // Archive tab.
-    await expect(page.getByText('Bulk Candidate A')).toHaveCount(0);
+    await expect(desktopList.getByText('Bulk Candidate A')).toHaveCount(0);
     await page.getByTestId('candidates-tab-archived').click();
     await expect(page.getByTestId(`candidate-card-${menteeA.id}`)).toBeVisible({ timeout: 10_000 });
     await expect(page.getByText('Inactive').first()).toBeVisible();

--- a/e2e/dashboard-links.spec.ts
+++ b/e2e/dashboard-links.spec.ts
@@ -39,11 +39,14 @@ test('candidates can be filtered by pipeline stage via ?status=', async ({ page 
     // Target the chip by testid: its label also renders as an <option> in the
     // "All stages" select, so matching on text is a strict-mode violation.
     await expect(page.getByTestId('candidates-status-filter-chip')).toContainText('660 · Hired');
-    await expect(page.getByText('ZZ InStage Mentee')).toBeVisible();
-    await expect(page.getByText('ZZ OutStage Mentee')).toHaveCount(0);
+    // Each candidate appears in both the md:hidden mobile list and the desktop
+    // grid, so scope to the list this viewport shows or strict mode trips.
+    const desktopList = page.getByTestId('candidates-desktop-list');
+    await expect(desktopList.getByText('ZZ InStage Mentee')).toBeVisible();
+    await expect(desktopList.getByText('ZZ OutStage Mentee')).toHaveCount(0);
 
     // Name links to the detail page
-    await page.getByRole('link', { name: 'ZZ InStage Mentee' }).click();
+    await desktopList.getByRole('link', { name: 'ZZ InStage Mentee' }).click();
     await page.waitForURL((u) => u.pathname.includes(`/admin/candidates/${inMentee.id}`), { timeout: 15_000 });
   } finally {
     await cleanupByEmail(mentorEmail);

--- a/e2e/export-filter.spec.ts
+++ b/e2e/export-filter.spec.ts
@@ -27,8 +27,11 @@ test('candidates: city filter narrows results and CSV export downloads', async (
     await page.goto('/admin/candidates');
     await page.getByPlaceholder('Filter by city').fill(`Cologne${tag}`);
     await page.waitForTimeout(1200);
-    await expect(page.getByText(`${tag} Koln Mentee`)).toBeVisible();
-    await expect(page.getByText(`${tag} Berlin Mentee`)).toHaveCount(0);
+    // Candidates render twice (md:hidden mobile list + desktop grid) — scope the
+    // name assertions to one list so they stay strict-mode safe.
+    const desktopList = page.getByTestId('candidates-desktop-list');
+    await expect(desktopList.getByText(`${tag} Koln Mentee`)).toBeVisible();
+    await expect(desktopList.getByText(`${tag} Berlin Mentee`)).toHaveCount(0);
 
     // CSV export downloads
     const download = page.waitForEvent('download', { timeout: 15_000 });

--- a/e2e/export.spec.ts
+++ b/e2e/export.spec.ts
@@ -25,7 +25,12 @@ test('candidates can be exported to Excel (.xlsx)', async ({ page }) => {
   try {
     await adminLogin(page, adminEmail, 'AdminPass123');
     await page.goto('/admin/candidates');
-    await expect(page.getByText('Xls Candidate')).toBeVisible({ timeout: 10_000 });
+    // /admin/candidates renders every candidate twice — once in the md:hidden
+    // mobile list, once in the desktop grid — so an unscoped name locator is a
+    // strict-mode violation. Scope to the list this viewport actually shows.
+    await expect(
+      page.getByTestId('candidates-desktop-list').getByText('Xls Candidate'),
+    ).toBeVisible({ timeout: 10_000 });
 
     const [download] = await Promise.all([
       page.waitForEvent('download'),

--- a/e2e/security-headers.spec.ts
+++ b/e2e/security-headers.spec.ts
@@ -8,7 +8,17 @@ test('responses carry the security headers', async ({ request }) => {
   expect(h['referrer-policy']).toBe('strict-origin-when-cross-origin');
   expect(h['content-security-policy']).toContain("default-src 'self'");
   expect(h['content-security-policy']).toContain("frame-ancestors 'none'");
-  expect(h['permissions-policy']).toContain('camera=()');
+  // camera/microphone/display-capture are delegated to the app itself and to the
+  // embedded Jitsi room only (the meeting panel needs them); a blanket
+  // `camera=()` would leave that iframe with a picture of nobody. What matters
+  // here is that the allow-lists stay pinned to meet.jit.si — never `*` — and
+  // that geolocation is still denied outright.
+  const permissions = h['permissions-policy'];
+  expect(permissions).toContain('camera=(self "https://meet.jit.si")');
+  expect(permissions).toContain('microphone=(self "https://meet.jit.si")');
+  expect(permissions).toContain('display-capture=(self "https://meet.jit.si")');
+  expect(permissions).toContain('geolocation=()');
+  expect(permissions).not.toContain('*');
 });
 
 test('home page still renders without console errors under CSP', async ({ page }) => {


### PR DESCRIPTION
Closes #1083. Zamanlanmış koşu: https://github.com/21072026/Internship/actions/runs/31051715943 (387/392)

İki kök neden, ikisi de **ürün hatası değil** — testler shipped değişikliklerin gerisinde kalmış. Her ikisi de yerelde (socket ile bağlanan yerel MariaDB) **önce birebir tekrar üretildi, sonra düzeltildi**.

## 1) Duyarlı ikinci liste → strict mode ihlali (4 spec)

#1008 `/admin/candidates`'e `md:hidden` mobil kart listesi ekledi, masaüstü grid'i de duruyor → **her aday DOM'da iki kez**. Playwright strict mode *görünür* eşleşmeyi değil **eşleşen düğüm sayısını** sayar, dolayısıyla `md:hidden` hiçbir şeyi kurtarmıyor: `getByText('<isim>')` 2 döner ve `toBeVisible()` görünürlüğe hiç bakmadan patlar.

`admin-bulk-candidates`, `dashboard-links`, `export-filter`, `export` artık isim locator'larını `candidates-desktop-list` kapsamına alıyor.

İki ek nokta:
- **Yokluk assertion'ları da kapsamlandı.** `getByText(x).toHaveCount(0)` hem "satır yok" hem "locator artık yanlış" durumunda yeşil — bu yüzden ikizleme bu spec'lerin yarısında gizli kalmıştı.
- **`dashboard-links` ilk hatanın arkasında ikinci bir bomba saklıyordu:** `getByRole('link', { name: 'ZZ InStage Mentee' })` de 2 eşleşiyordu; yalnızca `getByText`'i düzeltmek spec'i bir satır sonra yine düşürürdü.

## 2) `security-headers` Jitsi öncesi başlığı arıyordu

Gömülü görüşme paneli `Permissions-Policy`'yi bilerek `camera/microphone/display-capture = (self "https://meet.jit.si")` olarak genişletti; spec hâlâ `camera=()` bekliyordu. Yeni sabiti pinlemek yerine **niyet** test ediliyor: her yetki yalnızca o tek host'a delege mi, `geolocation=()` kapalı mı, ve hiçbir direktif `*`'a açılmış mı — böylece ileride sessiz bir genel gevşetme geçemez.

## Doğrulama (yerel, `npx playwright test`)

```
✓ admin-bulk-candidates … ✓ dashboard-links … ✓ export-filter … ✓ export (2) … ✓ security-headers (2)
7 passed
```
Düzeltme öncesi aynı komut `getByText(...) resolved to 2 elements` ve `camera=()` hatalarını birebir üretiyordu. Ayrıca komşu aday spec'leri regresyon için koşuldu: `candidates-mobile`, `candidates-archive`, `candidate-assign-mentor`, `search` → 4 passed.

Aynı sayfaya giden diğer spec'ler tarandı; kalan hepsi `candidate-card-<id>` testid'i üzerinden hedefliyor, gizli başka çakışma yok.

## Kapsam dışı bıraktığım

Ürün tarafına dokunmadım — iki listeyi DOM'da tek listeye indirmek (ör. yalnızca bir listeyi render etmek) daha büyük bir UI kararı ve bu kırmızıları çözmek için gerekmiyor.

Tuzak CLAUDE.md'nin "E2E locator pitfalls" listesine ve `docs/agent-experience.md`'ye yazıldı. **Sürüm bump'ı yok** — yalnızca testler + docs/changelog (#965 emsali).

🤖 Generated with [Claude Code](https://claude.com/claude-code)