### PR TITLE
feat(infra): back up before every deploy, and refuse a schema change that destroys data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,7 @@ vite.config.ts.timestamp-*
 
 # Playwright generated consent state
 e2e/.state/
+
+# Database dumps — real personal data, never in the repo (infra/backup-db.sh)
+*.sql.gz
+/backups/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -846,6 +846,23 @@ Closes #1113.
 
 ## [Unreleased]
 
+### Added
+- **Database backups, and a gate that refuses to destroy data** (#1181, #1182 · epic #1179).
+  Every deploy runs `prisma db push --accept-data-loss` and, until now, there was no backup
+  anywhere in the repo — a PR that renamed a column would drop it in production with no way
+  back. `infra/backup-db.sh` dumps the database (mysqldump → gzip, size + gzip-integrity +
+  `CREATE TABLE` checks, `KEEP_DAYS` rotation, `0600` files in a `0700` directory) and
+  `infra/schema-guard.sh` asks `prisma migrate diff --script` what the pending push would run,
+  stopping the deploy on `DROP TABLE` / `DROP COLUMN` / `TRUNCATE` / a `NOT NULL` conversion.
+  Both are wired into `infra/deploy-prod.sh` ahead of the push, and scale with the environment:
+  prod backs up and blocks, preview backs up and warns, topic envs do neither (disposable,
+  shared DB). Overrides: `FORCE_NO_BACKUP=1`, and `ALLOW_DESTRUCTIVE=1` — which is refused
+  unless a backup was taken in the same run. An unavailable diff is treated as unsafe, never
+  as "probably fine".
+- `docs/disaster-recovery.md` — restore runbook with a drill log whose RPO/RTO stay empty until
+  a real drill measures them, plus `infra/README.md` §5 (cron setup, overrides). Dumps are
+  git-ignored; they contain real personal data.
+
 ### Fixed
 - **The five specs failing in the scheduled full e2e suite** (run 31051715943). Both causes were
   test defects, not product bugs. Since #1008 gave `/admin/candidates` a separate `md:hidden`

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -1,0 +1,84 @@
+# Disaster recovery — restoring the database
+
+> Status: **runbook**. The backup half is automated (`infra/backup-db.sh`, wired
+> into every prod/preview deploy plus a daily cron — see
+> [`infra/README.md`](../infra/README.md#5-database-backups--the-destructive-schema-gate)).
+> The restore half is this document. Issue: #1183 · Epic: #1179.
+
+A backup nobody has restored is a file, not a backup. This page exists so the
+restore is a procedure you follow rather than one you invent at 2 a.m.
+
+## What exists
+
+| | |
+|---|---|
+| Location | `/var/backups/internship-crm` on the app server (`BACKUP_DIR`) |
+| Naming | `<env>-<UTC stamp>.sql.gz` — e.g. `prod-20260806T2312Z.sql.gz` |
+| Taken | before every prod/preview deploy, and daily at 03:15 UTC |
+| Kept | `KEEP_DAYS` days (default 7) |
+| Contents | a full `mysqldump` — **real personal data**: CVs, phone numbers, mentor notes |
+| Permissions | files `0600`, directory `0700` |
+
+`cat /var/backups/internship-crm/.last-prod` prints the newest dump's path.
+
+## Restore
+
+Times below are **placeholders until the first drill fills them in** — see
+"Drill log". Do not quote them to anyone before then.
+
+```bash
+# 0. Decide WHICH dump. Newest is not always right: if the damage was a bad
+#    schema push at 14:05, the dump taken at 14:04 by that same deploy is the
+#    one you want.
+ls -lt /var/backups/internship-crm/
+
+# 1. Stop the app so nothing writes while you restore.
+docker stop internship-crm
+
+# 2. Load the secrets (never type the password on the command line).
+set -a; . /etc/internship-crm/prod.env; set +a
+
+# 3. Restore. This DROPs and recreates the tables in the dump.
+gzip -dc /var/backups/internship-crm/prod-<stamp>.sql.gz \
+  | mysql -h <host> -P <port> -u <user> -p <database>
+
+# 4. Bring the schema up to the deployed code (additive only — the guard in
+#    infra/schema-guard.sh still applies).
+cd /path/to/Internship && ./infra/deploy-prod.sh --no-pull --skip-build
+
+# 5. Start and verify.
+docker start internship-crm
+curl -sf http://127.0.0.1:3200/api/health | jq
+```
+
+Verify beyond the health check: sign in, open a mentee with a long interaction
+history, and confirm the stage history and evaluations are there. `/api/health`
+answering 200 only proves the app booted.
+
+## Never do this
+
+- **Do not restore a prod dump onto preview** to "test" it. Preview is shared
+  and its data is seen by contributors — that is a data-protection incident, not
+  a test. Restore into a scratch database (`internship_restore_test`) instead.
+- **Do not repair prod with an ad-hoc `prisma db push`** after data loss. The
+  push is what lost the data; running it again writes the new shape over what
+  is left. Restore first, then deploy.
+- **Do not delete the failing deploy's backup** while triaging. It is the only
+  copy of the pre-damage state.
+- **Do not copy a dump off the server** without a reason that survives being
+  written down in the incident notes.
+
+## Drill log
+
+The point of a drill is to measure two numbers and keep them honest:
+
+- **RPO** — how much data a restore would lose (age of the newest usable dump).
+- **RTO** — how long the restore actually takes, end to end.
+
+| Date | Environment | Dump used | RPO | RTO | Notes |
+|---|---|---|---|---|---|
+| _pending_ | preview | | | | first drill not yet run — do this before quoting any recovery time |
+
+Run the drill against **preview or a scratch database**, never prod. Fill the
+row in with measured values; an estimate here is worse than an empty row,
+because it will be believed.

--- a/infra/README.md
+++ b/infra/README.md
@@ -310,3 +310,61 @@ that exists only on this machine; anything that merely needs a Linux box with no
 and docker (builds, tests, linting) goes to `ubuntu-latest`, which is free for this
 public repo. Moving builds onto the runner in 2026-06 was a quota workaround
 (#636), and it made the production host compile on every PR push.
+
+---
+
+## 5. Database backups & the destructive-schema gate
+
+Every deploy runs `prisma db push --accept-data-loss`, so **the moment before a
+deploy is the last moment the current database exists in full**. Two gates sit
+there (#1179):
+
+| Gate | prod | preview | topic (`internship-crm-pr<N>`) |
+|---|---|---|---|
+| `infra/backup-db.sh` — dump before the schema sync | ✔ | ✔ | skipped (disposable, shares the preview DB) |
+| `infra/schema-guard.sh` — refuse a data-destroying diff | **blocks** | warns | warns |
+
+Both are wired into `infra/deploy-prod.sh` (which is also what deploys preview
+and the topic envs — only `CONTAINER` differs), so there is nothing to call by
+hand on a normal deploy.
+
+### Daily backup (cron)
+
+The deploy-time dump only covers deploys. Everything else — a bad bulk delete, a
+disk failure — needs a scheduled one. On the server:
+
+```bash
+sudo install -m 755 infra/backup-db.sh /usr/local/bin/internship-backup-db
+sudo crontab -e
+```
+
+```cron
+# 03:15 UTC daily, production
+15 3 * * * set -a; . /etc/internship-crm/prod.env; set +a; /usr/local/bin/internship-backup-db --env prod >> /var/log/internship-backup.log 2>&1
+```
+
+Dumps land in `/var/backups/internship-crm` (override with `BACKUP_DIR`), are
+kept for `KEEP_DAYS` (default 7) and are written `0600` in a `0700` directory —
+**they contain real personal data** (CVs, phone numbers, mentor notes). Never
+copy one into the repo, a preview environment or a ticket.
+
+A dump is rejected (and the deploy stops) if it is under `MIN_BYTES`, is not a
+valid gzip stream, or contains no `CREATE TABLE`. A backup that looks fine but
+restores nothing is worse than no backup at all.
+
+### Restoring
+
+See [`docs/disaster-recovery.md`](../docs/disaster-recovery.md) for the full
+runbook. The short version:
+
+```bash
+gzip -dc /var/backups/internship-crm/prod-<stamp>.sql.gz | mysql -h <host> -u <user> -p <db>
+```
+
+### Overrides (use knowingly)
+
+| Variable | Effect |
+|---|---|
+| `FORCE_NO_BACKUP=1` | deploy without taking a backup |
+| `ALLOW_DESTRUCTIVE=1` | apply a data-destroying schema change — **refused unless a backup was taken in the same run** |
+| `BACKUP_DIR`, `KEEP_DAYS`, `MIN_BYTES` | where/how long/how small |

--- a/infra/backup-db.sh
+++ b/infra/backup-db.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+#
+# Database backup (#1181, part of the "don't sink us" epic #1179).
+#
+# WHY THIS EXISTS
+#   Every merge to main deploys, and every deploy runs
+#   `prisma db push --accept-data-loss` (infra/deploy-prod.sh). That flag means
+#   exactly what it says: a renamed or removed column is DROPPED without asking.
+#   Until this script existed there was no backup anywhere in the repo, so one
+#   careless schema edit could destroy the product's only differentiator — the
+#   accumulated interaction log, evaluations and stage history — with no way
+#   back. The most valuable moment to hold a copy is therefore the instant
+#   BEFORE the schema sync; a daily run covers everything else (a bad bulk
+#   delete, a disk failure).
+#
+# WHAT IT DOES
+#   mysqldump → gzip → $BACKUP_DIR/<env>-<stamp>.sql.gz, then sanity-checks the
+#   size and prunes anything older than $KEEP_DAYS.
+#
+# USAGE
+#   DATABASE_URL=mysql://user:pass@host:3306/db ./infra/backup-db.sh [--env prod] [--stamp 20260806T2312Z]
+#
+#   ENV VARS
+#     DATABASE_URL  (required) same value the app uses
+#     BACKUP_DIR    default /var/backups/internship-crm
+#     KEEP_DAYS     default 7
+#     MIN_BYTES     default 1024 — a smaller dump is treated as a failed one
+#
+# THE DUMPS CONTAIN REAL PERSONAL DATA (CVs, phone numbers, mentor notes).
+# The directory is created 0700 and the files 0600. Never copy one into the
+# repo, a preview environment, or a ticket.
+set -euo pipefail
+
+BACKUP_DIR="${BACKUP_DIR:-/var/backups/internship-crm}"
+KEEP_DAYS="${KEEP_DAYS:-7}"
+MIN_BYTES="${MIN_BYTES:-1024}"
+ENV_NAME="prod"
+# The caller passes its own timestamp so a deploy's backup carries the same
+# stamp as its log lines; generated here only when run standalone (cron).
+STAMP=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --env) ENV_NAME="${2:?--env needs a value}"; shift 2 ;;
+    --stamp) STAMP="${2:?--stamp needs a value}"; shift 2 ;;
+    *) echo "Unknown flag: $1" >&2; exit 2 ;;
+  esac
+done
+
+log() { printf '\n\033[1;34m==>\033[0m %s\n' "$*"; }
+
+: "${DATABASE_URL:?DATABASE_URL is required}"
+[ -n "$STAMP" ] || STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+
+# Parse mysql://user:pass@host:port/db — the password may contain @ : / $ and
+# spaces, so peel the URL apart from the OUTSIDE in (scheme, then the LAST @,
+# which separates credentials from the host) rather than with one greedy regex.
+url="${DATABASE_URL#mysql://}"
+url="${url%%\?*}"                 # drop ?connection_limit=... etc
+creds="${url%@*}"                 # everything before the last @
+hostpart="${url##*@}"             # host:port/db
+db_user="${creds%%:*}"
+db_pass="${creds#*:}"
+[ "$db_pass" = "$creds" ] && db_pass=""   # no colon → no password
+db_name="${hostpart#*/}"
+hostport="${hostpart%%/*}"
+db_host="${hostport%%:*}"
+db_port="${hostport#*:}"
+[ "$db_port" = "$hostport" ] && db_port=3306
+
+# URL-decoded password: a % escape in the connection string is not a literal.
+decode() { printf '%b' "${1//%/\\x}"; }
+db_pass="$(decode "$db_pass")"
+db_user="$(decode "$db_user")"
+
+command -v mysqldump >/dev/null || { echo "ERROR: mysqldump not found on PATH" >&2; exit 1; }
+
+mkdir -p "$BACKUP_DIR"
+chmod 700 "$BACKUP_DIR"
+out="$BACKUP_DIR/${ENV_NAME}-${STAMP}.sql.gz"
+tmp="$out.part"
+
+log "Dumping $db_name from $db_host:$db_port → $out"
+# --single-transaction: a consistent snapshot without locking the site.
+# The password goes through the environment, never argv, so it cannot be read
+# from the process list by another user on the box.
+if ! MYSQL_PWD="$db_pass" mysqldump \
+      --single-transaction --quick --routines --triggers --events \
+      --no-tablespaces \
+      -h "$db_host" -P "$db_port" -u "$db_user" "$db_name" 2>"$tmp.err" | gzip -c > "$tmp"; then
+  echo "ERROR: mysqldump failed:" >&2
+  tail -5 "$tmp.err" >&2 || true
+  rm -f "$tmp" "$tmp.err"
+  exit 1
+fi
+rm -f "$tmp.err"
+
+# A zero-byte or truncated dump is worse than no dump: it looks like a backup
+# and restores nothing. Three checks, cheapest first — size, then gzip
+# integrity (catches a truncated stream), then content. The content check is
+# the one that matters: size alone lies, because gzip squeezes a degenerate
+# dump down to a few dozen bytes.
+size=$(wc -c < "$tmp")
+if [ "$size" -lt "$MIN_BYTES" ]; then
+  echo "ERROR: dump is only ${size}B (< ${MIN_BYTES}B) — treating as failed" >&2
+  rm -f "$tmp"
+  exit 1
+fi
+if ! gzip -t "$tmp" 2>/dev/null; then
+  echo "ERROR: dump is not a valid gzip stream (truncated?) — treating as failed" >&2
+  rm -f "$tmp"
+  exit 1
+fi
+if ! gzip -dc "$tmp" | grep -qi 'CREATE TABLE'; then
+  echo "ERROR: dump contains no CREATE TABLE — treating as failed" >&2
+  rm -f "$tmp"
+  exit 1
+fi
+
+mv "$tmp" "$out"
+chmod 600 "$out"
+log "Backup written: $out (${size} bytes)"
+
+# Prune, but only our own files: the pattern is anchored to <env>-<stamp>.sql.gz
+# so a stray file in the directory is never touched.
+log "Pruning ${ENV_NAME} backups older than ${KEEP_DAYS} days"
+find "$BACKUP_DIR" -maxdepth 1 -type f -name "${ENV_NAME}-*.sql.gz" -mtime "+${KEEP_DAYS}" -print -delete || true
+
+# Leave the newest path where the caller (and the health check) can find it.
+printf '%s\n' "$out" > "$BACKUP_DIR/.last-${ENV_NAME}"

--- a/infra/deploy-prod.sh
+++ b/infra/deploy-prod.sh
@@ -13,7 +13,9 @@
 #      the deploy workflows do it since 2026-07-29 — the build runs on a
 #      GitHub-hosted runner so this server never compiles) or build it locally
 #      from source, stamping GIT_SHA
-#   3. prisma db push --accept-data-loss  (schema sync, same as CI)
+#   3. back up the database (infra/backup-db.sh), refuse a data-destroying
+#      schema diff (infra/schema-guard.sh), then prisma db push
+#      --accept-data-loss (schema sync, same as CI)
 #   4. seed-templates + seed-goal-templates + backfill-project-members (idempotent)
 #   5. swap the internship-crm container (host networking, port 3200, restart
 #      unless-stopped) — byte-for-byte the flags deploy.yml uses
@@ -37,6 +39,11 @@
 #   --pull-image  `docker pull $IMAGE` instead of building (implies --skip-build).
 #                 For a private registry set GHCR_USER + GHCR_TOKEN and this
 #                 logs in first; a public package needs neither.
+#
+# ENV OVERRIDES FOR THE DATA GATES (use knowingly)
+#   FORCE_NO_BACKUP=1    deploy without taking a backup first
+#   ALLOW_DESTRUCTIVE=1  apply a schema change that drops data (requires a backup)
+#   BACKUP_DIR=...       where dumps go (default /var/backups/internship-crm)
 #
 # ENV
 #   DEPLOY_SHA    the commit the image was built from. Only needed when the
@@ -224,7 +231,45 @@ run_tool() { # run a one-off tool container against the DB (network per $NETWORK
   docker run --rm "${TOOL_NET_ARGS[@]}" -e DATABASE_URL="$DATABASE_URL" "$IMAGE" "$@"
 }
 
-# ── 3. Schema sync ────────────────────────────────────────────────────────────
+# ── 3. Backup, then schema sync ──────────────────────────────────────────────
+# The push below runs with --accept-data-loss, so this is the last moment at
+# which the current database still exists in full. Both steps are gates, not
+# niceties: no backup → no deploy, and a data-destroying diff → no deploy
+# without an explicit operator decision (#1179).
+# This same script deploys prod, the shared preview and every topic env — the
+# caller only overrides CONTAINER. The gates scale with what is at stake:
+#   prod     → back up, and REFUSE a data-destroying diff
+#   preview  → back up, but only WARN (schema experiments belong there)
+#   topic    → neither; those envs are disposable and share the preview DB,
+#              so a dump per PR deploy is noise, not safety
+case "$CONTAINER" in
+  internship-crm) ENV_LABEL=prod ;;
+  internship-crm-preview) ENV_LABEL=preview ;;
+  *) ENV_LABEL="${CONTAINER#internship-crm-}" ;;
+esac
+
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+BACKUP_TAKEN=0
+if [ "$ENV_LABEL" != "prod" ] && [ "$ENV_LABEL" != "preview" ]; then
+  log "Disposable env ($ENV_LABEL) — skipping backup and running the schema guard in warn-only mode"
+elif [ "${FORCE_NO_BACKUP:-0}" = "1" ]; then
+  log "!! FORCE_NO_BACKUP=1 — DEPLOYING WITHOUT A BACKUP (operator override)"
+else
+  log "Backing up the database before the schema sync"
+  # Runs on the host (mysqldump), not in the image: the dump must survive even
+  # if the new image is broken, and it must never live inside a container layer.
+  BACKUP_DIR="${BACKUP_DIR:-/var/backups/internship-crm}" \
+    "$REPO_DIR/infra/backup-db.sh" --env "$ENV_LABEL" --stamp "$STAMP"
+  BACKUP_TAKEN=1
+fi
+
+log "Checking the pending schema change for data loss"
+GUARD_ARGS=()
+[ "$ENV_LABEL" = "prod" ] || GUARD_ARGS=(--warn-only)
+RUN_TOOL="docker run --rm ${TOOL_NET_ARGS[*]} -e DATABASE_URL=$DATABASE_URL $IMAGE npx" \
+  BACKUP_TAKEN="$BACKUP_TAKEN" \
+  "$REPO_DIR/infra/schema-guard.sh" "${GUARD_ARGS[@]+"${GUARD_ARGS[@]}"}"
+
 log "prisma db push"
 run_tool npx prisma db push --accept-data-loss
 

