### PR TITLE
ci: sweep leaked topic preview environments instead of trusting the teardown event

### DIFF
--- a/.github/workflows/topic-sweep.yml
+++ b/.github/workflows/topic-sweep.yml
@@ -1,0 +1,129 @@
+name: Topic Sweep (reconcile leaked preview environments)
+
+# Topic environments are torn down by an event (`pull_request: closed` in
+# topic-preview.yml), and an event that never fires leaves a container running
+# forever: a teardown run stuck on `action_required` approval, a cancelled run,
+# an offline runner, a reboot. #962 found ten such orphans holding ~1.58 GB on a
+# 7.7 GB box, and on 2026-08-08 one of them held port 3392 and blocked PR #1192
+# from deploying at all — topic ports are `3300 + PR % 100`, so a leaked
+# environment silently steals the slot of every hundredth PR after it.
+#
+# So: stop trusting the event, and reconcile the state instead. List the
+# `internship-crm-pr<N>` containers actually running on the box, ask GitHub
+# which of those PRs are still open, and tear down the rest.
+#
+# Split across two runners on purpose: only the self-hosted box can see docker,
+# and only a GitHub-hosted runner is guaranteed `gh`/`jq` for the PR lookup.
+
+on:
+  schedule:
+    # 04:20 UTC daily — after the nightly traffic, before the working day.
+    - cron: '20 4 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: topic-sweep
+  cancel-in-progress: false
+
+env:
+  BASE_DOMAIN: ersah.in
+
+jobs:
+  # ── 1. What is actually running on the box ──────────────────────────────────
+  collect:
+    name: List topic containers
+    runs-on: self-hosted
+    outputs:
+      numbers: ${{ steps.list.outputs.numbers }}
+    steps:
+      - id: list
+        run: |
+          set -euo pipefail
+          # -a: a stopped-but-not-removed container still owns its name (and can
+          # be restarted by a restart policy), so it counts as a leak too.
+          nums=$(docker ps -a --format '{{.Names}}' \
+                 | sed -n 's/^internship-crm-pr\([0-9]\{1,\}\)$/\1/p' \
+                 | sort -n | uniq | tr '\n' ' ')
+          echo "numbers=${nums% }" >> "$GITHUB_OUTPUT"
+          echo "### Topic containers on the box" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "${nums:-<none>}" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          # Who holds the 33xx range right now — the question a blocked deploy
+          # actually needs answered, and it is free to record here.
+          echo "### Bound topic ports" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          docker ps --format '{{.Names}} {{.Ports}}' | grep -E '33[0-9]{2}' \
+            >> "$GITHUB_STEP_SUMMARY" || echo "(no container publishes a 33xx port)" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+  # ── 2. Which of them belong to a PR that is no longer open ──────────────────
+  resolve:
+    name: Resolve PR states
+    needs: collect
+    if: needs.collect.outputs.numbers != ''
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      stale: ${{ steps.check.outputs.stale }}
+    steps:
+      - id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NUMBERS: ${{ needs.collect.outputs.numbers }}
+        run: |
+          set -euo pipefail
+          stale=""
+          for n in $NUMBERS; do
+            # A number that is not a PR at all (renamed container, manual test)
+            # is left alone: this job only removes environments it can PROVE are
+            # finished. Silence is not proof.
+            if ! state=$(gh pr view "$n" --repo "$GITHUB_REPOSITORY" --json state --jq .state 2>/dev/null); then
+              echo "pr#$n: not found — leaving it alone"
+              continue
+            fi
+            echo "pr#$n: $state"
+            [ "$state" = "OPEN" ] || stale="$stale $n"
+          done
+          echo "stale=${stale# }" >> "$GITHUB_OUTPUT"
+
+  # ── 3. Tear the finished ones down ──────────────────────────────────────────
+  sweep:
+    name: Tear down leaked environments
+    needs: [collect, resolve]
+    if: needs.resolve.outputs.stale != ''
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v7
+      - env:
+          STALE: ${{ needs.resolve.outputs.stale }}
+          BASE_DOMAIN: ${{ env.BASE_DOMAIN }}
+        run: |
+          set -euo pipefail
+          chmod +x infra/server/topic-teardown.sh
+          echo "### Swept" >> "$GITHUB_STEP_SUMMARY"
+          for n in $STALE; do
+            echo "==> tearing down pr$n"
+            # Never let one stubborn environment abort the sweep — the next one
+            # may be the one holding a port somebody is waiting for.
+            if TOPIC="pr$n" BASE_DOMAIN="$BASE_DOMAIN" ./infra/server/topic-teardown.sh; then
+              echo "- pr$n — removed" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "- pr$n — FAILED, see log" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done
+
+  # ── 4. Say so, even when there was nothing to do ────────────────────────────
+  # A sweep that only speaks up when it acts is a sweep nobody notices has
+  # stopped running — which is exactly how the leak in #962 went unseen.
+  report:
+    name: Report
+    needs: [collect, resolve, sweep]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "containers: '${{ needs.collect.outputs.numbers }}'" >> "$GITHUB_STEP_SUMMARY"
+          echo "stale: '${{ needs.resolve.outputs.stale }}'" >> "$GITHUB_STEP_SUMMARY"
+          echo "sweep result: ${{ needs.sweep.result }}" >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -846,6 +846,19 @@ Closes #1113.
 
 ## [Unreleased]
 
