### PR TITLE
feat(i18n): show which language a person reads where you write to them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.56.0-beta] - 2026-08-08
+
+### Added
+- **A person's language is visible where you write to them** (#1164). Every `User` carries a
+  `preferredLanguage` and the app speaks EN/TR/DE, but that preference was shown nowhere
+  outside the person's own settings — so mentors and admins were composing to people in a
+  language those people had not chosen.
+  - New `<LanguageBadge />` (`src/components/LanguageBadge.tsx`): a two-letter chip with the
+    language name in the `title`. It distinguishes *chosen* from *unset* — an unset preference
+    renders the app default in a muted style (`data-language-set="false"`), because "chose
+    English" and "never chose" are a fact and a guess respectively.
+  - Shown on the candidate list (both the desktop and the `md:hidden` mobile card), the 1:1
+    message thread header, and the bulk email composer's recipient list.
+  - The bulk composer additionally summarises the **selected** recipients' languages
+    (`data-testid="recipient-languages"`, e.g. `DE ×2 · TR ×1`) — one body goes to everyone
+    ticked, so the sender sees the spread before they start typing. `languageBreakdown()` folds
+    unset preferences into the app default, which is what those people actually receive.
+  - `preferredLanguage` now rides along in `/api/candidates`, `/api/mentorship`, and the
+    message thread's participant payload (`getThreadIfAllowed` / `getConversationIfAllowed`).
+    Group chats get no header badge — a room has no single language to name.
+
 ## [0.55.7-beta] - 2026-08-08
 
 ### Changed