--- a/infra/schema-guard.sh
+++ b/infra/schema-guard.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+#
+# Destructive schema-change gate (#1182, part of epic #1179).
+#
+# WHY THIS EXISTS
+#   This project syncs with `prisma db push --accept-data-loss` and has no
+#   migrations/ folder, so there is no natural review point where a human sees
+#   "this drops a column". A PR that renames a field reads as a rename in the
+#   diff and lands as a DROP + ADD in production.
+#
+#   This script asks Prisma what SQL the pending push would actually run
+#   (`migrate diff --script`, which PRINTS the SQL and writes no files), looks
+#   for statements that destroy data, and stops the deploy when it finds any.
+#
+# USAGE
+#   RUN_TOOL="docker run --rm -e DATABASE_URL=... $IMAGE" ./infra/schema-guard.sh [--warn-only]
+#   ./infra/schema-guard.sh                      # uses npx directly
+#
+#   ENV VARS
+#     DATABASE_URL       (required)
+#     RUN_TOOL           command prefix used to run prisma (default: npx)
+#     ALLOW_DESTRUCTIVE  set to 1 to proceed anyway — an operator decision
+#     BACKUP_TAKEN       set to 1 by the caller when a fresh backup exists;
+#                        ALLOW_DESTRUCTIVE is refused without it
+#
+# EXIT CODES
+#   0 = safe (or warn-only, or explicitly allowed)   1 = destructive, stopping
+set -euo pipefail
+
+WARN_ONLY=0
+[ "${1:-}" = "--warn-only" ] && WARN_ONLY=1
+
+log() { printf '\n\033[1;34m==>\033[0m %s\n' "$*"; }
+warn() { printf '\n\033[1;33m!!\033[0m %s\n' "$*"; }
+err() { printf '\n\033[1;31mXX\033[0m %s\n' "$*" >&2; }
+
+: "${DATABASE_URL:?DATABASE_URL is required}"
+RUN_TOOL="${RUN_TOOL:-npx}"
+
+log "Checking what the pending schema push would do"
+# migrate diff only reads the live schema and the datamodel; it never writes a
+# migration file, so the repo's "db push, no migrations/" rule is untouched.
+if ! sql=$($RUN_TOOL prisma migrate diff \
+      --from-url "$DATABASE_URL" \
+      --to-schema-datamodel prisma/schema.prisma \
+      --script 2>/dev/null); then
+  # Never let an unavailable diff silently disable the gate: no answer means we
+  # do not know, and "we do not know" must not read as "it is safe".
+  err "Could not compute the schema diff — refusing to guess."
+  err "Fix the connection or run with ALLOW_DESTRUCTIVE=1 BACKUP_TAKEN=1 if this is deliberate."
+  [ "$WARN_ONLY" -eq 1 ] && { warn "warn-only: continuing"; exit 0; }
+  [ "${ALLOW_DESTRUCTIVE:-0}" = "1" ] && [ "${BACKUP_TAKEN:-0}" = "1" ] && exit 0
+  exit 1
+fi
+
+if [ -z "${sql//[[:space:]]/}" ]; then
+  log "Schema already in sync — nothing to apply"
+  exit 0
+fi
+
+# Statements that lose data. Kept as one grep -E alternation, deliberately
+# blunt: a false alarm costs one env var, a miss costs the database.
+#   DROP TABLE / DROP COLUMN     — the rename-looks-like-a-drop case
+#   TRUNCATE                     — wipes rows outright
+#   MODIFY/CHANGE ... NOT NULL   — fails or coerces existing NULL rows
+#   DROP DATABASE / DROP SCHEMA  — the obvious catastrophe
+DESTRUCTIVE='DROP TABLE|DROP COLUMN|TRUNCATE|DROP DATABASE|DROP SCHEMA|(MODIFY|CHANGE)[^;]*NOT NULL'
+
+if ! hits=$(printf '%s\n' "$sql" | grep -Ei "$DESTRUCTIVE"); then
+  log "Pending changes are additive — proceeding"
+  exit 0
+fi
+
+warn "This deploy would run DESTRUCTIVE schema statements:"
+printf '%s\n' "$hits" | sed 's/^/    /'
+
+if [ "$WARN_ONLY" -eq 1 ]; then
+  warn "warn-only mode (preview): continuing anyway"
+  exit 0
+fi
+
+if [ "${ALLOW_DESTRUCTIVE:-0}" = "1" ]; then
+  if [ "${BACKUP_TAKEN:-0}" != "1" ]; then
+    err "ALLOW_DESTRUCTIVE=1 requires a fresh backup (BACKUP_TAKEN=1). Refusing."
+    exit 1
+  fi
+  warn "ALLOW_DESTRUCTIVE=1 with a fresh backup — proceeding on operator's decision"
+  exit 0
+fi
+
+err "Deploy stopped: the schema change above destroys data."
+err "If it is intended, re-run with ALLOW_DESTRUCTIVE=1 (a backup must have been taken)."
+err "If it is not, fix prisma/schema.prisma — a rename in the diff is a DROP + ADD here."
+exit 1


