### PR TITLE
fix(landing): send mentor CTAs to the application form, drop the mailto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.49.2-beta] - 2026-08-06
+
+### Changed
+- **The landing page no longer offers an email address for mentor applications.** Both mentor
+  CTAs on `/` — the button at the end of the mentor section (`audMentorCta`) and the "Apply as
+  a mentor" button in the closing CTA band (`ctaMentor`) — were `mailto:` links built from the
+  `supportEmail` setting; they now link to the public application form at `/apply-as-mentor`,
+  the same destination as the hero's "Want to become a mentor?" link. The mentor-section button
+  used to disappear entirely when no support address was configured (`{mentorHref && …}`) and
+  the CTA-band button fell back to the `#mentor` anchor — both now always render and always go
+  to the form. The company CTA keeps its `mailto:` (that door is still hand-run, #1102), so
+  `supportEmail` is still read on the page.
+
 ## [0.49.1-beta] - 2026-08-06
 
 ### Changed

--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -2678,3 +2678,24 @@ oldu — zaten yazılması gereken e2e testi görsel kontrolün yerini fazlasıy
 `globals.css`'teki mevcut override'lar `text-gray-900`'ü kutu içinde `rgb(243,244,246)`'ya
 çeviriyor; hesaplanan değeri mevcut mentor kutusuyla karşılaştırmak yeni bir compound kurala
 gerek olmadığını kanıtladı. Kontrast tahmininde `getComputedStyle` gözden hızlıdır.
+
+## 2026-08-06 — Form geldiğinde eski kapıyı kapatmak (#1124, 0.49.2-beta)
+
+**Bir özellik shipleyince onun *yerini aldığı* geçici çözüm kendiliğinden kaybolmuyor.** Public
+mentör başvuru formu (#905) haftalar önce canlıya çıkmıştı; ana sayfada hero linki forma
+gidiyordu ama mentör bölümündeki ve kapanış CTA bandındaki iki buton hâlâ
+`mailto:<supportEmail>` idi. Sonuç: ziyaretçinin gördüğü üç mentör CTA'sından ikisi başvuruyu
+inceleme kuyruğuna hiç düşürmüyordu. Yeni bir giriş yüzeyi eklerken "aynı işi yapan eski
+yüzeyler nerede?" diye `grep -rn "mailto"` çekmek 30 saniyelik iş — PR'ın kendisinde yapılmalıydı.
+
+**Kaldırmadan önce "bu koşullu render neden var?" diye sor.** Buton `{mentorHref && …}` ile
+sarılıydı; gerekçe koddaki yorumda yazıyordu ("adres tanımlı değilse buton hiç çıkmasın, yanlış
+butondan iyidir"). Hedef `/apply-as-mentor` olunca bu koşul anlamsızlaşıyor — koşulu da
+kaldırmak, sadece `href`'i değiştirmekten daha doğru sonuç verdi (destek adresi boş olan bir
+kurulumda mentör butonu artık kayıp değil). Yorumu da güncellemek gerekti; eskisi "mentör kapısı
+elle yürüyor" diyordu ve artık yanlış.
+
+**`data-testid` tekilliği, CTA'yı çoğaltırken hatırlanacak şey.** `become-mentor-link`
+hero'daki linkte ve `/auth/signin`'de duruyor, smoke testi ona bakıyor. Aynı testid'i "tutarlılık
+olsun" diye yeni butona da eklemek strict-mode ihlali üretirdi; testid'i tek yerde bırakıp yeni
+butonu testid'siz geçmek doğrusuydu.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.49.1-beta",
+  "version": "0.49.2-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "author": "Mehmet Erşahin",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,16 +26,15 @@ export default async function HomePage() {
   const { locale, t } = await getServerDictionary();
   const L = t.landing;
 
-  // The mentor and company doors are still hand-run (the public mentor
-  // application form is #905, the company page #1102). Rather than send those
-  // visitors to /auth/register — which would sign a mentor up as a mentee —
-  // the CTA is an email to whoever runs the program, and simply does not
-  // render when no address is configured. A missing button beats a wrong one.
+  // Mentors now have a real door: the public application form (#905) reviewed
+  // in /admin/mentor-applications — no mailto anywhere. The company door is
+  // still hand-run (#1102), so that CTA remains an email to whoever runs the
+  // program and simply does not render when no address is configured. A
+  // missing button beats a wrong one.
   const contactEmail = (await getSetting('supportEmail')).trim();
-  const mailto = (subject: string) =>
-    contactEmail ? `mailto:${contactEmail}?subject=${encodeURIComponent(subject)}` : null;
-  const mentorHref = mailto(L.ctaMentor);
-  const companyHref = mailto(L.ctaCompany);
+  const companyHref = contactEmail
+    ? `mailto:${contactEmail}?subject=${encodeURIComponent(L.ctaCompany)}`
+    : null;
 
   // Fed from the single-source catalogue (#584/#588): the landing shows the
   // featured subset; /features shows everything.
@@ -326,13 +325,11 @@ export default async function HomePage() {
           {audienceList(mentorItems)}
           <p className="mt-8 text-sm text-gray-700 text-center">{L.audMentorTrust}</p>
           <p className="mt-6 text-sm text-gray-600 bg-white border border-gray-200 rounded-xl p-5 leading-relaxed">{L.audMentorProof}</p>
-          {mentorHref && (
-            <div className="mt-8 flex justify-center">
-              <a href={mentorHref} className="inline-flex items-center justify-center gap-2 bg-blue-600 text-white px-7 py-3.5 rounded-xl font-semibold hover:bg-blue-700 transition-colors">
-                {L.audMentorCta} <ArrowRight className="h-5 w-5 flex-shrink-0" />
-              </a>
-            </div>
-          )}
+          <div className="mt-8 flex justify-center">
+            <Link href="/apply-as-mentor" className="inline-flex items-center justify-center gap-2 bg-blue-600 text-white px-7 py-3.5 rounded-xl font-semibold hover:bg-blue-700 transition-colors">
+              {L.audMentorCta} <ArrowRight className="h-5 w-5 flex-shrink-0" />
+            </Link>
+          </div>
           <p className="mt-3 text-center text-xs text-gray-500 max-w-xl mx-auto">{L.audMentorCtaNote}</p>
         </div>
       </section>
@@ -540,12 +537,12 @@ export default async function HomePage() {
             <Link href="/auth/register" className="inline-flex items-center justify-center gap-2 bg-white text-blue-700 px-7 py-3.5 rounded-xl font-semibold hover:bg-blue-50 transition-colors dark:!bg-white dark:!text-blue-700 dark:hover:!bg-blue-100">
               {L.ctaMentee} <ArrowRight className="h-5 w-5" />
             </Link>
-            <a
-              href={mentorHref ?? '#mentor'}
+            <Link
+              href="/apply-as-mentor"
               className="inline-flex items-center justify-center gap-2 border-2 border-white/60 text-white px-7 py-3.5 rounded-xl font-semibold hover:bg-white/10 transition-colors"
             >
               <Users className="h-5 w-5" /> {L.ctaMentor}
-            </a>
+            </Link>
             <a
               href={companyHref ?? '#company'}
               className="inline-flex items-center justify-center gap-2 border-2 border-white/60 text-white px-7 py-3.5 rounded-xl font-semibold hover:bg-white/10 transition-colors"

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,21 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.49.2-beta',
+    date: '2026-08-06',
+    highlights: {
+      en: [
+        'Becoming a mentor is one route now: the application form. The two buttons on the home page that used to open your email client instead go to the same short form as the "Apply here" link at the top — no more writing an email and waiting to hear back. They also always show up, even when no support address is configured.',
+      ],
+      tr: [
+        'Mentor olmanın tek bir yolu var artık: başvuru formu. Ana sayfada e-posta programını açan iki buton, en üstteki “Buradan başvur” bağlantısıyla aynı kısa forma gidiyor — e-posta yazıp cevap beklemek yok. Ayrıca destek adresi tanımlı olmasa da bu butonlar her zaman görünüyor.',
+      ],
+      de: [
+        'Mentor wirst du jetzt nur noch über einen Weg: das Bewerbungsformular. Die beiden Buttons auf der Startseite, die bisher dein E-Mail-Programm geöffnet haben, führen zum selben kurzen Formular wie der Link „Hier bewerben“ ganz oben — keine E-Mail mehr schreiben und auf Antwort warten. Außerdem sind sie immer sichtbar, auch ohne hinterlegte Support-Adresse.',
+      ],
+    },
+  },
+  {
     version: '0.49.1-beta',
     date: '2026-08-06',
     highlights: {


### PR DESCRIPTION
## Summary

The landing page offered two different ways to become a mentor: the hero link to the public application form (`/apply-as-mentor`, #905) and two buttons that opened the visitor's mail client (`mailto:<supportEmail>`). The mailto was the stopgap from before the form shipped — now it just sends people down a path that never reaches the review queue. Removed it; the form is the only mentor door.

Closes #1124

## Changes

- `src/app/page.tsx`
  - the mentor-section button (`audMentorCta`) now links to `/apply-as-mentor` and **always** renders — it used to be hidden entirely when no support address was configured (`{mentorHref && …}`)
  - the "Apply as a mentor" button in the closing CTA band (`ctaMentor`) now links to `/apply-as-mentor` instead of a mailto with a `#mentor` anchor fallback
  - dropped the `mailto()` helper and `mentorHref`; the company CTA keeps its mailto (that door is still hand-run, #1102), so `supportEmail` is still read on the page
  - updated the comment above it so it no longer claims the mentor door is hand-run
- Version `0.49.2-beta` + `CHANGELOG.md` entry + `src/lib/releaseNotes.ts` entry (EN/TR/DE)

No copy changes: `audMentorCtaNote` ("you fill in a short form and we open your account…") already described the form flow, and the hero's `becomeMentor` / `becomeMentorLink` strings are untouched, so the `become-mentor-link` e2e assertions still hold.

## Verification

- [x] `npm run lint` + `npx tsc --noEmit` clean (only the pre-existing warnings in `admin/companies`, `admin/mentorship`, `MessageThreadView`)
- [x] `npm run check:i18n` clean — 2082 keys × 3 locales
- [ ] `npm run test:e2e` passing (or CI green) — relying on CI; no local DB in this container
- [x] Reviewed the diff; the existing `mentor-application-review.spec.ts` smoke test covers the landing → form link

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7CdvWNJEEtdWnjcMr9ufp)_