### PR TITLE
fix(deploy): schema guard artık enum genişletmesini daraltmadan ayırt ediyor

### DIFF
--- a/infra/schema-guard.sh
+++ b/infra/schema-guard.sh
@@ -34,6 +34,106 @@ log() { printf '\n\033[1;34m==>\033[0m %s\n' "$*"; }
 warn() { printf '\n\033[1;33m!!\033[0m %s\n' "$*"; }
 err() { printf '\n\033[1;31mXX\033[0m %s\n' "$*" >&2; }
 
+# --- enum-widening helpers (#1244) ------------------------------------------
+# Adding a value to an enum emits
+#   ALTER TABLE `T` MODIFY `col` ENUM('A','B','NEW') NOT NULL;
+# which the blunt DESTRUCTIVE pattern flags although nothing is lost — while
+# REMOVING a value emits the exact same statement shape, so the SQL text alone
+# cannot tell the two apart. The reverse diff (schema -> live DB) can: for a
+# pure widening, the reverse statement is the same MODIFY whose member list is
+# a strict SUBSET of the forward one. Anything that fails to parse that way
+# stays destructive — these helpers only ever downgrade a hit, never upgrade.
+
+# Reprint SQL as one statement per line with single spaces and a canonical
+# ENUM keyword. The two diff directions come out of prisma formatted
+# differently (the reverse one splits ALTERs across lines, lowercases `enum`
+# and drops the spaces after commas), so comparisons only make sense on this
+# canonical form. POSIX awk on purpose — this must behave the same under GNU
+# (server, CI) and BSD (macOS) userlands.
+normalize_sql() { # stdin -> stdout
+  # Comment lines (`-- AlterTable`, `-- CreateIndex`, ...) must go first, or
+  # they get glued onto the front of the statement they precede when the
+  # newlines collapse.
+  awk '!/^[ \t]*--/' | awk 'BEGIN { RS=";" } {
+    gsub(/[ \t\r\n]+/, " ");
+    sub(/^ /, ""); sub(/ $/, "");
+    gsub(/[Ee][Nn][Uu][Mm]\(/, "ENUM(");
+    if (length($0)) print $0 ";";
+  }'
+}
+
+# Split a normalized ALTER TABLE statement into its clauses, one per line
+# (`MODIFY `col` ...`, `DROP COLUMN `x``, ...). Needed because MariaDB's Json
+# alias makes the reverse diff bundle unrelated longtext MODIFYs into the SAME
+# ALTER as the enum change — statements never compare equal there, clauses do.
+# A comma+keyword sequence inside a quoted enum member would split wrongly and
+# then fail the member comparison, which keeps things destructive (fail closed).
+alter_clauses() { # $1 = normalized ALTER TABLE statement
+  printf '%s\n' "$1" \
+    | sed -e 's/^ALTER TABLE `[^`]*` //' -e 's/;$//' \
+    | awk '{
+        gsub(/, MODIFY /, "\nMODIFY ");
+        gsub(/, CHANGE /, "\nCHANGE ");
+        gsub(/, DROP /,   "\nDROP ");
+        gsub(/, ADD /,    "\nADD ");
+        gsub(/, ALTER /,  "\nALTER ");
+        gsub(/, RENAME /, "\nRENAME ");
+        print;
+      }'
+}
+
+# Print one enum member per line from the first ENUM(...) in the clause.
+# A member containing a quote, comma or ')' breaks this parse — and then the
+# subset check below fails, which keeps the clause destructive (fail closed).
+enum_members() { # $1 = normalized SQL clause
+  printf '%s\n' "$1" | grep -oE "ENUM\([^)]*\)" | head -1 \
+    | sed -e 's/^ENUM(//' -e 's/)$//' | tr ',' '\n' \
+    | sed -e "s/^[[:space:]]*'//" -e "s/'[[:space:]]*$//"
+}
+
+# True iff the forward clause ($1) only ADDS enum values relative to the
+# reverse clause ($2): identical clauses apart from the member list, exactly
+# one ENUM(...) each, and the reverse members a strict subset of the forward
+# ones. Both arguments must come out of alter_clauses on normalized SQL.
+is_enum_widening() { # $1 = forward clause, $2 = reverse clause
+  local shape_f shape_r fwd rev m
+  case "$1" in 'MODIFY `'*'ENUM('*) ;; 'MODIFY COLUMN `'*'ENUM('*) ;; *) return 1 ;; esac
+  [ "$(printf '%s' "$1" | awk -F 'ENUM\\(' '{ print NF - 1 }')" = "1" ] || return 1
+  [ "$(printf '%s' "$2" | awk -F 'ENUM\\(' '{ print NF - 1 }')" = "1" ] || return 1
+  shape_f=$(printf '%s' "$1" | sed 's/ENUM([^)]*)/ENUM(#)/')
+  shape_r=$(printf '%s' "$2" | sed 's/ENUM([^)]*)/ENUM(#)/')
+  [ "$shape_f" = "$shape_r" ] || return 1
+  fwd=$(enum_members "$1")
+  rev=$(enum_members "$2")
+  [ -n "$fwd" ] && [ -n "$rev" ] || return 1
+  while IFS= read -r m; do
+    printf '%s\n' "$fwd" | grep -qxF "$m" || return 1
+  done <<EOF
+$rev
+EOF
+  [ "$(printf '%s\n' "$fwd" | wc -l)" -gt "$(printf '%s\n' "$rev" | wc -l)" ]
+}
+
+# Print the clause for `column` from the reverse diff's ALTERs on `table`,
+# provided exactly ONE such clause exists (ambiguity stays destructive).
+reverse_clause_for() { # $1 = reverse stmts (normalized), $2 = table, $3 = column
+  local stmts clauses
+  stmts=$(printf '%s\n' "$1" | grep -F "ALTER TABLE \`$2\` " || true)
+  [ -n "$stmts" ] || return 1
+  clauses=$(
+    while IFS= read -r s; do alter_clauses "$s"; done <<EOF
+$stmts
+EOF
+  )
+  clauses=$(printf '%s\n' "$clauses" | grep -E "^(MODIFY|CHANGE) (COLUMN )?\`$3\` " || true)
+  [ "$(printf '%s\n' "$clauses" | grep -c .)" = "1" ] || return 1
+  printf '%s\n' "$clauses"
+}
+
+# Sourced by infra/test/schema-guard.test.sh to unit-test the helpers above
+# without a database. Everything below this line needs DATABASE_URL.
+if [ "${SCHEMA_GUARD_LIB:-0}" = "1" ]; then return 0 2>/dev/null || exit 0; fi
+
 : "${DATABASE_URL:?DATABASE_URL is required}"
 RUN_TOOL="${RUN_TOOL:-npx}"
 