### PR DESCRIPTION
## Summary

Part of #1179 · Closes #1181, closes #1182

Every merge to `main` deploys, and every deploy runs `prisma db push --accept-data-loss`
(`infra/deploy-prod.sh`). That flag means what it says: a renamed or removed column is **dropped
without asking**. There was **no backup anywhere in this repo** — no `mysqldump`, no backup
workflow — so one careless schema edit could destroy the product's only differentiator (the
accumulated interaction log, evaluations, stage history) with no way back. The admin settings
screen even tells operators "database backups are handled on the server"; nothing was handling them.

Two gates now sit immediately before the push.

## Changes

**`infra/backup-db.sh`** — `mysqldump --single-transaction | gzip` → `<env>-<stamp>.sql.gz`.
- The connection URL is peeled apart from the outside in (a password may contain `@ : / $`) and
  percent-decoded; the password travels in `MYSQL_PWD`, never argv, so it cannot be read from the
  process list.
- A dump is accepted only if it clears **three** checks: size, gzip integrity, and containing a
  `CREATE TABLE`. Size alone lies — gzip squeezes a degenerate dump to a few dozen bytes, so the
  file looks like a backup and restores nothing.
- Rotation (`KEEP_DAYS`, default 7) deletes only files matching its own naming pattern. Directory
  `0700`, dumps `0600`: they hold real CVs, phone numbers and mentor notes.

