### PR TITLE
fix: let a mentor turn a placeholder mentee into a real account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,44 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.49.2-beta] - 2026-08-06
+
+Closes #1123.
+
+### Fixed
+- **A mentee added by a mentor can now become a real account.** A mentee created without an
+  e-mail got a generated `mentee.<name>.<hex>@import.local` address and the sentinel
+  `!created-no-login` in the password column — never a bcrypt hash, so `bcrypt.compare` could
+  never match and the record could not sign in. Every recovery path was a dead end:
+  `/api/auth/forgot` and `/api/admin/users/[id]/reset-password` only *mail* a link, and that
+  mail went to a domain that does not exist; no endpoint could change the address
+  (`/api/users/[id]` PATCH never accepted `email`, and `/api/account` PATCH requires the
+  account's own session plus `currentPassword`); and registering with the real address created
+  a second, unrelated user, orphaning the interaction log and stage history. The only way out
+  was deleting the record or editing the DB by hand.
+
+### Added
+- **`PATCH /api/mentor/mentees/[id]`** — sets the real e-mail on a mentee record and issues a
+  `SET_INITIAL` password token, mailing the activation link (and returning it, like
+  `POST /api/mentor/mentees` already does, so the mentor can pass it on when SMTP is down).
+  Allowed for the assigned mentor or an admin. Guards: target must be a `MENTEE`; the record
+  must still carry a no-login sentinel (`!created-no-login` / `!imported-no-login`) — once
+  someone has set a password the address is theirs and only they can change it, via
+  `/api/account`; `@import.local` / `@erased.local` are rejected as new addresses; erased or
+  deactivated records are refused; e-mail uniqueness is enforced (409); rate-limited to 20 per
+  15 min; every call writes a `mentee.activation_link_sent` activity row at warning level.
+  Sending with the address unchanged doubles as "resend the activation link".
+- **`MenteeActivationPanel`** (`src/components/MenteeActivationPanel.tsx`) — shown on the
+  mentor's mentee detail page and the admin candidate page whenever the record has no password
+  yet, driven by a new `pendingActivation` flag on `GET /api/mentorship/[id]` and
+  `GET /api/users/[id]` (derived server-side; the password column is destructured out before
+  the response). New `menteeActivation` i18n block (EN/TR/DE).
+- **`src/lib/menteeAccount.ts`** — single home for the no-login sentinels and the placeholder /
+  erased e-mail domains, previously inline string literals in the create route.
+- **`e2e/mentee-activation.spec.ts`** — the full path (create without e-mail → activate → the
+  mentee sets a password and signs in, on the same row with its relation intact) plus the
+  refusals: already has a password (409), placeholder domain (400), foreign mentor (403).
+
 ## [0.49.1-beta] - 2026-08-06
 
 ### Changed

--- a/e2e/mentee-activation.spec.ts
+++ b/e2e/mentee-activation.spec.ts
@@ -1,0 +1,151 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { signInAndSettle, signInAsFreshUser, gotoSettled } from './helpers/auth';
+
+/**
+ * A mentee a mentor adds without an e-mail gets a generated `@import.local`
+ * address and a sentinel password, so the record can never sign in and no reset
+ * mail can reach it. #1123 gives that record a way out: the mentor sets the real
+ * address on the *existing* row and the mentee gets an activation link.
+ */
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('a mentor can turn a placeholder mentee into an account that signs in', async ({ page }) => {
+  const mentorEmail = uniqueEmail('activate-mentor');
+  const menteeEmail = uniqueEmail('activate-mentee');
+  const mentorPw = 'MentorPass123!';
+  const menteePw = 'MenteeChosen456!';
+  const menteeName = `ZZ Activation Mentee ${Date.now()}`;
+  const mentor = await seedUser(mentorEmail, mentorPw, 'MENTOR', 'Activation Mentor');
+  let menteeId: string | null = null;
+
+  try {
+    await signInAndSettle(page, mentorEmail, mentorPw, '/mentor');
+
+    // Create a mentee WITHOUT an e-mail — the tracking-only case.
+    await gotoSettled(page, '/mentor/mentees/new');
+    await page.getByLabel(/Full Name/).fill(menteeName);
+    const created = page.waitForResponse(
+      (r) => r.url().includes('/api/mentor/mentees') && r.request().method() === 'POST'
+    );
+    await page.getByRole('button', { name: 'Create' }).click();
+    await created;
+
+    const mentee = await prisma.user.findFirst({ where: { fullName: menteeName, role: 'MENTEE' } });
+    expect(mentee).not.toBeNull();
+    menteeId = mentee!.id;
+    expect(mentee!.email).toContain('@import.local');
+
+    const relation = await prisma.mentorshipRelation.findFirst({
+      where: { mentorId: mentor.id, menteeId: mentee!.id },
+    });
+    expect(relation).not.toBeNull();
+
+    // The detail page offers the way in.
+    await gotoSettled(page, `/mentor/mentees/${relation!.id}`);
+    const panel = page.getByTestId('mentee-activation-panel');
+    await expect(panel).toBeVisible({ timeout: 15_000 });
+
+    await page.getByTestId('mentee-activation-email').fill(menteeEmail);
+    const patched = page.waitForResponse(
+      (r) => r.url().includes(`/api/mentor/mentees/${mentee!.id}`) && r.request().method() === 'PATCH'
+    );
+    await page.getByTestId('mentee-activation-submit').click();
+    expect((await patched).status()).toBe(200);
+
+    // Same row, real address — the record and its history are not replaced.
+    const updated = await prisma.user.findUnique({ where: { id: mentee!.id } });
+    expect(updated!.email).toBe(menteeEmail);
+    expect(await prisma.mentorshipRelation.count({ where: { menteeId: mentee!.id } })).toBe(1);
+
+    // The activation link is shown so the mentor can pass it on if mail is down.
+    const link = await page.getByTestId('mentee-activation-link').locator('input[readonly]').inputValue();
+    expect(link).toContain('/auth/reset?token=');
+    const token = new URL(link).searchParams.get('token')!;
+    const tokenRow = await prisma.passwordResetToken.findUnique({ where: { token } });
+    expect(tokenRow?.purpose).toBe('SET_INITIAL');
+    expect(tokenRow?.userId).toBe(mentee!.id);
+
+    // The mentee sets a password and signs in — the whole point of the fix.
+    await page.goto(`/auth/reset?token=${token}`);
+    await page.getByLabel(/New password/).fill(menteePw);
+    await page.getByLabel(/Confirm Password/i).fill(menteePw);
+    const done = page.waitForResponse(
+      (r) => r.url().includes('/api/auth/reset') && r.request().method() === 'POST'
+    );
+    await page.getByRole('button', { name: /Update password/ }).click();
+    await done;
+    await page.waitForURL((u) => u.pathname.startsWith('/auth/signin'), { timeout: 20_000 });
+
+    await signInAsFreshUser(page, menteeEmail, menteePw, '/portal');
+  } finally {
+    if (menteeId) {
+      await prisma.mentorshipRelation.deleteMany({ where: { menteeId } });
+      await prisma.user.delete({ where: { id: menteeId } }).catch(() => {});
+    }
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+  }
+});
+
+test('activation is refused for accounts with a password, placeholder domains and foreign mentors', async ({
+  page,
+}) => {
+  const mentorEmail = uniqueEmail('activate-guard-mentor');
+  const otherMentorEmail = uniqueEmail('activate-guard-other');
+  const activeMenteeEmail = uniqueEmail('activate-guard-mentee');
+  const pw = 'MentorPass123!';
+  const mentor = await seedUser(mentorEmail, pw, 'MENTOR', 'Guard Mentor');
+  await seedUser(otherMentorEmail, pw, 'MENTOR', 'Guard Other Mentor');
+  const activeMentee = await seedUser(activeMenteeEmail, 'MenteePass123!', 'MENTEE', 'Guard Active Mentee');
+  const placeholder = await prisma.user.create({
+    data: {
+      email: `mentee.guard.${Date.now()}@import.local`,
+      password: '!created-no-login',
+      role: 'MENTEE',
+      fullName: `ZZ Guard Placeholder ${Date.now()}`,
+      skills: [],
+    },
+  });
+  await prisma.mentorshipRelation.createMany({
+    data: [
+      { mentorId: mentor.id, menteeId: activeMentee.id },
+      { mentorId: mentor.id, menteeId: placeholder.id },
+    ],
+  });
+
+  try {
+    await signInAndSettle(page, mentorEmail, pw, '/mentor');
+
+    // Someone who already set a password owns their address — re-pointing it and
+    // mailing yourself a set-password link would be account takeover.
+    const hijack = await page.request.patch(`/api/mentor/mentees/${activeMentee.id}`, {
+      data: { email: uniqueEmail('activate-hijack') },
+    });
+    expect(hijack.status()).toBe(409);
+    expect((await prisma.user.findUnique({ where: { id: activeMentee.id } }))!.email).toBe(activeMenteeEmail);
+
+    // The stand-in domain is not a mailbox — accepting it would recreate the bug.
+    const fake = await page.request.patch(`/api/mentor/mentees/${placeholder.id}`, {
+      data: { email: 'still.not.real@import.local' },
+    });
+    expect(fake.status()).toBe(400);
+
+    // A mentor the record isn't assigned to cannot touch it.
+    await signInAsFreshUser(page, otherMentorEmail, pw, '/mentor');
+    const foreign = await page.request.patch(`/api/mentor/mentees/${placeholder.id}`, {
+      data: { email: uniqueEmail('activate-foreign') },
+    });
+    expect(foreign.status()).toBe(403);
+    expect((await prisma.user.findUnique({ where: { id: placeholder.id } }))!.email).toContain('@import.local');
+  } finally {
+    await prisma.mentorshipRelation.deleteMany({ where: { menteeId: placeholder.id } });
+    await prisma.user.delete({ where: { id: placeholder.id } }).catch(() => {});
+    await cleanupByEmail(activeMenteeEmail);
+    await cleanupByEmail(otherMentorEmail);
+    await cleanupByEmail(mentorEmail);
+  }
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.49.1-beta",
+  "version": "0.49.2-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "author": "Mehmet Erşahin",

--- a/src/app/admin/candidates/[id]/page.tsx
+++ b/src/app/admin/candidates/[id]/page.tsx
@@ -21,6 +21,7 @@ import { DocumentsManager } from '@/components/DocumentsManager';
 import { UserActivityPanel } from '@/components/UserActivityPanel';
 import { CandidateEraseDangerZone } from '@/components/CandidateEraseDangerZone';
 import { AddInteractionForm } from '@/components/AddInteractionForm';
+import { MenteeActivationPanel } from '@/components/MenteeActivationPanel';
 import { useT, useLocale } from '@/i18n/client';
 import { useToast } from '@/components/ui/Toast';
 import { formatDate } from '@/lib/relativeTime';
@@ -59,6 +60,8 @@ interface MenteeDetail {
   graduationYear?: number;
   skills: string[];
   cvUrl?: string;
+  // No password set yet → the candidate cannot sign in (#1123).
+  pendingActivation?: boolean;
   menteeRelations: Relation[];
 }
 
@@ -299,6 +302,16 @@ export default function AdminMenteeDetailPage() {
           </div>
         </div>
       </div>
+
+      {/* A candidate typed in by a mentor (or imported) has no login yet — the
+          reset-password button above can't help, its mail goes to a stand-in
+          address. This is the way in (#1123). */}
+      <MenteeActivationPanel
+        menteeId={user.id}
+        email={user.email}
+        pending={user.role === 'MENTEE' && !!user.pendingActivation}
+        onUpdated={load}
+      />
 
       {resetSent !== null && (
         <div

--- a/src/app/api/mentor/mentees/[id]/route.ts
+++ b/src/app/api/mentor/mentees/[id]/route.ts
@@ -1,0 +1,136 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { z } from 'zod';
+import { enforceRateLimit } from '@/lib/rateLimit';
+import { createPasswordResetToken } from '@/lib/passwordReset';
+import { sendPasswordResetEmail } from '@/services/emailService';
+import { withTenantScope } from '@/lib/orgContext';
+import { logActivity } from '@/lib/activity';
+import { isErasedAccount, isPendingActivation, isUnusableEmail } from '@/lib/menteeAccount';
+
+const schema = z.object({ email: z.string().email() });
+
+// PATCH — set the real e-mail on a mentee record and send the activation link.
+//
+// A mentee a mentor added by hand (or a CSV import) has no password and often a
+// generated `@import.local` address, so it can never sign in and no reset mail
+// can reach it. Once the mentor learns the real address this promotes the
+// existing record — with its interaction log and stage history — into a real
+// account, instead of the only alternatives available before (#1123): delete
+// and re-create, or register a second, unrelated user.
+//
+// Re-sending with the address unchanged is allowed, so the same action doubles
+// as "the mail never arrived, send it again".
+export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params;
+    const session = await getServerSession(authOptions);
+    if (!session || (session.user.role !== 'MENTOR' && session.user.role !== 'ADMIN')) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    // The endpoint sends mail to an address chosen by the caller, so it is
+    // bounded even though the caller is authenticated.
+    const limited = enforceRateLimit(request, 'mentee-activation', { limit: 20, windowMs: 15 * 60 * 1000 });
+    if (limited) return limited;
+
+    return await withTenantScope(session, async () => {
+      const parsed = schema.safeParse(await request.json());
+      if (!parsed.success) {
+        return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 });
+      }
+      // Normalized the same way registration and sign-in normalize, so the
+      // account can actually be found again afterwards.
+      const email = parsed.data.email.trim().toLowerCase();
+      if (isUnusableEmail(email)) {
+        return NextResponse.json({ error: 'That address is a placeholder, not a real mailbox' }, { status: 400 });
+      }
+
+      const mentee = await prisma.user.findUnique({
+        where: { id },
+        select: { id: true, email: true, fullName: true, role: true, password: true, isActive: true, orgId: true },
+      });
+      if (!mentee || mentee.role !== 'MENTEE') {
+        return NextResponse.json({ error: 'Mentee not found' }, { status: 404 });
+      }
+
+      // A mentor may only touch their own mentee; an admin any mentee in scope.
+      if (session.user.role !== 'ADMIN') {
+        const relation = await prisma.mentorshipRelation.findFirst({
+          where: { mentorId: session.user.id, menteeId: mentee.id },
+          select: { id: true },
+        });
+        if (!relation) {
+          return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+        }
+      }
+
+      // The whole point of the guard: once someone has set a password, the
+      // address is *theirs*. Letting a mentor re-point it at a mailbox they
+      // control, then mailing themselves a set-password link, would be account
+      // takeover. Those users change their own e-mail via /api/account, which
+      // re-authenticates them first.
+      if (!isPendingActivation(mentee)) {
+        return NextResponse.json(
+          { error: 'This mentee already has a password; only they can change their e-mail' },
+          { status: 409 }
+        );
+      }
+      // Erased records keep the sentinel password but must stay erased.
+      if (isErasedAccount(mentee) || !mentee.isActive) {
+        return NextResponse.json({ error: 'This account is not active' }, { status: 409 });
+      }
+
+      const changingEmail = email !== mentee.email;
+      if (changingEmail) {
+        const taken = await prisma.user.findUnique({ where: { email }, select: { id: true } });
+        if (taken) {
+          return NextResponse.json({ error: 'A user with this email already exists' }, { status: 409 });
+        }
+        await prisma.user.update({ where: { id: mentee.id }, data: { email } });
+      }
+
+      const token = await createPasswordResetToken(mentee.id, 'SET_INITIAL');
+      const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+      const setPasswordUrl = `${appUrl}/auth/reset?token=${token}`;
+      let emailSent = true;
+      try {
+        await sendPasswordResetEmail({
+          to: email,
+          token,
+          fullName: mentee.fullName,
+          purpose: 'SET_INITIAL',
+          orgId: mentee.orgId,
+        });
+      } catch (e) {
+        console.error('Mentee activation email failed:', e);
+        emailSent = false;
+      }
+
+      // Returning the link is what #875 removed from the *admin reset* endpoint,
+      // and deliberately not the same thing: there the target is a live account
+      // whose owner reads their own mailbox, so handing the token to a third
+      // party is takeover. Here the record has never been an account — the same
+      // link is already returned when the mentor creates a mentee with a real
+      // address (POST /api/mentor/mentees) — so there is nothing to take over,
+      // and the mentor needs a way through when SMTP is down.
+      await logActivity({
+        action: 'mentee.activation_link_sent',
+        level: 'warning',
+        actorId: session.user.id,
+        actorEmail: session.user.email ?? null,
+        targetType: 'user',
+        targetId: mentee.id,
+        detail: changingEmail ? `${mentee.email} → ${email}` : `resent to ${email}`,
+        request,
+      });
+
+      return NextResponse.json({ ok: true, email, emailSent, setPasswordUrl });
+    });
+  } catch (error) {
+    console.error('Mentee activation error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/mentor/mentees/route.ts
+++ b/src/app/api/mentor/mentees/route.ts
@@ -10,6 +10,7 @@ import { slugify } from '@/lib/transliterate';
 import { checkActiveRelationLimit, planLimitError } from '@/lib/planGate';
 import { resolveOrgId } from '@/lib/orgScope';
 import { withTenantScope } from '@/lib/orgContext';
+import { NO_LOGIN_PASSWORD, PLACEHOLDER_EMAIL_DOMAIN } from '@/lib/menteeAccount';
 
 const schema = z.object({
   fullName: z.string().min(1),
@@ -38,10 +39,12 @@ export async function POST(request: Request) {
 
       // A real email means the mentee can be invited to set a password and log in.
       // No email → a deterministic placeholder for a tracking-only mentee (no login).
+      // Not a dead end: once the mentor learns the real address, PATCH on this
+      // route's [id] child fixes it and sends the activation link (#1123).
       const hasRealEmail = !!(email && email.length > 0);
       const finalEmail = hasRealEmail
-        ? email!
-        : `mentee.${slugify(fullName)}.${crypto.randomBytes(2).toString('hex')}@import.local`;
+        ? email!.trim().toLowerCase()
+        : `mentee.${slugify(fullName)}.${crypto.randomBytes(2).toString('hex')}@${PLACEHOLDER_EMAIL_DOMAIN}`;
 
       const existing = await prisma.user.findUnique({ where: { email: finalEmail } });
       if (existing) {
@@ -60,7 +63,7 @@ export async function POST(request: Request) {
       const mentee = await prisma.user.create({
         data: {
           email: finalEmail,
-          password: '!created-no-login',
+          password: NO_LOGIN_PASSWORD,
           role: 'MENTEE',
           fullName,
           orgId,

--- a/src/app/api/mentorship/[id]/route.ts
+++ b/src/app/api/mentorship/[id]/route.ts
@@ -8,6 +8,7 @@ import { logActivity } from '@/lib/activity';
 import { notify } from '@/lib/notify';
 import { dispatchWebhook } from '@/lib/webhooks';
 import { withTenantScope } from '@/lib/orgContext';
+import { isPendingActivation } from '@/lib/menteeAccount';
 
 const updateRelationSchema = z.object({
   status: z.enum(['ACTIVE', 'COMPLETED']).optional(),
@@ -40,6 +41,9 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
               id: true,
               fullName: true,
               email: true,
+              // Only to derive `pendingActivation` below — destructured out
+              // before the response so the column never reaches a client.
+              password: true,
               university: true,
               graduationYear: true,
               skills: true,
@@ -81,7 +85,18 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
           })
         : null;
 
-      return NextResponse.json({ relation: { ...relation, companyInterest } });
+      // A mentee the mentor typed in has a sentinel where the hash goes and can
+      // never sign in; the detail page offers to fix the address and send the
+      // activation link (#1123). The sentinel itself stays server-side.
+      const { password: menteePassword, ...mentee } = relation.mentee;
+
+      return NextResponse.json({
+        relation: {
+          ...relation,
+          mentee: { ...mentee, pendingActivation: isPendingActivation({ password: menteePassword }) },
+          companyInterest,
+        },
+      });
     });
   } catch (error) {
     console.error('Get mentorship error:', error);

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { logActivity } from '@/lib/activity';
 import { withTenantScope } from '@/lib/orgContext';
+import { isPendingActivation } from '@/lib/menteeAccount';
 
 export async function GET(_request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
@@ -21,6 +22,9 @@ export async function GET(_request: Request, { params }: { params: Promise<{ id:
           email: true,
           fullName: true,
           role: true,
+          // Only to derive `pendingActivation` below — destructured out before
+          // the response so the column never reaches a client.
+          password: true,
           phone: true,
           whatsapp: true,
           city: true,
@@ -72,7 +76,14 @@ export async function GET(_request: Request, { params }: { params: Promise<{ id:
         return NextResponse.json({ error: 'User not found' }, { status: 404 });
       }
 
-      return NextResponse.json({ user });
+      // A mentee record typed in by a mentor (or imported) has a sentinel where
+      // the hash goes and can never sign in — the candidate page offers to fix
+      // the address and send the activation link (#1123).
+      const { password, ...rest } = user;
+
+      return NextResponse.json({
+        user: { ...rest, pendingActivation: isPendingActivation({ password }) },
+      });
     });
   } catch (error) {
     console.error('Get user error:', error);

--- a/src/app/mentor/mentees/[id]/page.tsx
+++ b/src/app/mentor/mentees/[id]/page.tsx
@@ -28,6 +28,7 @@ import { formatDate, formatDateTime } from '@/lib/relativeTime';
 import { Textarea } from '@/components/ui/Textarea';
 import { TEXT_LIMITS } from '@/lib/textLimits';
 import { cvViewHref } from '@/lib/cvLink';
+import { MenteeActivationPanel } from '@/components/MenteeActivationPanel';
 
 interface InteractionLog {
   id: string;
@@ -56,6 +57,8 @@ interface RelationDetail {
     birthDate?: string;
     referralSource?: string;
     cvUrl?: string;
+    // No password set yet → the mentee cannot sign in (#1123).
+    pendingActivation?: boolean;
   };
   company: { name: string; industry?: string } | null;
   companyInterest?: { status: 'INTERESTED' | 'SHORTLISTED' | 'PASS'; note?: string | null } | null;
@@ -206,6 +209,14 @@ export default function MenteeDetailPage() {
           </div>
         </div>
       </div>
+
+      {/* A mentee typed in by hand has no login yet — offer the way in (#1123). */}
+      <MenteeActivationPanel
+        menteeId={relation.mentee.id}
+        email={relation.mentee.email}
+        pending={!!relation.mentee.pendingActivation}
+        onUpdated={fetchRelation}
+      />
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* Mentee info */}

--- a/src/components/MenteeActivationPanel.tsx
+++ b/src/components/MenteeActivationPanel.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { useState } from 'react';
+import { KeyRound } from 'lucide-react';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { useToast } from '@/components/ui/Toast';
+import { useT } from '@/i18n/client';
+
+const PLACEHOLDER_DOMAIN = '@import.local';
+
+/**
+ * Turns a mentee *record* into a real account (#1123).
+ *
+ * A mentee a mentor added by hand has no password and — when the mentor didn't
+ * know the address yet — a generated `@import.local` one, so they can't sign in
+ * and no reset mail can reach them. This panel is the way back: correct the
+ * address (or leave it, to just resend) and the mentee gets a set-password link
+ * on the existing record, keeping its interaction log and stage history.
+ *
+ * Rendered on both the mentor's mentee detail page and the admin candidate page;
+ * `pending` comes from `pendingActivation` on the respective API.
+ */
+export function MenteeActivationPanel({
+  menteeId,
+  email,
+  pending,
+  onUpdated,
+}: {
+  menteeId: string;
+  email: string;
+  pending: boolean;
+  onUpdated: () => void | Promise<void>;
+}) {
+  const t = useT();
+  const toast = useToast();
+  const isPlaceholder = email.toLowerCase().endsWith(PLACEHOLDER_DOMAIN);
+  // A generated address is nothing to edit — start empty so the mentor types
+  // the real one; a real-looking address is prefilled so "resend" is one click.
+  const [value, setValue] = useState(isPlaceholder ? '' : email);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [link, setLink] = useState<string | null>(null);
+  const [mailFailed, setMailFailed] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  if (!pending) return null;
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    setError('');
+    try {
+      const res = await fetch(`/api/mentor/mentees/${menteeId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: value }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || t.menteeActivation.failed);
+      setLink(data.setPasswordUrl ?? null);
+      setMailFailed(data.emailSent === false);
+      toast(t.menteeActivation.sent);
+      await onUpdated();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t.menteeActivation.failed);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div
+      data-testid="mentee-activation-panel"
+      className="mb-6 rounded-lg border border-amber-200 bg-amber-50 p-4"
+    >
+      <div className="flex items-start gap-2">
+        <KeyRound className="mt-0.5 h-4 w-4 shrink-0 text-amber-700" />
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-medium text-amber-900">{t.menteeActivation.title}</p>
+          <p className="mt-1 text-sm text-amber-800">
+            {isPlaceholder ? t.menteeActivation.placeholderNote : t.menteeActivation.noPasswordNote}
+          </p>
+
+          {error && <p className="mt-2 text-sm text-red-700">{error}</p>}
+
+          <form onSubmit={submit} className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-end">
+            <div className="w-full sm:max-w-sm">
+              <Input
+                label={t.menteeActivation.emailLabel}
+                data-testid="mentee-activation-email"
+                type="email"
+                required
+                value={value}
+                onChange={(ev) => setValue(ev.target.value)}
+              />
+            </div>
+            <Button type="submit" size="sm" loading={saving} data-testid="mentee-activation-submit">
+              {isPlaceholder ? t.menteeActivation.saveAndSend : t.menteeActivation.resend}
+            </Button>
+          </form>
+
+          {link && (
+            <div className="mt-3" data-testid="mentee-activation-link">
+              <p className="text-sm text-amber-800">
+                {mailFailed ? t.menteeActivation.mailFailedHint : t.menteeActivation.linkHint}
+              </p>
+              <div className="mt-2 flex items-center gap-2">
+                <input
+                  readOnly
+                  value={link}
+                  onFocus={(ev) => ev.target.select()}
+                  className="min-w-0 flex-1 rounded-lg border border-gray-300 bg-gray-50 px-3 py-2 text-sm text-gray-700"
+                />
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="secondary"
+                  onClick={() => {
+                    navigator.clipboard?.writeText(link);
+                    setCopied(true);
+                    setTimeout(() => setCopied(false), 2000);
+                  }}
+                >
+                  {copied ? t.menteeActivation.copied : t.menteeActivation.copyLink}
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -278,6 +278,22 @@ const en = {
     deleteEntry: 'Delete entry',
     nextAction: 'Next action',
   },
+  menteeActivation: {
+    title: 'No account yet',
+    placeholderNote:
+      'This mentee was added without an e-mail address, so they have a stand-in one and cannot sign in. Enter their real address to activate the account — the record, its interaction log and its stage history are kept.',
+    noPasswordNote:
+      'This mentee has not set a password yet. Correct the address if it is wrong, then send the activation link again.',
+    emailLabel: 'Real e-mail address',
+    saveAndSend: 'Save & send activation link',
+    resend: 'Send activation link',
+    sent: 'Activation link sent',
+    linkHint: 'We e-mailed a link to set a password. If it doesn’t arrive, share this link directly:',
+    mailFailedHint: 'The e-mail could not be sent. Share this link with the mentee directly:',
+    copyLink: 'Copy link',
+    copied: 'Copied!',
+    failed: 'Could not send the activation link',
+  },
   mentors: {
     title: 'Mentors',
     subtitle: 'All mentors on the platform',
@@ -2410,6 +2426,22 @@ const tr: Dict = {
     deleteEntry: 'Kaydı sil',
     nextAction: 'Sonraki aksiyon',
   },
+  menteeActivation: {
+    title: 'Henüz hesabı yok',
+    placeholderNote:
+      'Bu mentee e-posta adresi girilmeden eklendiği için geçici bir adresi var ve giriş yapamıyor. Gerçek adresini yazarak hesabı aktive edebilirsin — kayıt, etkileşim geçmişi ve aşama geçmişi korunur.',
+    noPasswordNote:
+      'Bu mentee henüz parola belirlemedi. Adres yanlışsa düzelt, sonra aktivasyon bağlantısını yeniden gönder.',
+    emailLabel: 'Gerçek e-posta adresi',
+    saveAndSend: 'Kaydet ve aktivasyon bağlantısı gönder',
+    resend: 'Aktivasyon bağlantısı gönder',
+    sent: 'Aktivasyon bağlantısı gönderildi',
+    linkHint: 'Parola belirleme bağlantısını e-postayla gönderdik. Ulaşmazsa bu bağlantıyı doğrudan paylaşabilirsin:',
+    mailFailedHint: 'E-posta gönderilemedi. Bu bağlantıyı mentee ile doğrudan paylaş:',
+    copyLink: 'Bağlantıyı kopyala',
+    copied: 'Kopyalandı!',
+    failed: 'Aktivasyon bağlantısı gönderilemedi',
+  },
   mentors: {
     title: 'Mentorlar',
     subtitle: 'Platformdaki tüm mentorlar',
@@ -4539,6 +4571,22 @@ const de: Dict = {
     addEntry: 'Eintrag hinzufügen',
     deleteEntry: 'Eintrag löschen',
     nextAction: 'Nächster Schritt',
+  },
+  menteeActivation: {
+    title: 'Noch kein Konto',
+    placeholderNote:
+      'Dieser Mentee wurde ohne E-Mail-Adresse angelegt, hat deshalb eine Platzhalteradresse und kann sich nicht anmelden. Trage die echte Adresse ein, um das Konto zu aktivieren — der Datensatz, das Interaktionsprotokoll und die Phasenhistorie bleiben erhalten.',
+    noPasswordNote:
+      'Dieser Mentee hat noch kein Passwort gesetzt. Korrigiere die Adresse, falls sie falsch ist, und sende den Aktivierungslink erneut.',
+    emailLabel: 'Echte E-Mail-Adresse',
+    saveAndSend: 'Speichern & Aktivierungslink senden',
+    resend: 'Aktivierungslink senden',
+    sent: 'Aktivierungslink gesendet',
+    linkHint: 'Wir haben einen Link zum Setzen des Passworts geschickt. Falls er nicht ankommt, teile diesen Link direkt:',
+    mailFailedHint: 'Die E-Mail konnte nicht gesendet werden. Teile diesen Link direkt mit dem Mentee:',
+    copyLink: 'Link kopieren',
+    copied: 'Kopiert!',
+    failed: 'Aktivierungslink konnte nicht gesendet werden',
   },
   mentors: {
     title: 'Mentoren',

--- a/src/lib/menteeAccount.ts
+++ b/src/lib/menteeAccount.ts
@@ -1,0 +1,59 @@
+/**
+ * Mentee records that are not (yet) accounts.
+ *
+ * A mentee a mentor types into the CRM is a *record* first: it is created with
+ * a sentinel in the password column — never a bcrypt hash, so `bcrypt.compare`
+ * can never match it — and, when the mentor doesn't know an address yet, a
+ * generated stand-in e-mail on a domain that doesn't exist.
+ *
+ * Such a row can never sign in, and every recovery path is a dead end: both
+ * `/api/auth/forgot` and `/api/admin/users/[id]/reset-password` only *mail* a
+ * link, and that mail goes to the stand-in address. Registering with the real
+ * address later creates a second, unrelated user, orphaning the interaction log
+ * and stage history the mentor built up (#1123).
+ *
+ * `isPendingActivation` marks exactly the rows that a mentor/admin may still
+ * correct and turn into a real login via `PATCH /api/mentor/mentees/[id]`.
+ */
+
+// Written by POST /api/mentor/mentees when a mentor adds a mentee by hand.
+export const NO_LOGIN_PASSWORD = '!created-no-login';
+// Written by scripts/import-csv.mjs for rows imported from the spreadsheet.
+export const IMPORTED_NO_LOGIN_PASSWORD = '!imported-no-login';
+
+const NO_LOGIN_PASSWORDS: readonly string[] = [NO_LOGIN_PASSWORD, IMPORTED_NO_LOGIN_PASSWORD];
+
+// Generated stand-in addresses (mentor form + CSV import) live on this domain.
+export const PLACEHOLDER_EMAIL_DOMAIN = 'import.local';
+// What `anonymizeUser` rewrites an erased account's address to.
+export const ERASED_EMAIL_DOMAIN = 'erased.local';
+
+const REJECTED_EMAIL_DOMAINS: readonly string[] = [PLACEHOLDER_EMAIL_DOMAIN, ERASED_EMAIL_DOMAIN];
+
+function domainOf(email: string) {
+  return email.split('@')[1]?.toLowerCase() ?? '';
+}
+
+/** The account has never had a password set, so nobody can sign in as it. */
+export function isPendingActivation(user: { password: string }) {
+  return NO_LOGIN_PASSWORDS.includes(user.password);
+}
+
+/** A generated stand-in address rather than a mailbox someone actually reads. */
+export function isPlaceholderEmail(email: string) {
+  return domainOf(email) === PLACEHOLDER_EMAIL_DOMAIN;
+}
+
+/**
+ * Addresses that must never be *typed in* as the real one: the stand-in domain
+ * (that's the state we're fixing) and the erasure domain (accepting it would
+ * let someone re-address a record straight into the anonymised namespace).
+ */
+export function isUnusableEmail(email: string) {
+  return REJECTED_EMAIL_DOMAINS.includes(domainOf(email));
+}
+
+/** An erased/anonymised record — activating it would resurrect it. */
+export function isErasedAccount(user: { email: string }) {
+  return domainOf(user.email) === ERASED_EMAIL_DOMAIN;
+}

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,30 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.49.2-beta',
+    date: '2026-08-06',
+    highlights: {
+      en: [
+        'A mentee you added by hand can now get a real account. Until now, adding someone without an e-mail address gave them a stand-in one and there was no way back: they could never sign in, no reset mail could reach them, and nobody could correct the address afterwards.',
+        'On the mentee\'s page you now enter their real address and send them an activation link. It stays the same record — the interaction log, the stage history and the company link are all kept.',
+        'The same button resends the link if the e-mail did not arrive, and shows you the link so you can pass it on yourself.',
+        'Someone who has already set a password keeps control of their own address: only they can change it, from their account settings.',
+      ],
+      tr: [
+        'Elle eklediğin bir mentee artık gerçek bir hesaba kavuşabiliyor. Şimdiye kadar e-posta adresi girmeden eklediğin kişiye geçici bir adres veriliyordu ve geri dönüşü yoktu: hiç giriş yapamıyor, sıfırlama e-postası kendisine ulaşamıyor ve adresi sonradan kimse düzeltemiyordu.',
+        'Mentee sayfasında artık gerçek adresini yazıp ona aktivasyon bağlantısı gönderiyorsun. Kayıt aynı kayıt olarak kalıyor — etkileşim geçmişi, aşama geçmişi ve şirket bağlantısı korunuyor.',
+        'E-posta ulaşmadıysa aynı buton bağlantıyı yeniden gönderiyor; bağlantıyı ekranda da gösteriyor, istersen kendin iletebiliyorsun.',
+        'Parolasını çoktan belirlemiş biri kendi adresinin sahibi olmayı sürdürüyor: adresini yalnızca kendisi, hesap ayarlarından değiştirebiliyor.',
+      ],
+      de: [
+        'Ein von Hand angelegter Mentee kann jetzt ein echtes Konto bekommen. Bisher erhielt jemand ohne E-Mail-Adresse eine Platzhalteradresse und es gab keinen Weg zurück: Anmelden war unmöglich, keine Zurücksetzen-Mail kam an, und die Adresse ließ sich nachträglich von niemandem korrigieren.',
+        'Auf der Mentee-Seite trägst du nun die echte Adresse ein und schickst einen Aktivierungslink. Es bleibt derselbe Datensatz — Interaktionsprotokoll, Phasenhistorie und Firmenzuordnung bleiben erhalten.',
+        'Derselbe Button schickt den Link erneut, falls die E-Mail nicht ankam, und zeigt ihn dir an, damit du ihn selbst weitergeben kannst.',
+        'Wer bereits ein Passwort gesetzt hat, behält die Hoheit über die eigene Adresse: ändern kann sie nur die Person selbst, in den Kontoeinstellungen.',
+      ],
+    },
+  },
+  {
     version: '0.49.1-beta',
     date: '2026-08-06',
     highlights: {


### PR DESCRIPTION
## Summary

A mentee added by a mentor without an e-mail got a generated
`mentee.<name>.<hex>@import.local` address and the sentinel `!created-no-login` in the
password column — never a bcrypt hash, so `bcrypt.compare` could never match and the record
could **never** sign in. Every recovery path was a dead end:

- `/api/auth/forgot` and `/api/admin/users/[id]/reset-password` only *mail* a link, and that
  mail went to a domain that does not exist (returning the link was removed in #875);
- no endpoint could change the address — `/api/users/[id]` PATCH never accepted `email`, and
  `/api/account` PATCH requires the account's own session plus `currentPassword`;
- registering with the real address created a **second, unrelated user**, orphaning the
  interaction log and stage history the mentor had built up.

So the only ways out were deleting the record (losing its history) or editing the DB by hand.
The same applied to rows from `scripts/import-csv.mjs` (`!imported-no-login`).

This gives the record a way out: the assigned mentor (or an admin) sets the real address on
the **existing row** and the mentee gets an activation link.

Closes #1123.

## Changes

- **`PATCH /api/mentor/mentees/[id]`** — sets the real e-mail and issues a `SET_INITIAL`
  password token, mailing the activation link (and returning it, like `POST
  /api/mentor/mentees` already does, so the mentor can pass it on when SMTP is down).
  Guards: assigned mentor or admin; target must be a `MENTEE`; the record must still carry a
  no-login sentinel — **once someone has set a password the address is theirs** and only they
  can change it via `/api/account`, otherwise this would be account takeover; `@import.local`
  / `@erased.local` rejected as new addresses; erased or deactivated records refused;
  uniqueness enforced (409); rate-limited to 20/15 min; every call writes a
  `mentee.activation_link_sent` activity row at warning level. Sending with the address
  unchanged doubles as "resend the activation link".
- **`MenteeActivationPanel`** — shown on the mentor's mentee detail page and the admin
  candidate page while the record has no password, driven by a new `pendingActivation` flag on
  `GET /api/mentorship/[id]` and `GET /api/users/[id]` (derived server-side; the password
  column is destructured out before the response). New `menteeActivation` i18n block (EN/TR/DE).
- **`src/lib/menteeAccount.ts`** — one home for the no-login sentinels and the placeholder /
  erased e-mail domains, previously inline literals in the create route.
- **`e2e/mentee-activation.spec.ts`** — full path (create without e-mail → activate → the
  mentee sets a password and **signs in**, same row, relation intact) plus the refusals:
  already has a password (409), placeholder domain (400), foreign mentor (403).
- Version bump `0.49.2-beta` + CHANGELOG + release notes.

## Verification

- [x] `npm run lint` + `npx tsc --noEmit` clean (`npm run check:i18n` OK, `npm run build` OK)
- [x] `npm run test:e2e` passing (or CI green) — ran locally against MariaDB in the container:
      the 2 new tests plus `mentor-add-mentee`, `mentee-setpw`, `admin-mentee`,
      `admin-reset-password`, `mentor-detail`, `candidate-erasure`, `authz-idor`,
      `authz-matrix` — 16 passed
- [x] Tested the change manually / added an e2e test

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JJyYvysp87oYekjWpaVs7f)_