### PR TITLE
fix(deps): nodemailer 7.0.13 → 9.0.5 with a next-auth peer override (#1143)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,38 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.55.1-beta] - 2026-08-07
+
+### Security
+- **`nodemailer` 7.0.13 → 9.0.5** (#1143) — closes the open **high** finding
+  ([GHSA-p6gq-j5cr-w38f](https://github.com/advisories/GHSA-p6gq-j5cr-w38f): the
+  message-level `raw` option bypasses `disableFileAccess`/`disableUrlAccess`, giving
+  arbitrary file read and full-response SSRF, range `<=9.0.0`) plus three moderates that
+  cover `<=8.0.8`. On a clean `npm ci`, `npm audit` goes from 6 findings (3 high, 3
+  moderate) to 4 (2 high, 2 moderate): `next-auth`'s moderate was transitive through
+  nodemailer and cleared with it, and both rows moved out of
+  `docs/security-exceptions.md`. What remains is untouched by this change — `xlsx` and
+  `node-cron`/`uuid` are written up there, and `nanoid` (high, via `postcss`) is a
+  pre-existing finding that is in neither — filed as #1144.
+- **Bumping the root range alone does not install.** `next-auth@4.24.15` declares
+  `peerOptional nodemailer@"^7.0.7"`, so `npm ci` fails with ERESOLVE — which is exactly
+  where Dependabot's #1129 (7.0.13 → 9.0.1) died, in under 30s, before any of the three
+  jobs ran a line of project code. The fix is one `overrides` entry pinning next-auth's
+  peer to the root's: `"next-auth": { "nodemailer": "$nodemailer" }`. Safe because
+  `src/lib/auth.ts` only registers `CredentialsProvider` — there is no `EmailProvider`, so
+  next-auth never loads nodemailer at runtime and the peer is unused as well as optional.
+- **The 7 → 9 breaking change does not reach this app.** 9.0.0 made HTTPS requests
+  validate the server's TLS certificate *when fetching remote content* — attachment
+  `path`/`href` URLs, OAuth2 token endpoints, proxy CONNECT. Our transport is plain SMTP
+  host/port/password (`src/services/emailService.ts:41`) and every attachment is an
+  in-memory `Buffer` (`emailService.ts:93`, and the message/announcement senders that feed
+  it); nothing fetches remote content. Verified beyond the type level: `tsc --noEmit` is
+  clean against `@types/nodemailer` 6.4.23, and a message built with our exact shape
+  (multipart, `cid` attachment, UTF-8 subject) renders correctly on 9.0.5.
+- Taken deliberately rather than as an automated PR, which is what `.github/dependabot.yml`
+  intends by ignoring `semver-major` — #1129 is a security update, so Dependabot opened it
+  past that rule anyway. Closed in favour of this one.
+
 ## [0.55.0-beta] - 2026-08-07
 
 ### Added

--- a/docs/security-exceptions.md
+++ b/docs/security-exceptions.md
@@ -9,16 +9,21 @@ Bir bastırma dosyası yerine düz metin: gerekçe diğer güvenlik dokümanlar�
 yanında okunabilir kalıyor ve biri okuduğunda **hâlâ geçerli mi** diye sorması
 gerektiği belli oluyor.
 
-Son gözden geçirme: **2026-07-31** · Kaynak epic: [#823](https://github.com/21072026/Internship/issues/823)
+Son gözden geçirme: **2026-08-07** · Kaynak epic: [#823](https://github.com/21072026/Internship/issues/823)
 
 ## Açık bulgular
 
 | Paket | Şiddet | Durum | Gerekçe |
 |---|---|---|---|
 | `xlsx` | high | **Yama yok** | Prototype pollution + ReDoS. Upstream (SheetJS) npm'deki `xlsx` paketini terk etti; düzeltme yalnız kendi CDN'lerinde yayınlanıyor. Tek kullanım yerimiz `src/lib/excel.ts`: **istemci tarafında**, dinamik `import('xlsx')` ile, yalnız `XLSX.writeFile` — hiç dosya okumuyoruz. Her iki advisory de *parse* yolunda, üstelik kod sunucuda değil tarayıcıda çalışıyor. Kalıcı çözüm paketi değiştirmek — ayrı iş. |
-| `nodemailer` | high | Majör gerekiyor (7.x → 9.x) | SMTP komut enjeksiyonu ve `disableFileAccess` atlatma sınıfı bulgular. Hepsi **saldırganın kontrol ettiği zarf/başlık alanları** gerektiriyor; bizim gönderim yolumuzda alıcı adresi ve gövde uygulama tarafından üretiliyor. Yine de gerçek — majör yükseltme ayrı task. |
-| `next-auth` | moderate | Geçişli | Kendi kodundan değil, `next` ve `nodemailer` üzerinden geliyor. Onlar kapandığında bu da kapanır. |
 | `node-cron` · `uuid` | moderate | Majör gerekiyor (3.x → 4.x) | `uuid` v3/v5/v6'da buffer sınır kontrolü eksikliği; `node-cron` üzerinden geliyor. Bu kod yolunu **hiç çağırmıyoruz** — cron yalnız zamanlama için kullanılıyor. |
+
+## Kapatılanlar (2026-08-07, #1143)
+
+| Paket | Nasıl |
+|---|---|
+| `nodemailer` | 7.0.13 → 9.0.5. Yalnız kök aralığı bumplamak yetmiyordu: `next-auth@4.24.15` `peerOptional nodemailer@"^7.0.7"` istiyor ve `npm ci` ERESOLVE ile düşüyor (Dependabot'un #1129'u tam olarak burada kırıldı). `overrides` ile `next-auth`'un peer'i köke bağlandı (`"next-auth": { "nodemailer": "$nodemailer" }`) — güvenli, çünkü `src/lib/auth.ts` yalnız `CredentialsProvider` kullanıyor, `EmailProvider` yok, yani next-auth nodemailer'ı runtime'da hiç yüklemiyor. |
+| `next-auth` | Kendi kodundan değil `nodemailer` üzerinden geliyordu; onunla birlikte kapandı. |
 
 ## Kapatılanlar (2026-07-31, #882)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "internship-crm",
-  "version": "0.55.0-beta",
+  "version": "0.55.1-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "internship-crm",
-      "version": "0.55.0-beta",
+      "version": "0.55.1-beta",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {
@@ -23,7 +23,7 @@
         "next": "^15.5.14",
         "next-auth": "^4.24.7",
         "node-cron": "^3.0.3",
-        "nodemailer": "^7.0.11",
+        "nodemailer": "^9.0.5",
         "pdf-parse": "^2.4.5",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
@@ -5624,9 +5624,9 @@
       }
     },
     "node_modules/nodemailer": {
-      "version": "7.0.13",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.13.tgz",
-      "integrity": "sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.5.tgz",
+      "integrity": "sha512-wvjiKvjczmsN7U/8006JOdXubgBk2XFAbioDMbT+sM7cPs0QrhJTa6KBRX7P5REGGkDcLUz/EarWidb8G8C1jQ==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.55.0-beta",
+  "version": "0.55.1-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "author": "Mehmet Erşahin",
@@ -38,7 +38,7 @@
     "next": "^15.5.14",
     "next-auth": "^4.24.7",
     "node-cron": "^3.0.3",
-    "nodemailer": "^7.0.11",
+    "nodemailer": "^9.0.5",
     "pdf-parse": "^2.4.5",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
@@ -67,6 +67,9 @@
   },
   "overrides": {
     "postcss": "^8.5.18",
-    "sharp": "^0.35.0"
+    "sharp": "^0.35.0",
+    "next-auth": {
+      "nodemailer": "$nodemailer"
+    }
   }
 }


### PR DESCRIPTION
Closes #1143. Replaces #1129 (Dependabot's 7.0.13 → 9.0.1), which cannot go green as-is.

## Why #1129 is red

All three of its jobs died in 13–34s, before a line of project code ran — `npm ci`:

```
While resolving: next-auth@4.24.15
Found: nodemailer@9.0.1
Could not resolve dependency:
peerOptional nodemailer@"^7.0.7" from next-auth@4.24.15
```

Dependabot only bumps the root range; `next-auth`'s peer stays on 7.x. `.github/dependabot.yml` already says majors should "land as deliberate, tested work, not as an automated PR" — #1129 slipped past that rule because it is a *security* update, which Dependabot opens regardless. This is that deliberate work.

## What this does

- `nodemailer` → `^9.0.5`. 9.0.1 also closes the high advisory, but 9.0.5 is current and is what `npm audit` recommends.
- `overrides`: `"next-auth": { "nodemailer": "$nodemailer" }` — pins next-auth's peer to the root's.

Overriding that peer is safe: [`src/lib/auth.ts:2`](src/lib/auth.ts#L2) registers only `CredentialsProvider`. There is no `EmailProvider`, so next-auth never loads nodemailer at runtime — the peer is unused as well as `peerOptional`.

## Security

Closes [GHSA-p6gq-j5cr-w38f](https://github.com/advisories/GHSA-p6gq-j5cr-w38f) (**high**): the message-level `raw` option bypasses `disableFileAccess`/`disableUrlAccess`, giving arbitrary file read and full-response SSRF; range `<=9.0.0`. Three moderates covering `<=8.0.8` go with it.

On a clean `npm ci`, measured both ways:

| | findings | high | moderate |
|---|---|---|---|
| before | 6 | 3 | 3 |
| after | 4 | 2 | 2 |

`next-auth`'s moderate was transitive through nodemailer and cleared with it, so both rows move out of `docs/security-exceptions.md` — that doc has carried nodemailer as "majör gerekiyor (7.x → 9.x), ayrı task" since 2026-07-31.

What remains is untouched by this PR: `xlsx` and `node-cron`/`uuid` are written up in that doc, and `nanoid` (high, via `postcss`) is a pre-existing finding listed in neither — filed as #1144 rather than widened into this PR, since it needs its own exploitability analysis.

## Is 7 → 9 safe for us?

9.0.0's only breaking change is that HTTPS requests validate the server's TLS certificate **when fetching remote content** — attachment `path`/`href` URLs, OAuth2 token endpoints, HTTP/HTTPS proxy CONNECT. None of that is on our path: the transport is plain SMTP host/port/password ([`emailService.ts:41`](src/services/emailService.ts#L41)) and every attachment is an in-memory `Buffer` ([`emailService.ts:93`](src/services/emailService.ts#L93), and the message/announcement senders that feed it).

Verified locally, not just at the type level:

- `npm ci` resolves clean; `node -e` confirms 9.0.5 installed.
- `tsc --noEmit` → 0 errors. `@types/nodemailer` 6.4.23 still fits (unchanged).
- Built a message with our exact shape through `streamTransport` on 9.0.5 — multipart ✅, `cid` attachment ✅, UTF-8 subject encoded ✅.
- `npm run lint` fails in my worktree, but it fails identically on `main` (duplicate `.eslintrc.json` between the worktree and its parent checkout) — a worktree artifact, not this change. CI runs on a plain checkout.

## Versioning

`0.55.0-beta` → `0.55.1-beta` + a `### Security` section in `CHANGELOG.md`. **No `releaseNotes.ts` entry on purpose**: nothing about this is user-visible, and it follows the precedent of `0.33.2-beta` (the previous security-only dependency release, #882), which also has none.

## Test plan

- [ ] CI green — the three jobs that #1129 could not get past (Lint · Typecheck · Build, Playwright smoke, Build image)
- [ ] Preview env boots and sends mail: https://crm-pr1145.ersah.in

🤖 Generated with [Claude Code](https://claude.com/claude-code)
