### PR TITLE
feat(meetings): gömülü görüşmeler kendi Jitsi kiracımızda (JaaS) — 5 dakika sınırı kalktı

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -122,6 +122,33 @@ GOOGLE_CLIENT_SECRET=
 # Optional; defaults to <NEXTAUTH_URL>/api/integrations/google/callback
 GOOGLE_OAUTH_REDIRECT_URI=
 
+# Optional — video calls on our own Jitsi tenant (JaaS, #1237). See
+# docs/video-calls-jaas.md for how to get these from the 8x8 JaaS console.
+#
+# UNSET (the default, and what local dev / CI / e2e run with): meetings keep
+# getting public `https://meet.jit.si/...` rooms. Those still work in a browser
+# tab, but the public instance HANGS UP AN EMBEDDED CALL AFTER FIVE MINUTES, so
+# the in-app meeting panel is only usable for a demo.
+#
+# SET (all three, or the feature stays off): new meetings get
+# `https://8x8.vc/<appId>/<room>` rooms and the panel loads them with a
+# short-lived per-participant JWT — no time limit, display names filled in, the
+# organizer joins as moderator.
+#
+#   JAAS_APP_ID      the tenant's App ID, "vpaas-magic-cookie-…". Not secret: it
+#                    is part of every room URL.
+#   JAAS_API_KEY_ID  the API key's id (the JWT `kid`), "vpaas-magic-cookie-…/ab12cd".
+#   JAAS_PRIVATE_KEY the RSA private key that pairs with it — SECRET. Either the
+#                    PEM with literal \n escapes, or the whole PEM base64-encoded
+#                    (both are accepted; a `.env` file cannot hold real newlines).
+#                    Keep it in the server's env file / GitHub secrets only.
+#
+# Billing: JaaS has a monthly-active-user free allowance and charges past it —
+# enabling this on a deployment real people use is a spending decision.
+JAAS_APP_ID=
+JAAS_API_KEY_ID=
+JAAS_PRIVATE_KEY=
+
 # Optional — multi-tenancy (#543). When "true", every tenant-scoped Prisma query
 # is auto-isolated to the request's organization (see docs/tenant-isolation.md).
 # Leave unset/false to keep the app single-tenant (default). Do NOT enable in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,46 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.73.0-beta] - 2026-08-17
+
+### Added
+- **Video calls on our own Jitsi tenant (JaaS, #1237).** The embedded meeting panel used
+  the public `meet.jit.si`, which *disconnects an embedded call after five minutes* and
+  says so in a banner — the in-app call was a demo, not a feature. With
+  `JAAS_APP_ID` + `JAAS_API_KEY_ID` + `JAAS_PRIVATE_KEY` set, new rooms are
+  `https://8x8.vc/<appId>/InternshipCRM-<hex>` and the panel loads them through 8x8's
+  `external_api.js` with a signed per-participant JWT: no cutoff, display name filled in
+  from the account, and the organizer (plus admins) joins as moderator. Setup, costs and
+  the rollback are in [docs/video-calls-jaas.md](docs/video-calls-jaas.md).
+  - `src/lib/jaas.ts` signs the token with `node:crypto` (RS256, `kid` = the API key id) —
+    no new dependency. It is scoped to **one room**, never `*`, lives two hours, is minted
+    per join and never stored. Recording/live-streaming/transcription/dial-out are off in
+    every token. `JAAS_PRIVATE_KEY` accepts a PEM with escaped newlines or a base64 PEM,
+    and all three variables are required or the feature stays off — a half-configured
+    tenant would mint tokens 8x8 rejects, which reads to the user as a broken call.
+  - `GET /api/meetings/[id]/call-token` mints it, but only for someone who was in the
+    meeting: `canAccessMeeting` (`src/lib/meetingAccess.ts`, extracted from
+    `canAttachNoteToMeeting` so notes and calls share one rule). Anyone else gets a 404,
+    the same answer as a meeting that does not exist. `Cache-Control: no-store`.
+  - **Unset, nothing changes**: rooms stay on `meet.jit.si`, the panel keeps its plain
+    iframe, and the endpoint answers `409 { code: 'not-configured' }`. That is the state of
+    local dev, CI and every e2e run — and the rollback for production.
+  - The panel falls back to "open in a new tab" whenever the room cannot be shown inside
+    the app: an old link, a rejected token, a fatal error from 8x8, or a blocked script.
+    A blank panel is worse than a working link.
+  - Rooms are only mounted on the wide layout now. The phone branch was already a Join
+    button, and `display:none` does not stop an iframe from joining a call.
+
+### Changed
+- `Permissions-Policy` and the CSP `script-src`/`frame-src` name `https://8x8.vc` (exact
+  host, no wildcard) alongside `meet.jit.si`, which stays for rooms created before the
+  switch. `e2e/security-headers.spec.ts` pins both.
+- The room-link template lived in three places (instant meetings, accepted meeting
+  requests, recurring series); it is one `generateMeetingLink()` in `src/lib/meetingRoom.ts`
+  now, so the JaaS switch applies to all three.
+- New feature-catalogue entry for in-app video calls (`src/lib/features.ts` +
+  `featureCatalog` EN/TR/DE) — the claim only became true with this change.
+
 ## [0.72.0-beta] - 2026-08-14
 
 ### Added

--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -10,6 +10,45 @@ Newest entries on top.
 
 ---
 
+## 2026-08-17 — Gömülü görüşme JaaS'a taşındı (#1237, 0.73.0-beta)
+
+**Üçüncü tarafın "demo" sınırını koda değil ortama bağlayın.** `meet.jit.si` gömülü çağrıyı
+5 dakikada kesiyor; çözüm JaaS ama kimse yerelde/CI'da özel anahtar tutmuyor. Anahtar üçlüsü
+(`JAAS_APP_ID`/`JAAS_API_KEY_ID`/`JAAS_PRIVATE_KEY`) **yoksa** eski davranışın aynen kalması,
+`meet.jit.si` bekleyen ~8 e2e assertion'ını hiç değiştirmeden yeşil tuttu ve prod için geri
+alma yolunu bedava verdi. "Üçünden biri eksikse kapalı" kuralı da bilinçli: yarım
+yapılandırma, 8x8'in reddettiği token üretir ve kullanıcıya "görüşme bozuk" diye görünür.
+
+**JWT için bağımlılık eklemeye gerek yok.** RS256 imzalama `node:crypto`'nun
+`createSign('RSA-SHA256')` + `base64url` ile ~10 satır; repoda doğrudan `jose`/`jsonwebtoken`
+bağımlılığı yok ve transitive olana yaslanmak daha kötü olurdu. Doğrulaması da ucuz: atılabilir
+bir RSA çifti üretip `node --experimental-strip-types` ile `src/lib/*.ts`'i doğrudan import eden
+bir scratch script yazın (`check-i18n.ts` zaten bu şekilde koşuyor) — imzayı `createVerify` ile
+teyit edin, üç anahtar biçimini (düz PEM, `\n` kaçışlı, base64) tek koşuda geçirin.
+
+**Sahte bir kiracı, gerçek anahtar olmadan akışın %90'ını doğruluyor.** `openssl genrsa` ile
+üretilmiş anahtarı `JAAS_*` env'lerine verip geçici bir spec koşmak: oda linkinin `8x8.vc`'ye
+çıktığını, token'ın 200 + `no-store` döndüğünü, `roomName`/`moderator` payload'ını ve iframe'in
+panelde tam boy kurulduğunu gösterdi. **Sürpriz:** 8x8, `external_api.js`'i *herhangi* bir
+appId yolundan servis ediyor — yani script yükleniyor, `JitsiMeetExternalAPI` tanımlı oluyor,
+iframe kuruluyor ve yalnızca içi boş kalıyor. "Script 404 verir, fallback'e düşer" varsayımıyla
+yazılan test yanlış nedenle geçer; DOM'u (`panel.innerHTML`, iframe rect'i) gerçekten okuyun.
+Bu yüzden fallback'e ikinci bir tetik eklendi: `errorOccurred` + `isFatal`.
+
+**`display:none` bir iframe'i görüşmeden çıkarmaz.** Panelin telefon dalı zaten "Katıl"
+düğmesiydi ama masaüstü iframe'i `hidden lg:block` ile DOM'da duruyordu. Public Jitsi'de prejoin
+ekranı bunu zararsız kılıyordu; JWT'li otomatik katılımda aynı yapı sessizce ikinci bir
+katılımcı (ve açık mikrofon) demek olurdu. Mevcut `useIsNarrow` hook'u ile mount'u koşullamak
+doğru çözüm — CSS bunu ifade edemiyor.
+
+**Yerel `.env` paylaşılan preview DB'sine bakıyor.** e2e'yi düşünmeden koşarsanız gerçek
+preview verisine yazarsınız. `DATABASE_URL="mysql://crm:crm@127.0.0.1:3306/internship_e2e"`
+öneki ile koşun (yerel MariaDB, kullanıcı `crm:crm`). Ayrıca bu makinede SMTP kimlik doğrulaması
+başarısız olduğu için `e2e/meeting-series.spec.ts` **değişiklikten bağımsız** olarak kırmızı:
+`POST /api/meeting-series` davet e-postasını beklerken 15 sn'de zaman aşımına uğruyor.
+Suçlamadan önce `git stash -u` + aynı spec ile `origin/main` tabanını ölçün — 40 saniyede
+cevap veriyor.
+
 ## 2026-08-11 — Offline fallback metni değişikliği (#1219, 0.63.2-beta)
 
 Offline fallback gibi küçük, herkese açık metin değişikliklerinde bile bu repoda sürüm disiplini

--- a/docs/video-calls-jaas.md
+++ b/docs/video-calls-jaas.md
@@ -63,6 +63,14 @@ Where to put them:
 
 - **Production / preview / demo** — the server's env file for that container (the same
   file `HEALTH_TOKEN` and `CRON_SECRET` live in), then redeploy. Never in the repo.
