### PR TITLE
fix(email): harden what #1195 shipped — token TTL, delivery-log retention, digest link count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.63.1-beta] - 2026-08-09
+
+### Security
+- **Email action links expire after 90 days** (#1211). They previously never aged out, so a
+  forwarded notification or a leaked mailbox archive let someone mark-read/react as that user
+  indefinitely. An expired link answers `410 Gone` and the page says so, rather than showing
+  the misleading "invalid link". Both actions remain low-severity and reversible — hence 90
+  days rather than hours.
+- **`EmailLog` is now covered by erasure and retention** (#1211). The log is keyed by
+  recipient address, not by a relation, so nothing cascaded to it: an erased account's address
+  survived in it. `hardDeleteUser` and `anonymizeUser` now clear it (reading the address
+  *before* the row is deleted or rewritten), and a daily job prunes rows older than
+  `EMAIL_LOG_RETENTION_DAYS` (90).
+- **Regression test for the password column** (#1211). `accountState` has to *read*
+  `User.password` to tell a mentor-created record apart from a deactivated account, which
+  puts the hash one spread operator away from a response. A spec now asserts that no
+  `/api/users` response contains a bcrypt prefix — matching on `$2a$`/`$2b$` rather than a key
+  name, so a rename cannot silence it.
+### Changed
+- **The unread digest no longer carries per-line reaction links** (#1211). A five-item digest
+  meant 25 extra links, and a high link count is one of the strongest spam signals there is —
+  the opposite of what this change set exists to achieve. The five reactions stay on the
+  single-message notification, where "the message this email is about" is unambiguous; the
+  digest keeps its per-conversation "mark as read" link.
+
 ## [0.63.0-beta] - 2026-08-09
 
 ### Added
@@ -50,30 +75,6 @@ version is shown in the sidebar footer of every page (links to the
     and the cross-zone scheduling preview.
 
 ## [0.62.0-beta] - 2026-08-09
-
-### Security
-- **Email action links expire after 90 days** (#1211). They previously never aged out, so a
-  forwarded notification or a leaked mailbox archive let someone mark-read/react as that user
-  indefinitely. An expired link answers `410 Gone` and the page says so, rather than showing
-  the misleading "invalid link". Both actions remain low-severity and reversible — hence 90
-  days rather than hours.
-- **`EmailLog` is now covered by erasure and retention** (#1211). The log is keyed by
-  recipient address, not by a relation, so nothing cascaded to it: an erased account's address
-  survived in it. `hardDeleteUser` and `anonymizeUser` now clear it (reading the address
-  *before* the row is deleted or rewritten), and a daily job prunes rows older than
-  `EMAIL_LOG_RETENTION_DAYS` (90).
-- **Regression test for the password column** (#1211). `accountState` has to *read*
-  `User.password` to tell a mentor-created record apart from a deactivated account, which
-  puts the hash one spread operator away from a response. A spec now asserts that no
-  `/api/users` response contains a bcrypt prefix — matching on `$2a$`/`$2b$` rather than a key
-  name, so a rename cannot silence it.
-
-### Changed
-- **The unread digest no longer carries per-line reaction links** (#1211). A five-item digest
-  meant 25 extra links, and a high link count is one of the strongest spam signals there is —
-  the opposite of what this change set exists to achieve. The five reactions stay on the
-  single-message notification, where "the message this email is about" is unambiguous; the
-  digest keeps its per-conversation "mark as read" link.
 
 ### Added
 - **One-click actions in notification emails** (#1204): the five composer reactions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,30 @@ version is shown in the sidebar footer of every page (links to the
 
 ## [0.62.0-beta] - 2026-08-09
 
+### Security
+- **Email action links expire after 90 days** (#1205). They previously never aged out, so a
+  forwarded notification or a leaked mailbox archive let someone mark-read/react as that user
+  indefinitely. An expired link answers `410 Gone` and the page says so, rather than showing
+  the misleading "invalid link". Both actions remain low-severity and reversible — hence 90
+  days rather than hours.
+- **`EmailLog` is now covered by erasure and retention** (#1205). The log is keyed by
+  recipient address, not by a relation, so nothing cascaded to it: an erased account's address
+  survived in it. `hardDeleteUser` and `anonymizeUser` now clear it (reading the address
+  *before* the row is deleted or rewritten), and a daily job prunes rows older than
+  `EMAIL_LOG_RETENTION_DAYS` (90).
+- **Regression test for the password column** (#1205). `accountState` has to *read*
+  `User.password` to tell a mentor-created record apart from a deactivated account, which
+  puts the hash one spread operator away from a response. A spec now asserts that no
+  `/api/users` response contains a bcrypt prefix — matching on `$2a$`/`$2b$` rather than a key
+  name, so a rename cannot silence it.
+
+### Changed
+- **The unread digest no longer carries per-line reaction links** (#1205). A five-item digest
+  meant 25 extra links, and a high link count is one of the strongest spam signals there is —
+  the opposite of what this change set exists to achieve. The five reactions stay on the
+  single-message notification, where "the message this email is about" is unambiguous; the
+  digest keeps its per-conversation "mark as read" link.
+
 ### Added
 - **One-click actions in notification emails** (#1204): the five composer reactions
   (`👍 ❤️ 😂 😮 🎉`) and a "mark this conversation as read" link, in both the per-message

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,24 +52,24 @@ version is shown in the sidebar footer of every page (links to the
 ## [0.62.0-beta] - 2026-08-09
 
 ### Security
-- **Email action links expire after 90 days** (#1205). They previously never aged out, so a
+- **Email action links expire after 90 days** (#1211). They previously never aged out, so a
   forwarded notification or a leaked mailbox archive let someone mark-read/react as that user
   indefinitely. An expired link answers `410 Gone` and the page says so, rather than showing
   the misleading "invalid link". Both actions remain low-severity and reversible — hence 90
   days rather than hours.
-- **`EmailLog` is now covered by erasure and retention** (#1205). The log is keyed by
+- **`EmailLog` is now covered by erasure and retention** (#1211). The log is keyed by
   recipient address, not by a relation, so nothing cascaded to it: an erased account's address
   survived in it. `hardDeleteUser` and `anonymizeUser` now clear it (reading the address
   *before* the row is deleted or rewritten), and a daily job prunes rows older than
   `EMAIL_LOG_RETENTION_DAYS` (90).
-- **Regression test for the password column** (#1205). `accountState` has to *read*
+- **Regression test for the password column** (#1211). `accountState` has to *read*
   `User.password` to tell a mentor-created record apart from a deactivated account, which
   puts the hash one spread operator away from a response. A spec now asserts that no
   `/api/users` response contains a bcrypt prefix — matching on `$2a$`/`$2b$` rather than a key
   name, so a rename cannot silence it.
 
 ### Changed
-- **The unread digest no longer carries per-line reaction links** (#1205). A five-item digest
+- **The unread digest no longer carries per-line reaction links** (#1211). A five-item digest
   meant 25 extra links, and a high link count is one of the strongest spam signals there is —
   the opposite of what this change set exists to achieve. The five reactions stay on the
   single-message notification, where "the message this email is about" is unambiguous; the
@@ -162,7 +162,7 @@ version is shown in the sidebar footer of every page (links to the
 ## [0.61.1-beta] - 2026-08-09
 
 ### Fixed
-- **The public chrome no longer tells a signed-in user they are signed out** (#1205). A
+- **The public chrome no longer tells a signed-in user they are signed out** (#1211). A
   regression from #1197: `/release-notes`, `/privacy`, `/terms`, `/code-of-conduct`,
   `/features`, `/projects` and `/for-companies` gained the shared header, but it rendered
   "Sign In / Register" unconditionally. Following the sidebar's version link mid-session

--- a/docs/EMAIL_DELIVERABILITY.md
+++ b/docs/EMAIL_DELIVERABILITY.md
@@ -232,6 +232,17 @@ who ignored their messages. Read the statuses as:
 
 The body is deliberately not stored — metadata only.
 
+**Retention.** Rows hold a recipient address, so the log is covered by the same
+discipline as the rest of the personal data:
+
+- a daily job prunes anything older than `EMAIL_LOG_RETENTION_DAYS` (90) —
+  `pruneEmailLog()`, registered on the 09:00 schedule;
+- account erasure clears the address explicitly (`src/lib/accountErasure.ts`).
+  The log is keyed by address rather than by a relation, so **nothing cascades
+  to it** — without that call an erased person's address outlives their account.
+
+Add both whenever a new log-like table starts holding addresses.
+
 ## 3. Inbound replies → Messages
 
 The full round trip is in place:

--- a/e2e/email-hardening.spec.ts
+++ b/e2e/email-hardening.spec.ts
@@ -12,7 +12,7 @@ test.afterAll(async () => {
   await prisma.$disconnect();
 });
 
-// Risk hardening for the email work (#1205): the token TTL, the delivery log's
+// Risk hardening for the email work (#1211): the token TTL, the delivery log's
 // retention window, and the guarantee that deriving `accountState` never leaks
 // the password column it has to read.
 

--- a/e2e/email-hardening.spec.ts
+++ b/e2e/email-hardening.spec.ts
@@ -1,0 +1,148 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { makeEmailActionToken, EMAIL_ACTION_TTL_DAYS } from '../src/lib/emailActionToken';
+// Static imports, not `await import()` inside a test: Playwright resolves the
+// `@/…` path alias when it transforms the spec's import graph, but a dynamic
+// import is resolved by Node at runtime, which knows nothing about tsconfig
+// paths and fails with "Cannot find module '@/lib/prisma'".
+import { hardDeleteUser } from '../src/lib/accountErasure';
+import { pruneEmailLog, EMAIL_LOG_RETENTION_DAYS } from '../src/services/emailService';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// Risk hardening for the email work (#1205): the token TTL, the delivery log's
+// retention window, and the guarantee that deriving `accountState` never leaks
+// the password column it has to read.
+
+test('an email-action token past its TTL is refused, and says so', async ({ page, request }) => {
+  const mentorEmail = uniqueEmail('h-mentor');
+  const menteeEmail = uniqueEmail('h-mentee');
+  const mentor = await seedUser(mentorEmail, 'x', 'MENTOR', 'H Mentor');
+  const mentee = await seedUser(menteeEmail, 'x', 'MENTEE', 'H Mentee');
+  const relation = await prisma.mentorshipRelation.create({
+    data: { mentorId: mentor.id, menteeId: mentee.id },
+  });
+
+  try {
+    const msg = await prisma.message.create({
+      data: { relationId: relation.id, senderId: mentor.id, channel: 'IN_APP', body: 'old' },
+    });
+
+    const dayNow = Math.floor(Date.now() / (24 * 60 * 60 * 1000));
+    const stale = makeEmailActionToken(
+      { kind: 'read', relationId: relation.id, userId: mentee.id },
+      dayNow - (EMAIL_ACTION_TTL_DAYS + 1),
+    );
+
+    // 410 Gone, not 400: the link was genuine, it just aged out.
+    const res = await request.post('/api/email-action', { data: { token: stale } });
+    expect(res.status()).toBe(410);
+    expect((await res.json()).expired).toBe(true);
+
+    // …and it did nothing.
+    expect(await prisma.message.count({ where: { id: msg.id, readAt: null } })).toBe(1);
+
+    // The page explains it rather than showing the misleading "invalid link".
+    await page.goto(`/m/${encodeURIComponent(stale)}`);
+    await expect(page.getByTestId('email-action-error')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText(/90/)).toBeVisible();
+
+    // A token minted just inside the window still works.
+    const fresh = makeEmailActionToken(
+      { kind: 'read', relationId: relation.id, userId: mentee.id },
+      dayNow - (EMAIL_ACTION_TTL_DAYS - 1),
+    );
+    const ok = await request.post('/api/email-action', { data: { token: fresh } });
+    expect(ok.ok()).toBeTruthy();
+    expect(await prisma.message.count({ where: { id: msg.id, readAt: null } })).toBe(0);
+  } finally {
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+  }
+});
+
+test('erasing an account removes its address from the delivery log', async ({ request }) => {
+  const email = uniqueEmail('h-erase');
+  const user = await seedUser(email, 'x', 'MENTEE', 'H Erase');
+  try {
+    await prisma.emailLog.create({
+      data: { to: email, subject: 'Verify your email', category: 'verification', transport: 'primary', status: 'SENT' },
+    });
+    expect(await prisma.emailLog.count({ where: { to: email } })).toBe(1);
+
+    await hardDeleteUser(user.id);
+
+    // The log is keyed by address, not by a relation, so nothing cascades to it
+    // — erasure has to clear it explicitly or the address outlives the account.
+    expect(await prisma.emailLog.count({ where: { to: email } })).toBe(0);
+  } finally {
+    await cleanupByEmail(email);
+    await prisma.emailLog.deleteMany({ where: { to: email } });
+  }
+  void request;
+});
+
+test('the delivery log is pruned past its retention window', async () => {
+  const oldEmail = uniqueEmail('h-old');
+  const newEmail = uniqueEmail('h-new');
+  const day = 24 * 60 * 60 * 1000;
+
+  try {
+    await prisma.emailLog.create({
+      data: {
+        to: oldEmail,
+        subject: 'ancient',
+        status: 'SENT',
+        createdAt: new Date(Date.now() - (EMAIL_LOG_RETENTION_DAYS + 5) * day),
+      },
+    });
+    await prisma.emailLog.create({ data: { to: newEmail, subject: 'recent', status: 'SENT' } });
+
+    const { deleted } = await pruneEmailLog();
+    expect(deleted).toBeGreaterThanOrEqual(1);
+
+    expect(await prisma.emailLog.count({ where: { to: oldEmail } })).toBe(0);
+    // Anything inside the window is untouched — pruning must not eat the very
+    // diagnostics the log exists for.
+    expect(await prisma.emailLog.count({ where: { to: newEmail } })).toBe(1);
+  } finally {
+    await prisma.emailLog.deleteMany({ where: { to: { in: [oldEmail, newEmail] } } });
+  }
+});
+
+test('no /api/users response ever carries the password column', async ({ page }) => {
+  const adminEmail = uniqueEmail('h-admin');
+  await seedUser(adminEmail, 'AdminPass123', 'ADMIN', 'H Admin');
+  const subject = await seedUser(uniqueEmail('h-subject'), 'SubjectPass123', 'MENTEE', 'H Subject');
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', 'AdminPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    // `accountState` has to READ the password column to tell a mentor-created
+    // record (no login) apart from a deactivated account, so the risk of it
+    // riding along in a response is real and permanent. Assert on the bcrypt
+    // prefix rather than on a key name — a rename must not silence this.
+    for (const url of [
+      '/api/users?view=directory&page=1&perPage=20&status=active',
+      '/api/users?view=directory&page=1&perPage=20&status=archived',
+      '/api/users',
+      `/api/users/${subject.id}`,
+    ]) {
+      const res = await page.request.get(url);
+      expect(res.ok(), `${url} should be readable by an admin`).toBeTruthy();
+      const body = await res.text();
+      expect(body, `${url} leaked a password hash`).not.toContain('$2a$');
+      expect(body, `${url} leaked a password hash`).not.toContain('$2b$');
+      expect(body, `${url} leaked a password field`).not.toMatch(/"password"\s*:/);
+    }
+  } finally {
+    await cleanupByEmail(subject.email);
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.63.0-beta",
+  "version": "0.63.1-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "author": "Mehmet Erşahin",

--- a/src/app/api/email-action/route.ts
+++ b/src/app/api/email-action/route.ts
@@ -26,6 +26,11 @@ export async function POST(request: Request) {
   if (!parsed.success) return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
 
   const action = verifyEmailActionToken(parsed.data.token);
+  // 410 Gone, not 400: the link was genuine, it just aged out. The page shows
+  // "open it in the app" instead of the misleading "invalid link".
+  if (action === 'expired') {
+    return NextResponse.json({ error: 'expired', expired: true }, { status: 410 });
+  }
   if (!action) return NextResponse.json({ error: 'This link is not valid.' }, { status: 400 });
 
   // The token names a user, but it was minted long ago — confirm the account

--- a/src/app/m/[token]/page.tsx
+++ b/src/app/m/[token]/page.tsx
@@ -39,7 +39,11 @@ export default function EmailActionPage({ params }: { params: Promise<{ token: s
       .then(async (res) => {
         const data = await res.json().catch(() => ({}));
         if (!res.ok) {
-          setResult({ state: 'error', message: data.error ?? t.emailAction.failed });
+          setResult(
+            data.expired
+              ? { state: 'error', message: t.emailAction.expired }
+              : { state: 'error', message: data.error ?? t.emailAction.failed },
+          );
           return;
         }
         setResult(

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -966,6 +966,7 @@ const en = {
   emailAction: {
     working: 'Working…',
     failed: 'This link did not work',
+    expired: 'This link has expired — email links stay valid for 90 days. Open the conversation in the app instead.',
     readTitle: 'Marked as read',
     readBody: '{n} message(s) in this conversation are now marked as read. They will not appear in your unread summary again.',
     readAlready: 'This conversation was already up to date — nothing left to mark.',
@@ -3330,6 +3331,7 @@ const tr: Dict = {
   emailAction: {
     working: 'İşleniyor…',
     failed: 'Bu bağlantı çalışmadı',
+    expired: 'Bu bağlantının süresi doldu — e-posta bağlantıları 90 gün geçerli. Sohbeti uygulamadan açabilirsin.',
     readTitle: 'Okundu olarak işaretlendi',
     readBody: 'Bu sohbetteki {n} mesaj artık okundu sayılıyor. Okunmamış özetinde bir daha çıkmayacak.',
     readAlready: 'Bu sohbet zaten güncelmiş — işaretlenecek bir şey kalmamış.',
@@ -5690,6 +5692,7 @@ const de: Dict = {
   emailAction: {
     working: 'Wird ausgeführt…',
     failed: 'Dieser Link hat nicht funktioniert',
+    expired: 'Dieser Link ist abgelaufen — E-Mail-Links gelten 90 Tage. Öffne die Unterhaltung stattdessen in der App.',
     readTitle: 'Als gelesen markiert',
     readBody: '{n} Nachricht(en) in dieser Unterhaltung gelten jetzt als gelesen. Sie tauchen in deiner Zusammenfassung nicht wieder auf.',
     readAlready: 'Diese Unterhaltung war bereits aktuell — es gab nichts zu markieren.',

--- a/src/lib/accountErasure.ts
+++ b/src/lib/accountErasure.ts
@@ -10,7 +10,7 @@ import { prisma } from '@/lib/prisma';
 
 // The delivery log (#1194) is keyed by recipient address, not by user id, so
 // neither erasure path reaches it through a relation — it has to be cleared
-// explicitly or an erased person's address survives in it (#1205). Read the
+// explicitly or an erased person's address survives in it (#1211). Read the
 // address BEFORE the row is deleted or rewritten, or there is nothing left to
 // match on.
 async function forgetEmailLog(userId: string): Promise<void> {

--- a/src/lib/accountErasure.ts
+++ b/src/lib/accountErasure.ts
@@ -8,7 +8,19 @@ import { prisma } from '@/lib/prisma';
 //   analytics) but scrubs PII and removes uploaded file bytes. Preferred when
 //   the candidate's history should stay visible to the org.
 
+// The delivery log (#1194) is keyed by recipient address, not by user id, so
+// neither erasure path reaches it through a relation — it has to be cleared
+// explicitly or an erased person's address survives in it (#1205). Read the
+// address BEFORE the row is deleted or rewritten, or there is nothing left to
+// match on.
+async function forgetEmailLog(userId: string): Promise<void> {
+  const user = await prisma.user.findUnique({ where: { id: userId }, select: { email: true } });
+  if (!user?.email) return;
+  await prisma.emailLog.deleteMany({ where: { to: user.email } });
+}
+
 export async function hardDeleteUser(userId: string): Promise<void> {
+  await forgetEmailLog(userId);
   await prisma.mentorshipRelation.deleteMany({ where: { OR: [{ mentorId: userId }, { menteeId: userId }] } });
   await prisma.statusChange.deleteMany({ where: { changedById: userId } });
   // Optional references without a DB-level cascade (FK restrict) would abort
@@ -23,6 +35,9 @@ export async function hardDeleteUser(userId: string): Promise<void> {
 }
 
 export async function anonymizeUser(userId: string): Promise<void> {
+  // Before the address is rewritten to erased-*@erased.local below, or the log
+  // keeps the real one forever.
+  await forgetEmailLog(userId);
   await prisma.$transaction([
     // Remove uploaded file bytes; anonymize doesn't need the CV/photo to remain.
     prisma.cvFile.deleteMany({ where: { userId } }),

--- a/src/lib/emailActionToken.ts
+++ b/src/lib/emailActionToken.ts
@@ -14,8 +14,18 @@ import { requireServerSecret } from '@/lib/serverSecret';
 // ever delivered to that user's registered address, so honouring it grants
 // nothing a mailbox holder could not already get from a password reset.
 //
-// Deliberately NOT expiring: a digest someone opens a week later should still
-// work, and both actions are trivially reversible in the app.
+// Tokens expire after 90 days. Long enough that a digest opened weeks later
+// still works, short enough that the exposure window closes: a notification
+// email that gets forwarded, or an old mailbox archive that leaks, would
+// otherwise let someone act as that user forever. Both actions are low-severity
+// and reversible (a reaction, a read flag — never a message), which is why this
+// is 90 days and not 24 hours.
+export const EMAIL_ACTION_TTL_DAYS = 90;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+// Days since the epoch, base36 — a compact, ASCII, sortable stamp. Day
+// granularity is plenty for a 90-day window and keeps the token short.
+const today = () => Math.floor(Date.now() / DAY_MS);
 
 // Mirrors REACTION_EMOJIS in src/app/api/messages/[id]/reactions/route.ts. The
 // token stores the *index*, never the emoji itself, so a token can never carry
@@ -43,18 +53,25 @@ function sign(payload: string): string {
   return createHmac('sha256', requireServerSecret()).update(payload).digest('hex').slice(0, 32);
 }
 
-function serialize(action: EmailAction): string {
+function serialize(action: EmailAction, day: number): string {
+  const stamp = day.toString(36);
   return action.kind === 'read'
-    ? ['k', action.relationId, action.userId].join(SEP)
-    : ['r', action.messageId, action.userId, String(action.emojiIndex)].join(SEP);
+    ? ['k', action.relationId, action.userId, stamp].join(SEP)
+    : ['r', action.messageId, action.userId, String(action.emojiIndex), stamp].join(SEP);
 }
 
-export function makeEmailActionToken(action: EmailAction): string {
-  const payload = serialize(action);
+export function makeEmailActionToken(action: EmailAction, day: number = today()): string {
+  const payload = serialize(action, day);
   return `${payload}.${sign(payload)}`;
 }
 
-export function verifyEmailActionToken(token: string): EmailAction | null {
+/**
+ * `null` when the signature does not verify or the payload is malformed;
+ * `'expired'` when it verifies but is older than the TTL — the caller turns
+ * that into "this link has expired, open it in the app" rather than the
+ * misleading "invalid link".
+ */
+export function verifyEmailActionToken(token: string): EmailAction | 'expired' | null {
   const dot = token.lastIndexOf('.');
   if (dot <= 0) return null;
   const payload = token.slice(0, dot);
@@ -68,18 +85,28 @@ export function verifyEmailActionToken(token: string): EmailAction | null {
   }
 
   const parts = payload.split(SEP);
-  if (parts[0] === 'k' && parts.length === 3) {
-    const [, relationId, userId] = parts;
+
+  // The stamp is the last field of both shapes. Checked before the action is
+  // returned, so an expired token can never reach the handler.
+  const expired = (stamp: string) => {
+    const issued = parseInt(stamp, 36);
+    return !Number.isFinite(issued) || today() - issued > EMAIL_ACTION_TTL_DAYS;
+  };
+
+  if (parts[0] === 'k' && parts.length === 4) {
+    const [, relationId, userId, stamp] = parts;
     if (!relationId || !userId) return null;
+    if (expired(stamp)) return 'expired';
     return { kind: 'read', relationId, userId };
   }
-  if (parts[0] === 'r' && parts.length === 4) {
-    const [, messageId, userId, rawIndex] = parts;
+  if (parts[0] === 'r' && parts.length === 5) {
+    const [, messageId, userId, rawIndex, stamp] = parts;
     const emojiIndex = Number(rawIndex);
     // A signed payload cannot normally be malformed, but never hand back an
     // index that would read past the emoji table.
     if (!messageId || !userId) return null;
     if (!Number.isInteger(emojiIndex) || emojiIndex < 0 || emojiIndex >= EMAIL_REACTION_EMOJIS.length) return null;
+    if (expired(stamp)) return 'expired';
     return { kind: 'react', messageId, userId, emojiIndex };
   }
   return null;

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,24 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.63.1-beta',
+    date: '2026-08-09',
+    highlights: {
+      en: [
+        'Links inside notification emails now stop working after 90 days. If you open an old email and the link has expired, sign in and the conversation is waiting for you.',
+        'The unread summary email is lighter: reactions now live on the individual message notification, where the emoji clearly belongs to one message. This also keeps the summary out of spam folders.',
+      ],
+      tr: [
+        'Bildirim e-postalarındaki bağlantılar artık 90 gün sonra geçerliliğini yitiriyor. Eski bir e-postayı açıp bağlantının süresi dolmuşsa, giriş yaptığınızda sohbet sizi bekliyor olacak.',
+        'Okunmamış özet e-postası sadeleşti: tepki emojileri artık tek tek mesaj bildirimlerinde — emojinin hangi mesaja ait olduğu orada net. Bu aynı zamanda özetin spam klasörüne düşmesini de engelliyor.',
+      ],
+      de: [
+        'Links in Benachrichtigungs-E-Mails verlieren nach 90 Tagen ihre Gültigkeit. Wenn du eine alte E-Mail öffnest und der Link abgelaufen ist, melde dich an — die Unterhaltung wartet dort auf dich.',
+        'Die Zusammenfassung ungelesener Nachrichten ist schlanker: Reaktionen sitzen jetzt in der einzelnen Nachrichtenbenachrichtigung, wo das Emoji eindeutig zu einer Nachricht gehört. Das hält die Zusammenfassung außerdem aus dem Spam-Ordner.',
+      ],
+    },
+  },
+  {
     version: '0.63.0-beta',
     date: '2026-08-09',
     highlights: {

--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -1945,7 +1945,7 @@ export async function sendUnreadMessageDigests() {
   return { sent, considered: allIds.length };
 }
 
-// How long a delivery-log row is kept (#1205). The log exists to answer "did
+// How long a delivery-log row is kept (#1211). The log exists to answer "did
 // our mail go out?", and that question is asked within hours of a problem —
 // but every row holds a recipient address, so keeping them forever would build
 // a second, unmanaged store of personal data next to the one the retention
@@ -1976,7 +1976,7 @@ export function initCronJobs() {
       const nm = await checkCompanyNeedMatches();
       console.log(`[Cron] Company need-match alerts: ${nm.alerts}`);
       // Housekeeping, not mail: keeps the delivery log inside its retention
-      // window so recipient addresses do not accumulate indefinitely (#1205).
+      // window so recipient addresses do not accumulate indefinitely (#1211).
       const pruned = await pruneEmailLog();
       console.log(`[Cron] Email log pruned: ${pruned.deleted} row(s) older than ${EMAIL_LOG_RETENTION_DAYS} days`);
     } catch (error) {

--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -4,7 +4,7 @@ import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 import { logger } from '@/lib/logger';
 import { notify } from '@/lib/notify';
-import { reactionLinksHtml, markReadUrl } from '@/lib/emailActionToken';
+import { markReadUrl } from '@/lib/emailActionToken';
 import { getSetting } from '@/lib/settings';
 import { emailAllowed } from '@/lib/notificationPrefs';
 import { makeConsentRenewToken } from '@/lib/consentRenew';
@@ -1873,7 +1873,7 @@ export async function sendUnreadMessageDigests() {
   type Recipient = NonNullable<(typeof msgs)[number]['relation']>['mentor'];
   const byRecipient = new Map<
     string,
-    { recipient: Recipient; items: { messageId: string; relationId: string; from: string; preview: string }[] }
+    { recipient: Recipient; items: { relationId: string; from: string; preview: string }[] }
   >();
   const allIds: string[] = [];
   for (const m of msgs) {
@@ -1885,11 +1885,7 @@ export async function sendUnreadMessageDigests() {
     const sender = m.senderId === rel.mentorId ? rel.mentor : rel.mentee;
     if (!recipient?.email) continue;
     const entry = byRecipient.get(recipient.id) ?? { recipient, items: [] };
-    // The message id rides along so the digest can offer the same one-click
-    // reactions as the live notification (#1204), bound to the exact message
-    // rather than to "whatever is newest when the link is clicked".
     entry.items.push({
-      messageId: m.id,
       relationId: rel.id,
       from: sender?.fullName ?? 'Someone',
       preview: m.body.slice(0, 120),
@@ -1903,10 +1899,12 @@ export async function sendUnreadMessageDigests() {
     const rows = items
       .map((it) => {
         const safe = it.preview.replace(/[<>&]/g, (c) => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;' }[c] as string));
-        // Each line gets the same five reactions as the app, so a one-word
-        // acknowledgement ("got it") no longer costs a round trip through the
-        // browser — and reacting also clears the thread (#1204).
-        return `<li style="margin-bottom:12px;"><strong>${it.from}:</strong> ${safe || '(attachment)'} — <a href="${appUrl}/messages/${it.relationId}">Open</a>${reactionLinksHtml(it.messageId, recipient.id)}</li>`;
+        // Deliberately NO per-line reaction links here, unlike the live
+        // notification. A five-item digest would carry 25 extra links, and a
+        // high link count is one of the strongest spam signals there is —
+        // exactly what this whole change set exists to avoid. The digest is a
+        // "what did I miss" summary; reacting belongs on the message email.
+        return `<li style="margin-bottom:8px;"><strong>${it.from}:</strong> ${safe || '(attachment)'} — <a href="${appUrl}/messages/${it.relationId}">Open</a></li>`;
       })
       .join('');
     // One link that clears the whole summary. Every item here belongs to the
@@ -1947,6 +1945,19 @@ export async function sendUnreadMessageDigests() {
   return { sent, considered: allIds.length };
 }
 
+// How long a delivery-log row is kept (#1205). The log exists to answer "did
+// our mail go out?", and that question is asked within hours of a problem —
+// but every row holds a recipient address, so keeping them forever would build
+// a second, unmanaged store of personal data next to the one the retention
+// rules already govern.
+export const EMAIL_LOG_RETENTION_DAYS = 90;
+
+export async function pruneEmailLog(retentionDays: number = EMAIL_LOG_RETENTION_DAYS) {
+  const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000);
+  const { count } = await prisma.emailLog.deleteMany({ where: { createdAt: { lt: cutoff } } });
+  return { deleted: count, cutoff };
+}
+
 const scheduledTasks = new Map<string, ReturnType<typeof cron.schedule>>();
 
 export function initCronJobs() {
@@ -1964,6 +1975,10 @@ export function initCronJobs() {
       console.log(`[Cron] Retention re-consent reminders: ${rr.reminded}`);
       const nm = await checkCompanyNeedMatches();
       console.log(`[Cron] Company need-match alerts: ${nm.alerts}`);
+      // Housekeeping, not mail: keeps the delivery log inside its retention
+      // window so recipient addresses do not accumulate indefinitely (#1205).
+      const pruned = await pruneEmailLog();
+      console.log(`[Cron] Email log pruned: ${pruned.deleted} row(s) older than ${EMAIL_LOG_RETENTION_DAYS} days`);
     } catch (error) {
       console.error('[Cron] Error running reminder check:', error);
     }


### PR DESCRIPTION
## Summary

#1195 merged and deployed **before these hardening commits were pushed**, so production has been running the unhardened version of the email work since `0051d27`. This is that follow-up, rebased onto current `main` and released as `0.63.1-beta`.

Closes #1211

Each item closes a risk that is **live right now**.

## What is currently exposed in production

| Risk | Live today | This PR |
|------|-----------|---------|
| Email action tokens (`/m/[token]`) never expire | a forwarded notification or leaked mailbox archive is an indefinite licence to mark-read/react as that user | 90-day TTL, `410 Gone` + "this link has expired, open it in the app" |
| `EmailLog` outside retention/erasure | recipient addresses accumulate forever; an **erased** account's address survives in the log | daily prune past `EMAIL_LOG_RETENTION_DAYS` (90) + both erasure paths clear it |
| Unread digest carries per-line reaction links | a five-item digest = **25 extra links**, one of the strongest spam signals there is — the hourly digest is sending this now | reactions move to the single-message notification only |

Severity on the token TTL is genuinely low — the actions are a reaction and a read flag, both reversible, neither can post a message — but the window never closed.

The `EmailLog` gap is the sharpest one: the table is keyed by **address**, not by a relation or `userId`, so nothing cascades to it. `hardDeleteUser` / `anonymizeUser` now read the address *before* the row is deleted or rewritten, because afterwards there is nothing left to match on.

## Standing guard: the password column

`accountState` must **read** `User.password` to tell a mentor-created record (no login) apart from an admin-deactivated account. That leaves the bcrypt hash one spread operator away from a response, permanently.

Audited every path that selects it — the three `/api/users` responses, `/api/users/[id]`, `resend-verification`, the messages counterpart lookup — none leak. Added a regression spec asserting no `/api/users` response contains a bcrypt prefix, matched on `$2a$`/`$2b$` rather than a key name so a rename cannot silence it.

## Verification

- [x] `npx tsc --noEmit` + `npm run lint` clean (only the three pre-existing warnings); `npm run build` succeeds
- [x] `check:i18n` — 2284 keys × 3 locales
- [x] `e2e/email-hardening.spec.ts` (4) — expired token refused with `410` **and** a token just inside the window still works; erasure clears the log; pruning removes only rows past the window; no `/api/users` response carries a password hash
- [x] `e2e/email-actions.spec.ts` (4) — still green on the new base
- [x] Rebased cleanly onto `main` (`6024a10`); `npx prisma generate` re-run afterwards, since main's new `Meeting.timeZone` otherwise fails the type-check against a stale client

## Residual risks (unchanged, documented in #1211)

- Relay cutover is all-or-nothing — but now visible within minutes via `EmailLog` `FAILED` + the health panel rather than silent.
- Replying marks the whole thread read, including old messages. Explicitly requested; matches every chat client.
- `/api/email-action` rate limit is per IP (60 / 10 min); a large NAT could hit it. Failure mode is a retry.

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QsMhbNwwLgatehPYsaFs5V)_