### PR TITLE
fix(deploy): stop the schema guard rejecting additive CREATE TABLEs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,4 +41,9 @@ jobs:
       # (#1200). Cheap to run here; the alternative is finding out on the server.
       - name: backup dump validation (#1200)
         run: bash infra/test/backup-db.test.sh
+      # Same reasoning for the destructive-schema gate: it only ever runs on the
+      # server mid-deploy, and being too broad is as costly as being too narrow
+      # — it silently stops prod from deploying at all (#1230).
+      - name: schema guard pattern (#1230)
+        run: bash infra/test/schema-guard.test.sh
       - run: npm run build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.71.1-beta] - 2026-08-14
+
+### Fixed
+- **The destructive-schema gate no longer blocks additive deploys** (#1230). The
+  `DESTRUCTIVE` pattern in `infra/schema-guard.sh` matched `MODIFY`/`CHANGE` without a
+  trailing word boundary, so any identifier or enum value merely *starting* with "change"
+  matched and the rest of the line satisfied `[^;]*NOT NULL` on its own. `WeeklyReport`'s
+  `CHANGES_REQUESTED` enum value (#1218) tripped it inside a plain `CREATE TABLE`, and
+  production stopped deploying — six releases' worth of merged work stayed off prod while
+  preview kept deploying, because preview runs the gate with `--warn-only`. Added `\b` on
+  both sides of the alternation.
+- New `infra/test/schema-guard.test.sh`, wired into the CI job next to the backup-dump
+  test: it reads the pattern out of the guard itself (so it cannot pass against a stale
+  copy) and asserts both directions — every genuinely destructive statement still matches,
+  and additive `CREATE TABLE` / `ADD COLUMN` / index statements do not.
+
 ## [0.71.0-beta] - 2026-08-14
 
 ### Added

--- a/infra/schema-guard.sh
+++ b/infra/schema-guard.sh
@@ -64,7 +64,15 @@ fi
 #   TRUNCATE                     — wipes rows outright
 #   MODIFY/CHANGE ... NOT NULL   — fails or coerces existing NULL rows
 #   DROP DATABASE / DROP SCHEMA  — the obvious catastrophe
-DESTRUCTIVE='DROP TABLE|DROP COLUMN|TRUNCATE|DROP DATABASE|DROP SCHEMA|(MODIFY|CHANGE)[^;]*NOT NULL'
+#
+# MODIFY/CHANGE carry \b on both sides on purpose. Without the trailing one,
+# any identifier that merely STARTS with "change" matches, and the rest of the
+# line then satisfies `[^;]*NOT NULL` on its own — so a purely additive
+# CREATE TABLE was rejected for containing an enum value named
+# CHANGES_REQUESTED (WeeklyReport, #1218), blocking production deploys while
+# preview sailed through on --warn-only. Blunt is fine; matching a substring of
+# a column value is not.
+DESTRUCTIVE='DROP TABLE|DROP COLUMN|TRUNCATE|DROP DATABASE|DROP SCHEMA|\b(MODIFY|CHANGE)\b[^;]*NOT NULL'
 
 if ! hits=$(printf '%s\n' "$sql" | grep -Ei "$DESTRUCTIVE"); then
   log "Pending changes are additive — proceeding"

--- a/infra/test/schema-guard.test.sh
+++ b/infra/test/schema-guard.test.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# Regression tests for infra/schema-guard.sh's destructive-statement pattern.
+#
+# WHY THIS EXISTS
+#   The pattern decides whether production is allowed to deploy at all, and it
+#   runs nowhere else: only on the server, against a live DB, mid-deploy. Both
+#   ways it can be wrong are expensive and neither shows up in normal CI:
+#
+#     - too narrow -> a DROP COLUMN reaches prod unannounced;
+#     - too broad  -> a purely additive change is refused and prod silently
+#       falls behind. That is what happened: `(MODIFY|CHANGE)[^;]*NOT NULL` has
+#       no trailing word boundary, so the enum value CHANGES_REQUESTED in
+#       WeeklyReport's CREATE TABLE (#1218) matched "CHANGE", the rest of the
+#       line satisfied `[^;]*NOT NULL`, and prod stopped deploying while
+#       preview kept going because it runs --warn-only.
+#
+#   So the fixtures below are real `prisma migrate diff --script` shapes, and
+#   both directions are asserted — every genuinely destructive statement must
+#   still match.
+#
+# USAGE
+#   bash infra/test/schema-guard.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GUARD_SH="$SCRIPT_DIR/../schema-guard.sh"
+
+pass=0; fail=0
+ok()  { printf '  \033[32mok\033[0m   %s\n' "$1"; pass=$((pass + 1)); }
+bad() { printf '  \033[31mFAIL\033[0m %s\n' "$1"; fail=$((fail + 1)); }
+
+# Read the pattern out of the guard itself rather than copying it, so this test
+# cannot pass against a stale duplicate of the regex.
+DESTRUCTIVE="$(sed -n "s/^DESTRUCTIVE='\(.*\)'$/\1/p" "$GUARD_SH")"
+if [ -z "$DESTRUCTIVE" ]; then
+  printf '\033[31mXX\033[0m could not read DESTRUCTIVE from %s\n' "$GUARD_SH" >&2
+  exit 1
+fi
+printf '\nPattern under test: %s\n\n' "$DESTRUCTIVE"
+
+matches() { printf '%s\n' "$1" | grep -Eqi "$DESTRUCTIVE"; }
+
+expect_destructive() { # $1 = label, $2 = sql
+  if matches "$2"; then ok "flags: $1"; else bad "MISSED (would reach prod): $1"; fi
+}
+expect_safe() { # $1 = label, $2 = sql
+  if matches "$2"; then bad "false alarm (would block prod): $1"; else ok "allows: $1"; fi
+}
+
+echo "Destructive statements must be flagged:"
+expect_destructive 'DROP TABLE'                 'DROP TABLE `Old`;'
+expect_destructive 'DROP COLUMN'                'ALTER TABLE `User` DROP COLUMN `bio`;'
+expect_destructive 'TRUNCATE'                   'TRUNCATE TABLE `Session`;'
+expect_destructive 'DROP DATABASE'              'DROP DATABASE `internship_crm`;'
+expect_destructive 'DROP SCHEMA'                'DROP SCHEMA `public`;'
+expect_destructive 'MODIFY ... NOT NULL'        'ALTER TABLE `User` MODIFY `bio` VARCHAR(191) NOT NULL;'
+expect_destructive 'CHANGE ... NOT NULL'        'ALTER TABLE `User` CHANGE `old` `new` VARCHAR(191) NOT NULL;'
+expect_destructive 'lowercase modify'           'alter table `User` modify `bio` varchar(191) not null;'
+expect_destructive 'MODIFY COLUMN ... NOT NULL' 'ALTER TABLE `User` MODIFY COLUMN `bio` TEXT NOT NULL;'
+
+echo
+echo "Additive statements must be allowed:"
+# The exact line that blocked production after #1218 merged.
+expect_safe 'enum value containing CHANGE' \
+  "    \`status\` ENUM('DRAFT', 'SUBMITTED', 'APPROVED', 'CHANGES_REQUESTED') NOT NULL DEFAULT 'DRAFT',"
+expect_safe 'new NOT NULL column on a new table' \
+  '    `position` VARCHAR(191) NOT NULL,'
+expect_safe 'CREATE TABLE'                  'CREATE TABLE `Offer` ('
+expect_safe 'ADD COLUMN, nullable'          'ALTER TABLE `User` ADD COLUMN `acceptingMentees` BOOLEAN NULL;'
+expect_safe 'CREATE INDEX'                  'CREATE UNIQUE INDEX `Offer_scopeKey_key` ON `Offer`(`scopeKey`);'
+expect_safe 'DROP INDEX (an index is not data)' 'DROP INDEX `CompanyInterest_companyId_menteeId_idx` ON `CompanyInterest`;'
+expect_safe 'a column merely named changeNote' \
+  '    `changeNote` TEXT NOT NULL,'
+
+echo
+printf 'Total: %d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ] || exit 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "internship-crm",
-  "version": "0.71.0-beta",
+  "version": "0.71.1-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "internship-crm",
-      "version": "0.71.0-beta",
+      "version": "0.71.1-beta",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.71.0-beta",
+  "version": "0.71.1-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "author": "Mehmet Erşahin",


### PR DESCRIPTION
`Closes #1230`

## Sorun

Production deploy'ları #1218 merge edildikten beri sessizce düşüyordu. Prod `0.66.0-beta` / `3ffc69c` (#1216) sürümünde takılı kaldı; #1218, #1224, #1225, #1226, #1227, #1228 canlıya inmedi. Preview etkilenmedi çünkü guard'ı `--warn-only` ile çalıştırıyor — yani hata **yalnızca prod'u durduruyor ve kimse fark etmiyor.**

`infra/schema-guard.sh`'daki desende `CHANGE` alternatifinin sonunda word boundary yoktu:

```sh
DESTRUCTIVE='...|(MODIFY|CHANGE)[^;]*NOT NULL'
```

#1218'in `WeeklyReportStatus` enum'undaki **`CHANGES_REQUESTED`** değeri `CHANGE` alt dizesiyle eşleşiyor, satırın kalanı da `[^;]*NOT NULL` kısmını tek başına karşılıyor. Sonuç: yepyeni bir tablonun tamamen additive `CREATE TABLE` ifadesi "veri yok ediyor" sayılıyor:

```
!! This deploy would run DESTRUCTIVE schema statements:
        `status` ENUM('DRAFT', 'SUBMITTED', 'APPROVED', 'CHANGES_REQUESTED') NOT NULL DEFAULT 'DRAFT',
XX Deploy stopped: the schema change above destroys data.
```

Guard doğru davranıp `db push`'tan **önce** durdu: veri kaybı olmadı, container swap edilmedi (prod ayakta kaldı, sadece bayat), ve her denemede yedek alındı. Sorun tamamen yanlış pozitif olması.

## Değişiklik

- Alternasyonun iki yanına `\b`: `\b(MODIFY|CHANGE)\b[^;]*NOT NULL`. `CHANGES_REQUESTED` artık eşleşmiyor; gerçek `ALTER TABLE ... MODIFY/CHANGE ... NOT NULL` eşleşmeye devam ediyor.
- Yeni `infra/test/schema-guard.test.sh`, CI'da backup-dump testinin yanına bağlandı (`#1200` ile aynı gerekçe: bu mantık yalnızca sunucuda, deploy sırasında çalışıyor).
  - Deseni **guard'ın kendisinden okuyor**, kopyalamıyor — bayat bir kopyaya karşı yeşil veremez.
  - **İki yönü de** doğruluyor: 9 gerçek yıkıcı ifade hâlâ yakalanmalı, 7 additive ifade (prod'u durduran satırın aynısı dahil) geçmeli.
  - Eski desene karşı çalıştırıldığında 2 hata veriyor, yani regresyonu gerçekten yakalıyor.

```
Total: 16 passed, 0 failed
```

## Sürümleme

`package.json` → `0.71.1-beta` + `CHANGELOG.md` girdisi eklendi. `releaseNotes.ts` girdisi **bilinçli olarak eklenmedi**: burada kullanıcıya görünen bir davranış değişikliği yok, değişiklik tamamen deploy hattının içinde. (Kullanıcıya görünen etki, bu düzeltme sayesinde canlıya inecek olan #1218–#1228'in kendi release note'ları.)

## Merge sonrası beklenen

`main`'e indiğinde prod deploy'u guard'ı geçip birikmiş 7 sürümü tek seferde canlıya almalı (`0.66.0-beta` → `0.71.1-beta`). Merge'den sonra `deploy-prod` run'ını ve `/api/health` sürümünü doğrulayacağım.

🤖 Generated with [Claude Code](https://claude.com/claude-code)