+  Concretely: `/etc/internship-crm/prod.env` and `/etc/internship-crm/preview.env`
+  (`chmod 600`); the topic environments read the preview file, so one entry covers every
+  `crm-pr<N>` env too.
+  ⚠️ The env file is **sourced by the deploy script, not handed to the container** — every
+  variable also needs an `-e NAME="${NAME:-}"` line in `infra/deploy-prod.sh` (prod + shared
+  preview) and `infra/server/topic-deploy.sh` (topic envs). The `JAAS_*` lines are already
+  there; the failure mode if one is missing is silent — the file looks configured while the
+  app sees nothing and quietly keeps using the public instance.
 - **Local dev** — your own `.env`, or leave unset and keep the public rooms.
 - **CI / e2e** — leave unset on purpose. The suite asserts the *unconfigured* contract
   (`e2e/meeting-call-token.spec.ts`), and no CI job needs to talk to 8x8.

--- a/docs/video-calls-jaas.md
+++ b/docs/video-calls-jaas.md
@@ -1,0 +1,114 @@
+# Video calls: moving the embedded room to JaaS (8x8)
+
+The in-app meeting panel (#1053/#1054) embeds a Jitsi room. Against the **public**
+`meet.jit.si` instance that embed is explicitly a demo: the call is cut after five
+minutes and Jitsi says so in a banner —
+
+> Embedding meet.jit.si is only meant for demo purposes, so this call will disconnect in 5
+> minutes. Please use Jitsi as a Service for production embedding!
+
+**JaaS** (Jitsi as a Service) is the same software on our own 8x8 tenant, addressed as
+`https://8x8.vc/<appId>/<room>`, with a signed JWT per participant. #1237 wires the app
+up for it; this document is the setup that lives outside the repo.
+
+## What the app does once configured
+
+| | Unconfigured (default) | Configured |
+|---|---|---|
+| New room links | `https://meet.jit.si/InternshipCRM-<hex>` | `https://8x8.vc/<appId>/InternshipCRM-<hex>` |
+| Embedded panel | plain iframe, **5-minute cutoff** | `external_api.js` + JWT, no cutoff |
+| Display name | typed by whoever joins | filled in from the account |
+| Moderator | whoever arrives first | the person who called the meeting (and admins) |
+
+Nothing else changes: the room URL is still emailed to invitees, still opens in any
+browser, and rooms created before the switch keep working as they did (the panel keeps
+the old iframe path for `meet.jit.si` links).
+
+## One-time setup in the JaaS console
+
+1. Sign in at <https://jaas.8x8.vc/> and note the **App ID** — `vpaas-magic-cookie-…`.
+   It is not a secret; it is part of every room URL.
+2. **API keys → Add API key**. Either let the console generate the RSA key pair (download
+   the private key — it is shown once) or upload the public half of a pair you generate:
+
+   ```bash
+   openssl genrsa -out jaas.key 2048 && openssl rsa -in jaas.key -pubout -out jaas.pub
+   ```
+
+3. Copy the **API key ID** shown next to it. It looks like
+   `vpaas-magic-cookie-…/ab12cd` and becomes the JWT's `kid`.
+
+## Environment
+
+Three variables, all three or nothing (a half-configured tenant would mint tokens 8x8
+rejects, so the app treats it as "off"):
+
+```
+JAAS_APP_ID=vpaas-magic-cookie-…
+JAAS_API_KEY_ID=vpaas-magic-cookie-…/ab12cd
+JAAS_PRIVATE_KEY=-----BEGIN PRIVATE KEY-----\nMIIE…\n-----END PRIVATE KEY-----\n
+```
+
+`.env` files cannot hold real newlines, so `JAAS_PRIVATE_KEY` accepts either the PEM with
+literal `\n` escapes or the whole PEM base64-encoded:
+
+```bash
+# escaped newlines
+perl -pe 's/\n/\\n/g' < jaas.key
+# or base64
+base64 -i jaas.key | tr -d '\n'
+```
+
+Where to put them:
+
+- **Production / preview / demo** — the server's env file for that container (the same
+  file `HEALTH_TOKEN` and `CRON_SECRET` live in), then redeploy. Never in the repo.
+- **Local dev** — your own `.env`, or leave unset and keep the public rooms.
+- **CI / e2e** — leave unset on purpose. The suite asserts the *unconfigured* contract
+  (`e2e/meeting-call-token.spec.ts`), and no CI job needs to talk to 8x8.
+
+Preview and production can share one tenant, but they will share its MAU allowance too.
+
+## How it fits together
+
+```
+Meeting.meetLink  https://8x8.vc/<appId>/InternshipCRM-<hex>     ← src/lib/meetingRoom.ts
+        │
+panel   ├─ GET /api/meetings/<id>/call-token                     ← authorizes, then signs
+        │     200 { domain, appId, roomName, jwt }                  (src/lib/jaas.ts)
+        │     409 { code: 'not-configured' | 'not-a-jaas-room' } → falls back to the link
+        │
+        └─ new JitsiMeetExternalAPI('8x8.vc', { roomName, jwt })  ← src/components/meeting/JaasCall.tsx
+```
+
+- The token is signed **RS256**, `kid` = the API key id, `sub` = the app id, and `room`
+  scoped to that one room — never `*`, so a leaked token cannot open another call.
+  It lives two hours and is minted per join, never stored.
+- Premium features (recording, live streaming, transcription, dial-out) are switched
+  **off** in every token. Recording in particular is a consent question
+  ([DATA_ACCESS_POLICY.md](DATA_ACCESS_POLICY.md)), not a flag to flip quietly.
+- Only meeting participants get a token: `canAccessMeeting` in `src/lib/meetingAccess.ts`
+  (mentor/mentee of the relation, project member, chat participant, organizer, admin).
+  Everyone else gets a 404 — the same answer as a meeting that does not exist.
+- `next.config.js` allows exactly `https://8x8.vc` in `script-src`/`frame-src` and in the
+  camera/microphone/display-capture `Permissions-Policy`. Adding a host to
+  `EMBEDDABLE_MEETING_HOSTS` without updating both leaves an empty box or a call with no
+  camera.
+
+## Verifying after deployment
+
+1. Start a call from a mentee card. The stored link should be an `8x8.vc` one:
+   `select meetLink from Meeting order by createdAt desc limit 1;`
+2. `GET /api/meetings/<id>/call-token` as a participant returns `200` with a `jwt`
+   (and `Cache-Control: no-store`). A `409` names the reason in `code`.
+3. The panel shows the prejoin screen, then the call — and stays up past five minutes.
+   If the token were rejected the panel falls back to "open in a new tab" rather than
+   showing a blank box.
+
+## Costs and limits
+
+JaaS bills by **monthly active users** with a free allowance on top of which usage is
+charged. Turning this on for a deployment real people use is a spending decision, and the
+usage page in the JaaS console is the only place it is visible — the app does not meter
+it. Leaving the variables unset is always a safe rollback: existing `8x8.vc` links keep
+opening in a browser tab, and new rooms go back to the public instance.

--- a/e2e/meeting-call-token.spec.ts
+++ b/e2e/meeting-call-token.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test';
+import { randomBytes } from 'crypto';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { signInAndSettle } from './helpers/auth';
+
+// #1237 — the token behind the embedded call.
+//
+// CI has no JaaS credentials, so what can be asserted here is the contract
+// around the signature rather than a signature: who may ask for a token at all,
+// and that an unconfigured deployment says so in a way the panel can fall back
+// on (409 + a code) instead of failing shut.
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('only the meeting\'s own people may ask for a call token', async ({ page }) => {
+  const mentorEmail = uniqueEmail('tok-mentor');
+  const strangerEmail = uniqueEmail('tok-stranger');
+  const mentor = await seedUser(mentorEmail, 'TokenPass123', 'MENTOR', 'Token Mentor');
+  const mentee = await seedUser(uniqueEmail('tok-mentee'), 'x', 'MENTEE', 'Token Mentee');
+  await seedUser(strangerEmail, 'TokenPass123', 'MENTOR', 'Token Stranger');
+  const rel = await prisma.mentorshipRelation.create({ data: { mentorId: mentor.id, menteeId: mentee.id } });
+  const meeting = await prisma.meeting.create({
+    data: {
+      relationId: rel.id,
+      title: 'Token check',
+      meetLink: 'https://meet.jit.si/InternshipCRM-tokencheck',
+      rsvpToken: randomBytes(24).toString('hex'),
+      createdById: mentor.id,
+    },
+  });
+
+  try {
+    // Anonymous: no session, no token.
+    expect((await page.request.get(`/api/meetings/${meeting.id}/call-token`)).status()).toBe(401);
+
+    // A signed-in user with nothing to do with this meeting gets 404, not 403:
+    // "exists but not yours" and "does not exist" must be indistinguishable.
+    await signInAndSettle(page, strangerEmail, 'TokenPass123', '/mentor');
+    expect((await page.request.get(`/api/meetings/${meeting.id}/call-token`)).status()).toBe(404);
+    await page.context().clearCookies();
+
+    // The organizer is allowed through the access check — and then hits the
+    // configuration gate, because this deployment has no JaaS tenant. The panel
+    // reads that code and keeps offering the plain link.
+    await signInAndSettle(page, mentorEmail, 'TokenPass123', '/mentor');
+    const res = await page.request.get(`/api/meetings/${meeting.id}/call-token`);
+    expect(res.status()).toBe(409);
+    expect((await res.json()).code).toBe('not-configured');
+
+    // A made-up id is a 404 for everyone.
+    expect((await page.request.get('/api/meetings/does-not-exist/call-token')).status()).toBe(404);
+  } finally {
+    await prisma.meeting.deleteMany({ where: { id: meeting.id } });
+    await prisma.mentorshipRelation.deleteMany({ where: { id: rel.id } });
+    await cleanupByEmail(mentee.email);
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(strangerEmail);
+  }
+});

