### PR TITLE
fix(ci): topic preview portlarını MariaDB'nin portundan uzağa taşı (#1208)

### DIFF
--- a/.github/workflows/topic-preview.yml
+++ b/.github/workflows/topic-preview.yml
@@ -84,9 +84,16 @@ jobs:
           PR: ${{ github.event.pull_request.number }}
         run: |
           echo "topic=pr${PR}" >> "$GITHUB_OUTPUT"
-          # Deterministic port in 3300–3399 (prod=3200, preview=3201). 100 slots;
-          # PRs whose numbers collide mod 100 would clash — fine at our volume.
-          echo "port=$((3300 + PR % 100))" >> "$GITHUB_OUTPUT"
+          # Deterministic port in 3400–3499 (prod=3200, preview=3201, buch=3202).
+          # 100 slots; PRs whose numbers collide mod 100 clash — fine at our volume.
+          #
+          # NOT 3300–3399, which is where this used to live: slot 06 lands on
+          # 3306, and 3306 is MariaDB. Every PR numbered ...06 therefore tried to
+          # publish a container on the database's port and died with "address
+          # already in use" — a permanent collision, not a volume problem (#1208,
+          # hit by #1206). 3389 (RDP) sits in that block too. 3400–3499 is clear
+          # of both and, checked on the box, of everything else.
+          echo "port=$((3400 + PR % 100))" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
Closes #1208

## Sorun

Topic ortamları portu `3300 + PR % 100` ile alıyor. Slot 06 → **3306** → **MariaDB'nin portu**.

```
PORT: 3306
docker: failed to bind host port 0.0.0.0:3306/tcp: address already in use
```

#1206 buna çarptı. `Deploy topic environment` **zorunlu** bir check olduğu için PR merge olamadı — ve port satırını okuyana kadar flake gibi görünüyor.

## Mevcut yorum yanlış tehlikeyi öngörmüş

```
# 100 slots; PRs whose numbers collide mod 100 would clash — fine at our volume.
```

Bu çakışma **hacimle ilgili değil**. Kalıcı, tüm PR'ların %1'ini sonsuza kadar vuruyor, ve #1306 / #1406 diye tekrar edecek.

## Düzeltme: 3400–3499

Sunucuda 3200–3599 arasında dinlenen her şey:

```
3200  prod        3306  MariaDB   ← çakışma
3201  preview     3332/3333/3395/3396  canlı topic konteynerleri (acik PR'lar)
3202  buch
```

3400–3499 tamamen boş; hem 3306'dan hem eski blokta duran 3389'dan (RDP) uzak.

## Taşımak neden güvenli

- Port `topic-deploy.sh`'e **parametre** geçiyor, nginx server bloğu ondan üretiliyor — sabitlenmiş bir yer yok.
- Konteyner **adla** değiştiriliyor (`docker stop/rm "$CONTAINER"`), yani açık PR'lar bir sonraki push'ta yeni porta geçiyor, eskisini sızdırmıyor.
- Teardown da ada bakıyor, porta değil.

Sunucudaki 33xx konteynerlerinin **açık** PR'lara ait olduğunu ayrıca doğruladım (#1132, #1133, #1195, #1196) — yani sweep (#1193) çalışıyor, ortada sızıntı yok.

Sadece CI yapılandırması — sürüm bump'ı yok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)