### PR TITLE
fix(infra): preview yedeği tavsiye niteliğine geçsin, prod'unki sert kalsın (#1200)

### DIFF
--- a/infra/deploy-prod.sh
+++ b/infra/deploy-prod.sh
@@ -238,10 +238,20 @@ run_tool() { # run a one-off tool container against the DB (network per $NETWORK
 # without an explicit operator decision (#1179).
 # This same script deploys prod, the shared preview and every topic env — the
 # caller only overrides CONTAINER. The gates scale with what is at stake:
-#   prod     → back up, and REFUSE a data-destroying diff
-#   preview  → back up, but only WARN (schema experiments belong there)
+#   prod     → back up (REQUIRED — a failed dump stops the deploy), and REFUSE
+#              a data-destroying diff
+#   preview  → try to back up but only WARN on failure, and only WARN on a
+#              destructive diff (schema experiments belong there)
 #   topic    → neither; those envs are disposable and share the preview DB,
 #              so a dump per PR deploy is noise, not safety
+#
+# Preview's backup became advisory in #1200. It is the same tiering the schema
+# guard already uses one block down, applied to the other gate: preview's DB
+# user is granted from the docker gateway only, so a dump taken on the host
+# authenticates as the server's public IP and is refused (error 1045). Until
+# that grant exists, a hard gate there blocks every preview deploy to protect a
+# database whose whole purpose is to be disposable — while prod, which is what
+# the gate was actually built for (#1179), keeps its guarantee unchanged.
 case "$CONTAINER" in
   internship-crm) ENV_LABEL=prod ;;
   internship-crm-preview) ENV_LABEL=preview ;;
@@ -259,14 +269,18 @@ else
   # Runs on the host (mysqldump), not in the image: the dump must survive even
   # if the new image is broken, and it must never live inside a container layer.
   #
-  # Which is exactly why the URL needs rewriting first (#1200). Under bridge
-  # networking $DATABASE_URL names the DB as `host.docker.internal`, and that
-  # name exists ONLY inside a container started with --add-host — on the host it
-  # does not resolve, so preview's backup died with "Unknown server host" on
-  # every deploy. Substituting `localhost` would not help either: preview's DB
-  # user is granted from the docker gateway, not from localhost. Use the gateway
-  # address itself — reachable from the host, and traffic to it is sourced from
-  # that same interface, so it matches the grant the container relies on.
+  # Which is why the URL needs rewriting first (#1200). Under bridge networking
+  # $DATABASE_URL names the DB as `host.docker.internal`, and that name exists
+  # ONLY inside a container started with --add-host — on the host it does not
+  # resolve, so preview's backup died with "Unknown server host" on every
+  # deploy. The gateway address does resolve and connects.
+  #
+  # It is still not sufficient, and the log line below is honest about that:
+  # MySQL sees a dump taken on the host as coming from the server's PUBLIC ip,
+  # not from the gateway, so `crm-preview` is refused with error 1045. Granting
+  # that user from the host's address (or dumping from inside a container that
+  # already has the gateway grant) is the real fix and needs a decision on the
+  # server — until then preview's backup is advisory, per the tiering above.
   BACKUP_DATABASE_URL="$DATABASE_URL"
   if [ "$NETWORK" != host ]; then
     DOCKER_GW="$(docker network inspect bridge \
@@ -278,10 +292,21 @@ else
       log "!! Could not resolve the docker bridge gateway — backup will use $DATABASE_URL as-is"
     fi
   fi
-  DATABASE_URL="$BACKUP_DATABASE_URL" \
-  BACKUP_DIR="${BACKUP_DIR:-/var/backups/internship-crm}" \
-    "$REPO_DIR/infra/backup-db.sh" --env "$ENV_LABEL" --stamp "$STAMP"
-  BACKUP_TAKEN=1
+  # On prod a failed dump stops the deploy; on preview it is reported and the
+  # deploy continues (see the tiering note above). BACKUP_TAKEN stays 0 in that
+  # case, which is what keeps ALLOW_DESTRUCTIVE unusable there — a preview whose
+  # backup failed still cannot be talked into a data-destroying schema push.
+  if DATABASE_URL="$BACKUP_DATABASE_URL" \
+     BACKUP_DIR="${BACKUP_DIR:-/var/backups/internship-crm}" \
+       "$REPO_DIR/infra/backup-db.sh" --env "$ENV_LABEL" --stamp "$STAMP"; then
+    BACKUP_TAKEN=1
+  elif [ "$ENV_LABEL" = "prod" ]; then
+    log "Backup FAILED on prod — refusing to deploy. Fix the dump, or set
+FORCE_NO_BACKUP=1 as a deliberate one-off override."
+    exit 1
+  else
+    warn "Backup FAILED on $ENV_LABEL — deploying anyway without a fresh dump (advisory on this env, see #1200)"
+  fi
 fi
 
 log "Checking the pending schema change for data loss"


### PR DESCRIPTION
Refs #1200 (grant için açık kalıyor)

## Durum

#1201 prod'u açtı — **v0.61.0-beta canlıda** (`sha 88835b3`). Preview hâlâ düşüyor, ama artık benim taraftan kodla çözülemeyecek bir sebeple:

```
==> Backup will reach the DB at the docker gateway (172.17.0.1)
mysqldump: Got error: 1045: "Access denied for user
           'crm-preview'@'212.132.111.125' (using password: YES)"
```

Gateway adresi **bağlanıyor** (önceki "Unknown server host" gitti), ama MySQL bağlantıyı gateway'den değil **sunucunun public IP'sinden** geliyor sayıyor. Konteynerin dayandığı grant bu adresi tanımıyor.

Yani preview'ı host'tan dump etmek, ya o kullanıcıya host adresinden grant vermeden ya da dump'ı zaten gateway grant'ına sahip bir konteynerin içinde çalıştırmadan mümkün değil. İkisi de sunucuda verilecek kararlar; buradan tahminle yapılacak şeyler değil.

## Bu PR ne yapıyor

Preview'ın yedeğini **tavsiye niteliğine** çeviriyor: deneniyor, başarısız olursa gürültülü şekilde raporlanıyor, ama dağıtımı durdurmuyor.

Bu, bir blok aşağıdaki şema guard'ının **zaten kullandığı** kademelendirmenin diğer kapıya uygulanmış hâli:

| | şema guard | yedek (önce) | yedek (bu PR) |
|---|---|---|---|
| prod | REDDET | zorunlu | **zorunlu** (değişmedi) |
| preview | uyar | zorunlu | uyar |
| topic | uyar | atla | atla |

Preview'da sert kapı, **tüm dağıtımları** durdurarak amacı zaten atılabilir olmak olan ve her topic env'in paylaştığı bir veritabanını koruyor. Bu takas doğru tarafta değil.

**Prod'a dokunulmadı** ve dump olmadan hâlâ dağıtımı reddediyor — #1179'un yazılma sebebi buydu ve artık çalışıyor.

## Güvenlik ağı korunuyor

Yedek düştüğünde `BACKUP_TAKEN=0` kalıyor. `ALLOW_DESTRUCTIVE=1` taze yedek şart koştuğu için, **yedeği düşmüş bir preview yine de veri yok eden bir şema push'una ikna edilemiyor.** Kapı gevşemiyor, sadece dağıtımı rehin almıyor.

## Açık kalan

`crm-preview` kullanıcısına doğru grant (#1200). O geldiğinde bu satır tekrar zorunluya çekilebilir — kod hazır, tek `ENV_LABEL` kontrolü.

Sadece infra — sürüm bump'ı yok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)