### PR TITLE
feat(announcements): a user only sees what was broadcast after they joined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.55.7-beta] - 2026-08-08
+
+### Changed
+- **Announcements start the day you join** (#1161). The dashboard card and the
+  `/announcements` archive both read `GET /api/announcements`, which returned the whole
+  `Announcement` table to every signed-in user — so a brand-new account's first screen was
+  filled with other people's history ("the meeting has started", "re-point your git remote
+  today"), messages written for whoever was in the room at the time and, read weeks later,
+  misleading.
+  - The feed is now cut at the reader's own `User.createdAt` (`where: { createdAt: { gte } }`,
+    applied to the `count` as well, so pagination cannot walk back past it).
+  - The per-user notification bell already behaved this way for free — `Notification` rows are
+    created during the broadcast fan-out, so an account created later simply has none. This
+    brings the two remaining surfaces in line with it.
+  - The complete record is untouched at `/admin/announcements`, which is the sending log.
+  - The cutoff is read from the database, never from the session: a JWT minted before this
+    shipped carries no such claim, and a client-supplied date would be a trivial way to read
+    the archive back. A session pointing at a deleted user row gets an empty feed.
+
 ## [0.55.6-beta] - 2026-08-08
 
 ### Fixed

--- a/e2e/announcements-feed.spec.ts
+++ b/e2e/announcements-feed.spec.ts
@@ -60,6 +60,57 @@ test('an admin announcement is also visible to mentors, via the same shared feed
   }
 });
 