--- a/e2e/security-headers.spec.ts
+++ b/e2e/security-headers.spec.ts
@@ -9,16 +9,26 @@ test('responses carry the security headers', async ({ request }) => {
   expect(h['content-security-policy']).toContain("default-src 'self'");
   expect(h['content-security-policy']).toContain("frame-ancestors 'none'");
   // camera/microphone/display-capture are delegated to the app itself and to the
-  // embedded Jitsi room only (the meeting panel needs them); a blanket
+  // embedded Jitsi rooms only (the meeting panel needs them); a blanket
   // `camera=()` would leave that iframe with a picture of nobody. What matters
-  // here is that the allow-lists stay pinned to meet.jit.si — never `*` — and
+  // here is that the allow-lists stay pinned to the two meeting hosts — our JaaS
+  // tenant `8x8.vc` (#1237) and the older public `meet.jit.si`, never `*` — and
   // that geolocation is still denied outright.
   const permissions = h['permissions-policy'];
-  expect(permissions).toContain('camera=(self "https://meet.jit.si")');
-  expect(permissions).toContain('microphone=(self "https://meet.jit.si")');
-  expect(permissions).toContain('display-capture=(self "https://meet.jit.si")');
+  expect(permissions).toContain('camera=(self "https://meet.jit.si" "https://8x8.vc")');
+  expect(permissions).toContain('microphone=(self "https://meet.jit.si" "https://8x8.vc")');
+  expect(permissions).toContain('display-capture=(self "https://meet.jit.si" "https://8x8.vc")');
   expect(permissions).toContain('geolocation=()');
   expect(permissions).not.toContain('*');
+
+  // The JaaS embed loads `<appId>/external_api.js` from 8x8.vc and that script
+  // builds the call as an iframe on the same host: both directives have to name
+  // it, and by exact host — a wildcard here would be a wide-open script source.
+  const policy = h['content-security-policy'];
+  expect(policy).toContain('script-src');
+  expect(policy).toMatch(/script-src[^;]*https:\/\/8x8\.vc/);
+  expect(policy).toMatch(/frame-src[^;]*https:\/\/8x8\.vc/);
+  expect(policy).not.toContain('https://*.8x8.vc');
 });
 
 test('home page still renders without console errors under CSP', async ({ page }) => {

--- a/infra/deploy-prod.sh
+++ b/infra/deploy-prod.sh
@@ -26,6 +26,12 @@
 # NEXTAUTH_URL, SMTP_HOST/PORT/USER/PASS/FROM. Default path /etc/internship-crm/prod.env
 # (override with ENV_FILE=...). Create it once, chmod 600.
 #
+# Every variable the app reads at runtime has to be listed in the `docker run`
+# below — the env file is sourced here, not handed to the container. Adding a
+# value to the file and forgetting the `-e` line is a silent no-op (that is how
+# JAAS_* would have looked "configured" while video calls stayed on the public
+# instance).
+#
 # USAGE
 #   # on the server, from a checkout of the repo:
 #   sudo ENV_FILE=/etc/internship-crm/prod.env ./infra/deploy-prod.sh
@@ -89,7 +95,7 @@ if [ ! -f "$ENV_FILE" ] && docker inspect "$CONTAINER" >/dev/null 2>&1; then
            SMTP_BULK_HOST SMTP_BULK_PORT SMTP_BULK_USER SMTP_BULK_PASS SMTP_BULK_FROM \
            INBOUND_EMAIL_DOMAIN INBOUND_SECRET INBOUND_IMAP_HOST INBOUND_IMAP_PORT INBOUND_IMAP_USER \
            INBOUND_IMAP_PASS INBOUND_IMAP_MAILBOX INBOUND_IMAP_POLL_SECONDS INBOUND_IMAP_ENABLED \
-           CRON_SECRET CRON_ENABLED; do
+           CRON_SECRET CRON_ENABLED JAAS_APP_ID JAAS_API_KEY_ID JAAS_PRIVATE_KEY; do
     v=$(docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$CONTAINER" | sed -n "s/^$k=//p" | head -1)
     # Single-quote the value so `. "$ENV_FILE"` sources it verbatim — a
     # DATABASE_URL/password can contain characters ($, spaces, @, :) that the
@@ -394,6 +400,9 @@ docker run -d \
   -e CRON_ENABLED="${CRON_ENABLED:-}" \
   -e TRUSTED_PROXY_COUNT="${TRUSTED_PROXY_COUNT:-1}" \
   -e HEALTH_TOKEN="${HEALTH_TOKEN:-}" \
+  -e JAAS_APP_ID="${JAAS_APP_ID:-}" \
+  -e JAAS_API_KEY_ID="${JAAS_API_KEY_ID:-}" \
+  -e JAAS_PRIVATE_KEY="${JAAS_PRIVATE_KEY:-}" \
   "$IMAGE"
 
 # ── 6. Health check + prune ──────────────────────────────────────────────────

--- a/infra/server/topic-deploy.sh
+++ b/infra/server/topic-deploy.sh
@@ -30,7 +30,9 @@
 #       B64_SMTP_FROM   (base64, piped over SSH by the hosted workflow), or
 #   (b) ENV_FILE=/path/to/preview.env — sourced directly (self-hosted runner;
 #       same file deploy-preview uses). Provides DATABASE_URL, NEXTAUTH_SECRET,
-#       SMTP_*. NEXTAUTH_URL from the file is ignored — it's set per-topic below.
+#       SMTP_*, and JAAS_* when the video-call tenant is configured
+#       (docs/video-calls-jaas.md). NEXTAUTH_URL from the file is ignored — it's
+#       set per-topic below.
 #
 # Optional overrides (server paths / commands):
 #   NGINX_CONF_DIR    (default /etc/nginx/conf.d)
@@ -116,6 +118,9 @@ docker run -d \
   -e SMTP_USER="${SMTP_USER:-}" \
   -e SMTP_PASS="${SMTP_PASS:-}" \
   -e SMTP_FROM="${SMTP_FROM:-}" \
+  -e JAAS_APP_ID="${JAAS_APP_ID:-}" \
+  -e JAAS_API_KEY_ID="${JAAS_API_KEY_ID:-}" \
+  -e JAAS_PRIVATE_KEY="${JAAS_PRIVATE_KEY:-}" \
   "$IMAGE"
 
 # ── Container health (local) ─────────────────────────────────────────────────

--- a/next.config.js
+++ b/next.config.js
@@ -11,10 +11,17 @@ const TAWK = 'https://*.tawk.to';
 // CDN. Pinned to that one path prefix — allowing all of cdn.jsdelivr.net would
 // mean allowing anything anyone has ever published to npm.
 const TAWK_EMOJI = 'https://cdn.jsdelivr.net/emojione/';
+// Our JaaS (Jitsi as a Service) tenant, #1237. Two things need it: the meeting
+// panel loads `<appId>/external_api.js` from this host (script-src), and that
+// script then builds the call as an iframe on the same host (frame-src). Listed
+// unconditionally rather than behind the JAAS_* env: these headers are baked at
+// build time and the credentials only exist at runtime. One exact host, and the
+// same one Permissions-Policy hands camera/microphone to.
+const JAAS = 'https://8x8.vc';
 
 const csp = [
   "default-src 'self'",
-  `script-src 'self' 'unsafe-inline' 'unsafe-eval' ${TAWK} ${TAWK_EMOJI}`,
+  `script-src 'self' 'unsafe-inline' 'unsafe-eval' ${JAAS} ${TAWK} ${TAWK_EMOJI}`,
   `style-src 'self' 'unsafe-inline' ${TAWK} ${TAWK_EMOJI}`,
   `img-src 'self' data: blob: ${TAWK} ${TAWK_EMOJI}`,
   `font-src 'self' ${TAWK}`,
@@ -24,11 +31,12 @@ const csp = [
   // than default-src 'self', which would block it.
   `media-src 'self' ${TAWK}`,
   // The in-app meeting side panel embeds the Jitsi room we generate (#1054) —
-  // narrow on purpose: only the host we actually create links for, and only
-  // that host is allowed camera/microphone below (keep this in sync with
-  // EMBEDDABLE_MEETING_HOSTS in src/lib/meetingLink.ts). The chat widget renders
-  // itself in an iframe, hence tawk.to here as well.
-  `frame-src 'self' https://meet.jit.si ${TAWK}`,
+  // narrow on purpose: only the hosts we actually create links for, and only
+  // those hosts are allowed camera/microphone below (keep this in sync with
+  // EMBEDDABLE_MEETING_HOSTS in src/lib/meetingLink.ts). meet.jit.si stays for
+  // rooms created before the JaaS switch. The chat widget renders itself in an
+  // iframe, hence tawk.to here as well.
+  `frame-src 'self' https://meet.jit.si ${JAAS} ${TAWK}`,
   "frame-ancestors 'none'",
   "base-uri 'self'",
   "form-action 'self'",
@@ -41,13 +49,18 @@ const securityHeaders = [
   { key: 'X-Content-Type-Options', value: 'nosniff' },
   { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
   // camera/microphone/display-capture are granted to the app itself and to the
-  // embedded Jitsi room only — a blanket `camera=()` disables them for every
-  // frame, which would leave the meeting panel with a picture of nobody.
-  // geolocation stays fully denied.
+  // embedded Jitsi rooms only (8x8.vc is our JaaS tenant, meet.jit.si the older
+  // public rooms) — a blanket `camera=()` disables them for every frame, which
+  // would leave the meeting panel with a picture of nobody. geolocation stays
+  // fully denied.
   {
     key: 'Permissions-Policy',
-    value:
-      'camera=(self "https://meet.jit.si"), microphone=(self "https://meet.jit.si"), display-capture=(self "https://meet.jit.si"), geolocation=()',
+    value: [
+      `camera=(self "https://meet.jit.si" "${JAAS}")`,
+      `microphone=(self "https://meet.jit.si" "${JAAS}")`,
+      `display-capture=(self "https://meet.jit.si" "${JAAS}")`,
+      'geolocation=()',
+    ].join(', '),
   },
   { key: 'Strict-Transport-Security', value: 'max-age=63072000; includeSubDomains; preload' },
 ];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.72.0-beta",
+  "version": "0.73.0-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "author": "Mehmet Erşahin",

--- a/src/app/api/meeting-requests/[id]/route.ts
+++ b/src/app/api/meeting-requests/[id]/route.ts
@@ -7,6 +7,7 @@ import { randomBytes } from 'crypto';
 import { notify } from '@/lib/notify';
 import { emailAllowed } from '@/lib/notificationPrefs';
 import { sendMeetingRequestDecisionEmail } from '@/services/emailService';
+import { generateMeetingLink } from '@/lib/meetingRoom';
 
 const schema = z.object({ action: z.enum(['accept', 'decline']) });
 
@@ -55,7 +56,7 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
   }
 
   // Accept → create the confirmed meeting with an auto video link.
-  const link = `https://meet.jit.si/InternshipCRM-${randomBytes(8).toString('hex')}`;
+  const link = generateMeetingLink();
   // The wall clock behind `proposedAt` was typed by the *requester* (see
   // POST /api/meeting-requests), so theirs is the zone this time was agreed on —
   // not the mentor's, even though the mentor is the one confirming it (#1210).

--- a/src/app/api/meeting-series/route.ts
+++ b/src/app/api/meeting-series/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { z } from 'zod';
-import { randomBytes } from 'crypto';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { canManageProject, isProjectMember } from '@/lib/projectAccess';
@@ -10,6 +9,7 @@ import { dispatchWebhook } from '@/lib/webhooks';
 import { withTenantScope } from '@/lib/orgContext';
 import { nextOccurrence } from '@/lib/meetingSeriesOccurrences';
 import { isValidTimeZone } from '@/lib/timezone';
+import { generateMeetingLink } from '@/lib/meetingRoom';
 
 // A recurring project meeting is a *rule*, not a pile of rows (#1110).
 //
@@ -48,10 +48,6 @@ const recurrenceSchema = z.object({
 const updateSchema = recurrenceSchema.partial().extend({ id: z.string().min(1) });
 
 const deleteSchema = z.object({ id: z.string().min(1) });
-
-function nextJitsiLink() {
-  return `https://meet.jit.si/InternshipCRM-${randomBytes(8).toString('hex')}`;
-}
 
 async function ensureProjectAccess(
   user: { id: string; role: string; companyId?: string | null },
@@ -212,7 +208,7 @@ export async function POST(request: Request) {
     const access = await ensureProjectAccess(session.user, projectId);
     if (access.error) return access.error;
 
-    const fixedLink = meetLink || nextJitsiLink();
+    const fixedLink = meetLink || generateMeetingLink();
     const series = await prisma.meetingSeries.create({
       data: {
         projectId,

--- a/src/app/api/meetings/[id]/call-token/route.ts
+++ b/src/app/api/meetings/[id]/call-token/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { withTenantScope } from '@/lib/orgContext';
+import { enforceRateLimit } from '@/lib/rateLimit';
+import { loadAccessibleMeeting } from '@/lib/meetingAccess';
+import { parseJaasMeetingLink } from '@/lib/meetingLink';
+import { JAAS_HOST, JAAS_TOKEN_TTL_SECONDS, jaasConfig, signJaasToken } from '@/lib/jaas';
+
+// GET — the JaaS token this user needs to enter this meeting's room (#1237).
+//
+// The room URL is public (it is emailed out, and guests join through it); what
+// this endpoint adds is a *signed* identity: display name filled in, and
+// moderator rights for the person who called the meeting. Without a token the
+// embedded call is a five-minute demo on the public Jitsi; with one it is our
+// own tenant, uncapped.
+//
+// The token is minted per request and never stored: it is scoped to one room,
+// lives ~2h, and is only ever handed to someone who already has access to the
+// meeting itself.
+export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  // Signing is cheap but not free, and a token per join is the expected volume —
+  // a page in a reload loop should not be able to spin the CPU.
+  const limited = enforceRateLimit(request, 'meeting-call-token', { limit: 30, windowMs: 60_000 });
+  if (limited) return limited;
+
+  const { id } = await params;
+
+  return await withTenantScope(session, async () => {
+    const meeting = await loadAccessibleMeeting(session.user, id);
+    // Missing and not-yours answer the same, so the id space stays opaque.
+    if (!meeting) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    const config = jaasConfig();
+    if (!config) {
+      // Not an error: no JaaS credentials is the normal state of local dev, CI
+      // and any deployment that has not been given a tenant. The client falls
+      // back to embedding the link as-is.
+      return NextResponse.json({ error: 'JaaS is not configured', code: 'not-configured' }, { status: 409 });
+    }
+
+    const room = parseJaasMeetingLink(meeting.meetLink);
+    // Meetings created before the switch (and any hand-typed link) still point at
+    // the public instance — nothing to sign, and signing our tenant's token for
+    // someone else's host would be pointless anyway. Also rejects a link that
+    // carries a *different* app id than the key we hold.
+    if (!room || room.appId !== config.appId) {
+      return NextResponse.json({ error: 'Not a JaaS room', code: 'not-a-jaas-room' }, { status: 409 });
+    }
+
+    const jwt = signJaasToken(config, {
+      room: room.room,
+      user: {
+        id: session.user.id,
+        name: session.user.name ?? null,
+        email: session.user.email ?? null,
+        moderator: meeting.organizer,
+      },
+    });
+
+    return NextResponse.json(
+      {
+        domain: JAAS_HOST,
+        appId: config.appId,
+        // What JitsiMeetExternalAPI wants: the tenant-prefixed room path.
+        roomName: `${config.appId}/${room.room}`,
+        jwt,
+        expiresIn: JAAS_TOKEN_TTL_SECONDS,
+      },
+      // A bearer credential in a response body — never in a shared cache, and not
+      // in the browser's disk cache either.
+      { headers: { 'Cache-Control': 'no-store' } }
+    );
+  });
+}

--- a/src/components/meeting/JaasCall.tsx
+++ b/src/components/meeting/JaasCall.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { parseJaasMeetingLink } from '@/lib/meetingLink';
+
+// The embedded call, on our own JaaS tenant (#1237).
+//
+// A plain `<iframe src>` was enough against the public Jitsi, but that instance
+// hangs up on embedded calls after five minutes. JaaS wants a signed JWT, and the
+// supported way to hand one over is 8x8's `external_api.js`, which builds the
+// iframe itself — hence a script tag and an imperative API instead of markup.
+//
+// The token is fetched per mount from GET /api/meetings/[id]/call-token and lives
+// only in this component. Anything that goes wrong — no tenant configured, an old
+// meet.jit.si link, a blocked script — renders `fallback` instead, which is how
+// the panel keeps offering "open in a new tab" rather than showing a black box.
+
+interface JitsiError {
+  error?: { name?: string; message?: string; isFatal?: boolean };
+}
+
+interface ExternalApi {
+  dispose(): void;
+  addListener(event: string, listener: (payload?: JitsiError) => void): void;
+}
+
+declare global {
+  interface Window {
+    JitsiMeetExternalAPI?: new (domain: string, options: Record<string, unknown>) => ExternalApi;
+  }
+}
+
+// One promise per tenant script: the panel can be reopened many times in a
+// session, and each remount must not append another copy of the same script.
+const scriptLoads = new Map<string, Promise<void>>();
+
+function loadExternalApi(appId: string): Promise<void> {
+  const src = `https://8x8.vc/${appId}/external_api.js`;
+  const cached = scriptLoads.get(src);
+  if (cached) return cached;
+
+  const load = new Promise<void>((resolve, reject) => {
+    if (window.JitsiMeetExternalAPI) {
+      resolve();
+      return;
+    }
+    const el = document.createElement('script');
+    el.src = src;
+    el.async = true;
+    el.onload = () => resolve();
+    el.onerror = () => {
+      // Drop the failed attempt so reopening the panel retries rather than
+      // remembering a rejection forever (a flaky network, an offline moment).
+      scriptLoads.delete(src);
+      reject(new Error('Could not load the JaaS external API'));
+    };
+    document.head.appendChild(el);
+  });
+
+  scriptLoads.set(src, load);
+  return load;
+}
+
+interface CallTokenResponse {
+  domain: string;
+  appId: string;
+  roomName: string;
+  jwt: string;
+}
+
+export function JaasCall({
+  meetingId,
+  meetLink,
+  title,
+  className,
+  fallback,
+  onReadyToClose,
+}: {
+  meetingId: string;
+  meetLink: string;
+  title: string;
+  className?: string;
+  fallback: React.ReactNode;
+  /** Fired when the participant leaves from inside the call ("hang up"). */
+  onReadyToClose?: () => void;
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [failed, setFailed] = useState(false);
+  // Kept in a ref so the effect below doesn't have to re-run (and tear the call
+  // down) just because the parent re-rendered with a new closure.
+  const closeRef = useRef(onReadyToClose);
+  closeRef.current = onReadyToClose;
+
+  useEffect(() => {
+    if (!parseJaasMeetingLink(meetLink)) {
+      setFailed(true);
+      return;
+    }
+
+    let cancelled = false;
+    let api: ExternalApi | null = null;
+
+    (async () => {
+      try {
+        const res = await fetch(`/api/meetings/${meetingId}/call-token`);
+        if (!res.ok) throw new Error(`call-token: ${res.status}`);
+        const data: CallTokenResponse = await res.json();
+        await loadExternalApi(data.appId);
+        // The panel may well have been closed while the script was loading.
+        if (cancelled) return;
+        const Api = window.JitsiMeetExternalAPI;
+        if (!Api || !containerRef.current) throw new Error('external API unavailable');
+
+        api = new Api(data.domain, {
+          roomName: data.roomName,
+          jwt: data.jwt,
+          parentNode: containerRef.current,
+          // The prejoin screen stays on purpose: it is where someone confirms
+          // which camera and microphone they are about to open, and skipping it
+          // would put a live mic in a panel that opens on a click elsewhere.
+          configOverwrite: { prejoinPageEnabled: true },
+        });
+        api.addListener('readyToClose', () => closeRef.current?.());
+        // A rejected token or a dead tenant leaves the iframe blank — 8x8 reports
+        // it here, and a blank panel is worse than the plain link. Only fatal
+        // errors: the recoverable ones (a reconnect, a failed device) are the
+        // call's own business and it recovers on its own.
+        api.addListener('errorOccurred', (payload) => {
+          if (!payload?.error?.isFatal) return;
+          // Tear the dead call down here rather than waiting for the unmount:
+          // rendering the fallback removes the container, and an orphaned iframe
+          // could hold the microphone until the panel is closed.
+          try {
+            api?.dispose();
+          } catch {
+            /* already gone */
+          }
+          api = null;
+          setFailed(true);
+        });
+      } catch {
+        if (!cancelled) setFailed(true);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      // Leaves the room and removes the iframe — without this, closing the panel
+      // would keep the microphone open.
+      try {
+        api?.dispose();
+      } catch {
+        /* already gone */
+      }
+    };
+  }, [meetingId, meetLink]);
+
+  if (failed) return <>{fallback}</>;
+
+  return <div ref={containerRef} aria-label={title} className={className} />;
+}

--- a/src/components/meeting/MeetingLauncher.tsx
+++ b/src/components/meeting/MeetingLauncher.tsx
@@ -6,8 +6,10 @@ import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { useToast } from '@/components/ui/Toast';
 import { useT } from '@/i18n/client';
-import { isEmbeddableMeetingLink } from '@/lib/meetingLink';
+import { isEmbeddableMeetingLink, parseJaasMeetingLink } from '@/lib/meetingLink';
 import { meetingNotesAutoOpen, useFloatingNotes } from '@/components/meeting/FloatingNotes';
+import { JaasCall } from '@/components/meeting/JaasCall';
+import { useIsNarrow } from '@/hooks/useIsNarrow';
 
 // "Start a meeting now" (#1053, #1054).
 //
@@ -220,6 +222,13 @@ function MeetingSidePanel({ meeting, onClose }: { meeting: ActiveMeeting; onClos
   const t = useT();
   const [copied, setCopied] = useState(false);
   const embeddable = isEmbeddableMeetingLink(meeting.meetLink);
+  // A JaaS room (#1237) is embedded through 8x8's external API so the call can
+  // carry a signed token; anything else stays a plain iframe.
+  const jaas = parseJaasMeetingLink(meeting.meetLink);
+  // The room is mounted only on the wide layout — the phone branch below is a
+  // Join button, and building the call into a `display:none` box would join it
+  // twice. CSS alone cannot express that: the iframe would still be live.
+  const narrow = useIsNarrow();
 
   const copy = async () => {
     try {
@@ -230,6 +239,20 @@ function MeetingSidePanel({ meeting, onClose }: { meeting: ActiveMeeting; onClos
       window.prompt(t.meetings.copyLink, meeting.meetLink);
     }
   };
+
+  // Shown wherever the room cannot be put on screen here: a link we may not
+  // embed, or a JaaS call that failed to start. The link itself always works.
+  const linkFallback = (message: string) => (
+    <div className="hidden lg:flex flex-1 flex-col items-center justify-center gap-3 p-6 text-center">
+      <p className="text-sm text-gray-600 dark:text-gray-400">{message}</p>
+      <a href={meeting.meetLink} target="_blank" rel="noopener noreferrer">
+        <Button size="sm">
+          <ExternalLink className="h-4 w-4" />
+          {t.meetings.instant.openInNewTab}
+        </Button>
+      </a>
+    </div>
+  );
 
   return (
     <aside
@@ -275,25 +298,29 @@ function MeetingSidePanel({ meeting, onClose }: { meeting: ActiveMeeting; onClos
         </div>
       </header>
 
-      {/* Desktop: the room itself. */}
-      {embeddable ? (
-        <iframe
-          src={meeting.meetLink}
-          title={t.meetings.instant.panelTitle}
-          allow="camera; microphone; display-capture; fullscreen; autoplay; clipboard-write"
-          className="hidden lg:block flex-1 w-full border-0"
-        />
-      ) : (
-        <div className="hidden lg:flex flex-1 flex-col items-center justify-center gap-3 p-6 text-center">
-          <p className="text-sm text-gray-600 dark:text-gray-400">{t.meetings.instant.notEmbeddable}</p>
-          <a href={meeting.meetLink} target="_blank" rel="noopener noreferrer">
-            <Button size="sm">
-              <ExternalLink className="h-4 w-4" />
-              {t.meetings.instant.openInNewTab}
-            </Button>
-          </a>
-        </div>
-      )}
+      {/* Desktop: the room itself. The JaaS iframe is built by external_api.js
+          and sized by it (`height/width: 100%` inline), so its box only needs a
+          height of its own for the call to fill it. */}
+      {!narrow &&
+        (jaas ? (
+          <JaasCall
+            meetingId={meeting.meetingId}
+            meetLink={meeting.meetLink}
+            title={t.meetings.instant.panelTitle}
+            className="hidden lg:block flex-1 w-full"
+            onReadyToClose={onClose}
+            fallback={linkFallback(t.meetings.instant.embedFailed)}
+          />
+        ) : embeddable ? (
+          <iframe
+            src={meeting.meetLink}
+            title={t.meetings.instant.panelTitle}
+            allow="camera; microphone; display-capture; fullscreen; autoplay; clipboard-write"
+            className="hidden lg:block flex-1 w-full border-0"
+          />
+        ) : (
+          linkFallback(t.meetings.instant.notEmbeddable)
+        ))}
 
       {/* Phone: a strip with a Join button — a video this small helps nobody. */}
       <div className="lg:hidden p-3">

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -1000,6 +1000,7 @@ const en = {
       join: 'Join the meeting',
       openInNewTab: 'Open in a new tab',
       notEmbeddable: 'This link cannot be shown inside the app.',
+      embedFailed: 'The call could not be started here — open it in a new tab.',
     },
     notesWindow: {
       open: 'Notes window',
@@ -1823,6 +1824,7 @@ const en = {
       activityReport: { t: 'Daily activity reports', d: 'Consent-based mentee activity digests for mentors and admins: logins, time on site, pages visited and completed to-dos.' },
       talentPool: { t: 'Talent pool & alerts (Premium)', d: 'Companies search a consent-based talent pool, see verified candidate cards, and get alerts when a candidate matches an open position.' },
       requisitions: { t: 'Requisition management', d: 'Admins and company teams create structured hiring requests, track openings and filled positions, assign owners and manage status.' },
+      videoCalls: { t: 'Video calls in the app', d: 'Start a call with a mentee, a project team or a chat in one click and hold it in a side panel next to their record, on our own Jitsi tenant \u2014 no accounts, no install, and no time limit. The link is emailed to everyone invited and works in any browser.' },
       interviewRequests: { t: 'Shortlists & interview approvals', d: 'Companies shortlist candidates per requisition and request interviews; the program team or assigned mentor reviews each request before scheduling.' },
       aiPackage: { t: 'AI assistants (Premium)', d: 'CV feedback and interview prep for mentees, interaction-log summaries for mentors, AI-assisted matching — all consent- and quota-gated.' },
       security: { t: 'Two-factor auth & session control', d: 'Role-based 2FA enforcement, session timeouts and "sign out of all devices".' },
@@ -3604,6 +3606,7 @@ const tr: Dict = {
       join: 'Görüşmeye katıl',
       openInNewTab: 'Yeni sekmede aç',
       notEmbeddable: 'Bu link uygulama içinde gösterilemiyor.',
+      embedFailed: 'Görüşme burada başlatılamadı — yeni sekmede aç.',
     },
     notesWindow: {
       open: 'Not penceresi',
@@ -4424,6 +4427,7 @@ const tr: Dict = {
       activityReport: { t: 'Günlük aktivite raporları', d: 'Mentör ve adminler için rıza temelli mentee aktivite özetleri: girişler, sitede geçen süre, gezilen sayfalar ve tamamlanan görevler.' },
       talentPool: { t: 'Yetenek havuzu & bildirimler (Premium)', d: 'Şirketler rıza temelli yetenek havuzunda arama yapar, doğrulanmış aday kartlarını görür ve açık pozisyona uyan aday çıkınca bildirim alır.' },
       requisitions: { t: 'İş talebi yönetimi', d: 'Yöneticiler ve şirket ekipleri yapılandırılmış işe alım talepleri oluşturur, kontenjan ve dolulukları izler, sorumlu atar ve durumu yönetir.' },
+      videoCalls: { t: 'Uygulama içinde görüntülü görüşme', d: 'Bir mentee, proje ekibi veya sohbetle tek tıkla görüşme başlat; görüşme, kişinin kaydının yanındaki yan panelde kendi Jitsi kiracımızda açılır \u2014 hesap yok, kurulum yok, süre sınırı yok. Link davet edilen herkese e-postayla gider ve her tarayıcıda çalışır.' },
       interviewRequests: { t: 'Kısa liste ve mülakat onayları', d: 'Şirketler adayları iş talebi bazında kısa listeye alıp mülakat ister; program ekibi veya atanmış mentor her talebi planlamadan önce değerlendirir.' },
       aiPackage: { t: 'AI asistanları (Premium)', d: 'Mentee’lere CV geri bildirimi ve mülakat hazırlığı, mentörlere etkileşim özeti, AI destekli eşleştirme — hepsi rıza ve kota kapılı.' },
       security: { t: 'İki adımlı doğrulama & oturum kontrolü', d: 'Rol bazlı 2FA zorlama, oturum zaman aşımı ve "tüm cihazlardan çıkış".' },
@@ -6203,6 +6207,7 @@ const de: Dict = {
       join: 'An der Besprechung teilnehmen',
       openInNewTab: 'In neuem Tab öffnen',
       notEmbeddable: 'Dieser Link kann nicht in der App angezeigt werden.',
+      embedFailed: 'Der Anruf konnte hier nicht gestartet werden — bitte in einem neuen Tab öffnen.',
     },
     notesWindow: {
       open: 'Notizfenster',
@@ -7023,6 +7028,7 @@ const de: Dict = {
       activityReport: { t: 'Tägliche Aktivitätsberichte', d: 'Einwilligungsbasierte Mentee-Aktivitätsübersichten für Mentoren und Admins: Logins, Verweildauer, besuchte Seiten und erledigte To-dos.' },
       talentPool: { t: 'Talent-Pool & Benachrichtigungen (Premium)', d: 'Unternehmen durchsuchen einen einwilligungsbasierten Talent-Pool, sehen verifizierte Kandidatenkarten und werden bei passenden Kandidaten benachrichtigt.' },
       requisitions: { t: 'Stellenanforderungen verwalten', d: 'Admins und Unternehmensteams erstellen strukturierte Personalbedarfe, verfolgen offene und besetzte Stellen, weisen Verantwortliche zu und verwalten den Status.' },
+      videoCalls: { t: 'Videoanrufe in der App', d: 'Starte mit einem Klick einen Anruf mit einem Mentee, einem Projektteam oder einem Chat \u2014 er läuft in einem Seitenpanel neben dem Datensatz auf unserem eigenen Jitsi-Tenant: kein Konto, keine Installation, kein Zeitlimit. Der Link geht per E-Mail an alle Eingeladenen und funktioniert in jedem Browser.' },
       interviewRequests: { t: 'Shortlists & Interviewfreigaben', d: 'Unternehmen setzen Kandidaten je Stellenanforderung auf die Shortlist und fragen Interviews an; Programmteam oder zuständiger Mentor prüfen jede Anfrage vor der Planung.' },
       aiPackage: { t: 'KI-Assistenten (Premium)', d: 'Lebenslauf-Feedback und Interviewvorbereitung für Mentees, Interaktionszusammenfassungen für Mentoren, KI-gestütztes Matching — alles einwilligungs- und kontingentgesteuert.' },
       security: { t: 'Zwei-Faktor-Auth & Sitzungskontrolle', d: 'Rollenbasierte 2FA-Durchsetzung, Sitzungs-Timeouts und „Auf allen Geräten abmelden".' },

--- a/src/lib/features.ts
+++ b/src/lib/features.ts
@@ -14,7 +14,7 @@ import {
   GitBranch, Users, Building2, CalendarClock, FileText, Target,
   BarChart3, ShieldCheck, Sparkles, MessageCircle, Activity,
   Search, Bot, KeyRound, UserPlus, Users2, Share2, CalendarDays, ListChecks, GraduationCap, Sprout, Globe,
-  Briefcase, NotebookPen, BriefcaseBusiness, CalendarCheck,
+  Briefcase, NotebookPen, BriefcaseBusiness, CalendarCheck, Video,
 } from 'lucide-react';
 import type { Dictionary } from '@/i18n/dictionaries';
 
@@ -68,5 +68,6 @@ export function getFeatures(t: Dictionary): Feature[] {
     { key: 'weeklyReports', category: 'tracking', icon: NotebookPen, color: 'teal', title: C.weeklyReports.t, desc: C.weeklyReports.d },
     { key: 'requisitions', category: 'companies', icon: BriefcaseBusiness, color: 'purple', title: C.requisitions.t, desc: C.requisitions.d },
     { key: 'interviewRequests', category: 'companies', icon: CalendarCheck, color: 'blue', title: C.interviewRequests.t, desc: C.interviewRequests.d },
+    { key: 'videoCalls', category: 'collaboration', icon: Video, color: 'green', title: C.videoCalls.t, desc: C.videoCalls.d },
   ];
 }

--- a/src/lib/jaas.ts
+++ b/src/lib/jaas.ts
@@ -136,14 +136,12 @@ export function signJaasToken(
   };
 
   const signingInput = `${base64url(header)}.${base64url(payload)}`;
-  // CodeQL's `js/insufficient-password-hash` heuristic reads `apiKeyId` as a
-  // password and SHA-256 as the hash it is stored with. It is neither: this is
-  // an RS256 *signature* over a JWT — the algorithm JaaS requires — and the key
-  // id is a public identifier that travels in the token header. Nothing is
-  // hashed for storage anywhere in this file.
-  const signature = createSign('RSA-SHA256') // codeql[js/insufficient-password-hash]
-    .update(signingInput)
-    .sign(config.privateKey)
-    .toString('base64url');
+  // CodeQL flags this as `js/insufficient-password-hash` (high). It is a false
+  // positive, and one to dismiss in the Security tab rather than work around:
+  // its heuristic reads `apiKeyId` as a password and SHA-256 as the hash it is
+  // stored with. Neither holds — this is an RS256 *signature* over a JWT, the
+  // algorithm JaaS requires, the key id is a public identifier that travels in
+  // the token header, and nothing in this file is hashed for storage.
+  const signature = createSign('RSA-SHA256').update(signingInput).sign(config.privateKey).toString('base64url');
   return `${signingInput}.${signature}`;
 }

--- a/src/lib/jaas.ts
+++ b/src/lib/jaas.ts
@@ -1,0 +1,141 @@
+import { createSign } from 'crypto';
+
+// JaaS — "Jitsi as a Service", 8x8's hosted Jitsi (#1237).
+//
+// Why this exists at all: the public `meet.jit.si` instance allows being put in
+// an iframe, but *disconnects an embedded call after five minutes* and says so
+// in a banner ("Embedding meet.jit.si is only meant for demo purposes"). The
+// side panel from #1054 is therefore unusable in production against that host.
+// JaaS is the same software on our own tenant, addressed as
+// `https://8x8.vc/<appId>/<room>`, and it wants a per-participant JWT signed
+// with the RSA key we generated in the JaaS console.
+//
+// Server-only: the private key must never reach the browser. The client gets a
+// short-lived token from GET /api/meetings/[id]/call-token and nothing else.
+//
+// Everything here degrades to `null` when the environment is not configured —
+// that is the default in local dev, CI and every e2e run, and it keeps the old
+// meet.jit.si behaviour (see src/lib/meetingRoom.ts) rather than breaking calls.
+
+export const JAAS_HOST = '8x8.vc';
+
+// App IDs handed out by the JaaS console all carry this prefix. Checking it is
+// how we can tell one of our own room links apart from an arbitrary 8x8.vc URL.
+export const JAAS_APP_ID_PREFIX = 'vpaas-magic-cookie-';
+
+// Two hours. Long enough that a meeting never dies mid-sentence, short enough
+// that a token copied out of the network tab is worthless by tomorrow. The token
+// is minted per participant on join, so there is no reason to make it longer.
+export const JAAS_TOKEN_TTL_SECONDS = 2 * 60 * 60;
+
+export interface JaasConfig {
+  /** `vpaas-magic-cookie-…` — public, it appears in the room URL. */
+  appId: string;
+  /** The API key's id, used as the JWT `kid`: `vpaas-magic-cookie-…/abc123`. */
+  apiKeyId: string;
+  /** RSA private key, PEM. Secret. */
+  privateKey: string;
+}
+
+// Env files are a hostile place for a multi-line PEM: `.env` parsers keep the
+// literal `\n`, and people commonly base64 the whole key to sidestep that. Both
+// spellings are accepted so a working key is never rejected over formatting.
+function normalizePrivateKey(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return '';
+  if (trimmed.includes('BEGIN')) return trimmed.replace(/\\n/g, '\n');
+  try {
+    const decoded = Buffer.from(trimmed, 'base64').toString('utf8');
+    return decoded.includes('BEGIN') ? decoded : '';
+  } catch {
+    return '';
+  }
+}
+
+// All three parts or nothing: a half-configured tenant would mint tokens 8x8
+// rejects, which looks to the user like "the call is broken" rather than like
+// "the feature is off".
+export function jaasConfig(): JaasConfig | null {
+  const appId = process.env.JAAS_APP_ID?.trim();
+  const apiKeyId = process.env.JAAS_API_KEY_ID?.trim();
+  const privateKey = normalizePrivateKey(process.env.JAAS_PRIVATE_KEY ?? '');
+  if (!appId || !apiKeyId || !privateKey) return null;
+  if (!appId.startsWith(JAAS_APP_ID_PREFIX)) return null;
+  return { appId, apiKeyId, privateKey };
+}
+
+export function jaasEnabled(): boolean {
+  return jaasConfig() !== null;
+}
+
+/** The shareable room URL — what we store in `Meeting.meetLink` and email out. */
+export function jaasRoomUrl(config: JaasConfig, room: string): string {
+  return `https://${JAAS_HOST}/${config.appId}/${room}`;
+}
+
+export interface JaasTokenUser {
+  id: string;
+  name?: string | null;
+  email?: string | null;
+  /** Moderators can mute others and end the call; the organizer gets it. */
+  moderator: boolean;
+}
+
+function base64url(value: object): string {
+  return Buffer.from(JSON.stringify(value)).toString('base64url');
+}
+
+// The JaaS token: RS256, `kid` = the API key id, `sub` = the app id, and `room`
+// scoped to the one room the caller is entitled to — never `*`, which would let
+// a leaked token open any room on the tenant.
+//
+// Signed with node:crypto rather than a JWT library on purpose: this is the
+// whole of RFC 7515 that we need, and the project has no direct jose/
+// jsonwebtoken dependency to reuse.
+export function signJaasToken(
+  config: JaasConfig,
+  args: { room: string; user: JaasTokenUser; ttlSeconds?: number }
+): string {
+  const now = Math.floor(Date.now() / 1000);
+  const ttl = args.ttlSeconds ?? JAAS_TOKEN_TTL_SECONDS;
+
+  const header = { alg: 'RS256', typ: 'JWT', kid: config.apiKeyId };
+  const payload = {
+    aud: 'jitsi',
+    iss: 'chat',
+    sub: config.appId,
+    room: args.room,
+    iat: now,
+    // A few seconds of slack: the container's clock and 8x8's need not agree to
+    // the second, and an `nbf` in the future is rejected outright.
+    nbf: now - 30,
+    exp: now + ttl,
+    context: {
+      user: {
+        id: args.user.id,
+        name: args.user.name || 'Guest',
+        email: args.user.email || '',
+        avatar: '',
+        moderator: args.user.moderator,
+        'hidden-from-recorder': false,
+      },
+      // Premium features stay off: they are billed per use, and nothing in the
+      // app asks for them. Recording in particular would be a consent question
+      // (docs/DATA_ACCESS_POLICY.md), not a flag to flip quietly.
+      features: {
+        livestreaming: false,
+        recording: false,
+        transcription: false,
+        'outbound-call': false,
+        'sip-outbound-call': false,
+        'file-upload': false,
+        'list-visitors': false,
+        flip: false,
+      },
+    },
+  };
+
+  const signingInput = `${base64url(header)}.${base64url(payload)}`;
+  const signature = createSign('RSA-SHA256').update(signingInput).sign(config.privateKey).toString('base64url');
+  return `${signingInput}.${signature}`;
+}

--- a/src/lib/jaas.ts
+++ b/src/lib/jaas.ts
@@ -136,6 +136,14 @@ export function signJaasToken(
   };
 
   const signingInput = `${base64url(header)}.${base64url(payload)}`;
-  const signature = createSign('RSA-SHA256').update(signingInput).sign(config.privateKey).toString('base64url');
+  // CodeQL's `js/insufficient-password-hash` heuristic reads `apiKeyId` as a
+  // password and SHA-256 as the hash it is stored with. It is neither: this is
+  // an RS256 *signature* over a JWT — the algorithm JaaS requires — and the key
+  // id is a public identifier that travels in the token header. Nothing is
+  // hashed for storage anywhere in this file.
+  const signature = createSign('RSA-SHA256') // codeql[js/insufficient-password-hash]
+    .update(signingInput)
+    .sign(config.privateKey)
+    .toString('base64url');
   return `${signingInput}.${signature}`;
 }

--- a/src/lib/meetingAccess.ts
+++ b/src/lib/meetingAccess.ts
@@ -1,0 +1,76 @@
+import { prisma } from '@/lib/prisma';
+
+// "Were you in this meeting, or did you call it?" — the one rule that governs a
+// meeting row, wherever it is reached from.
+//
+// It was written for notes (#1056, `canAttachNoteToMeeting`, which now delegates
+// here) and the call-token endpoint (#1237) needs exactly the same answer before
+// it will sign anything: a token is scoped to a room, so handing one to a
+// stranger is handing them the call.
+
+export interface AccessibleMeeting {
+  id: string;
+  title: string;
+  meetLink: string | null;
+  createdById: string;
+  /** True for the person who called the meeting (and for an admin). */
+  organizer: boolean;
+}
+
+// Returns the meeting when this user may take part in it, null otherwise —
+// including when it does not exist, so a probe cannot tell the two apart.
+export async function loadAccessibleMeeting(
+  user: { id: string; role: string },
+  meetingId: string
+): Promise<AccessibleMeeting | null> {
+  const meeting = await prisma.meeting.findUnique({
+    where: { id: meetingId },
+    select: {
+      id: true,
+      title: true,
+      meetLink: true,
+      createdById: true,
+      relation: { select: { mentorId: true, menteeId: true } },
+      projectId: true,
+      conversationId: true,
+    },
+  });
+  if (!meeting) return null;
+
+  const isAdmin = user.role === 'ADMIN';
+  const isCreator = meeting.createdById === user.id;
+  const found = {
+    id: meeting.id,
+    title: meeting.title,
+    meetLink: meeting.meetLink,
+    createdById: meeting.createdById,
+    organizer: isCreator || isAdmin,
+  };
+
+  if (isCreator || isAdmin) return found;
+  if (meeting.relation && (meeting.relation.mentorId === user.id || meeting.relation.menteeId === user.id)) {
+    return found;
+  }
+  if (meeting.projectId) {
+    const member = await prisma.projectMember.findUnique({
+      where: { projectId_userId: { projectId: meeting.projectId, userId: user.id } },
+      select: { id: true },
+    });
+    if (member) return found;
+  }
+  if (meeting.conversationId) {
+    const participant = await prisma.conversationParticipant.findUnique({
+      where: { conversationId_userId: { conversationId: meeting.conversationId, userId: user.id } },
+      select: { id: true },
+    });
+    if (participant) return found;
+  }
+  return null;
+}
+
+export async function canAccessMeeting(
+  user: { id: string; role: string },
+  meetingId: string
+): Promise<boolean> {
+  return (await loadAccessibleMeeting(user, meetingId)) !== null;
+}

--- a/src/lib/meetingContext.ts
+++ b/src/lib/meetingContext.ts
@@ -1,4 +1,3 @@
-import { randomBytes } from 'crypto';
 import { prisma } from '@/lib/prisma';
 
 // A meeting hangs off exactly one context (#1051). MySQL can't express
@@ -47,11 +46,11 @@ export function countContexts(input: MeetingContextInput): number {
 
 // The shared video room. Jitsi needs no account and — unlike Meet/Zoom — allows
 // being embedded in an iframe, which is what the in-app side panel relies on.
-// Server-only (node:crypto); the embeddability check lives in @/lib/meetingLink
-// so client components can import it.
-export function generateMeetingLink(): string {
-  return `https://meet.jit.si/InternshipCRM-${randomBytes(8).toString('hex')}`;
-}
+// Re-exported here because every write path already imports it from this module;
+// the implementation (and the JaaS/public-instance choice) lives in
+// @/lib/meetingRoom, and the embeddability check in @/lib/meetingLink so client
+// components can import it.
+export { generateMeetingLink } from '@/lib/meetingRoom';
 
 const INVITEE_SELECT = {
   id: true,

--- a/src/lib/meetingLink.ts
+++ b/src/lib/meetingLink.ts
@@ -1,12 +1,16 @@
 // Pure link helpers with no imports, kept apart from meetingContext.ts so
 // client components can use them without dragging Prisma (or node:crypto) into
 // the browser bundle. `generateMeetingLink` stays server-side in
-// meetingContext.ts for that reason.
+// meetingRoom.ts for that reason.
 
 // Hosts we are willing to put in an iframe. Must stay in sync with `frame-src`
 // and the `Permissions-Policy` allowlist in next.config.js — widening one
 // without the other yields an empty box or a call with no camera.
-export const EMBEDDABLE_MEETING_HOSTS = ['meet.jit.si'];
+//
+// `8x8.vc` is our JaaS tenant (#1237) and is the one that gets embedded in
+// production; `meet.jit.si` stays for links created before the switch and for
+// environments with no JaaS credentials (local dev, CI).
+export const EMBEDDABLE_MEETING_HOSTS = ['meet.jit.si', '8x8.vc'];
 
 // True when the link can safely be embedded. Meet/Zoom/Teams all send
 // X-Frame-Options and would render an empty box, so the UI has to offer
@@ -20,5 +24,36 @@ export function isEmbeddableMeetingLink(link: string | null | undefined): boolea
     return EMBEDDABLE_MEETING_HOSTS.some((h) => host === h || host.endsWith(`.${h}`));
   } catch {
     return false;
+  }
+}
+
+export interface JaasRoomRef {
+  /** `vpaas-magic-cookie-…` */
+  appId: string;
+  /** Room name on its own, e.g. `InternshipCRM-1a2b…`. */
+  room: string;
+}
+
+// Split a stored JaaS link back into the two parts the embed needs: the app id
+// (which selects the tenant's `external_api.js`) and the room name (which the
+// participant's token is scoped to).
+//
+// Strict on purpose, and used on the server too: the room name taken from here
+// ends up inside a signed token and in a URL, so anything that is not one of our
+// own generated links is rejected rather than passed along.
+export function parseJaasMeetingLink(link: string | null | undefined): JaasRoomRef | null {
+  if (!link) return null;
+  try {
+    const url = new URL(link);
+    if (url.protocol !== 'https:') return null;
+    if (url.hostname.toLowerCase() !== '8x8.vc') return null;
+    const parts = url.pathname.split('/').filter(Boolean);
+    if (parts.length !== 2) return null;
+    const [appId, room] = parts;
+    if (!appId.startsWith('vpaas-magic-cookie-')) return null;
+    if (!/^[A-Za-z0-9._-]{1,120}$/.test(room)) return null;
+    return { appId, room };
+  } catch {
+    return null;
   }
 }

--- a/src/lib/meetingRoom.ts
+++ b/src/lib/meetingRoom.ts
@@ -1,0 +1,30 @@
+import { randomBytes } from 'crypto';
+import { jaasConfig, jaasRoomUrl } from '@/lib/jaas';
+
+// Where a meeting's video room comes from. Server-only (node:crypto); the
+// client-side link *checks* live in @/lib/meetingLink so components can import
+// them without pulling crypto into the browser bundle.
+//
+// This used to be three copies of the same template literal (instant meetings,
+// accepted meeting requests, recurring series). They are one function now
+// because the JaaS switch below has to apply to all three — a room created on
+// the public instance would still cut out after five minutes.
+
+// The room name, without a host. Unguessable on purpose: the room is the only
+// thing protecting a call on the public instance, and on JaaS it is what the
+// participant's token is scoped to.
+export function generateMeetingRoomName(): string {
+  return `InternshipCRM-${randomBytes(8).toString('hex')}`;
+}
+
+// A JaaS room when the tenant is configured, the public Jitsi otherwise.
+//
+// The fallback is not a leftover: local dev, CI and every e2e run have no JaaS
+// credentials, and the five-minute embed limit is irrelevant there. It also
+// means a broken/expired key never leaves the app unable to create a meeting —
+// the link degrades to one that anybody can still open in a tab.
+export function generateMeetingLink(): string {
+  const room = generateMeetingRoomName();
+  const config = jaasConfig();
+  return config ? jaasRoomUrl(config, room) : `https://meet.jit.si/${room}`;
+}

--- a/src/lib/noteMeeting.ts
+++ b/src/lib/noteMeeting.ts
@@ -1,43 +1,15 @@
-import { prisma } from '@/lib/prisma';
+import { canAccessMeeting } from '@/lib/meetingAccess';
 
 // May this user attach a note to this meeting (#1056)?
 //
 // Without the check, any note could carry any meeting id: the note itself stays
 // private, but the id is a foreign key into someone else's meeting and
 // `GET /api/notes?meetingId=` would happily confirm it exists. So the rule is
-// the same one that governs the meeting: you were in it, or you called it.
+// the same one that governs the meeting: you were in it, or you called it —
+// which is `canAccessMeeting`, shared with the call-token endpoint (#1237).
 export async function canAttachNoteToMeeting(
   user: { id: string; role: string },
   meetingId: string
 ): Promise<boolean> {
-  const meeting = await prisma.meeting.findUnique({
-    where: { id: meetingId },
-    select: {
-      createdById: true,
-      relation: { select: { mentorId: true, menteeId: true } },
-      projectId: true,
-      conversationId: true,
-    },
-  });
-  if (!meeting) return false;
-  if (meeting.createdById === user.id) return true;
-  if (user.role === 'ADMIN') return true;
-  if (meeting.relation && (meeting.relation.mentorId === user.id || meeting.relation.menteeId === user.id)) {
-    return true;
-  }
-  if (meeting.projectId) {
-    const member = await prisma.projectMember.findUnique({
-      where: { projectId_userId: { projectId: meeting.projectId, userId: user.id } },
-      select: { id: true },
-    });
-    if (member) return true;
-  }
-  if (meeting.conversationId) {
-    const participant = await prisma.conversationParticipant.findUnique({
-      where: { conversationId_userId: { conversationId: meeting.conversationId, userId: user.id } },
-      select: { id: true },
-    });
-    if (participant) return true;
-  }
-  return false;
+  return canAccessMeeting(user, meetingId);
 }

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,24 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.73.0-beta',
+    date: '2026-08-17',
+    highlights: {
+      en: [
+        'Video calls inside the app no longer cut out after five minutes: meetings now run on our own Jitsi tenant, so a call can last as long as it needs to.',
+        'You join with your name already filled in, and whoever started the meeting joins as its moderator. Guests still get the same link by email and can join from any browser, with no account and nothing to install.',
+      ],
+      tr: [
+        'Uygulama içindeki görüntülü görüşmeler artık beş dakika sonra kesilmiyor: görüşmeler kendi Jitsi kiracımızda yürüyor, yani bir görüşme gerektiği kadar sürebiliyor.',
+        'Görüşmeye adınız hazır girilmiş olarak katılıyorsunuz; görüşmeyi başlatan kişi moderatör oluyor. Davet edilenler yine aynı linki e-postayla alıyor ve hesap açmadan, hiçbir şey kurmadan her tarayıcıdan katılabiliyor.',
+      ],
+      de: [
+        'Videoanrufe in der App brechen nicht mehr nach fünf Minuten ab: Besprechungen laufen jetzt auf unserem eigenen Jitsi-Tenant und dürfen so lange dauern, wie sie brauchen.',
+        'Du nimmst mit bereits eingetragenem Namen teil, und wer die Besprechung gestartet hat, ist deren Moderator. Eingeladene erhalten weiterhin denselben Link per E-Mail und können ohne Konto und ohne Installation aus jedem Browser beitreten.',
+      ],
+    },
+  },
+  {
     version: '0.72.0-beta',
     date: '2026-08-14',
     highlights: {


### PR DESCRIPTION
Closes #1237.

Gömülü görüşme panelinde (#1054) çıkan uyarının çözümü: oda artık **kendi JaaS
kiracımızda** açılıyor, public `meet.jit.si` yerine.

> Embedding meet.jit.si is only meant for demo purposes, so this call will disconnect in 5 minutes.

## Ne değişti

| | Yapılandırılmamış (varsayılan) | Yapılandırılmış |
|---|---|---|
| Yeni oda linki | `https://meet.jit.si/InternshipCRM-<hex>` | `https://8x8.vc/<appId>/InternshipCRM-<hex>` |
| Panel | düz iframe, **5 dakikada kesilir** | `external_api.js` + JWT, sınır yok |
| Görünen ad | katılan elle yazar | hesaptan gelir |
| Moderatör | ilk giren | görüşmeyi başlatan (ve adminler) |

- `src/lib/jaas.ts` — token'ı `node:crypto` ile RS256 imzalıyor (**yeni bağımlılık yok**).
  `kid` = API key id, `sub` = app id, `room` **tek odaya** sabit (`*` değil), ömrü 2 saat,
  her katılımda üretiliyor ve saklanmıyor. Kayıt/canlı yayın/transkripsiyon/dış arama her
  token'da kapalı. `JAAS_PRIVATE_KEY` hem `\n` kaçışlı PEM'i hem base64 PEM'i kabul ediyor;
  **üçü birlikte** set edilmezse özellik kapalı kalıyor (yarım yapılandırma, 8x8'in
  reddettiği token üretir — kullanıcıya "görüşme bozuk" diye görünür).
- `GET /api/meetings/[id]/call-token` — token'ı yalnız o toplantıda **olan** kişiye veriyor:
  `canAccessMeeting` (`src/lib/meetingAccess.ts`, `canAttachNoteToMeeting`'den çıkarıldı, artık
  notlar ve görüşmeler aynı kuralı paylaşıyor). Başkasına 404 — var olmayan toplantıyla aynı
  cevap. `Cache-Control: no-store`.
- **Set edilmezse hiçbir şey değişmiyor**: odalar `meet.jit.si`'de kalıyor, panel düz
  iframe'i kullanıyor, endpoint `409 { code: 'not-configured' }` diyor. Yerel geliştirme, CI
  ve e2e bu durumda — ve prod için geri alma yolu bu.
- Oda gösterilemiyorsa panel "yeni sekmede aç"a düşüyor (eski link, reddedilen token, 8x8'den
  fatal hata, engellenen script). Boş bir panel, çalışan bir linkten kötüdür.
- Oda **yalnız geniş ekranda** mount ediliyor: telefon dalı zaten Join düğmesiydi ve
  `display:none` bir iframe'in görüşmeye katılmasını engellemiyor.
- CSP `script-src`/`frame-src` ve kamera/mikrofon `Permissions-Policy` tam host olarak
  `https://8x8.vc` içeriyor (wildcard yok); `e2e/security-headers.spec.ts` ikisini de sabitliyor.
- Oda linki şablonu üç yerde kopyalanmıştı (anlık görüşme, kabul edilen görüşme talebi,
  tekrarlayan seri) → tek `generateMeetingLink()` (`src/lib/meetingRoom.ts`).

## Bakımcının yapması gerekenler (kod dışı)

1. JaaS konsolunda (<https://jaas.8x8.vc/>) **API key** üret → `JAAS_API_KEY_ID` (kid) + private key PEM.
2. Üç değişkeni **sunucudaki env dosyasına** yaz (repoya değil), sonra redeploy:
   `JAAS_APP_ID`, `JAAS_API_KEY_ID`, `JAAS_PRIVATE_KEY`.
3. Ücretsiz katman **aylık aktif kullanıcı** üzerinden; aşınca faturalanıyor. Kotayı yalnızca
   JaaS konsolu gösteriyor, uygulama ölçmüyor.

Kurulum, doğrulama ve maliyet notları: [`docs/video-calls-jaas.md`](docs/video-calls-jaas.md).
`.env.example` da aynı üç değişkeni açıklıyor.

## Test

- Yeni: `e2e/meeting-call-token.spec.ts` — anonim 401, yabancı 404, organizatör 409
  `not-configured`, uydurma id 404.
- Güncel: `e2e/security-headers.spec.ts` — `8x8.vc` hem `script-src` hem `frame-src` hem
  Permissions-Policy'de, wildcard yok.
- Yerelde geçen: instant-meeting, instant-meeting-team, meeting-notes, meeting-call-token,
  security-headers, features-catalog, landing-i18n, i18n-coverage, version-release-notes.
- İmzalama, atılabilir bir RSA çiftiyle doğrulandı (üç anahtar biçimi de, imza `createVerify`
  ile geçiyor; yarım yapılandırma kapalı sayılıyor). Sahte bir kiracıyla uçtan uca akış:
  link `8x8.vc`'ye çıkıyor, token 200 + `no-store`, `roomName`/`moderator` doğru, iframe
  panelde tam boy kuruluyor.
- **Gerçek kiracıyla görüşmenin uçtan uca doğrulaması bende yapılamadı** — özel anahtar
  yalnızca sizde. PR ortamına (`https://crm-pr<N>.ersah.in`) env'i verirseniz beş dakikayı
  geçen bir görüşmeyle teyit edilebilir.
- Not: `e2e/meeting-series.spec.ts` bu makinede **bu değişiklikten önce de** kırmızı (yerel
  SMTP kimlik doğrulaması başarısız → `POST /api/meeting-series` 15 sn'de zaman aşımı).
  `origin/main` üzerinde de aynı şekilde kırmızı.

## Sürüm

0.73.0-beta — `package.json` + `CHANGELOG.md` + `src/lib/releaseNotes.ts` (EN/TR/DE), ve
`src/lib/features.ts` + `featureCatalog` içine "uygulama içi görüntülü görüşme" kartı.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