--- a/e2e/language-badge.spec.ts
+++ b/e2e/language-badge.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { signInAsFreshUser } from './helpers/auth';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// #1164: every user has a preferredLanguage and the app speaks EN/TR/DE, but
+// that preference was invisible on the screens where someone is about to write
+// TO them — so people were being contacted in a language they had not chosen.
+// The badge distinguishes "chose German" from "never chose" (which reads as the
+// app default), because those are a fact and a guess respectively.
+test('a person’s language preference is visible where you write to them', async ({ page }) => {
+  const adminEmail = uniqueEmail('lang-admin');
+  const germanEmail = uniqueEmail('lang-de');
+  const unsetEmail = uniqueEmail('lang-unset');
+  const pw = 'LangAdmin123';
+
+  await seedUser(adminEmail, pw, 'ADMIN', 'Lang Admin');
+  const german = await seedUser(germanEmail, 'x', 'MENTEE', 'Lang German Mentee');
+  const unset = await seedUser(unsetEmail, 'x', 'MENTEE', 'Lang Unset Mentee');
+  await prisma.user.update({ where: { id: german.id }, data: { preferredLanguage: 'de' } });
+  // `unset` is deliberately left null — the seeder never sets one.
+
+  try {
+    await signInAsFreshUser(page, adminEmail, pw, '/admin');
+    await page.goto('/admin/candidates');
+
+    // Scope to the desktop grid: the page renders every candidate twice (the
+    // md:hidden mobile list is still in the DOM and strict mode counts it).
+    const list = page.getByTestId('candidates-desktop-list');
+    const germanCard = list.getByTestId(`candidate-card-${german.id}`);
+    await expect(germanCard).toBeVisible({ timeout: 15_000 });
+    await expect(germanCard.getByTestId('language-badge-de')).toBeVisible();
+    await expect(germanCard.getByTestId('language-badge-de')).toHaveAttribute('data-language-set', 'true');
+
+    // No preference: shown as the app default, and marked as *not* chosen.
+    const unsetCard = list.getByTestId(`candidate-card-${unset.id}`);
+    await expect(unsetCard.getByTestId('language-badge-en')).toHaveAttribute('data-language-set', 'false');
+  } finally {
+    await cleanupByEmail(adminEmail);
+    await cleanupByEmail(germanEmail);
+    await cleanupByEmail(unsetEmail);
+  }
+});
+
+// The bulk composer sends ONE body to everyone ticked, so it also has to say
+// which languages that one body is about to land in.
+test('the bulk email composer shows the language mix of the selected recipients', async ({ page }) => {
+  const mentorEmail = uniqueEmail('langmix-mentor');
+  const deEmail = uniqueEmail('langmix-de');
+  const trEmail = uniqueEmail('langmix-tr');
+  const pw = 'LangMentor123';
+
+  const mentor = await seedUser(mentorEmail, pw, 'MENTOR', 'Lang Mix Mentor');
+  const de = await seedUser(deEmail, 'x', 'MENTEE', 'Lang Mix German');
+  const tr = await seedUser(trEmail, 'x', 'MENTEE', 'Lang Mix Turkish');
+  await prisma.user.update({ where: { id: de.id }, data: { preferredLanguage: 'de' } });
+  await prisma.user.update({ where: { id: tr.id }, data: { preferredLanguage: 'tr' } });
+  await prisma.mentorshipRelation.createMany({
+    data: [
+      { mentorId: mentor.id, menteeId: de.id, status: 'ACTIVE' },
+      { mentorId: mentor.id, menteeId: tr.id, status: 'ACTIVE' },
+    ],
+  });
+
+  try {
+    await signInAsFreshUser(page, mentorEmail, pw, '/mentor');
+    await page.goto('/mentor/email');
+
+    // Nothing selected yet — nothing to summarise.
+    const summary = page.getByTestId('recipient-languages');
+    await expect(page.getByText('Lang Mix German')).toBeVisible({ timeout: 15_000 });
+    await expect(summary).toHaveCount(0);
+
+    // Tick both mentees: the summary names both languages.
+    await page.getByRole('checkbox').nth(1).check();
+    await page.getByRole('checkbox').nth(2).check();
+    await expect(summary).toBeVisible();
+    await expect(summary.getByTestId('language-badge-de')).toBeVisible();
+    await expect(summary.getByTestId('language-badge-tr')).toBeVisible();
+  } finally {
+    await prisma.mentorshipRelation.deleteMany({ where: { mentorId: mentor.id } });
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(deEmail);
+    await cleanupByEmail(trEmail);
+  }
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.55.7-beta",
+  "version": "0.56.0-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "author": "Mehmet Erşahin",

--- a/src/app/admin/candidates/page.tsx
+++ b/src/app/admin/candidates/page.tsx
@@ -16,6 +16,7 @@ import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { Select } from '@/components/ui/Select';
 import { Users, ExternalLink, Search, Filter, Download } from 'lucide-react';
+import { LanguageBadge } from '@/components/LanguageBadge';
 
 interface Candidate {
   id: string;
@@ -31,6 +32,7 @@ interface Candidate {
   city?: string;
   createdAt: string;
   isActive: boolean;
+  preferredLanguage?: string | null;
   menteeRelations: {
     pipelineStatus?: string;
     mentor: { id: string; fullName: string };
@@ -451,12 +453,15 @@ export default function CandidatesPage() {
                     aria-label={t.candidates.selectOne}
                   />
                   <div className="min-w-0 flex-1">
-                    <Link
-                      href={`/admin/candidates/${candidate.id}`}
-                      className="block break-words font-semibold text-gray-900 dark:text-gray-100 hover:text-blue-700 dark:hover:text-blue-300 hover:underline"
-                    >
-                      {candidate.fullName}
-                    </Link>
+                    <div className="flex min-w-0 items-center gap-1.5">
+                      <Link
+                        href={`/admin/candidates/${candidate.id}`}
+                        className="block break-words font-semibold text-gray-900 dark:text-gray-100 hover:text-blue-700 dark:hover:text-blue-300 hover:underline"
+                      >
+                        {candidate.fullName}
+                      </Link>
+                      <LanguageBadge language={candidate.preferredLanguage} />
+                    </div>
                     <p className="mt-1 min-w-0 break-words text-sm text-gray-600 dark:text-gray-300">
                       {t.candidates.mentor}: {activeRelation?.mentor.fullName ?? t.candidates.unassigned}
                     </p>
@@ -521,7 +526,11 @@ export default function CandidatesPage() {
                       >
                         {candidate.fullName}
                       </Link>
-                      <p className="text-sm text-gray-500">{candidate.email}</p>
+                      <p className="flex items-center gap-1.5 text-sm text-gray-500">
+                        <span className="truncate">{candidate.email}</span>
+                        {/* Which language to write to them in (#1164). */}
+                        <LanguageBadge language={candidate.preferredLanguage} />
+                      </p>
                     </div>
                   </div>
                   <div className="flex flex-col items-end gap-1 flex-shrink-0">

--- a/src/app/api/candidates/route.ts
+++ b/src/app/api/candidates/route.ts
@@ -82,6 +82,9 @@ export async function GET(request: Request) {
       city: true,
       createdAt: true,
       isActive: true,
+      // The candidate list is where you pick who to write to, so it says which
+      // language each of them reads (#1164).
+      preferredLanguage: true,
       source: { select: { id: true, name: true } },
       menteeRelations: {
         where: { status: 'ACTIVE' as const },

--- a/src/app/api/mentorship/route.ts
+++ b/src/app/api/mentorship/route.ts
@@ -72,6 +72,9 @@ export async function GET(request: Request) {
           university: true,
           graduationYear: true,
           skills: true,
+          // So the screens that write TO a mentee — the bulk email composer
+          // above all — can show which language they read (#1164).
+          preferredLanguage: true,
         },
       },
       company: { select: { id: true, name: true, industry: true } },

--- a/src/app/api/messages/route.ts
+++ b/src/app/api/messages/route.ts
@@ -114,7 +114,13 @@ export async function GET(request: Request) {
     // the project's team, annotated onto the participant list so the chat header
     // can show "6 people · who they are" instead of an anonymous thread.
     let group: { type: string; projectId: string | null; projectName: string | null } | null = null;
-    let participants: { id: string; fullName: string; role: string | null; functionalRole: string | null }[] = [];
+    let participants: {
+      id: string;
+      fullName: string;
+      role: string | null;
+      functionalRole: string | null;
+      preferredLanguage: string | null;
+    }[] = [];
     if (conversation) {
       const team =
         conversation.type === 'GROUP' && conversation.projectId
@@ -132,6 +138,7 @@ export async function GET(request: Request) {
           fullName: p.user.fullName,
           role: member?.role ?? null,
           functionalRole: member?.functionalRole ?? null,
+          preferredLanguage: p.user.preferredLanguage,
         };
       });
     }

--- a/src/components/LanguageBadge.tsx
+++ b/src/components/LanguageBadge.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { defaultLocale, isLocale, type Locale } from '@/i18n/config';
+import { useT } from '@/i18n/client';
+
+// Which language a person reads, shown next to their name wherever you are
+// about to write TO them (#1164).
+//
+// Every user has a `preferredLanguage` and the app speaks EN/TR/DE, but that
+// preference was invisible on exactly the screens where it matters — the bulk
+// email composer, a chat header — so people were being written to in a language
+// they had not chosen. An unmarked name gives the sender no clue; a two-letter
+// chip does, without taking a line of its own.
+//
+// A user who never picked one is shown the app default in a muted style: the
+// distinction between "chose English" and "never chose" is the difference
+// between a safe assumption and a guess, so it stays visible.
+export function LanguageBadge({
+  language,
+  className = '',
+}: {
+  language?: string | null;
+  className?: string;
+}) {
+  const t = useT();
+  const chosen = isLocale(language);
+  const locale: Locale = chosen ? language : defaultLocale;
+  const name = t.account.languages[locale];
+  const title = (chosen ? t.languageBadge.prefers : t.languageBadge.unset).replace('{lang}', name);
+
+  return (
+    <span
+      data-testid={`language-badge-${locale}`}
+      data-language-set={chosen ? 'true' : 'false'}
+      title={title}
+      className={`inline-flex shrink-0 items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
+        chosen
+          ? 'bg-blue-50 text-blue-700 dark:!bg-blue-900/40 dark:!text-blue-200'
+          : 'bg-gray-100 text-gray-400 dark:!bg-gray-800 dark:!text-gray-500'
+      } ${className}`}
+    >
+      {locale}
+    </span>
+  );
+}
+
+/**
+ * Count how many people in a group read each language, most-common first, so a
+ * bulk send can say "you are writing one text to 2 TR and 1 DE" before it goes
+ * out. Unset preferences fold into the app default — that is what those people
+ * will actually receive.
+ */
+export function languageBreakdown(languages: (string | null | undefined)[]): { locale: Locale; count: number }[] {
+  const counts = new Map<Locale, number>();
+  for (const raw of languages) {
+    const locale: Locale = isLocale(raw) ? raw : defaultLocale;
+    counts.set(locale, (counts.get(locale) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([locale, count]) => ({ locale, count }))
+    .sort((a, b) => b.count - a.count || a.locale.localeCompare(b.locale));
+}

--- a/src/components/MessageThreadView.tsx
+++ b/src/components/MessageThreadView.tsx
@@ -18,6 +18,7 @@ import {
 import { useMessagesHeaderTitle } from '@/components/MessagesShell';
 import { useIsNarrow } from '@/hooks/useIsNarrow';
 import { StartMeetingButton } from '@/components/meeting/StartMeetingButton';
+import { LanguageBadge } from '@/components/LanguageBadge';
 import type { MeetingTarget } from '@/components/meeting/MeetingLauncher';
 
 interface Attachment {
@@ -44,6 +45,8 @@ const REACTIONS = ['👍', '❤️', '😂', '😮', '🎉'] as const;
 interface Party {
   id: string;
   fullName: string;
+  // Which language they read, so the header can say so before you type (#1164).
+  preferredLanguage?: string | null;
   // Group (project) chats also carry who each person is on the project (#51).
   role?: 'OWNER' | 'MENTOR' | 'MENTEE' | null;
   functionalRole?: 'DEVELOPER' | 'TESTER' | 'MARKETING' | null;
@@ -340,7 +343,11 @@ export function MessageThreadView({ target }: { target: ThreadTarget }) {
         <div className="mb-6 flex items-start gap-3">
           <div className="min-w-0">
             <h1 className="text-2xl font-bold text-gray-900 mb-1">{t.messages.title}</h1>
-            <p className="text-gray-500">{threadTitle}</p>
+            <p className="flex items-center gap-2 text-gray-500">
+              <span className="truncate">{threadTitle}</span>
+              {/* 1:1 only — a group room has no single language to name. */}
+              {!group && other && <LanguageBadge language={other.preferredLanguage} />}
+            </p>
           </div>
           {startMeetingTarget && (
             <StartMeetingButton

--- a/src/components/TargetedEmailComposer.tsx
+++ b/src/components/TargetedEmailComposer.tsx
@@ -6,10 +6,11 @@ import { Input } from '@/components/ui/Input';
 import { Textarea } from '@/components/ui/Textarea';
 import { Button } from '@/components/ui/Button';
 import { useT } from '@/i18n/client';
+import { LanguageBadge, languageBreakdown } from '@/components/LanguageBadge';
 
 interface Relation {
   id: string;
-  mentee: { fullName: string; email: string };
+  mentee: { fullName: string; email: string; preferredLanguage?: string | null };
 }
 
 // Targeted email composer shared by the mentor (/mentor/email) and admin
@@ -35,8 +36,12 @@ export function TargetedEmailComposer() {
     load();
   }, [load]);
 
-  const chosen = relations.filter((r) => selected[r.id]).map((r) => r.id);
+  const chosenRelations = relations.filter((r) => selected[r.id]);
+  const chosen = chosenRelations.map((r) => r.id);
   const allChecked = relations.length > 0 && chosen.length === relations.length;
+  // One body goes to everyone selected, so the sender should see the languages
+  // they are about to write across before they start typing (#1164).
+  const breakdown = languageBreakdown(chosenRelations.map((r) => r.mentee.preferredLanguage));
 
   const send = async () => {
     setSending(true);
@@ -99,7 +104,22 @@ export function TargetedEmailComposer() {
                     onChange={(e) => setSelected((p) => ({ ...p, [r.id]: e.target.checked }))}
                   />
                   <span className="truncate">{r.mentee.fullName}</span>
+                  <LanguageBadge language={r.mentee.preferredLanguage} className="ml-auto" />
                 </label>
+              ))}
+            </div>
+          )}
+          {breakdown.length > 0 && (
+            <div
+              data-testid="recipient-languages"
+              className="mt-3 flex flex-wrap items-center gap-2 border-t border-gray-100 pt-3 text-xs text-gray-500"
+            >
+              <span>{t.languageBadge.recipients}</span>
+              {breakdown.map(({ locale, count }) => (
+                <span key={locale} className="inline-flex items-center gap-1">
+                  <LanguageBadge language={locale} />
+                  <span>×{count}</span>
+                </span>
               ))}
             </div>
           )}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -1000,6 +1000,11 @@ const en = {
       body: 'The stage deadline for {mentee} has passed. Please review their progress.',
     },
   },
+  languageBadge: {
+    prefers: 'Prefers {lang}',
+    unset: 'No language chosen — reads {lang}',
+    recipients: 'Recipient languages',
+  },
   announcementFeed: {
     cardTitle: 'Announcements',
     none: 'No announcements yet',
@@ -3262,6 +3267,11 @@ const tr: Dict = {
       body: '{mentee} için aşama son tarihi geçti. Lütfen ilerleme durumunu gözden geçirin.',
     },
   },
+  languageBadge: {
+    prefers: 'Tercih ettiği dil: {lang}',
+    unset: 'Dil seçmemiş — {lang} okuyor',
+    recipients: 'Alıcıların dilleri',
+  },
   announcementFeed: {
     cardTitle: 'Duyurular',
     none: 'Henüz duyuru yok',
@@ -5519,6 +5529,11 @@ const de: Dict = {
       greeting: 'Hallo {mentor},',
       body: 'Die Phasenfrist für {mentee} ist abgelaufen. Bitte prüfe den Fortschritt.',
     },
+  },
+  languageBadge: {
+    prefers: 'Bevorzugt {lang}',
+    unset: 'Keine Sprache gewählt — liest {lang}',
+    recipients: 'Sprachen der Empfänger',
   },
   announcementFeed: {
     cardTitle: 'Ankündigungen',

--- a/src/lib/conversations.ts
+++ b/src/lib/conversations.ts
@@ -111,7 +111,8 @@ export async function getConversationIfAllowed(user: SessionUser, conversationId
         select: {
           userId: true,
           lastReadAt: true,
-          user: { select: { id: true, fullName: true } },
+          // See messaging.ts — the chat header shows who reads what (#1164).
+          user: { select: { id: true, fullName: true, preferredLanguage: true } },
         },
       },
     },

--- a/src/lib/messaging.ts
+++ b/src/lib/messaging.ts
@@ -16,8 +16,10 @@ export async function getThreadIfAllowed(user: SessionUser, relationId: string |
   const rel = await prisma.mentorshipRelation.findUnique({
     where: { id: relationId },
     include: {
-      mentor: { select: { id: true, fullName: true } },
-      mentee: { select: { id: true, fullName: true } },
+      // preferredLanguage rides along so the thread header can say which
+      // language the other side reads before you start typing (#1164).
+      mentor: { select: { id: true, fullName: true, preferredLanguage: true } },
+      mentee: { select: { id: true, fullName: true, preferredLanguage: true } },
     },
   });
   if (!rel) return null;

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,24 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.56.0-beta',
+    date: '2026-08-08',
+    highlights: {
+      en: [
+        'You can now see which language someone reads before you write to them. A small EN / TR / DE chip sits next to their name on the candidate list, in a one-to-one chat header, and in the bulk email recipient list. A greyed-out chip means that person never picked a language and will get the app default.',
+        'Sending one email to several people? The composer sums up the languages of everyone you have ticked, so you know what you are writing across before you start.',
+      ],
+      tr: [
+        'Artık birine yazmadan önce hangi dili okuduğunu görebiliyorsunuz. Adının yanında küçük bir EN / TR / DE rozeti duruyor: aday listesinde, birebir sohbet başlığında ve toplu e-posta alıcı listesinde. Soluk bir rozet, o kişinin hiç dil seçmediğini ve uygulamanın varsayılanını alacağını gösterir.',
+        'Birden çok kişiye tek e-posta mı? Besteci, işaretlediğiniz herkesin dillerini özetliyor; böylece yazmaya başlamadan önce hangi dillere hitap ettiğinizi biliyorsunuz.',
+      ],
+      de: [
+        'Sie sehen jetzt, welche Sprache jemand liest, bevor Sie schreiben. Neben dem Namen steht ein kleines EN- / TR- / DE-Kürzel: in der Kandidatenliste, im Kopf eines Einzelchats und in der Empfängerliste des Sammel-E-Mail-Editors. Ein ausgegrautes Kürzel bedeutet, dass diese Person nie eine Sprache gewählt hat und die Standardsprache der App erhält.',
+        'Eine E-Mail an mehrere Personen? Der Editor fasst die Sprachen aller Angehakten zusammen — so wissen Sie vorher, in welche Sprachen Sie hineinschreiben.',
+      ],
+    },
+  },
+  {
     version: '0.55.7-beta',
     date: '2026-08-08',
     highlights: {


### PR DESCRIPTION
Closes #1164

## Sorun

Her kullanıcının bir `preferredLanguage` tercihi var ve uygulama EN/TR/DE konuşuyor — ama bu tercih kişinin **kendi ayarları dışında hiçbir yerde** görünmüyordu. Sonuç: mentor ve yöneticiler, karşısındaki kişinin seçmediği bir dilde yazıyor.

## Değişiklik

**`<LanguageBadge />`** — adın yanında duran iki harflik rozet, dilin tam adı `title`'ında.

Rozet **seçilmiş** ile **seçilmemiş**i ayırıyor: tercih yoksa uygulamanın varsayılanı soluk bir stille gösteriliyor (`data-language-set="false"`). "İngilizce seçti" ile "hiç seçmedi" biri olgu, diğeri tahmin — ve yalnızca birine güvenerek yazabilirsiniz.

Göründüğü yerler:
- Aday listesi (hem masaüstü kartı hem `md:hidden` mobil kart)
- Birebir mesaj başlığı (grup sohbetinde yok — bir odanın tek dili olmaz)
- Toplu e-posta alıcı listesi

**Toplu besteci ek olarak seçili alıcıların dil dağılımını özetliyor** (`DE ×2 · TR ×1`): tek gövde işaretlenen herkese gidiyor, dolayısıyla bu dağılım yazmaya başlamadan önce ekranda olmalı. `languageBreakdown()` tercihi olmayanları uygulama varsayılanına katıyor — o kişilerin gerçekten alacağı şey bu.

`preferredLanguage` artık `/api/candidates`, `/api/mentorship` ve mesaj thread'inin katılımcı yükünde taşınıyor.

## Test

`e2e/language-badge.spec.ts`:

```
✓ a person's language preference is visible where you write to them (26.9s)
✓ the bulk email composer shows the language mix of the selected recipients (15.9s)
2 passed
```

Ayrıca yerel dev sunucusunda (sentetik veri) aday listesinde `DE` rozeti görsel olarak doğrulandı — koyu temada da okunur.

## Not

Bu, çok dilli içerik işinin ilk parçası. Devamı: #1163 (çok dilli duyurular), #1165 (çok dilli mentee e-posta şablonları) — rozet oralarda da "bu metin kime hangi dilde gidiyor" sorusunu yanıtlayacak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)