### PR TITLE
fix(messages): one chat per person, not one per entry point (#1156)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,40 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.55.5-beta] - 2026-08-08
+
+### Fixed
+- **One 1:1 thread per pair** (#1156). The same person could show up twice in `/messages`,
+  each row holding half the history. A 1:1 chat had two homes: the mentorship thread
+  (`Message.relationId`, `/messages/<relationId>`, linked from the mentee card, the portal,
+  notifications and digest emails) and the conversation layer (`Message.conversationId`,
+  `/messages/c/<id>`, reached from user-card quick actions and the inbox's "new chat" picker).
+  The inbox listed both, so anyone reachable both ways — a mentee who is also a project
+  co-member — got two rows. `Conversation.directKey` only ever deduped *within* the second
+  layer; nothing tied the two together. Several `MentorshipRelation` rows for one pair had the
+  same effect, one thread each.
+  - The DIRECT conversation is now the single home for a 1:1 chat.
+    `conversationForRelation()` (`src/lib/conversations.ts`) create-or-gets the pair's
+    conversation and adopts the relation's messages into it with a single indexed
+    `UPDATE … WHERE relationId = ? AND conversationId IS NULL` — idempotent, so it runs
+    lazily on the paths that touch a thread rather than as a deploy-time migration.
+  - `/messages/<relationId>` is now a server component that redirects to `/messages/c/<id>`,
+    so every existing link, notification and digest email lands on the one thread. It keeps
+    the same participants-or-admin authorization and falls through to the old view (which
+    renders "not found") when the relation isn't the viewer's.
+  - The inbox resolves the viewer's mentorships first, then lists conversations only.
+    `/portal/messages` — a mentorship-only list that missed project DMs and group chats —
+    redirects to the shared inbox, and the portal nav points there.
+  - Messages carry **both** links whenever both exist: the conversation is where the thread
+    lives, `relationId` keeps them inside the mentorship-scoped features. So reply-by-email
+    (relation-scoped `replyAddress` tokens) now works in the conversation the mentorship
+    thread redirects to, and the unread digest, the inbound-mail bridge, the mentor bulk
+    email and the onboarding checklist are unaffected.
+  - `e2e/one-thread-per-person.spec.ts` seeds the split state (a mentorship message + a
+    separate DIRECT conversation for the same pair) and asserts it collapses into one inbox
+    row holding both histories; the two specs asserting the old thread URL now expect the
+    conversation URL.
+
 ## [0.55.4-beta] - 2026-08-08
 
 ### Added

--- a/e2e/messages-inbox.spec.ts
+++ b/e2e/messages-inbox.spec.ts
@@ -42,9 +42,9 @@ test('a mentor reaches messages from the header icon and sees their thread', asy
     await expect(page.getByText('Msg Mentee')).toBeVisible({ timeout: 10_000 });
     await expect(page.getByText(/quick question/i)).toBeVisible();
 
-    // Opening the thread navigates into the conversation.
+    // Opening the thread navigates into the pair's one conversation (#1156).
     await page.getByText('Msg Mentee').click();
-    await page.waitForURL((u) => u.pathname === `/messages/${relation.id}`, { timeout: 20_000 });
+    await page.waitForURL((u) => u.pathname.startsWith('/messages/c/'), { timeout: 20_000 });
   } finally {
     await cleanupByEmail(mentorEmail);
     await cleanupByEmail(menteeEmail);

--- a/e2e/messaging.spec.ts
+++ b/e2e/messaging.spec.ts
@@ -89,7 +89,9 @@ test('mentor opens the thread from the mentee page and uses a suggested opener',
     await signIn(page, mentorEmail, 'MentorPass123', '/mentor');
     await page.goto(`/mentor/mentees/${rel.id}`);
     await page.getByTestId('mentee-message-link').click();
-    await page.waitForURL((u) => u.pathname === `/messages/${rel.id}`, { timeout: 20_000 });
+    // The mentee card links to the relation URL, which hands over to the pair's
+    // single conversation (#1156).
+    await page.waitForURL((u) => u.pathname.startsWith('/messages/c/'), { timeout: 20_000 });
 
     // Empty thread → openers, and the mentor side gets the welcome one first.
     const suggestions = page.getByTestId('message-suggestions');

--- a/e2e/one-thread-per-person.spec.ts
+++ b/e2e/one-thread-per-person.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+// One 1:1 thread per pair (#1156).
+//
+// A chat with the same person used to be able to exist twice: once as the
+// mentorship thread (/messages/<relationId>) and once as a DIRECT conversation
+// (/messages/c/<id>), which is what a mentor sees when they write from the
+// mentee page one day and from a user card the next. The inbox listed both, so
+// the same name appeared twice with half the history behind each row.
+//
+// This seeds exactly that split state and asserts it collapses into one thread
+// holding both sides of the history.
+//
+// Deliberately NOT tagged @smoke: the PR gate stays small (see CLAUDE.md).
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+async function signIn(page: import('@playwright/test').Page, email: string, pw: string, home: string) {
+  await page.goto('/auth/signin');
+  await page.fill('input[type="email"], input[name="email"]', email);
+  await page.fill('input[type="password"]', pw);
+  await page.click('button[type="submit"]');
+  await page.waitForURL((u) => u.pathname.startsWith(home), { timeout: 20_000 });
+}
+
+test('a mentor sees one thread per mentee, holding both histories', async ({ page }) => {
+  const mentorEmail = uniqueEmail('one-mentor');
+  const menteeEmail = uniqueEmail('one-mentee');
+  const pw = 'OnePass123';
+  const mentor = await seedUser(mentorEmail, pw, 'MENTOR', 'One Mentor');
+  const mentee = await seedUser(menteeEmail, pw, 'MENTEE', 'Duplicate Mentee');
+
+  const rel = await prisma.mentorshipRelation.create({
+    data: { mentorId: mentor.id, menteeId: mentee.id },
+  });
+  // Session 1: the legacy mentorship thread.
+  await prisma.message.create({
+    data: { relationId: rel.id, senderId: mentor.id, body: 'Written in the mentorship thread' },
+  });
+  // Session 2: a separate DIRECT conversation with the same person — the second
+  // chat window the bug report is about.
+  const directKey = [mentor.id, mentee.id].sort().join('|');
+  const conversation = await prisma.conversation.create({
+    data: {
+      type: 'DIRECT',
+      directKey,
+      participants: { create: [{ userId: mentor.id }, { userId: mentee.id }] },
+    },
+  });
+  await prisma.message.create({
+    data: { conversationId: conversation.id, senderId: mentor.id, body: 'Written in the direct conversation' },
+  });
+
+  try {
+    await signIn(page, mentorEmail, pw, '/mentor');
+    await page.goto('/messages');
+
+    // Exactly one row for this person, and none of them is the old relation URL.
+    const rows = page.locator('a[href^="/messages/c/"]').filter({ hasText: 'Duplicate Mentee' });
+    await expect(rows).toHaveCount(1, { timeout: 10_000 });
+    await expect(page.locator(`a[href="/messages/${rel.id}"]`)).toHaveCount(0);
+
+    // Both sessions' messages live in that one thread now.
+    await rows.click();
+    await page.waitForURL((u) => u.pathname.startsWith('/messages/c/'), { timeout: 20_000 });
+    const thread = page.getByTestId('thread-messages');
+    await expect(thread.getByText('Written in the mentorship thread')).toBeVisible({ timeout: 10_000 });
+    await expect(thread.getByText('Written in the direct conversation')).toBeVisible();
+
+    // The mentorship URL is linked from the mentee card, the portal, notification
+    // and digest emails — it keeps working by handing over to that thread.
+    await page.goto(`/messages/${rel.id}`);
+    await expect(page).toHaveURL(new RegExp(`/messages/c/${conversation.id}$`), { timeout: 20_000 });
+  } finally {
+    await prisma.message.deleteMany({
+      where: { OR: [{ relationId: rel.id }, { conversationId: conversation.id }] },
+    });
+    await prisma.conversation.deleteMany({ where: { directKey } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+  }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "internship-crm",
-  "version": "0.55.1-beta",
+  "version": "0.55.5-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "internship-crm",
-      "version": "0.55.1-beta",
+      "version": "0.55.5-beta",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {
@@ -4044,6 +4044,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6117,6 +6118,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.55.4-beta",
+  "version": "0.55.5-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "author": "Mehmet Erşahin",

--- a/src/app/api/mentor/email/route.ts
+++ b/src/app/api/mentor/email/route.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import { sendEmail } from '@/services/emailService';
 import { notify } from '@/lib/notify';
 import { replyAddress } from '@/lib/replyToken';
+import { conversationForRelation } from '@/lib/conversations';
 import { withTenantScope } from '@/lib/orgContext';
 import { emailAllowed } from '@/lib/notificationPrefs';
 import { TEXT_LIMITS } from '@/lib/textLimits';
@@ -70,11 +71,21 @@ export async function POST(request: Request) {
       await prisma.interactionLog.create({
         data: { relationId: rel.id, date: new Date(), type: 'Email', notes: `${personalSubject} — ${personalBody}` },
       });
-      // Mirror the email into the conversation thread + notify the mentee in-app.
+      // Mirror the email into the pair's one chat thread (#1156) + notify the
+      // mentee in-app. Stamped with both links: the conversation is where it is
+      // read, the relation is what the digest and reply tokens work off.
+      const conversation = await conversationForRelation(rel);
       await prisma.message.create({
-        data: { relationId: rel.id, senderId: session.user.id, channel: 'EMAIL', body: `${personalSubject}\n\n${personalBody}` },
+        data: {
+          relationId: rel.id,
+          conversationId: conversation?.id ?? null,
+          senderId: session.user.id,
+          channel: 'EMAIL',
+          body: `${personalSubject}\n\n${personalBody}`,
+        },
       });
-      await notify(rel.menteeId, 'message', `New message from ${session.user.name ?? 'your mentor'}.`, `/messages/${rel.id}`);
+      const link = conversation ? `/messages/c/${conversation.id}` : `/messages/${rel.id}`;
+      await notify(rel.menteeId, 'message', `New message from ${session.user.name ?? 'your mentor'}.`, link);
       sent++;
     }
 

--- a/src/app/api/messages/route.ts
+++ b/src/app/api/messages/route.ts
@@ -4,7 +4,14 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { z } from 'zod';
 import { getThreadIfAllowed, otherParticipant } from '@/lib/messaging';
-import { getConversationIfAllowed, otherConversationParticipants, canPostToConversation } from '@/lib/conversations';
+import {
+  getConversationIfAllowed,
+  otherConversationParticipants,
+  canPostToConversation,
+  conversationForRelation,
+  directCounterpartId,
+  latestMentorshipFor,
+} from '@/lib/conversations';
 import { loadProjectTeam } from '@/lib/projectTeam';
 import { notify } from '@/lib/notify';
 import { replyAddress } from '@/lib/replyToken';
@@ -129,6 +136,13 @@ export async function GET(request: Request) {
       });
     }
 
+    // Which side of a 1:1 chat is the mentor, when a mentorship stands behind it.
+    // The empty-thread openers differ for the two (a mentor welcomes, everyone
+    // else says hello), and since the mentorship thread hands over to the
+    // conversation (#1156) that has to be answerable here too.
+    const counterpartId = conversation ? directCounterpartId(conversation, session.user.id) : null;
+    const mentorId = counterpartId ? (await latestMentorshipFor(session.user.id, counterpartId))?.mentorId ?? null : null;
+
     return NextResponse.json({
       ...(rel
         ? { relationId: rel.id, mentor: rel.mentor, mentee: rel.mentee }
@@ -136,6 +150,7 @@ export async function GET(request: Request) {
             conversationId: conversation!.id,
             ...group,
             participants,
+            mentorId,
             // Lets the client render the thread read-only instead of failing on
             // send. The POST route enforces the same rule regardless (#770).
             canPost: await canPostToConversation(session.user, conversation!),
@@ -221,11 +236,22 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: CONTENT_MISMATCH_ERROR }, { status: 400 });
     }
 
+    // Both links are set whenever both exist (#1156): the conversation is where
+    // the thread lives, and the relationId keeps the message inside the
+    // mentorship-scoped features (reply-by-email, the unread digest, the
+    // onboarding checklist). Addressed by relation, that means resolving the
+    // pair's conversation; addressed by conversation, looking up the mentorship
+    // behind a 1:1 chat. A project DM between two people with no mentorship, and
+    // a group chat, keep a conversationId alone.
+    const relConversationId = rel ? (await conversationForRelation(rel))?.id ?? null : null;
+    const directOtherId = conversation ? directCounterpartId(conversation, session.user.id) : null;
+    const stampRelationId = directOtherId ? (await latestMentorshipFor(session.user.id, directOtherId))?.id ?? null : null;
+
     const message = await prisma.message.create({
       data: {
-        // Exactly one link is set: a conversation message leaves relationId null
-        // (and vice versa), which is what the nullable columns from #768 allow.
-        ...(rel ? { relationId: rel.id } : { conversationId: conversation!.id }),
+        ...(rel
+          ? { relationId: rel.id, ...(relConversationId ? { conversationId: relConversationId } : {}) }
+          : { conversationId: conversation!.id, ...(stampRelationId ? { relationId: stampRelationId } : {}) }),
         senderId: session.user.id,
         body,
         channel: 'IN_APP',
@@ -242,7 +268,13 @@ export async function POST(request: Request) {
     const recipients = (
       rel ? [otherParticipant(rel, session.user.id)] : await otherConversationParticipants(conversation!, session.user.id)
     ).filter((id) => id && id !== session.user.id);
-    const link = rel ? `/messages/${rel.id}` : `/messages/c/${conversation!.id}`;
+    // Always the thread the recipient will actually read it in.
+    const threadConversationId = relConversationId ?? conversation?.id ?? null;
+    const link = threadConversationId ? `/messages/c/${threadConversationId}` : `/messages/${rel!.id}`;
+    // Email replies are routed by a relation-scoped token, so reply-by-email is
+    // offered wherever a mentorship stands behind the thread — including the
+    // conversation the mentorship thread now redirects to.
+    const replyRelationId = rel?.id ?? stampRelationId;
 
     for (const recipient of recipients) {
       await notify(recipient, 'message', `New message from ${session.user.name ?? 'your mentor'}.`, link);
@@ -261,10 +293,9 @@ export async function POST(request: Request) {
           to: rcpt.email,
           subject: `New message from ${sender}`,
           html: `<p>${sender} sent you a message:</p>${safe.trim() ? `<blockquote style="border-left:3px solid #ccc;padding-left:12px;color:#444">${safe.replace(/\n/g, '<br>')}</blockquote>` : ''}${attachCount ? `<p>📎 ${attachCount} attachment(s) included.</p>` : ''}<p>Reply to this email or open the conversation in the app.</p>`,
-          // Email replies are routed by a relation-scoped token, so only the
-          // mentorship path can offer reply-by-email today; conversation
-          // recipients get the same notification without a Reply-To.
-          ...(rel ? { replyTo: replyAddress(rel.id, recipient) } : {}),
+          // Project DMs with no mentorship behind them get the same notification
+          // without a Reply-To (see replyRelationId above).
+          ...(replyRelationId ? { replyTo: replyAddress(replyRelationId, recipient) } : {}),
           // Mirror the attachments (incl. pasted images) into the email too.
           attachments: fileBufs.map((fb) => ({ filename: fb.filename, content: fb.data, contentType: fb.contentType })),
         }).catch((e) => logger.error('Failed to mirror message email', { error: String(e) }));

--- a/src/app/messages/[relationId]/page.tsx
+++ b/src/app/messages/[relationId]/page.tsx
@@ -1,12 +1,28 @@
-'use client';
-
-import { use } from 'react';
+import { getServerSession } from 'next-auth';
+import { redirect } from 'next/navigation';
+import { authOptions } from '@/lib/auth';
+import { getThreadIfAllowed } from '@/lib/messaging';
+import { conversationForRelation } from '@/lib/conversations';
 import { MessageThreadView } from '@/components/MessageThreadView';
 
-// A mentorship thread, addressed by its relation id. The thread UI itself is
-// shared with the conversation route (/messages/c/[conversationId]) — see
-// MessageThreadView.
-export default function ThreadPage({ params }: { params: Promise<{ relationId: string }> }) {
-  const { relationId } = use(params);
+// A mentorship thread, addressed by its relation id.
+//
+// This URL is the app's oldest way into a 1:1 chat and it is linked from
+// everywhere — the mentee card, the portal, notifications, digest emails — so it
+// stays, but it no longer *is* a thread: it hands over to the pair's single
+// conversation (#1156). Two entry points to the same person used to mean two
+// threads with half the history in each.
+export default async function ThreadPage({ params }: { params: Promise<{ relationId: string }> }) {
+  const { relationId } = await params;
+  const session = await getServerSession(authOptions);
+  if (!session) redirect('/auth/signin');
+
+  // Same authorization as the thread API: participants and admins only. An
+  // unauthorized (or unknown) relation falls through to the view below, which
+  // renders the usual "not found" without leaking that the relation exists.
+  const rel = await getThreadIfAllowed(session.user, relationId);
+  const conversation = rel ? await conversationForRelation(rel) : null;
+  if (conversation) redirect(`/messages/c/${conversation.id}`);
+
   return <MessageThreadView target={{ kind: 'relation', id: relationId }} />;
 }

--- a/src/app/messages/page.tsx
+++ b/src/app/messages/page.tsx
@@ -8,7 +8,7 @@ import { prisma } from '@/lib/prisma';
 import { getServerDictionary } from '@/i18n/server';
 import { relativeTime } from '@/lib/relativeTime';
 import { StartConversationPicker } from '@/components/StartConversationPicker';
-import { createOrGetProjectConversation } from '@/lib/conversations';
+import { conversationForRelation, createOrGetProjectConversation } from '@/lib/conversations';
 
 // Unified message inbox for every role: lists the viewer's conversation
 // threads (mentor side or mentee side) with the other participant, a preview
@@ -26,6 +26,18 @@ export default async function MessagesInboxPage() {
   const myProjectIds = (
     await prisma.projectMember.findMany({ where: { userId: me }, select: { projectId: true } })
   ).map((m) => m.projectId);
+
+  // Every mentorship the viewer is in, resolved to the pair's one conversation
+  // and taking the relation's own messages with it (#1156). This list used to
+  // render mentorship threads *alongside* conversations, so anyone reachable
+  // both ways — as a mentee and as a project co-member — appeared twice, with
+  // half of the history behind each row. Runs before the query below so the
+  // adopted messages count towards the preview and the unread badge.
+  const myRelations = await prisma.mentorshipRelation.findMany({
+    where: { OR: [{ mentorId: me }, { menteeId: me }] },
+    select: { id: true, mentorId: true, menteeId: true },
+  });
+  await Promise.all(myRelations.map(conversationForRelation));
 
   // Lazy-create chats for projects that predate #771, then list GROUP and DIRECT
   // conversations together so the project chat is reachable from the inbox.
@@ -62,33 +74,9 @@ export default async function MessagesInboxPage() {
       })
     : [];
 
-  const relations = await prisma.mentorshipRelation.findMany({
-    where: { OR: [{ mentorId: me }, { menteeId: me }] },
-    select: {
-      id: true,
-      mentorId: true,
-      mentor: { select: { fullName: true } },
-      mentee: { select: { fullName: true } },
-      messages: {
-        orderBy: { createdAt: 'desc' },
-        take: 1,
-        select: { body: true, createdAt: true, senderId: true },
-      },
-      _count: { select: { messages: { where: { readAt: null, senderId: { not: me } } } } },
-    },
-  });
-
-  // Mentorship threads and conversations share one shape, so they sort and
-  // render as a single list; `href` is what distinguishes the two routes.
-  const threads = [
-    ...relations.map((r) => ({
-      key: `rel-${r.id}`,
-      href: `/messages/${r.id}`,
-      otherName: (r.mentorId === me ? r.mentee?.fullName : r.mentor?.fullName) ?? '—',
-      last: r.messages[0] ?? null,
-      unread: r._count.messages,
-    })),
-    ...conversations.map((c) => ({
+  // One row per conversation — which, for a 1:1 chat, means one row per person.
+  const threads = conversations
+    .map((c) => ({
       key: `conv-${c.id}`,
       href: `/messages/c/${c.id}`,
       otherName: c.type === 'GROUP'
@@ -96,12 +84,12 @@ export default async function MessagesInboxPage() {
         : c.participants.find((p) => p.userId !== me)?.user.fullName ?? '—',
       last: c.messages[0] ?? null,
       unread: c._count.messages,
-    })),
-  ].sort((a, b) => {
-    const at = a.last?.createdAt?.getTime() ?? 0;
-    const bt = b.last?.createdAt?.getTime() ?? 0;
-    return bt - at;
-  });
+    }))
+    .sort((a, b) => {
+      const at = a.last?.createdAt?.getTime() ?? 0;
+      const bt = b.last?.createdAt?.getTime() ?? 0;
+      return bt - at;
+    });
 
   // Offer only people we don't already have a DM with — those threads are in
   // the list above. DIRECT only: every co-member is also a participant of the

--- a/src/app/portal/messages/page.tsx
+++ b/src/app/portal/messages/page.tsx
@@ -1,55 +1,9 @@
-'use client';
+import { redirect } from 'next/navigation';
 
-import { useEffect, useState } from 'react';
-import Link from 'next/link';
-import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
-import { SkeletonRows } from '@/components/ui/Skeleton';
-import { MessageSquare } from 'lucide-react';
-import { useT } from '@/i18n/client';
-
-interface Relation {
-  id: string;
-  mentor: { fullName: string };
-}
-
-// Mentee view: list of conversation threads (one per mentorship).
+// The mentee portal had its own message list, built from mentorships alone: it
+// missed project DMs and group chats, and showed one row per mentorship rather
+// than one per person. /messages is the inbox for every role (#1156), so this
+// route only forwards — old links and bookmarks keep working.
 export default function PortalMessagesPage() {
-  const t = useT();
-  const [relations, setRelations] = useState<Relation[]>([]);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    fetch('/api/mentorship')
-      .then((r) => r.json())
-      .then((d) => setRelations(d.relations ?? []))
-      .finally(() => setLoading(false));
-  }, []);
-
-  return (
-    <div>
-      <div className="mb-6">
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.messages.title}</h1>
-        <p className="text-gray-500 mt-1">{t.messages.listSubtitle}</p>
-      </div>
-      <Card>
-        <CardHeader><CardTitle>{t.messages.threads}</CardTitle></CardHeader>
-        {loading ? (
-          <SkeletonRows rows={3} />
-        ) : relations.length === 0 ? (
-          <p className="text-center py-10 text-gray-400">{t.messages.noThreads}</p>
-        ) : (
-          <div className="divide-y divide-gray-50">
-            {relations.map((r) => (
-              <Link key={r.id} href={`/messages/${r.id}`} className="flex items-center gap-3 py-3 hover:bg-gray-50 rounded-lg px-2">
-                <div className="w-9 h-9 rounded-full bg-blue-100 flex items-center justify-center">
-                  <MessageSquare className="h-4 w-4 text-blue-600" />
-                </div>
-                <span className="text-sm font-medium text-gray-900">{r.mentor?.fullName ?? '—'}</span>
-              </Link>
-            ))}
-          </div>
-        )}
-      </Card>
-    </div>
-  );
+  redirect('/messages');
 }

--- a/src/components/MessageThreadView.tsx
+++ b/src/components/MessageThreadView.tsx
@@ -71,8 +71,10 @@ export function MessageThreadView({ target }: { target: ThreadTarget }) {
   // Set for a project group chat: which project it belongs to, so the header can
   // name the room, list who is in it and link back to the project (#51).
   const [group, setGroup] = useState<{ projectId: string | null; projectName: string | null } | null>(null);
-  // Mentorship threads only: who the mentor is, so an empty thread can suggest
-  // a *welcome* to the mentor and a neutral opener to the mentee (#1130).
+  // Who the mentor is, when a mentorship stands behind this 1:1 thread, so an
+  // empty thread can suggest a *welcome* to the mentor and a neutral opener to
+  // the mentee (#1130). Answered for conversations too since the mentorship
+  // thread hands over to one (#1156).
   const [mentorId, setMentorId] = useState<string | null>(null);
   const [showParties, setShowParties] = useState(false);
   const [body, setBody] = useState('');
@@ -148,7 +150,7 @@ export function MessageThreadView({ target }: { target: ThreadTarget }) {
     // A mentorship thread answers with mentor/mentee; a conversation with a
     // participants array. Normalize both to one list.
     setParties(d.participants ?? [d.mentor, d.mentee].filter(Boolean));
-    setMentorId(d.mentor?.id ?? null);
+    setMentorId(d.mentorId ?? d.mentor?.id ?? null);
     setGroup(d.type === 'GROUP' ? { projectId: d.projectId ?? null, projectName: d.projectName ?? null } : null);
     setCanPost(d.canPost !== false);
     setLoading(false);
@@ -301,7 +303,7 @@ export function MessageThreadView({ target }: { target: ThreadTarget }) {
   const suggestions =
     messages.length > 0 || !canPost || group || !otherFirstName
       ? []
-      : (target.kind === 'relation' && !!myId && mentorId === myId
+      : (!!myId && mentorId === myId
           ? [openers.welcome, openers.introCall, openers.goals]
           : [openers.hello, openers.intro, openers.question]
         ).map((o) => ({ label: o.label, text: o.text.replace('{name}', otherFirstName) }));

--- a/src/components/PortalNav.tsx
+++ b/src/components/PortalNav.tsx
@@ -17,7 +17,8 @@ export function PortalNav() {
     // Their own projects, not the public showcase at /projects (#1114).
     { href: '/portal/projects', label: t.nav.projects, Icon: FolderKanban },
     { href: '/todos', label: t.nav.todos, Icon: ListChecks },
-    { href: '/portal/messages', label: t.nav.messages, Icon: MessageSquare },
+    // The shared inbox, not a portal-only copy of it (#1156).
+    { href: '/messages', label: t.nav.messages, Icon: MessageSquare },
     { href: '/portal/interactions', label: t.nav.interactionLogs, Icon: BookOpen },
     { href: '/portal/notes', label: t.portal.notes.title, Icon: Lock },
   ];

--- a/src/lib/conversations.ts
+++ b/src/lib/conversations.ts
@@ -191,6 +191,88 @@ export async function findOrCreateDirectConversation(userAId: string, userBId: s
   }
 }
 
+// ---------------------------------------------------------------------------
+// One 1:1 thread per pair (#1156).
+//
+// A 1:1 chat grew two parallel homes: the original mentorship thread
+// (Message.relationId, /messages/<relationId>) and the conversation layer
+// (Message.conversationId, /messages/c/<id>). A mentor who wrote from the mentee
+// page and again from a user card ended up with the same person twice in the
+// inbox, each row holding half the history.
+//
+// The DIRECT conversation is now the single home for a 1:1 thread. A mentorship's
+// messages are adopted into it on first touch, and new messages keep their
+// relationId as an annotation, so everything that reads a thread through the
+// mentorship — reply-by-email tokens, the unread digest, the onboarding
+// checklist — keeps working off it.
+// ---------------------------------------------------------------------------
+
+// The pair's mentorship, if any; the most recently started one when a pair has
+// several (nothing stops an admin from assigning the same mentee twice). Used to
+// stamp a new conversation message so it stays visible to the mentorship-scoped
+// features, and to tell a 1:1 thread which side of it is the mentor.
+export async function latestMentorshipFor(
+  userAId: string,
+  userBId: string,
+): Promise<{ id: string; mentorId: string } | null> {
+  if (!userAId || !userBId || userAId === userBId) return null;
+  return prisma.mentorshipRelation.findFirst({
+    where: {
+      OR: [
+        { mentorId: userAId, menteeId: userBId },
+        { mentorId: userBId, menteeId: userAId },
+      ],
+    },
+    orderBy: { startDate: 'desc' },
+    select: { id: true, mentorId: true },
+  });
+}
+
+// The other side of a 1:1 conversation, from the viewer's seat.
+export function directCounterpartId(
+  conversation: { type: string; participants: { userId: string }[] },
+  userId: string,
+): string | null {
+  if (conversation.type !== 'DIRECT') return null;
+  return conversation.participants.map((p) => p.userId).find((id) => id !== userId) ?? null;
+}
+
+// The conversation that holds a mentorship's 1:1 thread, creating it on first
+// use and pulling the relation's own messages in with it.
+//
+// No canMessage() check: a mentorship IS permission to message (see
+// hasMentorship above), so re-deriving it here would only cost queries on a page
+// that resolves one of these per mentee. The adoption is a single indexed UPDATE
+// and idempotent — messages already carrying a conversationId are left alone, so
+// this is safe to call on every page load.
+export async function conversationForRelation(relation: { id: string; mentorId: string; menteeId: string }) {
+  const key = directKeyFor(relation.mentorId, relation.menteeId);
+  let conversation = await prisma.conversation.findUnique({ where: { directKey: key }, include: CONVERSATION_INCLUDE });
+  if (!conversation) {
+    try {
+      conversation = await prisma.conversation.create({
+        data: {
+          type: 'DIRECT',
+          directKey: key,
+          participants: { create: [{ userId: relation.mentorId }, { userId: relation.menteeId }] },
+        },
+        include: CONVERSATION_INCLUDE,
+      });
+    } catch (e) {
+      // Lost the race with another request (or a second relation for the same
+      // pair, resolved in parallel) — read the winner's row.
+      if (!(e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002')) throw e;
+      conversation = await prisma.conversation.findUnique({ where: { directKey: key }, include: CONVERSATION_INCLUDE });
+    }
+  }
+  if (!conversation) return null;
+  await prisma.message.updateMany({
+    where: { relationId: relation.id, conversationId: null },
+    data: { conversationId: conversation.id },
+  });
+  return conversation;
+}
+
 // Creates the project's single GROUP conversation on first use and reconciles
 // all current ProjectMember rows into its participant list. The compound unique
 // key keeps concurrent callers idempotent at database level.

--- a/src/lib/inboundEmail.ts
+++ b/src/lib/inboundEmail.ts
@@ -1,4 +1,5 @@
 import { prisma } from '@/lib/prisma';
+import { conversationForRelation } from '@/lib/conversations';
 import { verifyReplyToken, extractReplyToken } from '@/lib/replyToken';
 import { notify } from '@/lib/notify';
 import { logger } from '@/lib/logger';
@@ -80,8 +81,14 @@ export async function routeInboundEmail(input: InboundEmail): Promise<InboundRes
   }
 
   const body = stripQuoted(input.text ?? '') || '(empty message)';
+  // The reply belongs in the pair's one thread, not only on the mentorship it
+  // was addressed to (#1156) — otherwise an emailed answer never shows up in the
+  // chat the two of them are actually reading.
+  const conversation = await conversationForRelation(rel);
   try {
-    await prisma.message.create({ data: { relationId, senderId, channel: 'EMAIL', body, inboundMessageId } });
+    await prisma.message.create({
+      data: { relationId, conversationId: conversation?.id ?? null, senderId, channel: 'EMAIL', body, inboundMessageId },
+    });
   } catch (e) {
     // Unique violation on inboundMessageId — another tick won the race.
     if (inboundMessageId && (e as { code?: string }).code === 'P2002') {
@@ -91,7 +98,8 @@ export async function routeInboundEmail(input: InboundEmail): Promise<InboundRes
   }
 
   const recipient = senderId === rel.mentor.id ? rel.mentee.id : rel.mentor.id;
-  await notify(recipient, 'message', 'New message (by email).', `/messages/${relationId}`);
+  const link = conversation ? `/messages/c/${conversation.id}` : `/messages/${relationId}`;
+  await notify(recipient, 'message', 'New message (by email).', link);
 
   return { ok: true, relationId, duplicate: false };
 }

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,24 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.55.5-beta',
+    date: '2026-08-08',
+    highlights: {
+      en: [
+        'One chat per person. The same contact could appear twice in Messages — a chat opened from their mentee page and one opened from their profile card were two separate threads, each with half of what you had written. They are now a single conversation, with the whole history in order.',
+        'Old links still work: a message notification, a digest email or a bookmark to the previous thread opens that one conversation. Mentees reach the same inbox as everyone else, so project chats and group chats are in the list too.',
+      ],
+      tr: [
+        'Kişi başına tek sohbet. Aynı kişi Mesajlar’da iki kez görünebiliyordu — mentee sayfasından açtığınız sohbetle profil kartından açtığınız sohbet iki ayrı oturumdu ve yazdıklarınızın yarısı birinde, yarısı diğerindeydi. Artık tek bir konuşma var, tüm geçmiş sırasıyla orada.',
+        'Eski bağlantılar çalışmaya devam ediyor: mesaj bildirimi, özet e-postası ya da eski sohbete kaydettiğiniz bir yer imi hep o tek konuşmayı açıyor. Mentee’ler de herkesle aynı gelen kutusunu kullanıyor; proje ve grup sohbetleri de listede.',
+      ],
+      de: [
+        'Ein Chat pro Person. Dieselbe Person konnte zweimal in den Nachrichten auftauchen — ein über ihre Mentee-Seite geöffneter Chat und ein über ihre Profilkarte geöffneter waren zwei getrennte Verläufe, jeder mit der Hälfte des Geschriebenen. Daraus ist eine Unterhaltung geworden, mit dem vollständigen Verlauf in der richtigen Reihenfolge.',
+        'Alte Links funktionieren weiter: eine Nachrichten-Benachrichtigung, eine Zusammenfassungs-E-Mail oder ein Lesezeichen auf den früheren Verlauf öffnen diese eine Unterhaltung. Mentees nutzen denselben Posteingang wie alle anderen — Projekt- und Gruppenchats stehen dort ebenfalls.',
+      ],
+    },
+  },
+  {
     version: '0.55.4-beta',
     date: '2026-08-08',
     highlights: {


### PR DESCRIPTION
Closes #1156

## Sorun

Aynı kişiyle iki ayrı mesajlaşma oturumu olabiliyordu; gelen kutusunda aynı isim iki satırdı ve
geçmişin yarısı birinde, yarısı diğerinde kalıyordu.

Bir 1:1 sohbetin iki evi vardı:

| | Nerede saklanır | URL | Nereden açılır |
|---|---|---|---|
| Mentorluk kanalı | `Message.relationId` | `/messages/<relationId>` | mentee kartı, portal, bildirimler, özet e-postaları |
| Konuşma katmanı | `Message.conversationId` | `/messages/c/<id>` | kişi kartındaki hızlı eylemler, gelen kutusundaki "yeni sohbet" |

`/messages` her ikisini de listeliyordu. `Conversation.directKey` yalnızca ikinci katmanın kendi
içinde tekilliği sağlıyor, iki katman arasında hiçbir şey sağlamıyordu. Aynı çift için birden
fazla `MentorshipRelation` de aynı sonucu veriyordu.

## Çözüm

DIRECT konuşma artık 1:1 sohbetin **tek** evi:

- `conversationForRelation()` çiftin konuşmasını bul-veya-oluştur yapıyor ve ilişkinin
  mesajlarını tek bir indeksli `UPDATE … WHERE relationId = ? AND conversationId IS NULL` ile
  devralıyor. İdempotent — bu yüzden deploy zamanlı bir migration yerine sohbete dokunan
  yollarda tembel çalışıyor (şema değişikliği yok, `db push` gerekmiyor).
- `/messages/<relationId>` artık `/messages/c/<id>`'ye yönlendiriyor (aynı katılımcı/admin
  yetkilendirmesiyle), böylece mevcut tüm bağlantılar, bildirimler ve özet e-postaları o tek
  sohbete iniyor.
- Gelen kutusu yalnızca konuşmaları listeliyor. `/portal/messages` — proje DM'lerini ve grup
  sohbetlerini kaçıran, yalnızca mentorluklardan üretilen ayrı bir liste — ortak gelen kutusuna
  yönleniyor; portal menüsü de oraya bakıyor.
- Mesajlar iki bağlantıyı da taşıyor: sohbet konuşmada yaşıyor, `relationId` ise mesajı
  mentorluğa bağlı özelliklerin içinde tutuyor. Böylece **e-postayla yanıt** artık mentorluk
  kanalının yönlendirdiği konuşmada da çalışıyor; okunmamış özeti, gelen posta köprüsü, mentor
  toplu e-postası ve onboarding kontrol listesi etkilenmiyor.
- Sohbet API'si DIRECT konuşmalarda da mentörün kim olduğunu bildiriyor, böylece mentor boş
  sohbette "hoş geldin" önerisini kaybetmiyor (bu, ilk denemede e2e'nin yakaladığı gerçek bir
  gerilemeydi).

## Test

- `e2e/one-thread-per-person.spec.ts` (yeni): bölünmüş durumu tohumluyor (bir mentorluk mesajı +
  aynı çift için ayrı bir DIRECT konuşma) ve tek satıra, iki geçmişi de taşıyan tek sohbete
  indiğini doğruluyor; eski URL'nin yönlendirdiğini de.
- Eski thread URL'sini bekleyen iki spec konuşma URL'sini bekleyecek şekilde güncellendi.
- Yerel (sentetik veri, yerel MariaDB) koşum: `messaging`, `messages-inbox`,
  `message-attachments`, `project-dm`, `portal-quick-contact`, `mobile-chat-layout`, `comms`,
  `support-chat`, `project-team-and-goals` — hepsi yeşil. `tsc --noEmit` ve `check:i18n` temiz.
- Tarayıcıda elle doğrulandı: iki oturum tek satıra indi, `/messages/<relationId>` konuşmaya
  yönlendirdi, iki geçmiş kronolojik sırada birleşti ve yeni mesaj hem `conversationId` hem
  `relationId` taşıyor.

## Sürüm

0.55.4-beta + CHANGELOG + `/release-notes` (EN/TR/DE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
