### PR TITLE
Mentörün proje mentee erişimini düzelt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.80.1-beta] - 2026-08-19
+
+### Fixed
+- **Mentors can add their own mentees to their projects again** (#1103, from PR #1240).
+  The mentor-facing `/api/users?view=picker` directory only returned mentors and admins,
+  so the member picker was empty of mentees for mentors; it now also includes the
+  mentees of the requesting mentor's own mentorship relations. Defense in depth on the
+  write side: a MENTOR adding a MENTEE member to a project is refused with 403 unless a
+  mentorship relation between them exists (admins unchanged). `@smoke` e2e regression in
+  `e2e/project-members.spec.ts` covers picker scoping, own-mentee add (201), foreign-
+  mentee add (403) and the admin path.
+
 ## [0.80.0-beta] - 2026-08-19
 
 ### Added

--- a/e2e/project-members.spec.ts
+++ b/e2e/project-members.spec.ts
@@ -69,3 +69,74 @@ test('project members: add, promote, last-owner guard, legacy-owner repointing',
     await cleanupByEmail(adminEmail);
   }
 });
+
+test('project members: mentor can only list and add their own mentees', { tag: '@smoke' }, async ({ browser }) => {
+  const adminEmail = uniqueEmail('pm-scope-admin');
+  const mentorEmail = uniqueEmail('pm-scope-mentor');
+  const otherMentorEmail = uniqueEmail('pm-scope-other-mentor');
+  const ownMenteeEmail = uniqueEmail('pm-scope-own-mentee');
+  const otherMenteeEmail = uniqueEmail('pm-scope-other-mentee');
+  const pw = 'MembersScopePass123';
+  await seedUser(adminEmail, pw, 'ADMIN', 'Scope Admin');
+  const mentor = await seedUser(mentorEmail, pw, 'MENTOR', 'Scope Mentor');
+  const otherMentor = await seedUser(otherMentorEmail, 'x', 'MENTOR', 'Other Scope Mentor');
+  const ownMentee = await seedUser(ownMenteeEmail, 'x', 'MENTEE', 'Own Scope Mentee');
+  const otherMentee = await seedUser(otherMenteeEmail, 'x', 'MENTEE', 'Other Scope Mentee');
+  await prisma.mentorshipRelation.create({ data: { mentorId: mentor.id, menteeId: ownMentee.id } });
+  await prisma.mentorshipRelation.create({ data: { mentorId: otherMentor.id, menteeId: otherMentee.id } });
+
+  const adminCtx = await browser.newContext();
+  const mentorCtx = await browser.newContext();
+  let projectId = '';
+  try {
+    const adminPage = await adminCtx.newPage();
+    await adminPage.goto('/auth/signin');
+    await adminPage.fill('input[type="email"], input[name="email"]', adminEmail);
+    await adminPage.fill('input[type="password"]', pw);
+    await adminPage.click('button[type="submit"]');
+    await adminPage.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    const created = await adminPage.request.post('/api/projects', {
+      data: { name: 'Scoped Members Project', ownerType: 'MENTOR', ownerUserId: mentor.id },
+    });
+    expect(created.ok()).toBeTruthy();
+    projectId = (await created.json()).project.id;
+
+    const mentorPage = await mentorCtx.newPage();
+    await mentorPage.goto('/auth/signin');
+    await mentorPage.fill('input[type="email"], input[name="email"]', mentorEmail);
+    await mentorPage.fill('input[type="password"]', pw);
+    await mentorPage.click('button[type="submit"]');
+    await mentorPage.waitForURL((u) => u.pathname.startsWith('/mentor'), { timeout: 20_000 });
+
+    const picker = await mentorPage.request.get('/api/users?view=picker');
+    expect(picker.ok()).toBeTruthy();
+    const pickerUsers = (await picker.json()).users as { id: string }[];
+    expect(pickerUsers.some((user) => user.id === ownMentee.id)).toBeTruthy();
+    expect(pickerUsers.some((user) => user.id === otherMentee.id)).toBeFalsy();
+
+    const ownAdd = await mentorPage.request.post(`/api/projects/${projectId}/members`, {
+      data: { userId: ownMentee.id, role: 'MENTEE' },
+    });
+    expect(ownAdd.status()).toBe(201);
+
+    const otherAdd = await mentorPage.request.post(`/api/projects/${projectId}/members`, {
+      data: { userId: otherMentee.id, role: 'MENTEE' },
+    });
+    expect(otherAdd.status()).toBe(403);
+
+    const adminAdd = await adminPage.request.post(`/api/projects/${projectId}/members`, {
+      data: { userId: otherMentee.id, role: 'MENTEE' },
+    });
+    expect(adminAdd.status()).toBe(201);
+  } finally {
+    await mentorCtx.close();
+    await adminCtx.close();
+    if (projectId) await prisma.project.deleteMany({ where: { id: projectId } });
+    await cleanupByEmail(ownMenteeEmail);
+    await cleanupByEmail(otherMenteeEmail);
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(otherMentorEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.80.0-beta",
+  "version": "0.80.1-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "author": "Mehmet Erşahin",

--- a/src/app/api/projects/[id]/members/route.ts
+++ b/src/app/api/projects/[id]/members/route.ts
@@ -76,6 +76,14 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
       return NextResponse.json({ error: 'An owner or mentor member must be an active mentor or admin' }, { status: 400 });
     }
 
+    if (session.user.role === 'MENTOR' && role === 'MENTEE') {
+      const relation = await prisma.mentorshipRelation.findFirst({
+        where: { mentorId: session.user.id, menteeId: userId },
+        select: { id: true },
+      });
+      if (!relation) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
     // Demoting the last OWNER to a non-owner role would leave the project ownerless.
     const owners = project.members.filter((m) => m.role === 'OWNER');
     if (role !== 'OWNER' && owners.length === 1 && owners[0].userId === userId) {

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -93,7 +93,13 @@ export async function GET(request: Request) {
       // just enough for the project owner/member picker (#618).
       if (session.user.role === 'MENTOR') {
         const users = await prisma.user.findMany({
-          where: { role: { in: ['MENTOR', 'ADMIN'] }, isActive: true },
+          where: {
+            isActive: true,
+            OR: [
+              { role: { in: ['MENTOR', 'ADMIN'] } },
+              { role: 'MENTEE', menteeRelations: { some: { mentorId: session.user.id } } },
+            ],
+          },
           select: SELECTS.picker,
           orderBy: { fullName: 'asc' },
         });

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,21 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.80.1-beta',
+    date: '2026-08-19',
+    highlights: {
+      en: [
+        'Mentors can add their own mentees to their projects again: the member picker now lists a mentor\u2019s mentees, while other mentors\u2019 mentees stay out of reach — hidden from the picker and refused by the API.',
+      ],
+      tr: [
+        'Mentörler kendi mentee\u2019lerini projelerine yeniden ekleyebiliyor: üye seçici artık mentörün kendi mentee\u2019lerini listeliyor; başka mentörlerin mentee\u2019leri ise erişim dışı — seçicide görünmüyor ve API tarafından reddediliyor.',
+      ],
+      de: [
+        'Mentoren können ihre eigenen Mentees wieder zu ihren Projekten hinzufügen: Die Mitgliederauswahl listet jetzt die Mentees des Mentors, während die Mentees anderer Mentoren außer Reichweite bleiben — in der Auswahl verborgen und von der API abgelehnt.',
+      ],
+    },
+  },
+  {
     version: '0.80.0-beta',
     date: '2026-08-19',
     highlights: {


### PR DESCRIPTION
## Özet

Bu PR, mentörün proje üye seçicisinde kendi mentee’lerini görememesi sorununu giderir.

Mentör artık yalnızca kendi mentorship ilişkisi bulunan mentee’leri görebilir ve projeye ekleyebilir. Başka bir mentöre ait mentee’ler listelenmez ve doğrudan API çağrısıyla eklenmeye çalışıldığında erişim reddedilir.

## Yapılan değişiklikler

* Mentörün kullanıcı seçicisinde kendi mentee’leri gösteriliyor.
* Başka mentörlere ait mentee’ler mentör seçicisinden gizleniyor.
* Mentörün yabancı bir mentee’yi API üzerinden projeye eklemesi `403 Forbidden` ile engelleniyor.
* Admin davranışı değiştirilmedi.
* Regresyon E2E testi eklendi ve `@smoke` kapsamına alındı.
* Sürüm `0.65.1-beta` olarak güncellendi.
* EN/TR/DE release note eklendi.

## Doğrulama

* `npm run build` başarılı.
* İlgili proje üye E2E testleri: `2 passed`.
* PR CI ile uyumlu smoke testleri: `58 passed`.
* `git diff --check` başarılı.
* Version / release note testi başarılı.

Closes #1103 · Part of #1089
