### PR TITLE
feat(mentor): message a mentee from their page + suggested openers for an empty thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.51.0-beta] - 2026-08-07
+
+### Added
+- **"Send a message" on the mentor's mentee pages** (#1130) — `/mentor/mentees/<relationId>` now
+  links straight to the mentorship thread (`/messages/<relationId>`,
+  `data-testid="mentee-message-link"`), and each card on `/mentor/mentees` carries an icon-only
+  entry (`data-testid="message-mentee-<id>"`). The thread already existed; the page you read
+  about a mentee on simply had no way into it, so writing meant a detour through the messages
+  inbox to find the right person.
+- **Suggested openers for an empty thread** (`MessageThreadView`, #1130) — with no messages yet,
+  three chips (`data-testid="message-suggestions"`) offer a starting point; clicking one *fills*
+  the composer instead of sending, so the wording stays the sender's. The mentor side of a
+  mentorship thread gets welcome-flavoured openers (welcome / intro call / ask about goals), any
+  other viewer gets neutral ones (hello / introduce myself / ask a question), and the other
+  party's first name is interpolated into the text. Group (project) chats are excluded — there is
+  no single person to greet — as are read-only threads and threads that already have history.
+  New `messages.openers.*` i18n block (EN/TR/DE); `MessageComposer` gained an optional
+  `textareaRef` so the box can be focused after a chip is used. Covered by
+  `e2e/messaging.spec.ts` ("mentor opens the thread from the mentee page and uses a suggested
+  opener").
+
 ## [0.50.2-beta] - 2026-08-07
 
 ### Added

--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -2810,3 +2810,48 @@ sıfır timer'la veriyor.
 **Bu container'da `node_modules` yok.** `npm install` (~1 dk) arka planda başlatılıp bu sırada
 düzenlemeler yapılabiliyor; `npx prisma generate` sonrası `tsc --noEmit` + `npm run build` +
 `npm run check:i18n` üçlüsü lint uyarı gürültüsünden bağımsız net sinyal veriyor.
+
+## 2026-08-07 — "Buton yok" şikâyetinde arananın zaten var olduğunu varsay (#1130, 0.51.0-beta)
+
+**Bir ekran görüntüsünde "bu buton eksik" denince, ilk iş o özelliğin başka bir yerde
+çalışıp çalışmadığını aramak.** Mentee detay sayfasında mesaj butonu yoktu; ama sohbet
+`/messages/<relationId>` olarak zaten vardı, mentee tarafında `/portal` üzerinden linki de
+vardı — eksik olan tek şey mentor tarafındaki link. Yeni bir API, yeni bir sayfa ya da
+yeni bir izin katmanı gerekmedi. #1116'daki ders (`"göremiyorum" = link eksikliği`) bu
+sefer "yazamıyorum" biçiminde geri geldi: aynı teşhis sırası (veri → API → gating → *link*)
+yine dördüncü basamakta durdu.
+
+**"Yeni kullanıcıya öneri" isteği, öneriyi kimin gördüğüne göre değişir.** Boş sohbete
+"hoş geldin" önerisi koymak, aynı bileşeni kullanan mentee tarafında saçma olurdu (mentee
+mentoruna "hoş geldin" demez). `MessageThreadView` iki rotayı da (relation + conversation)
+paylaştığı için öneriyi role göre ayırmak gerekti: `GET /api/messages` relation cevabında
+`mentor` nesnesini zaten döndürüyordu, o yüzden ek endpoint gerekmedi — `d.mentor?.id ===
+myId` yeterli. Grup (proje) sohbetlerinde ise öneri hiç gösterilmiyor: selam verilecek tek
+bir kişi yok.
+
+**Öneri çipi göndermez, kutuyu doldurur.** Tek satırlık bir karar ama tonu belirliyor:
+mentor metni düzenleyip gönderiyor, uygulama onun adına konuşmuyor. Bunun yan etkisi
+`MessageComposer`'a opsiyonel `textareaRef` eklemek oldu — `Textarea` zaten `forwardRef`
+olduğu için tek satır.
+
+**`useSuggestion` diye bir yardımcı adı koymayın.** `use` önekli her fonksiyon ESLint'in
+rules-of-hooks kuralına hook gibi görünüyor ve `onClick` içinden çağrıldığında hata
+veriyor. `applySuggestion` ile geçti. (Kontrollü bir `textarea`'ya yeni `value` yazmak
+imleci kendiliğinden sona alıyor; `setSelectionRange` ile uğraşmak gereksizdi.)
+
+**Bu container'da Playwright'ı ayağa kaldırmanın çalışan yolu (2026-08 sürümü):**
+`/opt/pw-browsers` içinde `chromium_headless_shell-1194` var, Playwright ise
+`chromium_headless_shell-1234/chrome-headless-shell-linux64/chrome-headless-shell`
+arıyor. Playbook "symlink çalışmıyor" diyor ama **dizin adı + iç dosya adı birlikte
+köprülenirse çalışıyor**: beklenen sürüm dizinini yaratıp 1194'ün `chrome-linux`
+içeriğini tek tek symlink'lemek, `headless_shell`'i de `chrome-headless-shell` adıyla
+bağlamak ve `INSTALLATION_COMPLETE`/`DEPENDENCIES_VALIDATED` dosyalarına dokunmak yeterli
+— `playwright install` gerekmedi, `executablePath` yamasına da gerek kalmadı, testler
+`npm run test:e2e` yoluyla normal şekilde koştu. (Ekran görüntüsü almak için ayrı bir
+script yazarken `chromium-1194/chrome-linux/chrome` mutlak yolu iş görüyor.)
+
+**Kendi `npm run dev`'ini Playwright'ın bıraktığı `.next` üzerine kurmayın.** Dev sunucusu
+"Invariant: Expected clientReferenceManifest to be defined" ile açıldı; sebep uygulama
+kodu değil, önceki Playwright koşusunun yarım bıraktığı derleme önbelleğiydi. `rm -rf
+.next` + yeniden başlatmak düzeltti. Ekran görüntüsü almadan önce sayfaya ~6 sn vermek de
+gerekti (dev derlemesi ilk isteği yavaş karşılıyor).

--- a/e2e/messaging.spec.ts
+++ b/e2e/messaging.spec.ts
@@ -74,3 +74,47 @@ test('mentee can reply in the thread and the mentor is notified', async ({ page 
     await cleanupByEmail(mentorEmail);
   }
 });
+
+// #1130 — the mentee page used to be a dead end: you could read everything about
+// a mentee there and still have no way to write to them. Covers the new entry
+// point and the suggested opener an empty thread offers.
+test('mentor opens the thread from the mentee page and uses a suggested opener', async ({ page }) => {
+  const mentorEmail = uniqueEmail('sug-mentor');
+  const menteeEmail = uniqueEmail('sug-mentee');
+  const mentor = await seedUser(mentorEmail, 'MentorPass123', 'MENTOR', 'Sug Mentor');
+  const mentee = await seedUser(menteeEmail, 'MenteePass123', 'MENTEE', 'Yagmur Kuzu');
+  const rel = await prisma.mentorshipRelation.create({ data: { mentorId: mentor.id, menteeId: mentee.id } });
+
+  try {
+    await signIn(page, mentorEmail, 'MentorPass123', '/mentor');
+    await page.goto(`/mentor/mentees/${rel.id}`);
+    await page.getByTestId('mentee-message-link').click();
+    await page.waitForURL((u) => u.pathname === `/messages/${rel.id}`, { timeout: 20_000 });
+
+    // Empty thread → openers, and the mentor side gets the welcome one first.
+    const suggestions = page.getByTestId('message-suggestions');
+    await expect(suggestions).toBeVisible({ timeout: 10_000 });
+    await suggestions.getByRole('button').first().click();
+
+    const box = page.getByTestId('message-input');
+    await expect(box).toHaveValue(/welcome aboard/i);
+    // The mentee's first name is filled in, so the text is ready to send as is.
+    await expect(box).toHaveValue(/Yagmur/);
+
+    const done = page.waitForResponse((r) => r.url().includes('/api/messages') && r.request().method() === 'POST');
+    await page.getByRole('button', { name: 'Send' }).click();
+    await done;
+
+    await expect.poll(async () =>
+      prisma.message.count({ where: { relationId: rel.id, senderId: mentor.id } })
+    ).toBeGreaterThan(0);
+    // Once the thread has history the openers step aside.
+    await expect(suggestions).toHaveCount(0);
+  } finally {
+    await prisma.message.deleteMany({ where: { relationId: rel.id } });
+    await prisma.notification.deleteMany({ where: { userId: { in: [mentor.id, mentee.id] } } });
+    await prisma.mentorshipRelation.deleteMany({ where: { id: rel.id } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+  }
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.50.2-beta",
+  "version": "0.51.0-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "author": "Mehmet Erşahin",

--- a/src/app/mentor/mentees/[id]/page.tsx
+++ b/src/app/mentor/mentees/[id]/page.tsx
@@ -9,7 +9,7 @@ import { InteractionSummary } from '@/components/InteractionSummary';
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { Select } from '@/components/ui/Select';
-import { ArrowLeft, Plus, Trash2, ExternalLink } from 'lucide-react';
+import { ArrowLeft, Plus, Trash2, ExternalLink, MessageSquare } from 'lucide-react';
 import Link from 'next/link';
 import { useResolvedStages, useStageLabel } from '@/lib/pipelineStagesClient';
 import { useT, useLocale } from '@/i18n/client';
@@ -193,6 +193,15 @@ export default function MenteeDetailPage() {
           <div className="min-w-0">
             <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 break-words">{relation.mentee.fullName}</h1>
             <p className="text-gray-500 break-words">{relation.mentee.email}</p>
+            {/* The in-app thread with this mentee (#1130). It used to be reachable
+                only from the messages inbox, so the page you read about a mentee on
+                had no way to write to them. */}
+            <Link href={`/messages/${id}`} className="mt-3 inline-block" data-testid="mentee-message-link">
+              <Button size="sm">
+                <MessageSquare className="h-4 w-4" />
+                {t.messages.sendMessage}
+              </Button>
+            </Link>
           </div>
           <div className="flex w-full flex-col items-start gap-2 sm:w-auto sm:min-w-[240px] sm:items-end">
             <StatusBadge status={relation.status} />

--- a/src/app/mentor/mentees/page.tsx
+++ b/src/app/mentor/mentees/page.tsx
@@ -5,7 +5,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { Card } from '@/components/ui/Card';
 import { Badge, StatusBadge } from '@/components/ui/Badge';
 import { Button } from '@/components/ui/Button';
-import { Users } from 'lucide-react';
+import { Users, MessageSquare } from 'lucide-react';
 import Link from 'next/link';
 import { ApplyLinkBox } from '@/components/ApplyLinkBox';
 import { EmptyState } from '@/components/EmptyState';
@@ -119,6 +119,13 @@ export default function MenteesPage() {
                     defaultTitle={t.meetings.instant.defaultWith.replace('{name}', rel.mentee.fullName)}
                     testId={`start-meeting-${rel.id}`}
                   />
+                  {/* Icon-only: the row already carries two buttons, and writing to
+                      a mentee should not cost a detour through the detail page. */}
+                  <Link href={`/messages/${rel.id}`} data-testid={`message-mentee-${rel.id}`}>
+                    <Button size="sm" variant="outline" aria-label={t.messages.sendMessage} title={t.messages.sendMessage}>
+                      <MessageSquare className="h-4 w-4" />
+                    </Button>
+                  </Link>
                   <Link href={`/mentor/mentees/${rel.id}`}>
                     <Button size="sm" variant="outline">{t.mentor.viewDetails}</Button>
                   </Link>

--- a/src/components/MessageThread.tsx
+++ b/src/components/MessageThread.tsx
@@ -61,7 +61,7 @@ export function PendingAttachmentList({ attachments, onRemove, removeLabel }: {
 export function MessageComposer({
   body, onBodyChange, onSubmit, sending, hasAttachments, placeholder, sendLabel,
   attachLabel, fileInputRef, accept, onFilesSelected, onPaste, onKeyDown,
-  inputTestId, attachTestId, sendTestId, textareaTestId,
+  inputTestId, attachTestId, sendTestId, textareaTestId, textareaRef,
 }: {
   body: string;
   onBodyChange: (body: string) => void;
@@ -80,6 +80,8 @@ export function MessageComposer({
   attachTestId?: string;
   sendTestId?: string;
   textareaTestId?: string;
+  /** Lets the caller focus/caret the box — e.g. after filling it from a suggestion. */
+  textareaRef?: RefObject<HTMLTextAreaElement | null>;
 }) {
   const empty = !body.trim() && !hasAttachments;
   return (
@@ -90,7 +92,7 @@ export function MessageComposer({
       <Button type="button" variant="outline" disabled={sending} onClick={() => fileInputRef.current?.click()} aria-label={attachLabel} title={attachLabel} data-testid={attachTestId}>
         <Paperclip className="h-4 w-4" />
       </Button>
-      <Textarea value={body} onChange={(event) => onBodyChange(event.target.value)} onPaste={onPaste} onKeyDown={onKeyDown} rows={2} maxLength={TEXT_LIMITS.messageBody} showCounter placeholder={placeholder} data-testid={textareaTestId} wrapperClassName="flex-1" className="resize-none" />
+      <Textarea ref={textareaRef} value={body} onChange={(event) => onBodyChange(event.target.value)} onPaste={onPaste} onKeyDown={onKeyDown} rows={2} maxLength={TEXT_LIMITS.messageBody} showCounter placeholder={placeholder} data-testid={textareaTestId} wrapperClassName="flex-1" className="resize-none" />
       <Button type="submit" loading={sending} disabled={empty} data-testid={sendTestId}>{sendLabel}</Button>
     </form>
   );

--- a/src/components/MessageThreadView.tsx
+++ b/src/components/MessageThreadView.tsx
@@ -71,6 +71,9 @@ export function MessageThreadView({ target }: { target: ThreadTarget }) {
   // Set for a project group chat: which project it belongs to, so the header can
   // name the room, list who is in it and link back to the project (#51).
   const [group, setGroup] = useState<{ projectId: string | null; projectName: string | null } | null>(null);
+  // Mentorship threads only: who the mentor is, so an empty thread can suggest
+  // a *welcome* to the mentor and a neutral opener to the mentee (#1130).
+  const [mentorId, setMentorId] = useState<string | null>(null);
   const [showParties, setShowParties] = useState(false);
   const [body, setBody] = useState('');
   // Pending attachments (picked files + pasted images), each with an object URL
@@ -98,6 +101,7 @@ export function MessageThreadView({ target }: { target: ThreadTarget }) {
   const [enterToSend, setEnterToSend] = useState(false);
   const endRef = useRef<HTMLDivElement>(null);
   const fileRef = useRef<HTMLInputElement>(null);
+  const bodyRef = useRef<HTMLTextAreaElement>(null);
 
   // Load the saved Enter-to-send preference once on mount.
   useEffect(() => {
@@ -144,6 +148,7 @@ export function MessageThreadView({ target }: { target: ThreadTarget }) {
     // A mentorship thread answers with mentor/mentee; a conversation with a
     // participants array. Normalize both to one list.
     setParties(d.participants ?? [d.mentor, d.mentee].filter(Boolean));
+    setMentorId(d.mentor?.id ?? null);
     setGroup(d.type === 'GROUP' ? { projectId: d.projectId ?? null, projectName: d.projectName ?? null } : null);
     setCanPost(d.canPost !== false);
     setLoading(false);
@@ -286,6 +291,28 @@ export function MessageThreadView({ target }: { target: ThreadTarget }) {
     target.kind === 'conversation' ? { conversationId: target.id } : null;
   // On mobile the shell's header is the only title, so it carries the name.
   useMessagesHeaderTitle(threadTitle);
+
+  // Nothing has been said in this thread yet, so offer a way in instead of an
+  // empty box (#1130). The mentor gets welcome-flavoured openers — they are the
+  // one who reaches out first; everyone else gets neutral ones. Group chats are
+  // left alone: there is no single person to greet.
+  const openers = t.messages.openers;
+  const otherFirstName = (other?.fullName ?? '').trim().split(/\s+/)[0] ?? '';
+  const suggestions =
+    messages.length > 0 || !canPost || group || !otherFirstName
+      ? []
+      : (target.kind === 'relation' && !!myId && mentorId === myId
+          ? [openers.welcome, openers.introCall, openers.goals]
+          : [openers.hello, openers.intro, openers.question]
+        ).map((o) => ({ label: o.label, text: o.text.replace('{name}', otherFirstName) }));
+
+  // Fill the box rather than send: the sender stays in control of the wording.
+  // No explicit caret handling — writing a new `value` into a textarea puts the
+  // caret at the end by itself, which is where an unfinished opener continues.
+  const applySuggestion = (text: string) => {
+    setBody(text);
+    bodyRef.current?.focus();
+  };
 
   const partyRole = (p: Party) =>
     p.role === 'MENTEE'
@@ -542,6 +569,24 @@ export function MessageThreadView({ target }: { target: ThreadTarget }) {
       )}
       {canPost && (
       <>
+      {suggestions.length > 0 && (
+        <div className="mb-2" data-testid="message-suggestions">
+          <p className="mb-1.5 text-xs text-gray-400">{openers.title}</p>
+          <div className="flex flex-wrap gap-1.5">
+            {suggestions.map((s) => (
+              <button
+                key={s.label}
+                type="button"
+                onClick={() => applySuggestion(s.text)}
+                title={s.text}
+                className="rounded-full border border-blue-200 bg-blue-50 px-3 py-1.5 text-xs text-blue-700 hover:bg-blue-100 dark:border-blue-900"
+              >
+                {s.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
       <PendingAttachmentList attachments={attachments} onRemove={removeAttachment} removeLabel={t.common.delete} />
       <MessageComposer
         body={body}
@@ -558,6 +603,7 @@ export function MessageThreadView({ target }: { target: ThreadTarget }) {
         onPaste={onPaste}
         onKeyDown={onComposerKeyDown}
         inputTestId="message-attachment-input"
+        textareaRef={bodyRef}
         textareaTestId="message-input"
         sendTestId="message-send"
       />

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -1474,6 +1474,35 @@ const en = {
     groupChat: 'Group chat',
     participantCount: '{n} people in this chat',
     openProject: 'Open the project',
+    // Suggested openers for a thread with no messages yet (#1130): the first
+    // message is the hardest one to write, so offer a starting point.
+    openers: {
+      title: 'Suggested first message',
+      welcome: {
+        label: '👋 Welcome',
+        text: 'Hi {name}, welcome aboard! I will be your mentor from here on — you can reach me in this chat whenever something comes up.',
+      },
+      introCall: {
+        label: 'Intro call',
+        text: 'Hi {name}, shall we have a short intro call? Which days and times work for you this week?',
+      },
+      goals: {
+        label: 'Ask about goals',
+        text: 'Hi {name}, before we start I would like to hear what you want to get out of this internship and which topics you want to work on.',
+      },
+      hello: {
+        label: '👋 Say hello',
+        text: 'Hi {name}, how are you?',
+      },
+      intro: {
+        label: 'Introduce myself',
+        text: 'Hi {name}, let me introduce myself briefly: ',
+      },
+      question: {
+        label: 'Ask a question',
+        text: 'Hi {name}, I have a question: ',
+      },
+    },
   },
   logInteraction: {
     add: 'Log interaction',
@@ -3669,6 +3698,33 @@ const tr: Dict = {
     groupChat: 'Grup sohbeti',
     participantCount: 'Bu sohbette {n} kişi var',
     openProject: 'Projeye git',
+    openers: {
+      title: 'İlk mesaj önerileri',
+      welcome: {
+        label: '👋 Hoş geldin',
+        text: 'Merhaba {name}, hoş geldin! Bundan sonra mentorun olarak yanındayım — aklına takılan her şeyi bu sohbetten sorabilirsin.',
+      },
+      introCall: {
+        label: 'Tanışma görüşmesi',
+        text: 'Merhaba {name}, kısa bir tanışma görüşmesi yapalım mı? Bu hafta hangi gün ve saatler sana uygun?',
+      },
+      goals: {
+        label: 'Hedeflerini sor',
+        text: 'Merhaba {name}, başlamadan önce bu stajdan ne beklediğini ve hangi konularda ilerlemek istediğini öğrenmek isterim.',
+      },
+      hello: {
+        label: '👋 Selam ver',
+        text: 'Merhaba {name}, nasılsın?',
+      },
+      intro: {
+        label: 'Kendimi tanıtayım',
+        text: 'Merhaba {name}, kendimi kısaca tanıtmak isterim: ',
+      },
+      question: {
+        label: 'Soru sor',
+        text: 'Merhaba {name}, bir sorum olacak: ',
+      },
+    },
   },
   logInteraction: {
     add: 'Etkileşim ekle',
@@ -5862,6 +5918,33 @@ const de: Dict = {
     groupChat: 'Gruppenchat',
     participantCount: '{n} Personen in diesem Chat',
     openProject: 'Zum Projekt',
+    openers: {
+      title: 'Vorschläge für die erste Nachricht',
+      welcome: {
+        label: '👋 Willkommen',
+        text: 'Hallo {name}, willkommen! Ich begleite dich ab jetzt als Mentor:in — melde dich in diesem Chat, wann immer etwas ist.',
+      },
+      introCall: {
+        label: 'Kennenlerngespräch',
+        text: 'Hallo {name}, sollen wir ein kurzes Kennenlerngespräch führen? Welche Tage und Zeiten passen dir diese Woche?',
+      },
+      goals: {
+        label: 'Nach Zielen fragen',
+        text: 'Hallo {name}, bevor wir starten, würde ich gern hören, was du aus diesem Praktikum mitnehmen möchtest und an welchen Themen du arbeiten willst.',
+      },
+      hello: {
+        label: '👋 Hallo sagen',
+        text: 'Hallo {name}, wie geht es dir?',
+      },
+      intro: {
+        label: 'Mich vorstellen',
+        text: 'Hallo {name}, ich stelle mich kurz vor: ',
+      },
+      question: {
+        label: 'Eine Frage stellen',
+        text: 'Hallo {name}, ich habe eine Frage: ',
+      },
+    },
   },
   logInteraction: {
     add: 'Interaktion erfassen',

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,24 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.51.0-beta',
+    date: '2026-08-07',
+    highlights: {
+      en: [
+        'Mentors: a "Send a message" button now sits right on the mentee page — and on every mentee card — so you can write to a mentee without going hunting in the messages inbox.',
+        'Never messaged someone before? An empty chat now suggests a first message ("Hi …, welcome aboard!", an intro call, or asking about their goals). Tapping one fills the box with their name already in it, so you can edit before sending.',
+      ],
+      tr: [
+        'Mentorlar: “Mesaj gönder” butonu artık doğrudan mentee sayfasında — ve her mentee kartında — yani mesaj listesinde kişi aramadan yazabilirsiniz.',
+        'Daha önce hiç mesajlaşmadınız mı? Boş sohbet artık bir ilk mesaj öneriyor (“Merhaba …, hoş geldin!”, tanışma görüşmesi ya da hedeflerini sorma). Öneriye dokununca kutu, adı da yazılmış olarak dolar; göndermeden önce düzenleyebilirsiniz.',
+      ],
+      de: [
+        'Für Mentor:innen: Die Schaltfläche „Nachricht senden“ steht jetzt direkt auf der Mentee-Seite — und auf jeder Mentee-Karte — du musst die Person nicht mehr im Postfach suchen.',
+        'Noch nie geschrieben? Ein leerer Chat schlägt jetzt eine erste Nachricht vor („Hallo …, willkommen!“, ein Kennenlerngespräch oder die Frage nach den Zielen). Ein Tipp darauf füllt das Feld samt Name — vor dem Senden noch änderbar.',
+      ],
+    },
+  },
+  {
     version: '0.50.2-beta',
     date: '2026-08-07',
     highlights: {


### PR DESCRIPTION
## Summary

The mentee page (`/mentor/mentees/<relationId>`) showed everything about a mentee — pipeline stage, profile, Call/WhatsApp, interaction log — and had **no way to write to them**. The thread already existed at `/messages/<relationId>`; the only link to it lived in the messages inbox, so messaging a mentee meant leaving the page and finding the right person in a list.

Second half of the report: a mentee you have never messaged opens as an empty box, and the first message is the hardest one to write. An empty thread now suggests one.

Closes #1130

## Changes

- **`/mentor/mentees/<relationId>`** — a "Send a message" button under the name/e-mail, linking to the mentorship thread (`data-testid="mentee-message-link"`).
- **`/mentor/mentees`** — an icon-only message entry on every card (`data-testid="message-mentee-<id>"`), so writing does not cost a detour through the detail page.
- **Suggested openers (`MessageThreadView`)** — when a thread has no messages, three chips (`data-testid="message-suggestions"`) appear above the composer. Clicking one **fills** the box rather than sending, so the wording stays the sender's.
  - Mentor side of a mentorship thread → welcome / intro call / ask about goals ("Hi Yağmur, welcome aboard! …").
  - Any other viewer → neutral openers (hello / introduce myself / ask a question).
  - The other party's **first name is interpolated** into the text.
  - Skipped for group (project) chats — no single person to greet — for read-only threads, and as soon as the thread has any history.
- New `messages.openers.*` i18n block in EN/TR/DE; `MessageComposer` gained an optional `textareaRef` so the box can be focused after a chip is used.
- Version bumped to `0.51.0-beta` with matching `CHANGELOG.md` and `src/lib/releaseNotes.ts` entries.

## Verification

- [x] `npx tsc --noEmit` clean; `eslint` on the touched files reports only the pre-existing `no-img-element` warning; `npm run build` and `npm run check:i18n` green
- [x] `e2e/messaging.spec.ts` (3 tests, incl. the new "mentor opens the thread from the mentee page and uses a suggested opener"), plus `message-attachments.spec.ts` and `messages-inbox.spec.ts` — all pass locally against a local MariaDB
- [x] Tested manually at a phone viewport in dark mode: button on the mentee page, chips on the empty thread, chip click filling the composer with the mentee's name

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5kq4wY4UBT2BVMyVf5QRg)_