+// #1161: an announcement is a message to the people who were there, so a user
+// who joined afterwards must not see it — not on the dashboard card and not in
+// the /announcements archive. Both surfaces read GET /api/announcements, which
+// cuts the feed at the reader's own createdAt.
+test('a user does not see announcements broadcast before they joined', async ({ page }) => {
+  const adminEmail = uniqueEmail('annjoin-admin');
+  const menteeEmail = uniqueEmail('annjoin-mentee');
+  const stamp = Date.now().toString(36);
+  const beforeText = `Before-join announcement ${stamp}`;
+  const afterText = `After-join announcement ${stamp}`;
+  const admin = await seedUser(adminEmail, 'AdminPass123', 'ADMIN', 'Ann Join Admin');
+
+  // Broadcast a day before the mentee's account exists.
+  await prisma.announcement.create({
+    data: {
+      text: beforeText,
+      sentById: admin.id,
+      recipientCount: 1,
+      createdAt: new Date(Date.now() - 24 * 60 * 60 * 1000),
+    },
+  });
+
+  // The mentee joins now…
+  await seedUser(menteeEmail, 'MenteePass123', 'MENTEE', 'Ann Join Mentee');
+  // …and only then is the second announcement broadcast.
+  await prisma.announcement.create({ data: { text: afterText, sentById: admin.id, recipientCount: 2 } });
+
+  try {
+    await signInAsFreshUser(page, menteeEmail, 'MenteePass123', '/portal');
+
+    // Dashboard card: the post-join one only.
+    const card = page.getByTestId('announcements-list');
+    await expect(card.getByText(afterText)).toBeVisible({ timeout: 10_000 });
+    await expect(card.getByText(beforeText)).toHaveCount(0);
+
+    // The archive is cut at the same line — it is not a back door to the history.
+    await page.goto('/announcements');
+    const list = page.getByTestId('announcements-full-list');
+    await expect(list.getByText(afterText)).toBeVisible({ timeout: 10_000 });
+    await expect(list.getByText(beforeText)).toHaveCount(0);
+
+    // The API's own count agrees, so pagination cannot page back into the past.
+    const feed = await (await page.request.get('/api/announcements?page=1&pageSize=50')).json();
+    expect(feed.announcements.some((a: { text: string }) => a.text === beforeText)).toBe(false);
+  } finally {
+    await prisma.announcement.deleteMany({ where: { text: { in: [beforeText, afterText] } } });
+    await cleanupByEmail(adminEmail);
+    await cleanupByEmail(menteeEmail);
+  }
+});
+
 test('GET /api/announcements requires authentication', async ({ page }) => {
   const res = await page.request.get('/api/announcements');
   expect(res.status()).toBe(401);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.55.6-beta",
+  "version": "0.55.7-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "author": "Mehmet Erşahin",

--- a/src/app/api/announcements/route.ts
+++ b/src/app/api/announcements/route.ts
@@ -7,7 +7,17 @@ import { announcementImageUrl } from '@/lib/announcementImage';
 // GET — paginated announcement history for the signed-in user. Admin
 // broadcasts (POST /api/admin/announcements) always target every active user
 // and the Announcement model carries no per-role/org/user targeting fields,
-// so any authenticated user reads the same shared history here.
+// so the only thing that varies per reader is *when they joined*.
+//
+// A user sees nothing that was broadcast before their account existed (#1161).
+// An announcement is a message to the people who were there — "the meeting has
+// started", "re-point your git remote today" — not a history lesson for
+// whoever signs up next month; read weeks late it is noise at best and
+// actively misleading at worst. This covers both surfaces that read this route:
+// the dashboard card and the /announcements archive. The per-user notification
+// bell already behaves this way for free (rows are created at broadcast time,
+// so a later account simply has none). The full record stays available to
+// admins at /admin/announcements, which is the sending log.
 export async function GET(request: Request) {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -16,9 +26,22 @@ export async function GET(request: Request) {
   const page = Math.max(1, parseInt(searchParams.get('page') || '1', 10) || 1);
   const pageSize = Math.min(50, Math.max(1, parseInt(searchParams.get('pageSize') || '10', 10) || 10));
 
+  // The cutoff is read from the DB, never from the session/JWT: a token minted
+  // before this shipped has no joinedAt claim, and a client-supplied date would
+  // be a trivial way to read back the whole archive.
+  const me = await prisma.user.findUnique({
+    where: { id: session.user.id },
+    select: { createdAt: true },
+  });
+  // A session pointing at a user row that no longer exists gets an empty feed
+  // rather than the entire history.
+  if (!me) return NextResponse.json({ announcements: [], total: 0, page, pageSize });
+  const where = { createdAt: { gte: me.createdAt } };
+
   const [total, announcements] = await Promise.all([
-    prisma.announcement.count(),
+    prisma.announcement.count({ where }),
     prisma.announcement.findMany({
+      where,
       orderBy: { createdAt: 'desc' },
       skip: (page - 1) * pageSize,
       take: pageSize,

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,21 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.55.7-beta',
+    date: '2026-08-08',
+    highlights: {
+      en: [
+        'Announcements now start the day you join. A new account used to open onto everyone else\'s back catalogue — "the meeting has started", "re-point your git remote today" — messages written for the people who were there, which are confusing to read weeks later. You now see what was announced from your first day onward, on the dashboard card and in the announcements archive alike.',
+      ],
+      tr: [
+        'Duyurular artık katıldığınız günden başlıyor. Yeni bir hesap, açıldığında herkesin geçmiş duyurularını görüyordu — "toplantı başladı", "bugün git remote adresinizi değiştirin" gibi, o an orada olanlara yazılmış ve haftalar sonra okununca kafa karıştıran mesajlar. Artık ilk gününüzden itibaren duyurulanları görüyorsunuz; hem panel kartında hem duyuru arşivinde.',
+      ],
+      de: [
+        'Ankündigungen beginnen jetzt an dem Tag, an dem Sie dazukommen. Ein neues Konto öffnete sich bisher auf dem Archiv aller anderen — "das Meeting hat begonnen", "richtet heute euer Git-Remote neu aus" — Nachrichten für die, die damals dabei waren, und Wochen später verwirrend. Sie sehen nun, was ab Ihrem ersten Tag angekündigt wurde, auf der Dashboard-Karte wie im Ankündigungsarchiv.',
+      ],
+    },
+  },
+  {
     version: '0.55.6-beta',
     date: '2026-08-08',
     highlights: {


### PR DESCRIPTION
Closes #1161

## Sorun

Panel kartı ve `/announcements` arşivi aynı uca bakıyor: `GET /api/announcements`. Bu uç `Announcement` tablosunun **tamamını** her oturum açmış kullanıcıya döndürüyordu — katılım tarihi filtresi yoktu.

Sonuç: yeni bir hesabın ilk ekranı başkalarının geçmişiyle doluyordu. "toplanti basladi.", "repo yu yeni bir yere tasidim, dün clone edenler bugün add_remote ile yeni adresi yazmalilar." — bunlar o an orada olanlara yazılmış mesajlar; haftalar sonra okunduğunda en iyi ihtimalle gürültü, kötü ihtimalle yanıltıcı ("hangi toplantı? ben mi geç kaldım?").

## Değişiklik

- Akış artık **okuyanın kendi `User.createdAt`'inde** kesiliyor: `where: { createdAt: { gte: me.createdAt } }`, aynı filtre `count` için de uygulanıyor — yani sayfalama geçmişe geri yürüyemiyor.
- Bildirim zili zaten böyle davranıyordu (yayın anında kişi başına `Notification` satırı açılıyor, sonradan açılan hesapta hiç yok). Bu değişiklik kalan iki yüzeyi de onunla aynı hizaya getiriyor.
- Tam kayıt **`/admin/announcements`**'ta duruyor ve dokunulmadı — yöneticinin gönderim kaydı orası.

## Güvenlik notu

Kesim tarihi oturumdan/JWT'den değil **veritabanından** okunuyor: bu değişiklikten önce üretilmiş bir token'da böyle bir claim yok, ve istemciden gelen bir tarih tüm arşivi geri okumanın kolay yolu olurdu. Silinmiş bir kullanıcı satırına işaret eden oturum boş akış alıyor, her şeyi değil.

## Test

`e2e/announcements-feed.spec.ts`'e yeni durum: katılımdan bir gün önce yayınlanan duyuru ne kartta ne arşivde görünüyor, katılımdan sonraki ikisinde de görünüyor, API'nin kendi cevabı da bunu doğruluyor.

Yerel çalıştırma (local MariaDB, sentetik veri) — mevcut iki regresyon testi dâhil:

```
✓ an admin announcement shows up in the mentee dashboard card and the shared announcements page (31.4s)
✓ an admin announcement is also visible to mentors, via the same shared feed (18.6s)
✓ a user does not see announcements broadcast before they joined (8.0s)
✓ GET /api/announcements requires authentication (308ms)
4 passed
```

## Not

Bu, maintainer'ın açık kararı (2026-08-08): yeni gelenler geçmiş duyuruları **hiç** görmemeli. Arşivde bir "katılmadan önce" ayıracıyla göstermek de tartışıldı ve reddedildi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)