@@ -77,6 +177,79 @@ DESTRUCTIVE='DROP TABLE|DROP COLUMN|TRUNCATE|DROP DATABASE|DROP SCHEMA|\b(MODIFY
 if ! hits=$(printf '%s\n' "$sql" | grep -Ei "$DESTRUCTIVE"); then
   log "Pending changes are additive — proceeding"
   exit 0
+fi
+
+# Second look for MODIFY ... ENUM(...) NOT NULL hits: widening an enum matches
+# the pattern above but destroys nothing (#1223 was blocked by exactly this).
+# Verify each candidate against the reverse diff and drop the pure widenings;
+# every check that fails to line up keeps the hit destructive (fail closed).
+if printf '%s\n' "$hits" | grep -Eqi 'MODIFY[^;]*ENUM\('; then
+  log "ENUM change flagged — checking whether it only ADDS values"
+  if rsql=$($RUN_TOOL prisma migrate diff \
+        --from-schema-datamodel prisma/schema.prisma \
+        --to-url "$DATABASE_URL" \
+        --script 2>/dev/null); then
+    fwd_stmts=$(printf '%s\n' "$sql" | normalize_sql)
+    rev_stmts=$(printf '%s\n' "$rsql" | normalize_sql)
+    # Collect the forward statements in which EVERY alarming clause is a
+    # verified pure widening. Clause-by-clause, because either side may bundle
+    # several column changes into one ALTER.
+    accepted=""
+    while IFS= read -r stmt; do
+      case "$stmt" in
+        'ALTER TABLE `'*) ;;
+        *) continue ;;
+      esac
+      printf '%s\n' "$stmt" | grep -Eqi "$DESTRUCTIVE" || continue
+      table=$(printf '%s' "$stmt" | sed -n 's/^ALTER TABLE `\([^`]*\)` .*/\1/p')
+      [ -n "$table" ] || continue
+      stmt_safe=1
+      while IFS= read -r clause; do
+        [ -z "$clause" ] && continue
+        printf '%s\n' "$clause" | grep -Eqi "$DESTRUCTIVE" || continue
+        col=$(printf '%s' "$clause" | sed -n 's/^MODIFY \(COLUMN \)\{0,1\}`\([^`]*\)` .*/\2/p')
+        if [ -z "$col" ]; then stmt_safe=0; break; fi
+        rev_clause=$(reverse_clause_for "$rev_stmts" "$table" "$col") || { stmt_safe=0; break; }
+        if is_enum_widening "$clause" "$rev_clause"; then
+          log "  enum widening (adds values, removes none): $table.$col"
+        else
+          stmt_safe=0; break
+        fi
+      done <<EOF2
+$(alter_clauses "$stmt")
+EOF2
+      if [ "$stmt_safe" = "1" ]; then
+        accepted="${accepted}${stmt}
+"
+      fi
+    done <<EOF
+$fwd_stmts
+EOF
+    # Drop every hit whose normalized text sits inside an accepted statement
+    # (a hit can be a MODIFY fragment of a multi-line ALTER).
+    if [ -n "$accepted" ]; then
+      remaining=""
+      while IFS= read -r line; do
+        [ -z "$line" ] && continue
+        line_n=$(printf '%s\n' "$line" | normalize_sql)
+        case "$accepted" in
+          *"$line_n"*) continue ;;
+        esac
+        remaining="${remaining}${line}
+"
+      done <<EOF
+$hits
+EOF
+      hits="${remaining%
+}"
+      if [ -z "${hits//[[:space:]]/}" ]; then
+        log "All flagged statements are pure enum widenings — proceeding"
+        exit 0
+      fi
+    fi
+  else
+    warn "Could not compute the reverse diff — keeping the ENUM change flagged as destructive."
+  fi
 fi
 
 warn "This deploy would run DESTRUCTIVE schema statements:"

