### PR TITLE
test(e2e): harden admin-role-convert against the post-sign-in deep-link flake

### DIFF
--- a/e2e/admin-role-convert.spec.ts
+++ b/e2e/admin-role-convert.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
-import { signInAsFreshUser } from './helpers/auth';
+import { gotoSettled, signInAsFreshUser } from './helpers/auth';
 
 // Admin converts an account between MENTOR and MENTEE (#1243). The endpoint
 // revokes the target's sessions (role lives in the JWT until re-login), so the
@@ -13,19 +13,26 @@ test.afterAll(async () => {
 test('admin converts a mentee to a mentor; the old session is revoked', async ({ page, browser }) => {
   const adminEmail = uniqueEmail('convadmin');
   const menteeEmail = uniqueEmail('convmentee');
-  await seedUser(adminEmail, 'AdminPass123!', 'ADMIN', 'Convert Admin');
-  const mentee = await seedUser(menteeEmail, 'MenteePass123!', 'MENTEE', 'Convert Mentee');
-
-  // The mentee signs in on their own browser first — this session must not
-  // survive the conversion.
-  const menteeCtx = await browser.newContext();
-  const menteePage = await menteeCtx.newPage();
+  // Created inside the try so a failure between here and the finally can't
+  // skip the cleanup — a leaked context lingers for the whole worker, and on
+  // a BASE_URL run orphaned seed rows accumulate in the shared preview DB.
+  let menteeCtx: Awaited<ReturnType<typeof browser.newContext>> | undefined;
 
   try {
+    await seedUser(adminEmail, 'AdminPass123!', 'ADMIN', 'Convert Admin');
+    const mentee = await seedUser(menteeEmail, 'MenteePass123!', 'MENTEE', 'Convert Mentee');
+
+    // The mentee signs in on their own browser first — this session must not
+    // survive the conversion.
+    menteeCtx = await browser.newContext();
+    const menteePage = await menteeCtx.newPage();
     await signInAsFreshUser(menteePage, menteeEmail, 'MenteePass123!', '/portal');
 
     await signInAsFreshUser(page, adminEmail, 'AdminPass123!', '/admin');
-    await page.goto('/admin/users');
+    // gotoSettled: a deep link straight after sign-in can lose the race with
+    // the landing-page redirect ("interrupted by another navigation" — the
+    // flake class documented in helpers/auth.ts).
+    await gotoSettled(page, '/admin/users');
     const row = page.getByTestId(`user-row-${mentee.id}`);
     await expect(row).toBeVisible({ timeout: 10_000 });
 
@@ -35,7 +42,8 @@ test('admin converts a mentee to a mentor; the old session is revoked', async ({
       (r) => r.url().includes(`/api/users/${mentee.id}`) && r.request().method() === 'PATCH'
     );
     await page.getByTestId(`convert-role-confirm-${mentee.id}`).click();
-    await patched;
+    // Surface an endpoint failure as itself, not as a downstream DB mismatch.
+    expect((await patched).ok()).toBeTruthy();
 
     const updated = await prisma.user.findUnique({ where: { id: mentee.id } });
     expect(updated!.role).toBe('MENTOR');
@@ -50,7 +58,7 @@ test('admin converts a mentee to a mentor; the old session is revoked', async ({
     await menteePage.goto('/portal');
     await expect(menteePage).toHaveURL(/\/auth\/signin/, { timeout: 15_000 });
   } finally {
-    await menteeCtx.close();
+    await menteeCtx?.close();
     await cleanupByEmail(menteeEmail);
     await cleanupByEmail(adminEmail);
   }
@@ -60,11 +68,11 @@ test('role conversion refuses ADMIN targets and ADMIN grants', async ({ page }) 
   const adminEmail = uniqueEmail('convadmin2');
   const otherAdminEmail = uniqueEmail('convtargetadmin');
   const mentorEmail = uniqueEmail('convmentor');
-  await seedUser(adminEmail, 'AdminPass123!', 'ADMIN', 'Convert Admin Two');
-  const otherAdmin = await seedUser(otherAdminEmail, 'AdminPass123!', 'ADMIN', 'Target Admin');
-  const mentor = await seedUser(mentorEmail, 'MentorPass123!', 'MENTOR', 'Target Mentor');
-
   try {
+    await seedUser(adminEmail, 'AdminPass123!', 'ADMIN', 'Convert Admin Two');
+    const otherAdmin = await seedUser(otherAdminEmail, 'AdminPass123!', 'ADMIN', 'Target Admin');
+    const mentor = await seedUser(mentorEmail, 'MentorPass123!', 'MENTOR', 'Target Mentor');
+
     await signInAsFreshUser(page, adminEmail, 'AdminPass123!', '/admin');
 
     // An ADMIN account cannot be converted…


### PR DESCRIPTION
## Summary

Follow-up to #1245: an adversarial review of the merged spec confirmed three hardening gaps in `e2e/admin-role-convert.spec.ts`. None breaks the PR gate today, but the first is the documented flake class that historically only surfaces in the scheduled full runs (and each red run emails a failure report).

Closes #1247

## Changes

- Use `gotoSettled()` for the `/admin/users` deep link straight after `signInAsFreshUser` — the "interrupted by another navigation" race documented in `e2e/helpers/auth.ts` (it killed admin-organizations, company-shortlist and message-attachments in scheduled runs).
- Assert the conversion PATCH response is `ok()`, so a future endpoint regression fails as an HTTP error instead of a confusing downstream `expected 'MENTOR', received 'MENTEE'` DB assertion.
- Acquire the seeds and the second browser context **inside** the `try`, so a failure before the `finally` can no longer leak the context for the worker or orphan seed rows in a shared-DB (`BASE_URL`) run.

Test-only change — no version bump per the versioning policy.

## Verification

- [x] `npm run lint` + `npx tsc --noEmit` clean
- [x] `npm run test:e2e` passing — the hardened spec is 2/2 green locally against MariaDB
- [x] Tested the change manually / added an e2e test

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KYwDchPBHPtU4XiTFkCiw

---
_Generated by [Claude Code](https://claude.ai/code/session_019KYwDchPBHPtU4XiTFkCiw)_