+### Added
+- **Topic-environment sweep** (`.github/workflows/topic-sweep.yml`, #962). Teardown is driven by a
+  `pull_request: closed` event, and an event that never fires (approval-gated run, cancelled run,
+  offline runner, reboot) leaks a container forever. On 2026-08-08 one such orphan held port 3392
+  and stopped PR #1192 from deploying at all — topic ports are `3300 + PR % 100`, so a leak
+  silently steals the slot of every hundredth PR after it. The sweep reconciles instead of
+  trusting the event: list the `internship-crm-pr<N>` containers actually on the box, ask GitHub
+  which of those PRs are still open, tear down the rest. Split across runners because only the box
+  sees docker and only a hosted runner is guaranteed `gh`. A number that is not a PR at all is left
+  alone — the job only removes what it can prove is finished. It reports on every run, including
+  "nothing to do" (a silent janitor is how the ten orphans in #962 went unnoticed), and records
+  which container holds each 33xx port.
+
 ### Fixed
 - **The five specs failing in the scheduled full e2e suite** (run 31051715943). Both causes were
   test defects, not product bugs. Since #1008 gave `/admin/candidates` a separate `md:hidden`


### PR DESCRIPTION
## Summary

Closes #962 · unblocks #1192

Topic environments are torn down by a `pull_request: closed` event, so an event that never fires
leaves a container running forever: a teardown run stuck on `action_required`, a cancelled run, an
offline runner, a reboot. #962 found ten such orphans holding ~1.58 GB on a 7.7 GB box.

**Today it stopped being only a memory problem.** Topic ports are `3300 + PR % 100`
(`topic-preview.yml:89`), so a leaked environment owns the slot of every hundredth PR after it. A
leaked container on **3392** blocked #1192's topic deploy twice — and the failure says nothing but:

```
docker: Error response from daemon: ... Bind for :::3392 failed: port is already allocated
```

The deploy script had already stopped and removed its *own* `internship-crm-pr1192` container by
that point, so the holder is somebody else's leak.

## Changes

`.github/workflows/topic-sweep.yml` — daily (04:20 UTC) + `workflow_dispatch`, reconciling instead
of trusting the event:

1. **collect** (self-hosted) — `docker ps -a` for `internship-crm-pr<N>`. `-a` on purpose: a
   stopped-but-not-removed container still owns its name and can be restarted by a policy.
2. **resolve** (ubuntu-latest) — `gh pr view` per number. A number that is **not a PR at all**
   (renamed container, manual test) is left alone: this only removes what it can prove is
   finished, and silence is not proof.
3. **sweep** (self-hosted) — `infra/server/topic-teardown.sh` per stale number. One stubborn
   teardown does not abort the loop; the next one may be the one holding a port somebody is
   waiting for.
4. **report** — runs `always()`, including "nothing to do". A janitor that only speaks when it acts
   is one nobody notices has stopped, which is exactly how the ten orphans went unseen.

The collect step also records **which container holds each 33xx port** — the question a blocked
topic deploy actually needs answered, and free to capture there.

Split across two runners deliberately: only the self-hosted box can see docker, and only a
GitHub-hosted runner is guaranteed `gh`/`jq`.

## Verification

- [x] YAML parses; job graph is `collect → resolve → sweep → report`
- [ ] **Not executed here** — it needs docker on the deploy box. First run should be a manual
      `workflow_dispatch` after merge; its step summary will show what is running and what it swept.
      That run is also what should free 3392 and unblock #1192.

Not a user-visible change: no version bump, CHANGELOG entry under `[Unreleased]`.

### Known limitation, deliberately not fixed here

`3300 + PR % 100` gives 100 slots and collides silently — two *open* PRs whose numbers differ by
100 would fight over one port even with zero leaks. Worth its own issue; this PR fixes the leak,
not the addressing scheme.

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NgYXoDjd3EUoSPAxdyjKzD)_