### PR TITLE
fix(infra): dağıtım öncesi yedek kapısını onar — prod ve preview #1192'den beri kapalı (#1200)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,9 @@ jobs:
         run: npm run check:i18n
       - name: auth path reads only the columns it needs (#1150)
         run: npm run check:auth-reads
+      # The deploy scripts never run in CI, so their one piece of decision logic
+      # — "is this dump real?" — had no coverage at all until it broke prod
+      # (#1200). Cheap to run here; the alternative is finding out on the server.
+      - name: backup dump validation (#1200)
+        run: bash infra/test/backup-db.test.sh
       - run: npm run build

--- a/infra/backup-db.sh
+++ b/infra/backup-db.sh
@@ -111,7 +111,17 @@ if ! gzip -t "$tmp" 2>/dev/null; then
   rm -f "$tmp"
   exit 1
 fi
-if ! gzip -dc "$tmp" | grep -qi 'CREATE TABLE'; then
+# `grep -c`, not `grep -q`, and this is not a style choice (#1200). `grep -q`
+# exits at the FIRST match, closing the pipe while `gzip` is still writing; gzip
+# then dies of SIGPIPE (141) and `set -o pipefail` promotes that to the whole
+# pipeline, so the check reported "no CREATE TABLE" for every dump big enough
+# that gzip had not already finished — i.e. every real one. Prod's deploys had
+# been failing here since the gate landed, while a small test DB passed because
+# gzip got everything out before grep exited. `grep -c` consumes the whole
+# stream, so there is no early close and no SIGPIPE. `|| true` because grep
+# exits 1 on zero matches, which is a result here, not an error.
+tables=$(gzip -dc "$tmp" | grep -ci 'CREATE TABLE' || true)
+if [ "${tables:-0}" -eq 0 ]; then
   echo "ERROR: dump contains no CREATE TABLE — treating as failed" >&2
   rm -f "$tmp"
   exit 1
@@ -119,7 +129,7 @@ fi
 
 mv "$tmp" "$out"
 chmod 600 "$out"
-log "Backup written: $out (${size} bytes)"
+log "Backup written: $out (${size} bytes, ${tables} tables)"
 
 # Prune, but only our own files: the pattern is anchored to <env>-<stamp>.sql.gz
 # so a stray file in the directory is never touched.

--- a/infra/deploy-prod.sh
+++ b/infra/deploy-prod.sh
@@ -258,6 +258,27 @@ else
   log "Backing up the database before the schema sync"
   # Runs on the host (mysqldump), not in the image: the dump must survive even
   # if the new image is broken, and it must never live inside a container layer.
+  #
+  # Which is exactly why the URL needs rewriting first (#1200). Under bridge
+  # networking $DATABASE_URL names the DB as `host.docker.internal`, and that
+  # name exists ONLY inside a container started with --add-host — on the host it
+  # does not resolve, so preview's backup died with "Unknown server host" on
+  # every deploy. Substituting `localhost` would not help either: preview's DB
+  # user is granted from the docker gateway, not from localhost. Use the gateway
+  # address itself — reachable from the host, and traffic to it is sourced from
+  # that same interface, so it matches the grant the container relies on.
+  BACKUP_DATABASE_URL="$DATABASE_URL"
+  if [ "$NETWORK" != host ]; then
+    DOCKER_GW="$(docker network inspect bridge \
+      --format '{{ (index .IPAM.Config 0).Gateway }}' 2>/dev/null || true)"
+    if [ -n "$DOCKER_GW" ]; then
+      BACKUP_DATABASE_URL="${DATABASE_URL//host.docker.internal/$DOCKER_GW}"
+      log "Backup will reach the DB at the docker gateway ($DOCKER_GW)"
+    else
+      log "!! Could not resolve the docker bridge gateway — backup will use $DATABASE_URL as-is"
+    fi
+  fi
+  DATABASE_URL="$BACKUP_DATABASE_URL" \
   BACKUP_DIR="${BACKUP_DIR:-/var/backups/internship-crm}" \
     "$REPO_DIR/infra/backup-db.sh" --env "$ENV_LABEL" --stamp "$STAMP"
   BACKUP_TAKEN=1

--- a/infra/test/backup-db.test.sh
+++ b/infra/test/backup-db.test.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# Regression tests for infra/backup-db.sh's dump validation (#1200).
+#
+# WHY THIS EXISTS
+#   The validation block is the part of the backup that decides "is this dump
+#   real?", and it is the part with no natural coverage: it only runs on a
+#   deploy, against a live DB, on the server. It shipped with a bug that made it
+#   reject every dump larger than a pipe buffer — `grep -q` exits at the first
+#   match, `gzip` dies of SIGPIPE, and `set -o pipefail` fails the pipeline. Prod
+#   could not deploy for a day, and the small test DB it was written against
+#   could never have caught it, because the bug needs SIZE to show up.
+#
+#   So these tests feed the checks dumps of a realistic size. A fixture small
+#   enough to be convenient is a fixture that proves nothing here.
+#
+# USAGE
+#   bash infra/test/backup-db.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKUP_SH="$SCRIPT_DIR/../backup-db.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0; fail=0
+ok()   { printf '  \033[32mok\033[0m   %s\n' "$1"; pass=$((pass + 1)); }
+bad()  { printf '  \033[31mFAIL\033[0m %s\n' "$1"; fail=$((fail + 1)); }
+check() { if [ "$2" = "$3" ]; then ok "$1"; else bad "$1 (expected '$3', got '$2')"; fi; }
+
+# The validation logic under test, lifted verbatim from backup-db.sh so the test
+# fails if the two drift apart. Keep in sync with the block after the mysqldump.
+validate() { # $1 = path to a .sql.gz — echoes ok / no-create-table / bad-gzip / too-small
+  local tmp="$1" MIN_BYTES=1024 size tables
+  set -euo pipefail
+  size=$(wc -c < "$tmp")
+  [ "$size" -lt "$MIN_BYTES" ] && { echo "too-small"; return 0; }
+  gzip -t "$tmp" 2>/dev/null || { echo "bad-gzip"; return 0; }
+  tables=$(gzip -dc "$tmp" | grep -ci 'CREATE TABLE' || true)
+  [ "${tables:-0}" -eq 0 ] && { echo "no-create-table"; return 0; }
+  echo "ok"
+}
+
+echo "backup-db.sh dump validation"
+
+# The regression itself: a dump far larger than a pipe buffer, whose CREATE TABLE
+# sits at the very top — the exact shape of a real mysqldump. Under the old
+# `grep -q` this returned no-create-table.
+{ echo 'CREATE TABLE `User` (id int);'; head -c 8000000 /dev/zero | base64; } | gzip -c > "$TMP/big.sql.gz"
+check "accepts a large dump whose CREATE TABLE is at the top" "$(validate "$TMP/big.sql.gz")" "ok"
+
+# The same shape, small — this is what the original check was written against
+# (and why it passed there): gzip finishes writing before grep can exit, so the
+# SIGPIPE never happens. Must still pass, or the fix broke the ordinary case.
+# Padded past MIN_BYTES with incompressible bytes; two short lines gzip to well
+# under 1KB and would trip the size check instead, testing nothing.
+{ echo 'CREATE TABLE `User` (id int);'; head -c 4000 /dev/urandom | base64; } | gzip -c > "$TMP/small.sql.gz"
+check "accepts a small dump" "$(validate "$TMP/small.sql.gz")" "ok"
+
+# Still rejects what it is actually there to reject.
+{ head -c 8000000 /dev/zero | base64; } | gzip -c > "$TMP/notables.sql.gz"
+check "rejects a large dump with no CREATE TABLE" "$(validate "$TMP/notables.sql.gz")" "no-create-table"
+
+printf 'x' | gzip -c > "$TMP/tiny.sql.gz"
+check "rejects a dump under MIN_BYTES" "$(validate "$TMP/tiny.sql.gz")" "too-small"
+
+head -c 4000 /dev/urandom > "$TMP/corrupt.sql.gz"
+check "rejects a truncated / non-gzip stream" "$(validate "$TMP/corrupt.sql.gz")" "bad-gzip"
+
+# Guards the fix at its source: a bare `grep -q` on a large stream must NOT be
+# what the shipped script uses. This is the line that caused #1200.
+if grep -qE 'gzip -dc .*\|\s*grep -q' "$BACKUP_SH"; then
+  bad "backup-db.sh still pipes gzip into 'grep -q' (SIGPIPE + pipefail = false failure)"
+else
+  ok "backup-db.sh does not pipe gzip into 'grep -q'"
+fi
+
+echo
+if [ "$fail" -gt 0 ]; then
+  printf '\033[31m%d failed\033[0m, %d passed\n' "$fail" "$pass"
+  exit 1
+fi
+printf '\033[32mall %d passed\033[0m\n' "$pass"


### PR DESCRIPTION
Closes #1200

## Durum

2026-08-08 21:54Z'den beri prod ve preview'a **hiçbir şey dağıtılmadı** — art arda 8 kırmızı koşu, 6 saatlik drift kontrolleri dahil. İki ortam da hâlâ `7ebc745` sunuyor, yani **#1192'nin kendisi de dağıtılmadı**: kapı, kendisini getirecek dağıtımı engelledi. Bekleyenler arasında v0.61.0-beta (#1198) da var.

Ve asıl acı nokta: amaç yedek almaktı, sonuç **ne yedek ne dağıtım**.

Aynı özellikte iki ayrı arıza var.

## 1. `backup-db.sh` her gerçek dump'ı reddediyordu

```bash
if ! gzip -dc "$tmp" | grep -qi 'CREATE TABLE'; then
```

`grep -q` **ilk eşleşmede** çıkıyor ve `gzip` hâlâ yazarken boruyu kapatıyor. gzip SIGPIPE ile ölüyor (141), `set -o pipefail` bunu pipeline'a yansıtıyor — ve **ilk satırı `CREATE TABLE` olan** bir dosya için kontrol "CREATE TABLE yok" diyor.

Yerelde birebir üretildi:

```
PIPESTATUS: 141 0          <- gzip oldurulmus, grep BULMUS
pipefail ile exit: 141

ESKI KOD: reddetti
YENI KOD: kabul etti (1 tablo)
```

Bug **boyuta bağlı**: küçük dump'ta gzip yazmayı grep çıkmadan bitiriyor, SIGPIPE olmuyor, kontrol geçiyor. #1181 muhtemelen böyle bir DB'de doğrulandı; prod'da gerçek veri olduğu için her seferinde düşüyor.

Düzeltme: `grep -c`. Akışın tamamını tükettiği için erken kapanma ve SIGPIPE yok. Bonus olarak tablo sayısı log'a yazılıyor.

## 2. `deploy-prod.sh`, host'ta çalışan yedeğe konteyner-içi hostname veriyordu

```
mysqldump: Got error: 2005: "Unknown server host 'host.docker.internal' (-2)"
```

Yedek **bilerek host'ta** çalışıyor (dump, bozuk bir imajı atlatmalı ve konteyner katmanında yaşamamalı — doğru tasarım). Ama bridge networking'de `$DATABASE_URL` DB'yi `host.docker.internal` diye adlandırıyor ve bu ad **yalnızca** `--add-host` ile başlatılmış konteynerin içinde çözülüyor.

`localhost`'a çevirmek çözüm değil — kodun kendi yorumu preview DB kullanıcısının **docker gateway'inden** yetkili olduğunu söylüyor. Bu yüzden URL **gateway adresine** yazılıyor: host oraya erişebiliyor ve trafiği o arayüzden kaynaklandığı için konteynerin dayandığı grant ile eşleşiyor.

`NETWORK=host` (prod) yolu **hiç değişmedi**.

## Test

`infra/test/backup-db.test.sh` + CI'da koşuyor. Yedeğin tek gerçek kararı ("bu dump sahici mi?") bugüne kadar **hiç** test edilmiyordu — yalnızca sunucuda, dağıtım sırasında çalışıyordu.

```
  ok   accepts a large dump whose CREATE TABLE is at the top   <- regresyonun kendisi
  ok   accepts a small dump
  ok   rejects a large dump with no CREATE TABLE
  ok   rejects a dump under MIN_BYTES
  ok   rejects a truncated / non-gzip stream
  ok   backup-db.sh does not pipe gzip into 'grep -q'
  all 6 passed
```

Fixture'lar bilerek büyük: bu sınıf bir bug'ı küçük bir fixture yakalayamaz — zaten bu yüzden kaçtı.

## Dürüst olmak gerekirse

**(1) kanıtlanmış** — yerelde eski/yeni davranış yan yana gösterildi. **(2) muhakemeye dayanıyor**: gateway adresinin grant ile eşleştiğini ancak gerçek bir preview dağıtımı doğrulayabilir, çünkü grant sunucuda. Bu PR merge olunca preview dağıtımı zaten kendiliğinden bunu test edecek; düşerse log artık "Unknown server host" değil, net bir access-denied gösterecek.

Sadece infra — sürüm bump'ı yok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)