### PR TITLE
test(e2e): fix the 6 specs failing in the scheduled full run (#1148)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,43 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.55.2-beta] - 2026-08-08
+
+### Fixed
+- **Switching an account off no longer promises a review that never comes** (#1148) — since
+  #1085, `PATCH /api/users/[id]` set `pendingApproval = true` on every deactivation, so
+  `src/lib/auth.ts` answered the next sign-in with `ACCOUNT_PENDING_APPROVAL` and the page
+  showed *"Your account is waiting for a quick review. We will email you the moment it is
+  opened."* — to someone an admin had just switched off. That is the exact opposite of what
+  #1085 introduced the flag for ("tell 'waiting for a review' apart from 'an admin switched
+  you off', since both are `isActive=false`"): the same PR then set it on both paths and
+  collapsed the distinction. Deactivating now parks only an **unverified** account, which is
+  the sole case the flag was actually load-bearing for — a never-activated sign-up still
+  holding a verification link. A verified account is already barred from re-admitting itself
+  by `verify-email`'s own `!emailVerified` term, so it keeps the honest "this account has
+  been deactivated" message. Activating still clears the flag unconditionally.
+
+### Tests
+- **The four specs that still waited for a native `confirm()`** (#1148) — #1071 moved 16
+  components onto `ConfirmDialog` without touching a single spec, so
+  `page.on('dialog', d => d.accept())` sat waiting for an event that no longer fires. The
+  click opened ordinary DOM, was swallowed, and the failure surfaced one assertion later as
+  "the row I deleted is still there": `delete-confirm`, `goal-templates`,
+  `goals-archive-sort` and `todos` all went red in the scheduled full run
+  ([31220653046](https://github.com/21072026/Internship/actions/runs/31220653046)). New
+  `e2e/helpers/confirm.ts` (`acceptConfirmDialog` / `cancelConfirmDialog`) is the one place
+  the dialog's test ids live; `delete-confirm` keeps its #470 intent, now reading the
+  question out of the DOM — the click asks and sends no `DELETE`, cancelling keeps the note.
+  `impersonation-governance`, `search` and `xss-injection` also listen for dialogs and are
+  deliberately left alone: those are a `prompt()`, an `alert()` and XSS detection.
+- **`email-verification` seeded a mentor into the first-run wizard** (#1148) — it creates the
+  user by hand because it needs `emailVerified: false`, which also skipped `seedUser`'s
+  `mentorOnboardingSeenAt` concession, so the first `/mentor` visit was redirected to
+  `/onboarding` (#911) and the sign-in's landing wait timed out. Now stamped explicitly, with
+  the reason next to it.
+- `admin-user-active` additionally asserts `pendingApproval === false` after a deactivation,
+  so the message distinction above cannot disappear silently again.
+
 ## [0.55.1-beta] - 2026-08-07
 
 ### Security

--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -3018,3 +3018,55 @@ girdisiz. Bunu PR gövdesinde gerekçesiyle yazmak, gözden geçirenin checklist
 `.eslintrc.json`'ları çakışıyor (`Plugin "@next/next" was conflicted`) ve lint 1 dönüyor —
 `main`'de de aynısı oluyor. Bir kontrolü "bozuldu" diye raporlamadan önce `git stash` + aynı
 komut ile baseline alın; CI düz checkout'ta koştuğu için bu hiç görünmüyor.
+
+## 2026-08-08 — Altı kırmızı testin arkasında üç kök neden vardı, altısı da başka yeri işaret ediyordu (#1148, 0.55.2-beta)
+
+**Hata mesajının işaret ettiği yer ile kırığın olduğu yer aynı değil.** Altı düşen testin
+dördü "sildiğim satır listede duruyor" diye şikâyet ediyordu (`toHaveCount(0)` → 1,
+`archivedAt !== null` → false). Gerçek sebep dört farklı bileşen değil, tek bir UI kararıydı:
+#1071 `window.confirm()`'i `ConfirmDialog`'a çevirdi. `page.on('dialog', …)` kuran spec artık
+hiç gelmeyecek bir event bekliyor, Delete tıkı sıradan bir DOM penceresi açıyor ve **sessizce
+yutuluyor** — assertion bir sonraki satırda, alakasız görünen bir yerde patlıyor. Ders: aynı
+koşuda birbirine benzemeyen spec'ler benzer *şekilde* düşüyorsa (hepsi "işlem olmadı"),
+spec'leri tek tek okumak yerine önce **ortak etkileşimi** arayın — `git log -S "window.confirm"`
+üç dakikada cevabı verdi.
+
+**Bir UI mekanizmasını değiştiren PR'da e2e diff'inin boş olması tek başına kırmızı bayrak.**
+#1071 16 bileşene dokunup `e2e/` altında hiçbir dosyayı değiştirmemişti; `git show <sha> --stat
+| grep e2e` boş çıkıyor. Native `confirm()` → custom modal gibi bir geçişte bu matematiksel
+olarak imkânsız. Aynı kontrolü #1085 için yaptığımda da (giriş mesajı değişti, sadece
+`mentee-signup` güncellenmiş) altıncı test oradan çıktı.
+
+**Test drift'i mi ürün regresyonu mu sorusunu commit mesajı cevaplıyor.** `admin-user-active`
+"deactivated" arıyordu, uygulama "hesabın incelemeyi bekliyor" diyordu. Testi gevşetmek kolaydı
+— ama #1085'in kendi commit mesajı `pendingApproval`'ı *"'waiting for a review' ile 'an admin
+switched you off'u ayırmak için"* eklediğini yazıyordu, sonra aynı PR bayrağı her
+pasifleştirmede set ederek o ayrımı yok etmişti. Yani test niyeti, ürün ise kazayı kodluyordu.
+İki taraf çelişince `git log -1 -S "<satır>"` + o commit'in gövdesi hangisinin doğru olduğunu
+söylüyor.
+
+**Güvenlik gerekçeli bir bayrağı geri almadan önce onu gereksiz kılan ikinci savunmayı arayın.**
+"Pasifleştirmede `pendingApproval` set edilmesin" demek riskli görünüyordu (reddedilen kayıt
+elindeki linkle geri girer). Ama `verify-email` route'u yeniden içeri almayı
+`!isActive && !emailVerified && !pendingApproval` ile kapatıyor: doğrulanmış bir hesap zaten
+`emailVerified` teriminde duruyor. Bayrak yalnızca `emailVerified === false` olan hesap için
+yük taşıyormuş — düzeltme de tam o daralma oldu, mesaj ayrımı geri geldi, delik kapalı kaldı.
+
+**`prisma.user.create` ile elle açılan bir MENTOR, `seedUser`'ın tavizlerini kaybediyor.**
+`email-verification` `emailVerified: false` gerektirdiği için kullanıcıyı elle açıyor ve
+`mentorOnboardingSeenAt`'i almıyor → ilk `/mentor` ziyareti `/onboarding`'e yönleniyor (#911),
+`waitForURL('/mentor')` 20 sn sonra düşüyor. Hata çıktısı bunu açıkça söylüyor
+(`navigated to ".../onboarding"`) ama tek bir alanı geçmemenin bedeli olduğu görünmüyor.
+`seedUser`'ı bypass eden her spec için o helper'ın gövdesini okuyun: orada yorumla korunan her
+alan bir spec'i ayakta tutuyor.
+
+**Lokal e2e için `internship_e2e` DB'si ve `e2e@127.0.0.1` kullanıcısı hazır duruyor.**
+Parolası önceki oturumlarda kaybolmuş diye not düşülmüş (bkz. yukarıdaki unix-socket notu), ama
+`e2e:e2epass` çalışıyor:
+`DATABASE_URL="mysql://e2e:e2epass@127.0.0.1:3306/internship_e2e"`. Worktree'ye bu tek satırlık
+bir `.env` (gitignore'lu) + `npx prisma db push` yeterli; ana checkout'un `.env`'i **paylaşılan
+preview DB'sine** bakıyor, ona karşı koşmak veri yazmak demek.
+
+**`| tail -N` ile arka planda koşan Playwright'ta ilerleme görünmez.** Boru tamponlandığı için
+çıktı ancak koşu bitince yazılıyor; ara durumu göremeyip koşuyu iki kez başlattım. Arka plan
+koşularında `> dosya 2>&1` yazıp dosyayı `tail`'lemek doğru şekil.

--- a/e2e/admin-user-active.spec.ts
+++ b/e2e/admin-user-active.spec.ts
@@ -29,6 +29,10 @@ test('admin deactivates a user and that user can no longer sign in', async ({ pa
 
     const updated = await prisma.user.findUnique({ where: { id: mentor.id } });
     expect(updated!.isActive).toBe(false);
+    // Switching off a verified account is not the same as parking a sign-up for
+    // review: pendingApproval is what keeps those two apart on the sign-in page
+    // (#1085), so an admin's "off" must not borrow it.
+    expect(updated!.pendingApproval).toBe(false);
 
     // The deactivated mentor cannot sign in.
     // submitSignInForm, not signInAsFreshUser: a deactivated account is *supposed*

--- a/e2e/delete-confirm.spec.ts
+++ b/e2e/delete-confirm.spec.ts
@@ -1,12 +1,16 @@
 import { test, expect } from '@playwright/test';
 import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { acceptConfirmDialog, cancelConfirmDialog, confirmDialog } from './helpers/confirm';
 
 test.afterAll(async () => {
   await prisma.$disconnect();
 });
 
 // #470: unconfirmed delete actions must ask for confirmation first, and
-// cancelling must not send the delete request at all.
+// cancelling must not send the delete request at all. Since #1071 the question
+// is asked by the in-app ConfirmDialog rather than the browser's confirm(), so
+// the assertions read the dialog out of the DOM instead of listening for a
+// native `dialog` event.
 test('deleting a personal note asks for confirmation; cancelling keeps the note', async ({ page }) => {
   const email = uniqueEmail('delconfirm-mentee');
   const mentee = await seedUser(email, 'MenteePass123', 'MENTEE', 'Del Confirm Mentee');
@@ -23,19 +27,23 @@ test('deleting a personal note asks for confirmation; cancelling keeps the note'
     await page.click('button[type="submit"]');
     await expect(page.getByText('Note that should survive a cancelled delete')).toBeVisible();
 
-    let dialogMessage = '';
-    page.once('dialog', async (d) => {
-      dialogMessage = d.message();
-      await d.dismiss();
-    });
-    const deleteRequest = page.waitForRequest((r) => r.method() === 'DELETE' && r.url().includes('/api/notes/'), { timeout: 2_000 }).catch(() => null);
+    // Clicking Delete only asks the question — the dialog carries a message and
+    // no request has left the page yet.
+    const deleteRequest = page
+      .waitForRequest((r) => r.method() === 'DELETE' && r.url().includes('/api/notes/'), { timeout: 2_000 })
+      .catch(() => null);
     await page.getByLabel('Delete').click();
+    await expect(confirmDialog(page)).toBeVisible();
+    expect(((await page.locator('#confirm-dialog-message').textContent()) ?? '').trim().length).toBeGreaterThan(0);
     expect(await deleteRequest).toBeNull();
-    expect(dialogMessage.length).toBeGreaterThan(0);
+
+    // Cancelling keeps the note.
+    await cancelConfirmDialog(page);
     await expect(page.getByText('Note that should survive a cancelled delete')).toBeVisible();
 
-    page.once('dialog', (d) => d.accept());
+    // Confirming deletes it.
     await page.getByLabel('Delete').click();
+    await acceptConfirmDialog(page);
     await expect(page.getByText('Note that should survive a cancelled delete')).toHaveCount(0);
   } finally {
     await prisma.personalNote.deleteMany({ where: { userId: mentee.id } });

--- a/e2e/email-verification.spec.ts
+++ b/e2e/email-verification.spec.ts
@@ -12,8 +12,21 @@ test('unverified user is read-only until they confirm their email', async ({ pag
   const email = uniqueEmail('unverified');
   const password = 'Unverified123!';
   const hash = await bcrypt.hash(password, 10);
+  // Created by hand rather than via seedUser(), because this spec needs
+  // emailVerified: false. That means opting into seedUser's other concession
+  // explicitly: without mentorOnboardingSeenAt, a MENTOR's first /mentor visit
+  // is redirected to the first-run wizard at /onboarding (#911), so the
+  // sign-in's wait for the /mentor landing page times out.
   const user = await prisma.user.create({
-    data: { email, password: hash, role: 'MENTOR', fullName: 'Unverified Mentor', skills: [], emailVerified: false },
+    data: {
+      email,
+      password: hash,
+      role: 'MENTOR',
+      fullName: 'Unverified Mentor',
+      skills: [],
+      emailVerified: false,
+      mentorOnboardingSeenAt: new Date(),
+    },
   });
 
   try {

--- a/e2e/goal-templates.spec.ts
+++ b/e2e/goal-templates.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
 import { signInAndSettle, signInAsFreshUser, gotoSettled } from './helpers/auth';
+import { acceptConfirmDialog } from './helpers/confirm';
 
 /**
  * The shared goal-template pool and its management (#51 follow-up).
@@ -26,9 +27,6 @@ test('an admin can add, reword and retire a shared goal template', async ({ page
   const en = `Read the deploy script ${stamp}`;
   const tr = `Deploy betiğini oku ${stamp}`;
   const reworded = `Read the deploy script carefully ${stamp}`;
-
-  // The confirm() behind delete.
-  page.on('dialog', (d) => d.accept());
 
   try {
     await signInAndSettle(page, adminEmail, password, '/admin');
@@ -64,6 +62,7 @@ test('an admin can add, reword and retire a shared goal template', async ({ page
     // And retire it: the row is archived, not deleted — the to-dos handed out
     // from it read their wording here — but it leaves the pool.
     await page.getByTestId(`delete-template-${created.id}`).click();
+    await acceptConfirmDialog(page);
     await expect
       .poll(
         async () =>

--- a/e2e/goals-archive-sort.spec.ts
+++ b/e2e/goals-archive-sort.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { acceptConfirmDialog } from './helpers/confirm';
 
 test.afterAll(async () => {
   await prisma.$disconnect();
@@ -97,9 +98,9 @@ test('goals can be sorted, edited inline, archived, reopened and deleted', async
     await expect(activeCount).toContainText('2');
     await expect(completedCount).toContainText('0');
 
-    // Delete it from the active list (confirm dialog is accepted).
-    page.once('dialog', (dialog) => dialog.accept());
+    // Delete it from the active list (the in-app confirm dialog is accepted).
     await page.getByTestId(`goal-${newer.id}`).getByRole('button', { name: 'Delete' }).click();
+    await acceptConfirmDialog(page);
     await expect(page.getByTestId(`goal-${newer.id}`)).toHaveCount(0, { timeout: 10_000 });
     const deleted = await prisma.goal.findUnique({ where: { id: newer.id } });
     expect(deleted).toBeNull();

--- a/e2e/helpers/confirm.ts
+++ b/e2e/helpers/confirm.ts
@@ -1,0 +1,36 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+
+/**
+ * Destructive actions are gated by the in-app `ConfirmDialog`, not by the
+ * browser's native `confirm()` (#1071).
+ *
+ * WHY THIS EXISTS: a spec that registers `page.on('dialog', d => d.accept())`
+ * and then clicks a Delete button now waits for an event that never fires. The
+ * dialog it opens is ordinary DOM, so the click is swallowed silently and the
+ * row is still there — the failure surfaces later, as "the thing I deleted is
+ * still in the list", with nothing on screen explaining why. That is exactly how
+ * `delete-confirm`, `goal-templates`, `goals-archive-sort` and `todos` broke in
+ * the scheduled full run.
+ *
+ * Use these helpers rather than reaching for the test ids directly, so the next
+ * change to the dialog is a one-line fix here.
+ */
+export function confirmDialog(page: Page): Locator {
+  return page.getByTestId('confirm-dialog');
+}
+
+/** Wait for the confirm dialog and press its confirm button. */
+export async function acceptConfirmDialog(page: Page) {
+  const dialog = confirmDialog(page);
+  await expect(dialog).toBeVisible();
+  await dialog.getByTestId('confirm-dialog-confirm').click();
+  await expect(dialog).toHaveCount(0);
+}
+
+/** Wait for the confirm dialog and press its cancel button. */
+export async function cancelConfirmDialog(page: Page) {
+  const dialog = confirmDialog(page);
+  await expect(dialog).toBeVisible();
+  await dialog.getByTestId('confirm-dialog-cancel').click();
+  await expect(dialog).toHaveCount(0);
+}

--- a/e2e/todos.spec.ts
+++ b/e2e/todos.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
 import { signInAndSettle, signInAsFreshUser, gotoSettled } from './helpers/auth';
+import { acceptConfirmDialog } from './helpers/confirm';
 
 /**
  * The to-do list, reworked (#1113).
@@ -193,8 +194,6 @@ test('one page holds what a mentor asked for and what the person wrote themselve
   const stamp = Date.now();
   const fromMentor = `Prepare for the interview ${stamp}`;
   const own = `Buy a notebook ${stamp}`;
-  // The confirm() behind delete.
-  page.on('dialog', (d) => d.accept());
 
   try {
     // The mentor writes a to-do straight onto the mentee's list, from the mentee
@@ -222,6 +221,7 @@ test('one page holds what a mentor asked for and what the person wrote themselve
     const mineRow = await prisma.projectTask.findFirstOrThrow({ where: { assigneeId: mentee.id, title: own } });
     await expect(page.getByTestId(`todo-edit-${mineRow.id}`)).toBeVisible();
     await page.getByTestId(`todo-delete-${mineRow.id}`).click();
+    await acceptConfirmDialog(page);
     await expect
       .poll(async () => prisma.projectTask.count({ where: { id: mineRow.id } }), { timeout: 10_000 })
       .toBe(0);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.55.1-beta",
+  "version": "0.55.2-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "author": "Mehmet Erşahin",

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -117,11 +117,25 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
           return NextResponse.json({ error: 'You cannot deactivate your own account' }, { status: 400 });
         }
         data.isActive = body.isActive;
-        // An admin decision outranks the self-service door. Activating clears
-        // the "waiting for an admin" flag; deactivating sets it, so that a
-        // rejected sign-up cannot re-admit itself by clicking a verification
-        // link it still holds (see src/app/api/auth/verify-email/route.ts).
-        data.pendingApproval = !body.isActive;
+        // An admin decision outranks the self-service door, so activating always
+        // clears the "waiting for an admin" flag.
+        //
+        // Deactivating only *sets* it for an account that never got in. An
+        // unverified sign-up still holds a verification link, and clicking it
+        // would otherwise re-admit the account it was just rejected from
+        // (src/app/api/auth/verify-email/route.ts). A verified account is
+        // already barred there by its own `emailVerified`, so parking it too
+        // buys no safety and costs it an honest sign-in message: pendingApproval
+        // is exactly what lets /auth/signin tell "waiting for a review" apart
+        // from "an admin switched you off" (#1085). Setting it on every
+        // deactivation collapsed that distinction and told a deactivated user to
+        // wait for an email that is never coming.
+        if (body.isActive) {
+          data.pendingApproval = false;
+        } else {
+          const target = await prisma.user.findUnique({ where: { id }, select: { emailVerified: true } });
+          data.pendingApproval = target ? !target.emailVerified : false;
+        }
       }
 
       // Assign / clear the mentee's referral source.

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,21 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.55.2-beta',
+    date: '2026-08-08',
+    highlights: {
+      en: [
+        'If an admin switches your account off, the sign-in page now says so. It had started telling you your account was "waiting for a quick review" and that an email was on its way — for an account nobody was reviewing. Accounts that really are waiting for a review still get that message.',
+      ],
+      tr: [
+        'Bir yönetici hesabınızı kapattıysa giriş sayfası artık bunu söylüyor. Bir süredir hesabınızın "kısa bir incelemeyi beklediğini" ve e-posta göndereceğimizi yazıyordu — oysa kimse o hesabı incelemiyordu. Gerçekten incelemeyi bekleyen hesaplar o mesajı görmeye devam ediyor.',
+      ],
+      de: [
+        'Wenn ein Admin dein Konto abschaltet, sagt die Anmeldeseite das jetzt auch. Zuletzt stand dort, dein Konto warte „auf eine kurze Prüfung" und eine E-Mail sei unterwegs — bei einem Konto, das niemand prüfte. Konten, die wirklich auf eine Prüfung warten, sehen diese Meldung weiterhin.',
+      ],
+    },
+  },
+  {
     version: '0.55.0-beta',
     date: '2026-08-07',
     highlights: {


### PR DESCRIPTION
Zamanlanmış tam suite koşusu [31220653046](https://github.com/21072026/Internship/actions/runs/31220653046) (sha `ace338d`) **425/431** ile kırmızıydı — 6 deterministik hata, flaky 0. Altısının arkasında **üç** kök neden var; ikisi test drift'i, biri gerçek bir ürün regresyonu. Hepsi lokalde (lokal MySQL) birebir tekrarlandı, düzeltmeden sonra altı dosyadaki **10 testin tamamı yeşil (5.1 dk)**.

`Closes #1148`

## 1. Native `confirm()` gitti, 4 spec hâlâ onu bekliyordu (#1071) — test drift'i

PR #1071 16 bileşendeki `window.confirm()`'i `ConfirmDialog`'a çevirdi ve **`e2e/` altında hiçbir dosyaya dokunmadı**. `page.on('dialog', d => d.accept())` kuran spec artık hiç gelmeyecek bir event bekliyor; Delete tıkı sıradan bir DOM penceresi açıyor ve sessizce yutuluyor. Bu yüzden hata da bir sonraki assertion'da, alakasız görünen bir yerde çıkıyor:

| spec | görünen hata | gerçek sebep |
|---|---|---|
| `delete-confirm` | `dialogMessage.length` 0 | hiç native dialog yok |
| `goals-archive-sort` | `goal-<id>` 0 beklenirken 1 | silme hiç tetiklenmedi |
| `todos` | silinen satır 0 beklenirken 1 | aynı |
| `goal-templates` | `archivedAt !== null` false | aynı |

Yeni `e2e/helpers/confirm.ts` (`acceptConfirmDialog` / `cancelConfirmDialog` / `confirmDialog`) pencerenin test id'lerinin tek yeri olsun diye eklendi — pencere bir daha değişirse düzeltme tek satır. `delete-confirm` **#470 niyetini koruyor**: tık yalnızca soruyor (dialog görünüyor, mesajı boş değil, hiç `DELETE` gitmiyor), iptal notu bırakıyor, onay siliyor.

`impersonation-governance`, `search` ve `xss-injection` de dialog dinliyor ve **bilinçli olarak dokunulmadı**: sırasıyla bir `prompt()`, bir `alert()` ve XSS tespiti.

## 2. Pasifleştirme, hesabı "incelemeyi bekliyor" diye etiketliyordu (#1085) — **ürün regresyonu**

`PATCH /api/users/[id]` her pasifleştirmede `pendingApproval = true` yapıyordu. `src/lib/auth.ts` bu bayrağı görünce `ACCOUNT_PENDING_APPROVAL` fırlatıyor ve giriş sayfası, **admin'in az önce kapattığı** bir kullanıcıya şunu yazıyordu:

> Hesabın kısa bir incelemeyi bekliyor. Açıldığı anda sana e-posta göndereceğiz.

Kimse o hesabı incelemiyor, o e-posta hiç gelmeyecek ve "bu hesap devre dışı bırakıldı" mesajı hiç görünmüyordu. Bu, #1085'in kendi commit mesajındaki niyetin tersi: bayrak tam olarak *"'waiting for a review' ile 'an admin switched you off'u ayırmak"* için eklenmiş, sonra aynı PR bayrağı iki yolda da set ederek ayrımı yok etmiş.

Bayrağı geri almak güvenlik açısından güvenli, çünkü ikinci bir savunma zaten var: `verify-email` route'u yeniden içeri almayı `!isActive && !emailVerified && !pendingApproval` ile kapatıyor — doğrulanmış bir hesap `emailVerified` teriminde duruyor. Bayrağın gerçekten yük taşıdığı tek durum **hiç doğrulanmamış** bir kaydın elindeki linkle kendini geri alması. Düzeltme de tam o daralma:

- pasifleştirme → `pendingApproval` **yalnızca** `emailVerified === false` ise set edilir (reddedilen kayıt parklanmış kalır)
- aktifleştirme → her zaman temizler (değişmedi)
- doğrulanmış hesap → dürüst "This account has been deactivated." mesajını geri alır

`admin-user-active` artık pasifleştirme sonrası `pendingApproval === false` de doğruluyor, ayrım bir daha sessizce kaybolmasın.

Not: toplu işlem route'u (`/api/admin/candidates/bulk`) bayrağa hiç dokunmuyor, yani bu hata orada hiç yoktu; değişiklik tek kayıt yolunu toplu yola yaklaştırıyor.

## 3. Doğrulanmamış mentor ilk girişte `/onboarding`'e düşüyordu (#911) — test drift'i

`email-verification.spec.ts` `emailVerified: false` gerektirdiği için kullanıcıyı `seedUser()` yerine elle açıyor — ve `seedUser`'ın diğer tavizini kaybediyor: `mentorOnboardingSeenAt` boş olduğu için MENTOR'un ilk `/mentor` ziyareti first-run sihirbazına yönleniyor, `waitForURL('/mentor')` 20 sn sonra düşüyor (`navigated to ".../onboarding"`). Artık alan gerekçesiyle birlikte açıkça damgalanıyor.

## Doğrulama

- `npx playwright test` — altı dosyadaki **10/10 test yeşil** (5.1 dk), lokal MySQL'e karşı
- `npx tsc --noEmit` temiz
- `npm run check:i18n` → `i18n OK — 2183 keys × 3 locales`

## Sürüm checklist'i

- [x] `package.json` → **0.55.2-beta**
- [x] `CHANGELOG.md` → `## [0.55.2-beta] - 2026-08-08` (Fixed + Tests)
- [x] `src/lib/releaseNotes.ts` → 0.55.2-beta girdisi (EN/TR/DE) — giriş mesajı kullanıcıya görünen bir düzeltme
- [x] `docs/agent-experience.md` → oturum retrospektifi

🤖 Generated with [Claude Code](https://claude.com/claude-code)