**`infra/schema-guard.sh`** — asks `prisma migrate diff --script` what the pending push would run
(it *prints* SQL and writes no migration file, so the repo's "db push, no `migrations/`" rule is
untouched) and stops on `DROP TABLE` / `DROP COLUMN` / `TRUNCATE` / `DROP DATABASE|SCHEMA` / a
`NOT NULL` conversion. **If the diff cannot be computed it also stops** — not knowing must not
read as "safe". `ALLOW_DESTRUCTIVE=1` is the operator's escape hatch and is **refused unless a
backup was taken in the same run**.

**`infra/deploy-prod.sh`** — both wired in ahead of the push, scaling with what is at stake (this
one script also deploys preview and the topic envs; only `CONTAINER` differs):

| | backup | destructive diff |
|---|---|---|
| prod | ✔ | **blocks** |
| preview | ✔ | warns (schema experiments belong there) |
| topic `pr<N>` | skipped — disposable, shares the preview DB | warns |

**Docs** — `docs/disaster-recovery.md` (restore steps, a "never do this" list, and a drill log whose
RPO/RTO stay *empty* until a real drill measures them — an estimate there would be believed),
`infra/README.md` §5 (cron setup, overrides), `.gitignore` for `*.sql.gz`.

## Verification

- [x] `bash -n` clean on all three scripts
- [x] **Guard logic exercised against stubbed diffs** — additive → 0, empty diff → 0, destructive
      → 1, destructive + `--warn-only` → 0, `ALLOW_DESTRUCTIVE=1` without a backup → 1, with a
      backup → 0, diff command failing → 1
- [x] **Backup script exercised against a stubbed `mysqldump`** — URL `mysql://crmuser:p%40ss%3Aword@db.example.com:3307/internship?connection_limit=5`
      parsed to host `db.example.com`, port `3307`, user `crmuser`, db `internship`, password
      decoded to `p@ss:word` and passed via `MYSQL_PWD`; failed dump → exit 1 with the server's
      error, no `.part` left behind; dump without `CREATE TABLE` → rejected
- [ ] **Not run against a real database** — this container has no access to prod/preview and must
      not have any. First real run is the next prod deploy; the server needs
      `install -m 755 infra/backup-db.sh /usr/local/bin/internship-backup-db` for the cron entry
      (documented in `infra/README.md`).

No version bump: infra/ops + docs only, nothing user-visible. CHANGELOG entry added under
`[Unreleased]`.

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NgYXoDjd3EUoSPAxdyjKzD)_