--- a/infra/test/schema-guard.test.sh
+++ b/infra/test/schema-guard.test.sh
@@ -74,5 +74,107 @@ expect_safe 'a column merely named changeNote' \
   '    `changeNote` TEXT NOT NULL,'
 
 echo
+echo "Enum MODIFY statements still hit the pattern (refined afterwards, #1244):"
+expect_destructive 'MODIFY ... ENUM(...) NOT NULL' \
+  "ALTER TABLE \`Project\` MODIFY \`ownerType\` ENUM('ADMIN', 'MENTOR', 'MENTEE', 'COMPANY') NOT NULL;"
+
+# ---------------------------------------------------------------------------
+# Enum-widening refinement (#1244): source the guard's helpers (no DB needed)
+# and check that the clause-level comparison only ever accepts a pure widening.
+# ---------------------------------------------------------------------------
+# shellcheck source=../schema-guard.sh
+SCHEMA_GUARD_LIB=1 . "$GUARD_SH"
+
+expect_widening() { # $1 = label, $2 = forward clause, $3 = reverse clause
+  if is_enum_widening "$2" "$3"; then ok "widening: $1"; else bad "NOT recognized as widening (would block prod): $1"; fi
+}
+expect_not_widening() { # $1 = label, $2 = forward clause, $3 = reverse clause
+  if is_enum_widening "$2" "$3"; then bad "accepted as widening (would reach prod): $1"; else ok "stays destructive: $1"; fi
+}
+
+FWD_CLAUSE="MODIFY \`ownerType\` ENUM('ADMIN', 'MENTOR', 'MENTEE', 'COMPANY') NOT NULL"
+REV_CLAUSE="MODIFY \`ownerType\` ENUM('ADMIN','MENTOR','COMPANY') NOT NULL"
+
+echo
+echo "is_enum_widening must accept only pure widenings:"
+expect_widening 'adds one value (the #1223 case; comma spacing differs by direction)' "$FWD_CLAUSE" "$REV_CLAUSE"
+expect_widening 'adds a value, with DEFAULT kept' \
+  "MODIFY \`s\` ENUM('A', 'B', 'C') NOT NULL DEFAULT 'A'" \
+  "MODIFY \`s\` ENUM('A', 'B') NOT NULL DEFAULT 'A'"
+expect_not_widening 'narrowing (reverse adds the value back)' "$REV_CLAUSE" "$FWD_CLAUSE"
+expect_not_widening 'rename disguised as add (swaps a member)' \
+  "MODIFY \`s\` ENUM('A', 'B', 'NEW') NOT NULL" \
+  "MODIFY \`s\` ENUM('A', 'B', 'OLD') NOT NULL"
+expect_not_widening 'same members (no real change)' "$FWD_CLAUSE" "$FWD_CLAUSE"
+expect_not_widening 'NULL -> NOT NULL tightening alongside the add' \
+  "MODIFY \`s\` ENUM('A', 'B', 'C') NOT NULL" \
+  "MODIFY \`s\` ENUM('A', 'B') NULL"
+expect_not_widening 'DEFAULT changes alongside the add' \
+  "MODIFY \`s\` ENUM('A', 'B', 'C') NOT NULL DEFAULT 'C'" \
+  "MODIFY \`s\` ENUM('A', 'B') NOT NULL DEFAULT 'A'"
+expect_not_widening 'forward is not a MODIFY clause' \
+  "DROP COLUMN \`s\`" \
+  "$REV_CLAUSE"
+expect_not_widening 'reverse is not an enum clause' \
+  "$FWD_CLAUSE" \
+  "MODIFY \`ownerType\` VARCHAR(191) NOT NULL"
+
+echo
+echo "normalize_sql canonicalizes both prisma diff dialects (#1244):"
+# The reverse diff really does come out multi-line, lowercase, unspaced and
+# with comment headers — this fixture is verbatim MariaDB reverse-diff output,
+# including the Json-alias longtext noise bundled into the same ALTER.
+REV_RAW='-- AlterTable
+ALTER TABLE `Project` MODIFY `technologies` longtext NOT NULL,
+    MODIFY `ownerType` enum('\''ADMIN'\'','\''MENTOR'\'','\''COMPANY'\'') NOT NULL;'
+REV_NORM=$(printf '%s\n' "$REV_RAW" | normalize_sql)
+if [ "$REV_NORM" = 'ALTER TABLE `Project` MODIFY `technologies` longtext NOT NULL, MODIFY `ownerType` ENUM('\''ADMIN'\'','\''MENTOR'\'','\''COMPANY'\'') NOT NULL;' ]; then
+  ok "flattens the multi-line lowercase reverse dialect and strips comments"
+else
+  bad "normalize_sql output unexpected: $REV_NORM"
+fi
+
+echo
+echo "alter_clauses splits bundled ALTERs at clause boundaries:"
+CLAUSES=$(alter_clauses "$REV_NORM")
+if [ "$(printf '%s\n' "$CLAUSES" | grep -c .)" = "2" ] \
+   && printf '%s\n' "$CLAUSES" | grep -qxF "MODIFY \`ownerType\` ENUM('ADMIN','MENTOR','COMPANY') NOT NULL"; then
+  ok "MariaDB longtext noise and the enum change come apart cleanly"
+else
+  bad "alter_clauses output unexpected: $CLAUSES"
+fi
+
+echo
+echo "reverse_clause_for finds exactly one clause per table+column:"
+if REV_FOUND=$(reverse_clause_for "$REV_NORM" "Project" "ownerType") \
+   && [ "$REV_FOUND" = "MODIFY \`ownerType\` ENUM('ADMIN','MENTOR','COMPANY') NOT NULL" ]; then
+  ok "finds the ownerType clause inside the bundled ALTER"
+else
+  bad "reverse_clause_for output unexpected: ${REV_FOUND:-<none>}"
+fi
+if reverse_clause_for "$REV_NORM" "Project" "missingCol" >/dev/null 2>&1; then
+  bad "reverse_clause_for invented a clause for a missing column"
+else
+  ok "missing column stays destructive"
+fi
+AMBIG="$REV_NORM
+ALTER TABLE \`Project\` MODIFY \`ownerType\` ENUM('X') NOT NULL;"
+if reverse_clause_for "$AMBIG" "Project" "ownerType" >/dev/null 2>&1; then
+  bad "reverse_clause_for accepted an ambiguous (duplicated) clause"
+else
+  ok "duplicated table+column stays destructive"
+fi
+
+echo
+echo "end to end (no DB): the #1223 forward statement vs the MariaDB reverse:"
+FWD_STMT="ALTER TABLE \`Project\` MODIFY \`ownerType\` ENUM('ADMIN', 'MENTOR', 'MENTEE', 'COMPANY') NOT NULL;"
+FWD_ONLY_CLAUSE=$(alter_clauses "$FWD_STMT")
+if REVC=$(reverse_clause_for "$REV_NORM" "Project" "ownerType") && is_enum_widening "$FWD_ONLY_CLAUSE" "$REVC"; then
+  ok "the widening is recognized through the full helper pipeline"
+else
+  bad "helper pipeline failed to recognize the #1223 widening"
+fi
+
+echo
 printf 'Total: %d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
## Özet

Closes #1244 — #1223 incelemesindeki "2. yol".

Enum'a değer eklemek `ALTER TABLE ... MODIFY ... ENUM(...) NOT NULL` üretiyor ve guard'ın kaba desenine takılıp prod deploy'unu durduruyordu; oysa genişletme veri kaybetmez. Daraltma aynı ifade şeklini ürettiği için metinden ayırt edilemiyor — guard artık bayraklanan ENUM MODIFY'ları için **ters diff**'i (schema → canlı DB, aynı `prisma migrate diff` aracı) hesaplıyor ve clause bazında karşılaştırıyor:

- **Normalizasyon**: ters diff çok satırlı, küçük harf `enum`, boşluksuz virgül ve `-- AlterTable` yorum başlıklarıyla geliyor; iki lehçe kanonik forma indirgeniyor.
- **Clause bazlı karşılaştırma**: MariaDB'nin Json→longtext takma adı, ilgisiz `MODIFY x longtext` gürültüsünü enum değişikliğiyle **aynı ALTER'ın içine** koyuyor (prod MariaDB!) — ifadeler asla eşit çıkmaz, clause'lar çıkar.
- **Kabul koşulu**: üye listesi dışında birebir aynı clause + ters üyeler ileri üyelerin **katı alt kümesi**. Parse edilemeyen, birden çok ENUM içeren, DEFAULT'u değişen, NULL→NOT NULL sıkılaşan, tablo+kolonu ters diff'te 0 veya 2 kez görünen her durum **yıkıcı kalır** (fail-closed). İyileştirme bir hit'i yalnızca düşürebilir, asla yükseltemez.

## Doğrulama

- `infra/test/schema-guard.test.sh`: 32 test (CI'da koşuyor) — desen regresyonları + iki lehçenin birebir fixture'larıyla helper'lar; genişletme/daraltma/maskeli-rename/NULL-sıkılaşması/belirsizlik yönleri.
- Canlı MariaDB'ye karşı uçtan uca: #1223'ün `+MENTEE` genişletmesi **exit 0** ("All flagged statements are pure enum widenings"), `MENTOR` çıkaran daraltma **exit 1**.
- `ALLOW_DESTRUCTIVE` / `BACKUP_TAKEN` / `--warn-only` akışlarına dokunulmadı.

Bu merge olunca #1223 rebase edilip `ALLOW_DESTRUCTIVE=1` gerektirmeden merge edilebilir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)