### PR TITLE
docs: session retrospective — mentee project visibility

### DIFF
--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -2564,3 +2564,54 @@ projesi olan satırda proje sahibi, projesi olmayan satırda *yazan kişi*. Atan
 `smoke.spec.ts:53` bu değişiklikle birlikte kırmızı geldi; stash'leyip tekrar koşmak ikisinin de
 değişiklikten önce de kırmızı olduğunu 1 dakikada gösterdi (yerelde tohumlanmış admin/dev sunucusu
 kaynaklı). Suçlu aramaya girişmeden önce taban çizgisini ölç.
+
+## 2026-08-06 — "Mentee projesini göremiyor": yetki değil, bağlantı eksikliği (0.49.0-beta)
+
+**Bir "göremiyorum" şikâyetinde önce yetki katmanını değil, oraya giden bağlantıyı ara.** Bu
+oturumun tamamı `authzScope.ts`'de bir hata aramakla geçebilirdi; oysa `MENTEE` scope'u projeyi
+zaten döndürüyordu ve `/projects/[id]` üye olan mentee'ye zaten içeriden görünümü veriyordu. Eksik
+olan tek şey **linkti**: `PortalNav`'da girdi yok, panelin ilişki sorgusunda `project` seçilmiyor,
+ve tek liste sayfası olan `/projects` `isPublic: true` vitrini. Üç ayrı yerde "yok", tek bir yerde
+"yasak" değil. Teşhis sırası işe yaradı: (1) veri modeli, (2) API scope'u, (3) sayfanın gating'i,
+(4) *sayfaya giden link*. Dördüncüsü en sık atlanan ve bu sefer tek suçlu olan basamaktı.
+
+**Üyelik iki kaynaktan geliyorsa, yeni yazdığın her sorgu ikisini de okumak zorunda.** `mergeTeam`
+zaten `ProjectMember` ∪ `MentorshipRelation.projectId` birleşimini yapıyordu, ama yeni bir liste
+yazarken yalnızca birine bakmak çok kolay — pre-#617 atamalarını görünmez yapan hata tam olarak bu.
+Bu yüzden `lib/menteeProjects.ts` tek bir yardımcı olarak yazıldı ve hem sayfa hem panel onu
+kullanıyor; e2e testi de iki kaynağı ayrı ayrı tohumluyor.
+
+**Panel kartını `activeRelation` bloğunun içine koymak, düzelttiğin hatayı tekrar üretmek olurdu.**
+Bir mentee ilişkisi olmadan da `ProjectMember` olabiliyor; kartı o dalın içine koymak "mentoru
+olmayan mentee projesini görmez" diye yeni bir kör nokta açacaktı. Koşulu yazarken "bu veriyi
+görebilecek en dar durum hangisi?" diye sormak gerekti.
+
+**Geri linki de bir görünürlük yüzeyi.** Detay sayfasındaki geri linki mentee'yi `/projects`'e,
+yani projesinin *bulunmadığı* vitrine gönderiyordu. Sayfayı erişilebilir yapmak yeterli değil;
+oradan çıkış yolunun da aynı kapsamı bilmesi gerekiyor.
+
+**Repo'nun içine yerleşmiş bir git worktree'de `npm run lint` çalışmıyor.** Worktree
+`<repo>/.claude/worktrees/...` altında olduğu için ESLint yukarı yürüyüp *iki* `.eslintrc.json`
+buluyor ve `@next/next` eklentisini tekil olarak çözemediği için hata veriyor — hiç
+dokunulmamış dosyada da aynı şekilde patlıyor, yani diff'le ilgisi yok. Taban çizgisini ölçmek
+(`npx eslint src/lib/version.ts`) 30 saniyede ayırt etti. Değişen dosyaları gerçekten denetlemek
+için: `npx eslint --no-eslintrc -c .eslintrc.json --resolve-plugins-relative-to . <dosyalar>`.
+CI düz bir checkout'ta lint'lediği için orada sorun yok — nitekim "Lint · Typecheck · Build" yeşil
+geçti.
+
+**Playwright ve `node <script>.mjs`, `.env`'i kendiliğinden okumaz.** `playwright.config.ts`
+dotenv yüklemiyor (CI'da değişken gerçek env olarak geliyor), bu yüzden yerelde
+`DATABASE_URL=... npx playwright test ...` diye vermek gerekiyor; tek dosyalık script'ler için
+`node --env-file=.env ...` iş görüyor. Ayrıca ESM çözümlemesi *dosyanın* konumuna baktığı için
+scratchpad'e yazılan bir `.mjs` worktree'nin `node_modules`'ünü göremiyor — script'i worktree
+içine koyup sonra silmek gerekti.
+
+**Browser panelinin viewport'u 0×0 gelirse `read_page`/screenshot boş döner ama sayfa aslında
+yüklüdür** (`javascript_tool` ile `document.body.innerText.length` bunu hemen gösteriyor).
+`resize_window` düzeltmedi; doğrulamayı Playwright'a taşımak hem daha hızlı hem daha güçlü kanıt
+oldu — zaten yazılması gereken e2e testi görsel kontrolün yerini fazlasıyla aldı.
+
+**Karanlık modda `bg-*-50` kutu + `text-gray-900` metni varsayarak "kırık" demeyin, ölçün.**
+`globals.css`'teki mevcut override'lar `text-gray-900`'ü kutu içinde `rgb(243,244,246)`'ya
+çeviriyor; hesaplanan değeri mevcut mentor kutusuyla karşılaştırmak yeni bir compound kurala
+gerek olmadığını kanıtladı. Kontrast tahmininde `getComputedStyle` gözden hızlıdır.


### PR DESCRIPTION
Standing instruction (CLAUDE.md § End-of-session retrospective): a dated entry in [`docs/agent-experience.md`](docs/agent-experience.md) after the work in #1117.

Docs only — no version bump (per the CLAUDE.md carve-out for pure-docs changes).

What it records:

- **Diagnosis order for a "cannot see it" report**: data model → API scope → page gating → *the link that reaches the page*. The fourth step was the only culprit in #1116, and it is the one most easily skipped.
- **A two-source membership needs both sources read.** `mergeTeam` already unioned `ProjectMember` and the legacy `MentorshipRelation.projectId`; any new query that reads only one reproduces the original invisibility bug.
- **Placing a card inside the `activeRelation` branch would have re-created the bug** for a member without a relation.
- **The back link is a visibility surface too** — making a page reachable is not enough if the way out points at a scope that excludes it.
- **`npm run lint` cannot run in a git worktree nested inside the repo** (two `.eslintrc.json` files, `@next/next` not uniquely resolvable; fails on untouched files too). Includes the baseline check and the `--no-eslintrc -c … --resolve-plugins-relative-to .` invocation that does work.
- **Playwright and plain `node script.mjs` do not load `.env`**, plus the ESM detail that a script in a scratchpad directory cannot resolve the worktree's `node_modules`.
- **A 0×0 browser-pane viewport returns an empty `read_page` while the page is actually loaded**; moving verification to Playwright was both faster and stronger evidence.
- **Measure dark-mode contrast instead of assuming it**: `getComputedStyle` showed the existing `globals.css` overrides already handled `text-gray-900` on a retinted `bg-blue-50`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)