### PR TITLE
fix(infra): preview yedeğini loopback üzerinden al, grant'ı sunucuda ver (#1200)

### DIFF
--- a/infra/deploy-prod.sh
+++ b/infra/deploy-prod.sh
@@ -270,27 +270,24 @@ else
   # if the new image is broken, and it must never live inside a container layer.
   #
   # Which is why the URL needs rewriting first (#1200). Under bridge networking
-  # $DATABASE_URL names the DB as `host.docker.internal`, and that name exists
-  # ONLY inside a container started with --add-host — on the host it does not
-  # resolve, so preview's backup died with "Unknown server host" on every
-  # deploy. The gateway address does resolve and connects.
+  # $DATABASE_URL names the DB as `host.docker.internal` — a name that exists
+  # ONLY inside a container started with --add-host. On the host it does not
+  # resolve, so preview's backup died with "Unknown server host" on every deploy.
   #
-  # It is still not sufficient, and the log line below is honest about that:
-  # MySQL sees a dump taken on the host as coming from the server's PUBLIC ip,
-  # not from the gateway, so `crm-preview` is refused with error 1045. Granting
-  # that user from the host's address (or dumping from inside a container that
-  # already has the gateway grant) is the real fix and needs a decision on the
-  # server — until then preview's backup is advisory, per the tiering above.
+  # The docker gateway (172.17.0.1) was the first attempt and it connects, but
+  # MariaDB attributes the connection to the box's PUBLIC ip, and `crm-preview`
+  # is granted from `172.17.%` only — error 1045. So use loopback and mirror what
+  # prod has always done: `crm` is granted @localhost and dumps fine that way.
+  # `crm-preview`@localhost now exists too, deliberately READ-ONLY and scoped to
+  # internship_crm_preview (the 172.17.% entry keeps the full DDL rights the app
+  # needs). Verified on the server: 60 tables, 7.5MB.
+  #
+  # Loopback rather than the public ip on purpose — it does not change when the
+  # box is renumbered, and it is the one address a local dump can always reach.
   BACKUP_DATABASE_URL="$DATABASE_URL"
   if [ "$NETWORK" != host ]; then
-    DOCKER_GW="$(docker network inspect bridge \
-      --format '{{ (index .IPAM.Config 0).Gateway }}' 2>/dev/null || true)"
-    if [ -n "$DOCKER_GW" ]; then
-      BACKUP_DATABASE_URL="${DATABASE_URL//host.docker.internal/$DOCKER_GW}"
-      log "Backup will reach the DB at the docker gateway ($DOCKER_GW)"
-    else
-      log "!! Could not resolve the docker bridge gateway — backup will use $DATABASE_URL as-is"
-    fi
+    BACKUP_DATABASE_URL="${DATABASE_URL//host.docker.internal/127.0.0.1}"
+    log "Backup reaches the DB over loopback (the container's host alias is not resolvable here)"
   fi
   # On prod a failed dump stops the deploy; on preview it is reported and the
   # deploy continues (see the tiering note above). BACKUP_TAKEN stays 0 in that


### PR DESCRIPTION
Closes #1200

## Kalan yarı

#1201 prod'u açtı. Preview'da gateway adresi **bağlanıyordu** ama MariaDB bağlantıyı kutunun public IP'sinden sayıyor, `crm-preview` ise sadece `172.17.%`'den yetkili — hata 1045.

Sunucuda bakınca tablo netleşti:

```
crm          localhost      ← prod: host'tan dump ediyor, hep çalıştı
crm-preview  172.17.%       ← sadece docker subnet
```

## Çözüm: prod'un zaten çalışan modelini kopyala

Script artık `host.docker.internal` yerine **loopback** kullanıyor.

Sunucuda da eşleşen giriş açıldı (bu diff'te değil, sonradan gizem olmasın diye buraya yazıyorum):

```sql
CREATE USER 'crm-preview'@'localhost' IDENTIFIED BY PASSWORD <kopyalanan hash>
GRANT SELECT, SHOW VIEW, LOCK TABLES, TRIGGER, EVENT, EXECUTE
  ON internship_crm_preview.* TO 'crm-preview'@'localhost'
```

Mevcut `172.17.%` girişine göre iki bilinçli daraltma — o girişte tam DDL yetkisi var çünkü uygulama ona ihtiyaç duyuyor:

- yeni giriş **salt okunur** (bir dump'ın ihtiyacı bu kadar)
- yalnızca `internship_crm_preview` kapsamında

Parola, hazırlanmış ifade (prepared statement) ile **saklanan hash olarak** kopyalandı; düz metin ne komut satırına ne log'a düştü.

Public IP yerine loopback tercih edildi: kutu yeniden numaralandığında bozulmaz ve yerel bir dump'ın her zaman ulaşabileceği tek adres.

## Doğrulama — gerçek dump, sunucuda, bu script'le

```
==> Dumping internship_crm_preview from 127.0.0.1:3306 → …
==> Backup written: … (7825428 bytes, 60 tables)
CREATE TABLE sayisi: 60
```

Bu aynı zamanda **#1201'deki `grep` düzeltmesini gerçek boyutta sınıyor** — 7.5 MB, eski `grep -q`'nun kesinlikle reddedeceği bir dosya.

## Preview yedeği tavsiye niteliğinde kalıyor

#1202 bu bug için bir geçici çözüm değildi: her topic env'in paylaştığı, amacı atılabilir olmak olan bir ortam dağıtımı bloke edebilmemeli. Artık hem **bloke etmeyecek hem de gerçekten başarılı olacak.**

Sadece infra — sürüm bump'ı yok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)