### PR TITLE
fix(landing): giriş yapmışken public chrome oturumu doğru göstersin (#1205)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.61.1-beta] - 2026-08-09
+
+### Fixed
+- **The public chrome no longer tells a signed-in user they are signed out** (#1205). A
+  regression from #1197: `/release-notes`, `/privacy`, `/terms`, `/code-of-conduct`,
+  `/features`, `/projects` and `/for-companies` gained the shared header, but it rendered
+  "Sign In / Register" unconditionally. Following the sidebar's version link mid-session
+  replaced the app nav with a logged-out one and offered no way back into the app.
+  - `PublicShell` resolves the session on the server (behind the existing `hasSessionCookie()`
+    gate) and passes a `dashboardHref` to `PublicHeader`, which then shows a link to the
+    user's own dashboard instead of the sign-in pair. Resolved server-side on purpose: a
+    client `useSession()` would paint the signed-out chrome first and swap it a beat later,
+    which looks like the very bug being fixed.
+  - `/` was never affected — it already redirects a signed-in visitor to their role home.
+
 ## [0.61.0-beta] - 2026-08-09
 
 ### Added

--- a/e2e/public-chrome.spec.ts
+++ b/e2e/public-chrome.spec.ts
@@ -1,4 +1,10 @@
 import { test, expect, type Page } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { signInAndSettle } from './helpers/auth';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
 
 /**
  * #1197 — every public page wears the same header and footer.
@@ -124,6 +130,45 @@ test.describe('phone width', () => {
         () => document.documentElement.scrollWidth - window.innerWidth,
       );
       expect(overflow, `${path} at 390px`).toBeLessThanOrEqual(1);
+    }
+  });
+});
+
+// #1203 — the public chrome must not tell a signed-in user they are signed out.
+//
+// These pages are public but not only for the public: /release-notes is reached
+// from the sidebar version footer, /privacy and /terms from consent screens.
+// When they gained the shared chrome (#1197) it was hardcoded signed-out, so
+// following any of those links replaced the app nav with "Sign In / Register" —
+// which reads as having been logged out mid-session.
+test.describe('signed in', () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test('the public chrome shows the dashboard, not Sign In', { tag: '@smoke' }, async ({ page }) => {
+    const email = uniqueEmail('chrome-session');
+    const password = 'ChromePass123!';
+    await seedUser(email, password, 'MENTEE', 'Chrome Session Mentee');
+
+    try {
+      await signInAndSettle(page, email, password, '/portal');
+
+      for (const path of ['/release-notes', '/privacy', '/terms', '/features']) {
+        await page.goto(path);
+        const header = page.getByTestId('public-header');
+        // The tell: a signed-in visitor was being offered sign-in and sign-up.
+        await expect(header.getByRole('link', { name: /^Sign In$/ }), `${path} offers Sign In`).toHaveCount(0);
+        await expect(header.getByRole('link', { name: /^Register$/ }), `${path} offers Register`).toHaveCount(0);
+        // …and gets a way back into the app instead.
+        const dash = page.getByTestId('public-dashboard-link');
+        await expect(dash, `${path} has no dashboard link`).toBeVisible();
+        await expect(dash).toHaveAttribute('href', '/portal');
+      }
+
+      // It really goes back into the app.
+      await page.getByTestId('public-dashboard-link').click();
+      await expect(page).toHaveURL(/\/portal$/);
+    } finally {
+      await cleanupByEmail(email);
     }
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.61.0-beta",
+  "version": "0.61.1-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "author": "Mehmet Erşahin",

--- a/src/components/landing/PublicHeader.tsx
+++ b/src/components/landing/PublicHeader.tsx
@@ -30,7 +30,14 @@ import { GITHUB_URL } from './links';
  * mounts the same chrome. Its strings live in the `publicNav` namespace, which
  * — unlike `landing` — is shipped to the browser.
  */
-export function PublicHeader({ showRegister = true }: { showRegister?: boolean }) {
+export function PublicHeader({
+  showRegister = true,
+  dashboardHref,
+}: {
+  showRegister?: boolean;
+  /** Set when the visitor is signed in — the route to their own dashboard. */
+  dashboardHref?: string;
+}) {
   const t = useT();
   const locale = useLocale();
   const n = t.publicNav;
@@ -114,19 +121,31 @@ export function PublicHeader({ showRegister = true }: { showRegister?: boolean }
               <LanguageSwitcher current={locale} />
               <ThemeToggle />
             </div>
-            <Link
-              href="/auth/signin"
-              className="hidden lg:inline text-sm font-medium text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white whitespace-nowrap transition-colors"
-            >
-              {n.signIn}
-            </Link>
-            {showRegister && (
+            {dashboardHref ? (
               <Link
-                href="/auth/register"
+                href={dashboardHref}
+                data-testid="public-dashboard-link"
                 className="hidden lg:inline bg-blue-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-blue-700 whitespace-nowrap transition-colors"
               >
-                {n.register}
+                {n.dashboard}
               </Link>
+            ) : (
+              <>
+                <Link
+                  href="/auth/signin"
+                  className="hidden lg:inline text-sm font-medium text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white whitespace-nowrap transition-colors"
+                >
+                  {n.signIn}
+                </Link>
+                {showRegister && (
+                  <Link
+                    href="/auth/register"
+                    className="hidden lg:inline bg-blue-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-blue-700 whitespace-nowrap transition-colors"
+                  >
+                    {n.register}
+                  </Link>
+                )}
+              </>
             )}
 
             <button
@@ -172,19 +191,31 @@ export function PublicHeader({ showRegister = true }: { showRegister?: boolean }
               {n.github}
             </a>
             <div className="mt-2 pt-3 border-t border-gray-100 dark:border-gray-800 flex flex-wrap items-center gap-3">
-              <Link
-                href="/auth/signin"
-                className="text-sm font-medium text-gray-700 dark:text-gray-200"
-              >
-                {n.signIn}
-              </Link>
-              {showRegister && (
+              {dashboardHref ? (
                 <Link
-                  href="/auth/register"
+                  href={dashboardHref}
+                  data-testid="public-dashboard-link-mobile"
                   className="bg-blue-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-blue-700 transition-colors"
                 >
-                  {n.register}
+                  {n.dashboard}
                 </Link>
+              ) : (
+                <>
+                  <Link
+                    href="/auth/signin"
+                    className="text-sm font-medium text-gray-700 dark:text-gray-200"
+                  >
+                    {n.signIn}
+                  </Link>
+                  {showRegister && (
+                    <Link
+                      href="/auth/register"
+                      className="bg-blue-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-blue-700 transition-colors"
+                    >
+                      {n.register}
+                    </Link>
+                  )}
+                </>
               )}
               <span className="ml-auto flex items-center gap-2">
                 <LanguageSwitcher current={locale} />

--- a/src/components/landing/PublicShell.tsx
+++ b/src/components/landing/PublicShell.tsx
@@ -1,3 +1,7 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { hasSessionCookie } from '@/lib/sessionCookie';
+import { roleHome } from '@/lib/roleHome';
 import { PublicHeader } from './PublicHeader';
 import { PublicFooter } from './PublicFooter';
 
@@ -17,16 +21,26 @@ import { PublicFooter } from './PublicFooter';
  * sign-up (#1102/#1104), so a "Register" button there would send them into the
  * mentee flow. Everything else about the chrome stays identical.
  */
-export function PublicShell({
+export async function PublicShell({
   children,
   showRegister = true,
 }: {
   children: React.ReactNode;
   showRegister?: boolean;
 }) {
+  // These pages are public but not only for the public (#1203): a signed-in user
+  // reaches /release-notes from the sidebar version footer, and /privacy or
+  // /terms from a consent screen. Showing them "Sign In / Register" told them
+  // they had been logged out. Resolved here, on the server, so the header is
+  // right in the first byte — a client-side useSession() would render the
+  // signed-out chrome first and swap it a moment later, which looks like the
+  // very bug it would be fixing.
+  const session = (await hasSessionCookie()) ? await getServerSession(authOptions) : null;
+  const dashboardHref = session ? roleHome(session.user.role) : undefined;
+
   return (
     <div className="min-h-screen flex flex-col bg-gradient-to-br from-blue-50 via-white to-indigo-50 dark:from-gray-950 dark:via-gray-900 dark:to-gray-950">
-      <PublicHeader showRegister={showRegister} />
+      <PublicHeader showRegister={showRegister} dashboardHref={dashboardHref} />
       <main id="main-content" className="flex-1">
         {children}
       </main>

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -502,6 +502,7 @@ const en = {
   // from the heading of the page it points at.
   publicNav: {
     home: 'Home',
+    dashboard: 'My dashboard',
     features: 'Features',
     forCompanies: 'For companies',
     showcase: 'Project showcase',
@@ -2812,6 +2813,7 @@ const tr: Dict = {
   },
   publicNav: {
     home: 'Ana sayfa',
+    dashboard: 'Panelim',
     features: 'Özellikler',
     forCompanies: 'Firmalar için',
     showcase: 'Proje vitrini',
@@ -5118,6 +5120,7 @@ const de: Dict = {
   },
   publicNav: {
     home: 'Startseite',
+    dashboard: 'Mein Bereich',
     features: 'Funktionen',
     forCompanies: 'Für Unternehmen',
     showcase: 'Projektschaufenster',

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,21 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.61.1-beta',
+    date: '2026-08-09',
+    highlights: {
+      en: [
+        'Opening the release notes, privacy or terms pages while signed in no longer shows a logged-out menu. You stay signed in and get a link straight back to your dashboard.',
+      ],
+      tr: [
+        'Giriş yapmışken sürüm notları, gizlilik veya kullanım şartları sayfalarını açtığınızda menü artık çıkış yapmışsınız gibi görünmüyor. Oturumunuz açık kalıyor ve doğrudan panelinize dönen bir bağlantı çıkıyor.',
+      ],
+      de: [
+        'Wenn du die Release-Notes, den Datenschutz oder die Nutzungsbedingungen im angemeldeten Zustand öffnest, erscheint kein abgemeldetes Menü mehr. Du bleibst angemeldet und bekommst einen direkten Link zurück zu deinem Bereich.',
+      ],
+    },
+  },
+  {
     version: '0.61.0-beta',
     date: '2026-08-09',
     highlights: {


### PR DESCRIPTION
Closes #1205

## Hata

#1197'nin regresyonu. Ortak header'ı giyen sayfalar giriş/kayıt bağlantılarını **koşulsuz** render ediyordu:

`/release-notes` · `/privacy` · `/terms` · `/code-of-conduct` · `/features` · `/projects` · `/for-companies`

Kenar çubuğundaki sürüm bağlantısına tıklayan giriş yapmış bir kullanıcı, uygulama menüsünün yerine "Sign In / Register" buluyordu — yani oturumu kapanmış gibi görünüyordu, üstelik uygulamaya dönecek hiçbir bağlantı olmadan.

Bu sayfalar public ama *yalnızca* public değil: sürüm bağlantısı `/release-notes`'a, onam ekranları `/privacy` ve `/terms`'e gidiyor.

`/` etkilenmemişti — giriş yapmış ziyaretçiyi zaten `roleHome`'a yönlendiriyor.

## Düzeltme

`PublicShell` (sunucu bileşeni) oturumu, zaten kullandığı `hasSessionCookie()` kapısının arkasında çözüyor ve `PublicHeader`'a `dashboardHref` geçiyor. Header giriş yapmışken giriş/kayıt ikilisi yerine kullanıcının kendi paneline giden bağlantıyı gösteriyor.

**Sunucu tarafında bilerek**: istemcide `useSession()` kullanmak önce çıkış yapılmış chrome'u basıp bir an sonra değiştirirdi — yani düzeltmeye çalıştığı hatanın görüntüsünü verirdi.

## Test

`e2e/public-chrome.spec.ts` içine giriş yapmış senaryo eklendi (@smoke). Düzeltme olmadan **düşüyor**, doğrulandı:

```
Error: /release-notes offers Sign In
  expect(locator).toHaveCount(expected) failed
```

Düzeltmeyle 16/16 geçiyor.

Test dört sayfada hem giriş/kayıt bağlantılarının **yokluğunu** hem de panel bağlantısının varlığını ve gerçekten `/portal`'a götürdüğünü doğruluyor.

## Sürüm

0.61.0-beta → **0.61.1-beta** (+ CHANGELOG + releaseNotes EN/TR/DE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)