### PR TITLE
feat(meetings): hybrid Jitsi routing — JaaS 1:1-only + free-room fallback (#1256)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -130,10 +130,14 @@ GOOGLE_OAUTH_REDIRECT_URI=
 # tab, but the public instance HANGS UP AN EMBEDDED CALL AFTER FIVE MINUTES, so
 # the in-app meeting panel is only usable for a demo.
 #
-# SET (all three, or the feature stays off): new meetings get
+# SET (all three, or the feature stays off): new ONE-ON-ONE meetings get
 # `https://8x8.vc/<appId>/<room>` rooms and the panel loads them with a
 # short-lived per-participant JWT — no time limit, display names filled in, the
-# organizer joins as moderator.
+# organizer joins as moderator. Group/bulk meetings and recurring series stay
+# on the free meet.jit.si instance regardless (hybrid routing: JaaS bills per
+# participant per month, so the tenant is reserved for 1:1 calls — see
+# docs/video-calls-jaas.md). If a JaaS call cannot start, the panel offers the
+# same room on the free instance as a fallback.
 #
 #   JAAS_APP_ID      the tenant's App ID, "vpaas-magic-cookie-…". Not secret: it
 #                    is part of every room URL.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.81.0-beta] - 2026-08-19
+
+### Changed
+- **Hybrid Jitsi routing — JaaS is now 1:1-only (#1256).** JaaS bills per monthly
+  active user (25 MAU on the free dev tier) and every participant of an `8x8.vc` room
+  counts, so `generateMeetingLink()` now takes the invitee count and only mints a JaaS
+  room for one-on-one meetings (organizer + exactly one invitee: single-relation
+  instant/scheduled meetings, accepted meeting requests, two-person project/chat
+  calls). Group and bulk meetings (2+ invitees) and recurring series (audience derived
+  from membership later, so never fixed) always get a free `meet.jit.si` link, tenant
+  configured or not. All four link-generation call sites pass the count; unit-style
+  coverage in `e2e/meeting-link-hybrid.unit.spec.ts` (tagged `@smoke`) exercises the
+  JaaS branch that CI's env-less browser suite cannot.
+
+### Added
+- **Free-room fallback for failing JaaS calls.** A JaaS room name works verbatim on the
+  public instance, so `freeMeetingFallbackLink()` (`src/lib/meetingLink.ts`) derives
+  `https://meet.jit.si/<room>` from any of our own `8x8.vc` links (pasted third-party
+  URLs get none). When the embedded JaaS call fails to start — tenant down, MAU quota
+  blocked, token rejected — the meeting panel now offers "Continue in the free room"
+  next to "Open in a new tab"; everyone who switches lands in the same room. New
+  `meetings.instant.freeRoomHint` / `openFreeRoom` strings in EN/TR/DE.
+  Docs: `docs/video-calls-jaas.md` gains the hybrid-routing table and fallback section.
+
 ## [0.80.0-beta] - 2026-08-19
 
 ### Added

--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -10,6 +10,30 @@ Newest entries on top.
 
 ---
 
+## 2026-08-19 — Hibrit Jitsi: JaaS yalnızca 1:1 + ücretsiz oda fallback'i (#1256, 0.81.0-beta)
+
+**JaaS MAU'su katılımcı başına sayılır, oda başına değil.** 25 MAU'luk ücretsiz katman ilk
+ayda 4/25'e geldi bile; `8x8.vc` odasına giren *her* kişi kotadan düşer. Bu yüzden
+yönlendirme kuralı davetli sayısına bağlandı (`generateMeetingLink({ inviteeCount })`,
+1 → JaaS, diğer her şey + `null` → meet.jit.si). Yeni bir env değişkeni **bilerek** yok:
+`JAAS_*`'ı silmek zaten kill-switch ve yeni var eklemek 4 ayrı infra dosyasına dokunmayı
+gerektirirdi (deploy-prod.sh'ta -e satırı + env-capture listesi, topic-deploy.sh, .env.example).
+
+**JaaS oda adı ücretsiz sunucuda birebir çalışır** — `8x8.vc/<appId>/<oda>` →
+`meet.jit.si/<oda>` türetmesi bedava bir kesinti sigortası (`freeMeetingFallbackLink`,
+`parseJaasMeetingLink` üstüne kurulu; yapıştırılmış Zoom/Meet linklerine asla uygulanmaz).
+
+**JaaS dalını e2e'de test etmenin yolu unit-tarzı spec:** CI'da `JAAS_*` yok, sunucu hep
+meet.jit.si üretir. `e2e/notification-text.unit.spec.ts` emsali gibi Playwright içinde
+`@/lib/...` import edip testte env kurup çözmek çalışıyor (`BASE_URL=http://localhost:9999`
+ile webServer'sız, DB'siz koşuyor — global-setup sunucu istemiyor).
+
+**Adversarial review yine kazandı:** 6 bulgudan 4'ü doğrulandı, hepsi "yardımcı metin
+yanlış yönlendiriyor" sınıfı (hint 'linki paylaş' diyor ama kopyalama yoktu; doküman eski
+fallback UI'ını anlatıyordu; panel akış diyagramındaki 409 notu panelin hiç yapmadığı bir
+istek ima ediyordu). Kod doğru olsa da *anlatı* yanlışsa review bunu buluyor — dokümana
+eklenen her cümleyi koda karşı doğrulatmak değiyor.
+
 ## 2026-08-19 — Rol dönüşümü: profil sayfaları + kişiye bildirim (#1252, 0.75.0-beta)
 
 **Bir kullanıcıya koşulsuz e-posta atan her yeni akış, sentinel adresleri düşünmeli.**

--- a/docs/video-calls-jaas.md
+++ b/docs/video-calls-jaas.md
@@ -13,16 +13,39 @@ up for it; this document is the setup that lives outside the repo.
 
 ## What the app does once configured
 
-| | Unconfigured (default) | Configured |
-|---|---|---|
-| New room links | `https://meet.jit.si/InternshipCRM-<hex>` | `https://8x8.vc/<appId>/InternshipCRM-<hex>` |
-| Embedded panel | plain iframe, **5-minute cutoff** | `external_api.js` + JWT, no cutoff |
-| Display name | typed by whoever joins | filled in from the account |
-| Moderator | whoever arrives first | the person who called the meeting (and admins) |
+**Hybrid routing:** JaaS bills by monthly active user and *every participant of a JaaS
+room counts against the allowance* (25 MAU on the free tier), so the tenant is not used
+for everything. Only **one-on-one meetings** (organizer + exactly one invitee: a single
+mentorship relation, a 1:1 meeting request, a two-person project/chat call) get an
+`8x8.vc` room. **Group and bulk meetings** (2+ invitees) and **recurring series** (whose
+audience is derived from membership later and can grow) always get a free
+`meet.jit.si` link, configured tenant or not. The decision is made once per meeting in
+`generateMeetingLink()` (`src/lib/meetingRoom.ts`).
+
+| | Unconfigured (default) | Configured, 1:1 meeting | Configured, group/series |
+|---|---|---|---|
+| New room links | `https://meet.jit.si/InternshipCRM-<hex>` | `https://8x8.vc/<appId>/InternshipCRM-<hex>` | `https://meet.jit.si/InternshipCRM-<hex>` |
+| Embedded panel | plain iframe, **5-minute cutoff** | `external_api.js` + JWT, no cutoff | plain iframe, **5-minute cutoff** — open in a tab for longer calls |
+| Display name | typed by whoever joins | filled in from the account | typed by whoever joins |
+| Moderator | whoever arrives first | the person who called the meeting (and admins) | whoever arrives first |
 
 Nothing else changes: the room URL is still emailed to invitees, still opens in any
 browser, and rooms created before the switch keep working as they did (the panel keeps
 the old iframe path for `meet.jit.si` links).
+
+### Fallback: no meeting is ever stranded
+
+Two layers keep calls possible when JaaS misbehaves:
+
+1. **Creation-time** — no/broken credentials degrade every new link to `meet.jit.si`
+   (this has always been the unconfigured behaviour). Unsetting the `JAAS_*` variables
+   is the kill switch.
+2. **Run-time** — a JaaS room name works verbatim on the free public instance, so from
+   any stored `8x8.vc/<appId>/<room>` link the app derives `https://meet.jit.si/<room>`
+   (`freeMeetingFallbackLink`, `src/lib/meetingLink.ts`). When the embedded JaaS call
+   fails to start (tenant down, MAU quota blocked, token rejected), the panel offers
+   **“Continue in the free room”** next to “Open in a new tab”. Everyone who switches
+   lands in the same room, because the room name is shared between the two hosts.
 
 ## One-time setup in the JaaS console
 
@@ -85,6 +108,8 @@ Meeting.meetLink  https://8x8.vc/<appId>/InternshipCRM-<hex>     ← src/lib/mee
 panel   ├─ GET /api/meetings/<id>/call-token                     ← authorizes, then signs
         │     200 { domain, appId, roomName, jwt }                  (src/lib/jaas.ts)
         │     409 { code: 'not-configured' | 'not-a-jaas-room' } → falls back to the link
+        │     ('not-a-jaas-room' is the *normal* answer for group/series meetings —
+        │      hybrid routing puts those on meet.jit.si by design)
         │
         └─ new JitsiMeetExternalAPI('8x8.vc', { roomName, jwt })  ← src/components/meeting/JaasCall.tsx
 ```
@@ -105,7 +130,8 @@ panel   ├─ GET /api/meetings/<id>/call-token                     ← authori
 
 ## Verifying after deployment
 
-1. Start a call from a mentee card. The stored link should be an `8x8.vc` one:
+1. Start a call from a mentee card (a 1:1 — group meetings stay on `meet.jit.si` by
+   design). The stored link should be an `8x8.vc` one:
    `select meetLink from Meeting order by createdAt desc limit 1;`
 2. `GET /api/meetings/<id>/call-token` as a participant returns `200` with a `jwt`
    (and `Cache-Control: no-store`). A `409` names the reason in `code`.
@@ -115,8 +141,12 @@ panel   ├─ GET /api/meetings/<id>/call-token                     ← authori
 
 ## Costs and limits
 
-JaaS bills by **monthly active users** with a free allowance on top of which usage is
-charged. Turning this on for a deployment real people use is a spending decision, and the
-usage page in the JaaS console is the only place it is visible — the app does not meter
-it. Leaving the variables unset is always a safe rollback: existing `8x8.vc` links keep
-opening in a browser tab, and new rooms go back to the public instance.
+JaaS bills by **monthly active users** with a free allowance (25 MAU on the dev tier) on
+top of which usage is charged — and every *participant* of a JaaS room counts, not just
+the organizer. The hybrid routing above is the MAU-saving mechanism: only 1:1 meetings
+(two participants) touch the tenant, group/bulk/series traffic never does. Turning JaaS
+on for a deployment real people use is still a spending decision, and the usage page in
+the JaaS console is the only place it is visible — the app does not meter it. Leaving
+the variables unset is always a safe rollback: existing `8x8.vc` links keep opening in a
+browser tab (and the panel offers the free-room fallback), and new rooms go back to the
+public instance.

--- a/docs/video-calls-jaas.md
+++ b/docs/video-calls-jaas.md
@@ -108,8 +108,10 @@ Meeting.meetLink  https://8x8.vc/<appId>/InternshipCRM-<hex>     ← src/lib/mee
 panel   ├─ GET /api/meetings/<id>/call-token                     ← authorizes, then signs
         │     200 { domain, appId, roomName, jwt }                  (src/lib/jaas.ts)
         │     409 { code: 'not-configured' | 'not-a-jaas-room' } → falls back to the link
-        │     ('not-a-jaas-room' is the *normal* answer for group/series meetings —
-        │      hybrid routing puts those on meet.jit.si by design)
+        │     (the panel only requests a token for 8x8.vc links; group/series
+        │      meetings live on meet.jit.si by design and take the plain-iframe
+        │      path with no token round trip — 'not-a-jaas-room' answers direct
+        │      API calls for them)
         │
         └─ new JitsiMeetExternalAPI('8x8.vc', { roomName, jwt })  ← src/components/meeting/JaasCall.tsx
 ```
@@ -136,8 +138,9 @@ panel   ├─ GET /api/meetings/<id>/call-token                     ← authori
 2. `GET /api/meetings/<id>/call-token` as a participant returns `200` with a `jwt`
    (and `Cache-Control: no-store`). A `409` names the reason in `code`.
 3. The panel shows the prejoin screen, then the call — and stays up past five minutes.
-   If the token were rejected the panel falls back to "open in a new tab" rather than
-   showing a blank box.
+   If the token were rejected the panel shows the failure view rather than a blank box:
+   "open in a new tab" plus the free-room fallback ("Continue in the free room", which
+   opens `https://meet.jit.si/<room>` and copies that link).
 
 ## Costs and limits
 

--- a/e2e/meeting-link-hybrid.unit.spec.ts
+++ b/e2e/meeting-link-hybrid.unit.spec.ts
@@ -1,0 +1,95 @@
+// Unit tests for the hybrid meeting-link routing — pure node, no browser/page.
+// (Playwright resolves the tsconfig @/ paths, which node --test cannot.)
+//
+// The browser suite can't cover the JaaS branch: CI deliberately runs the app
+// with no JAAS_* env, so every link the *server* generates there is
+// meet.jit.si. These tests exercise generateMeetingLink in-process instead,
+// setting fake credentials around each call — nothing is ever signed or sent
+// to 8x8, the config only shapes the URL.
+import { test, expect } from '@playwright/test';
+import { generateMeetingLink } from '@/lib/meetingRoom';
+import { freeMeetingFallbackLink, isEmbeddableMeetingLink, parseJaasMeetingLink } from '@/lib/meetingLink';
+
+const FAKE_APP_ID = 'vpaas-magic-cookie-0123456789abcdef0123456789abcdef';
+const FAKE_ENV = {
+  JAAS_APP_ID: FAKE_APP_ID,
+  JAAS_API_KEY_ID: `${FAKE_APP_ID}/ab12cd`,
+  // Never used for signing here — jaasConfig() only checks it is PEM-shaped.
+  JAAS_PRIVATE_KEY: '-----BEGIN PRIVATE KEY-----\\nnot-a-real-key\\n-----END PRIVATE KEY-----',
+} as const;
+
+function withJaasEnv<T>(vars: Partial<Record<keyof typeof FAKE_ENV, string>>, fn: () => T): T {
+  const saved = Object.fromEntries(Object.keys(FAKE_ENV).map((k) => [k, process.env[k]]));
+  try {
+    for (const key of Object.keys(FAKE_ENV) as (keyof typeof FAKE_ENV)[]) {
+      const value = vars[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    return fn();
+  } finally {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+test.describe('generateMeetingLink — hybrid routing (JaaS 1:1, free instance for the rest)', () => {
+  test('1:1 meeting gets a JaaS room when the tenant is configured', { tag: '@smoke' }, () => {
+    const link = withJaasEnv(FAKE_ENV, () => generateMeetingLink({ inviteeCount: 1 }));
+    expect(link).toMatch(new RegExp(`^https://8x8\\.vc/${FAKE_APP_ID}/InternshipCRM-[0-9a-f]{16}$`));
+    // The generated link must round-trip through the strict parser the panel
+    // and the call-token endpoint both rely on.
+    expect(parseJaasMeetingLink(link)?.appId).toBe(FAKE_APP_ID);
+    expect(isEmbeddableMeetingLink(link)).toBe(true);
+  });
+
+  test('group meetings stay on the free instance even with a configured tenant', { tag: '@smoke' }, () => {
+    for (const inviteeCount of [0, 2, 3, 25]) {
+      const link = withJaasEnv(FAKE_ENV, () => generateMeetingLink({ inviteeCount }));
+      expect(link, `inviteeCount=${inviteeCount}`).toMatch(/^https:\/\/meet\.jit\.si\/InternshipCRM-[0-9a-f]{16}$/);
+    }
+  });
+
+  test('unknown audience (recurring series) stays on the free instance', () => {
+    const link = withJaasEnv(FAKE_ENV, () => generateMeetingLink({ inviteeCount: null }));
+    expect(link).toMatch(/^https:\/\/meet\.jit\.si\/InternshipCRM-[0-9a-f]{16}$/);
+  });
+
+  test('unconfigured tenant degrades every meeting to the free instance', { tag: '@smoke' }, () => {
+    const link = withJaasEnv({}, () => generateMeetingLink({ inviteeCount: 1 }));
+    expect(link).toMatch(/^https:\/\/meet\.jit\.si\/InternshipCRM-[0-9a-f]{16}$/);
+  });
+
+  test('half-configured tenant counts as off (all three vars or nothing)', () => {
+    const link = withJaasEnv({ JAAS_APP_ID: FAKE_ENV.JAAS_APP_ID }, () => generateMeetingLink({ inviteeCount: 1 }));
+    expect(link).toMatch(/^https:\/\/meet\.jit\.si\//);
+  });
+});
+
+test.describe('freeMeetingFallbackLink — same room on the free instance', () => {
+  test('derives meet.jit.si/<room> from our own JaaS links only', { tag: '@smoke' }, () => {
+    expect(freeMeetingFallbackLink(`https://8x8.vc/${FAKE_APP_ID}/InternshipCRM-1a2b3c4d5e6f7a8b`)).toBe(
+      'https://meet.jit.si/InternshipCRM-1a2b3c4d5e6f7a8b'
+    );
+    // Already free — nothing to fall back to.
+    expect(freeMeetingFallbackLink('https://meet.jit.si/InternshipCRM-1a2b3c4d5e6f7a8b')).toBeNull();
+    // Pasted third-party links never get a derived fallback.
+    expect(freeMeetingFallbackLink('https://zoom.us/j/123456789')).toBeNull();
+    expect(freeMeetingFallbackLink('https://meet.google.com/abc-defg-hij')).toBeNull();
+    // An 8x8.vc URL that is not one of our tenant links is rejected too.
+    expect(freeMeetingFallbackLink('https://8x8.vc/some-other-tenant/room')).toBeNull();
+    expect(freeMeetingFallbackLink(`http://8x8.vc/${FAKE_APP_ID}/room`)).toBeNull();
+    expect(freeMeetingFallbackLink(null)).toBeNull();
+    expect(freeMeetingFallbackLink('')).toBeNull();
+  });
+
+  test('a freshly generated 1:1 JaaS link always has a derivable fallback', () => {
+    const link = withJaasEnv(FAKE_ENV, () => generateMeetingLink({ inviteeCount: 1 }));
+    const fallback = freeMeetingFallbackLink(link);
+    expect(fallback).toMatch(/^https:\/\/meet\.jit\.si\/InternshipCRM-[0-9a-f]{16}$/);
+    // Same room name on both hosts — that is what makes the fallback coherent.
+    expect(fallback!.split('/').pop()).toBe(link.split('/').pop());
+  });
+});

--- a/next.config.js
+++ b/next.config.js
@@ -33,9 +33,11 @@ const csp = [
   // The in-app meeting side panel embeds the Jitsi room we generate (#1054) —
   // narrow on purpose: only the hosts we actually create links for, and only
   // those hosts are allowed camera/microphone below (keep this in sync with
-  // EMBEDDABLE_MEETING_HOSTS in src/lib/meetingLink.ts). meet.jit.si stays for
-  // rooms created before the JaaS switch. The chat widget renders itself in an
-  // iframe, hence tawk.to here as well.
+  // EMBEDDABLE_MEETING_HOSTS in src/lib/meetingLink.ts). meet.jit.si carries
+  // group/bulk meetings and recurring series (hybrid routing — JaaS is 1:1
+  // only, src/lib/meetingRoom.ts), rooms created before the JaaS switch, and
+  // the free-room fallback when a JaaS call fails. The chat widget renders
+  // itself in an iframe, hence tawk.to here as well.
   `frame-src 'self' https://meet.jit.si ${JAAS} ${TAWK}`,
   "frame-ancestors 'none'",
   "base-uri 'self'",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "internship-crm",
-  "version": "0.79.0-beta",
+  "version": "0.80.0-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "internship-crm",
-      "version": "0.79.0-beta",
+      "version": "0.80.0-beta",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.80.0-beta",
+  "version": "0.81.0-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "author": "Mehmet Erşahin",

--- a/src/app/api/meeting-requests/[id]/route.ts
+++ b/src/app/api/meeting-requests/[id]/route.ts
@@ -56,7 +56,8 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
   }
 
   // Accept → create the confirmed meeting with an auto video link. A request
-  // is always mentee → mentor, so the meeting is structurally a 1:1 call.
+  // lives in one relation's thread (either side may file it), so the confirmed
+  // meeting is structurally a 1:1 call: one mentor, one mentee.
   const link = generateMeetingLink({ inviteeCount: 1 });
   // The wall clock behind `proposedAt` was typed by the *requester* (see
   // POST /api/meeting-requests), so theirs is the zone this time was agreed on —

--- a/src/app/api/meeting-requests/[id]/route.ts
+++ b/src/app/api/meeting-requests/[id]/route.ts
@@ -55,8 +55,9 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
     return NextResponse.json({ ok: true, status: 'DECLINED' });
   }
 
-  // Accept → create the confirmed meeting with an auto video link.
-  const link = generateMeetingLink();
+  // Accept → create the confirmed meeting with an auto video link. A request
+  // is always mentee → mentor, so the meeting is structurally a 1:1 call.
+  const link = generateMeetingLink({ inviteeCount: 1 });
   // The wall clock behind `proposedAt` was typed by the *requester* (see
   // POST /api/meeting-requests), so theirs is the zone this time was agreed on —
   // not the mentor's, even though the mentor is the one confirming it (#1210).

--- a/src/app/api/meeting-series/route.ts
+++ b/src/app/api/meeting-series/route.ts
@@ -208,7 +208,9 @@ export async function POST(request: Request) {
     const access = await ensureProjectAccess(session.user, projectId);
     if (access.error) return access.error;
 
-    const fixedLink = meetLink || generateMeetingLink();
+    // A series' audience is derived from project membership at announce time
+    // and can grow over the series' life — never a 1:1, so never a JaaS room.
+    const fixedLink = meetLink || generateMeetingLink({ inviteeCount: null });
     const series = await prisma.meetingSeries.create({
       data: {
         projectId,

--- a/src/app/api/meetings/instant/route.ts
+++ b/src/app/api/meetings/instant/route.ts
@@ -47,7 +47,9 @@ export async function POST(request: Request) {
     const ctx = await resolveMeetingContext(session.user, { relationIds, projectId, conversationId });
     if (!ctx.ok) return NextResponse.json({ error: ctx.error }, { status: ctx.status });
 
-    const meetLink = generateMeetingLink();
+    // Invitee count decides the host (1:1 → JaaS, groups → free instance);
+    // resolveMeetingContext already excluded the organizer from the list.
+    const meetLink = generateMeetingLink({ inviteeCount: ctx.invitees.length });
 
     // RELATION keeps the established shape — one row (and one RSVP token) per
     // relation, all sharing the room. PROJECT/CONVERSATION are a single row: the

--- a/src/app/api/meetings/route.ts
+++ b/src/app/api/meetings/route.ts
@@ -95,7 +95,7 @@ export async function POST(request: Request) {
     // same room, so the video link is generated once (Jitsi, no account needed)
     // when the organizer didn't paste one. The per-person RSVP token stays
     // unique — each participant confirms attendance individually.
-    const link = meetLink || generateMeetingLink();
+    const link = meetLink || generateMeetingLink({ inviteeCount: relations.length });
 
     let created = 0;
     for (const rel of relations) {

--- a/src/components/meeting/MeetingLauncher.tsx
+++ b/src/components/meeting/MeetingLauncher.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { useToast } from '@/components/ui/Toast';
 import { useT } from '@/i18n/client';
-import { isEmbeddableMeetingLink, parseJaasMeetingLink } from '@/lib/meetingLink';
+import { freeMeetingFallbackLink, isEmbeddableMeetingLink, parseJaasMeetingLink } from '@/lib/meetingLink';
 import { meetingNotesAutoOpen, useFloatingNotes } from '@/components/meeting/FloatingNotes';
 import { JaasCall } from '@/components/meeting/JaasCall';
 import { useIsNarrow } from '@/hooks/useIsNarrow';
@@ -241,7 +241,12 @@ function MeetingSidePanel({ meeting, onClose }: { meeting: ActiveMeeting; onClos
   };
 
   // Shown wherever the room cannot be put on screen here: a link we may not
-  // embed, or a JaaS call that failed to start. The link itself always works.
+  // embed, or a JaaS call that failed to start. The link itself always works —
+  // and for a JaaS room that failed, the same room name exists on the free
+  // public instance too, so the call can continue there if 8x8 itself is the
+  // problem (tenant down, MAU quota blocked). Everyone who switches lands in
+  // the same room because the name is shared between the two hosts.
+  const freeFallback = freeMeetingFallbackLink(meeting.meetLink);
   const linkFallback = (message: string) => (
     <div className="hidden lg:flex flex-1 flex-col items-center justify-center gap-3 p-6 text-center">
       <p className="text-sm text-gray-600 dark:text-gray-400">{message}</p>
@@ -251,6 +256,17 @@ function MeetingSidePanel({ meeting, onClose }: { meeting: ActiveMeeting; onClos
           {t.meetings.instant.openInNewTab}
         </Button>
       </a>
+      {freeFallback && (
+        <>
+          <p className="text-xs text-gray-500 dark:text-gray-400 max-w-xs">{t.meetings.instant.freeRoomHint}</p>
+          <a href={freeFallback} target="_blank" rel="noopener noreferrer" data-testid="meeting-free-fallback">
+            <Button size="sm" variant="outline">
+              <ExternalLink className="h-4 w-4" />
+              {t.meetings.instant.openFreeRoom}
+            </Button>
+          </a>
+        </>
+      )}
     </div>
   );
 

--- a/src/components/meeting/MeetingLauncher.tsx
+++ b/src/components/meeting/MeetingLauncher.tsx
@@ -259,7 +259,17 @@ function MeetingSidePanel({ meeting, onClose }: { meeting: ActiveMeeting; onClos
       {freeFallback && (
         <>
           <p className="text-xs text-gray-500 dark:text-gray-400 max-w-xs">{t.meetings.instant.freeRoomHint}</p>
-          <a href={freeFallback} target="_blank" rel="noopener noreferrer" data-testid="meeting-free-fallback">
+          <a
+            href={freeFallback}
+            target="_blank"
+            rel="noopener noreferrer"
+            data-testid="meeting-free-fallback"
+            // The hint asks the organizer to share the free-room link, and the
+            // header's copy button holds the (failing) original — so opening
+            // the free room also puts *its* link on the clipboard. Best-effort:
+            // a blocked clipboard must not stop the room from opening.
+            onClick={() => navigator.clipboard?.writeText(freeFallback).catch(() => {})}
+          >
             <Button size="sm" variant="outline">
               <ExternalLink className="h-4 w-4" />
               {t.meetings.instant.openFreeRoom}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -1011,6 +1011,9 @@ const en = {
       openInNewTab: 'Open in a new tab',
       notEmbeddable: 'This link cannot be shown inside the app.',
       embedFailed: 'The call could not be started here — open it in a new tab.',
+      freeRoomHint:
+        'If the room will not open at all, the same room also exists on the free server — share that link with the participants so everyone lands in the same call.',
+      openFreeRoom: 'Continue in the free room',
     },
     notesWindow: {
       open: 'Notes window',
@@ -3720,6 +3723,9 @@ const tr: Dict = {
       openInNewTab: 'Yeni sekmede aç',
       notEmbeddable: 'Bu link uygulama içinde gösterilemiyor.',
       embedFailed: 'Görüşme burada başlatılamadı — yeni sekmede aç.',
+      freeRoomHint:
+        'Oda hiç açılmıyorsa aynı oda ücretsiz sunucuda da mevcut — o linki katılımcılarla paylaşın, herkes aynı görüşmede buluşur.',
+      openFreeRoom: 'Ücretsiz odada devam et',
     },
     notesWindow: {
       open: 'Not penceresi',
@@ -6420,6 +6426,9 @@ const de: Dict = {
       openInNewTab: 'In neuem Tab öffnen',
       notEmbeddable: 'Dieser Link kann nicht in der App angezeigt werden.',
       embedFailed: 'Der Anruf konnte hier nicht gestartet werden — bitte in einem neuen Tab öffnen.',
+      freeRoomHint:
+        'Wenn sich der Raum gar nicht öffnet: Denselben Raum gibt es auch auf dem freien Server — teilen Sie diesen Link mit den Teilnehmenden, damit alle im selben Gespräch landen.',
+      openFreeRoom: 'Im freien Raum fortfahren',
     },
     notesWindow: {
       open: 'Notizfenster',

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -1012,7 +1012,7 @@ const en = {
       notEmbeddable: 'This link cannot be shown inside the app.',
       embedFailed: 'The call could not be started here — open it in a new tab.',
       freeRoomHint:
-        'If the room will not open at all, the same room also exists on the free server — share that link with the participants so everyone lands in the same call.',
+        'If the room will not open at all, the same room also exists on the free server. Opening it also copies its link — share it with the participants so everyone lands in the same call.',
       openFreeRoom: 'Continue in the free room',
     },
     notesWindow: {
@@ -3724,7 +3724,7 @@ const tr: Dict = {
       notEmbeddable: 'Bu link uygulama içinde gösterilemiyor.',
       embedFailed: 'Görüşme burada başlatılamadı — yeni sekmede aç.',
       freeRoomHint:
-        'Oda hiç açılmıyorsa aynı oda ücretsiz sunucuda da mevcut — o linki katılımcılarla paylaşın, herkes aynı görüşmede buluşur.',
+        'Oda hiç açılmıyorsa aynı oda ücretsiz sunucuda da mevcut. Açtığınızda linki de kopyalanır — katılımcılarla paylaşın, herkes aynı görüşmede buluşur.',
       openFreeRoom: 'Ücretsiz odada devam et',
     },
     notesWindow: {
@@ -6427,7 +6427,7 @@ const de: Dict = {
       notEmbeddable: 'Dieser Link kann nicht in der App angezeigt werden.',
       embedFailed: 'Der Anruf konnte hier nicht gestartet werden — bitte in einem neuen Tab öffnen.',
       freeRoomHint:
-        'Wenn sich der Raum gar nicht öffnet: Denselben Raum gibt es auch auf dem freien Server — teilen Sie diesen Link mit den Teilnehmenden, damit alle im selben Gespräch landen.',
+        'Wenn sich der Raum gar nicht öffnet: Denselben Raum gibt es auch auf dem freien Server. Beim Öffnen wird sein Link mitkopiert — teilen Sie ihn mit den Teilnehmenden, damit alle im selben Gespräch landen.',
       openFreeRoom: 'Im freien Raum fortfahren',
     },
     notesWindow: {

--- a/src/lib/meetingLink.ts
+++ b/src/lib/meetingLink.ts
@@ -7,9 +7,11 @@
 // and the `Permissions-Policy` allowlist in next.config.js — widening one
 // without the other yields an empty box or a call with no camera.
 //
-// `8x8.vc` is our JaaS tenant (#1237) and is the one that gets embedded in
-// production; `meet.jit.si` stays for links created before the switch and for
-// environments with no JaaS credentials (local dev, CI).
+// `8x8.vc` is our JaaS tenant (#1237), used for one-on-one calls when
+// configured; `meet.jit.si` carries everything else — group/bulk meetings and
+// recurring series (JaaS bills per monthly active user, so the tenant is
+// reserved for 1:1 calls — see src/lib/meetingRoom.ts), links created before
+// the JaaS switch, and environments with no JaaS credentials (local dev, CI).
 export const EMBEDDABLE_MEETING_HOSTS = ['meet.jit.si', '8x8.vc'];
 
 // True when the link can safely be embedded. Meet/Zoom/Teams all send
@@ -56,4 +58,17 @@ export function parseJaasMeetingLink(link: string | null | undefined): JaasRoomR
   } catch {
     return null;
   }
+}
+
+// The uninterrupted-service escape hatch: a JaaS room name works verbatim on
+// the free public instance, so from any of our own 8x8.vc links a working
+// meet.jit.si link can be derived. The panel offers it when the JaaS call
+// fails to start (tenant down, quota blocked, token rejected) — everyone who
+// switches to it lands in the *same* room, because the name is the same.
+//
+// Deliberately built on parseJaasMeetingLink: a pasted Meet/Zoom/arbitrary
+// URL yields null here, and only our own generated links get a fallback.
+export function freeMeetingFallbackLink(link: string | null | undefined): string | null {
+  const jaas = parseJaasMeetingLink(link);
+  return jaas ? `https://meet.jit.si/${jaas.room}` : null;
 }

--- a/src/lib/meetingRoom.ts
+++ b/src/lib/meetingRoom.ts
@@ -7,8 +7,7 @@ import { jaasConfig, jaasRoomUrl } from '@/lib/jaas';
 //
 // This used to be three copies of the same template literal (instant meetings,
 // accepted meeting requests, recurring series). They are one function now
-// because the JaaS switch below has to apply to all three — a room created on
-// the public instance would still cut out after five minutes.
+// because the JaaS/free-instance choice below has to apply to all of them.
 
 // The room name, without a host. Unguessable on purpose: the room is the only
 // thing protecting a call on the public instance, and on JaaS it is what the
@@ -17,14 +16,25 @@ export function generateMeetingRoomName(): string {
   return `InternshipCRM-${randomBytes(8).toString('hex')}`;
 }
 
-// A JaaS room when the tenant is configured, the public Jitsi otherwise.
+// Hybrid routing: JaaS MAU is a metered allowance (25/month on the free tier,
+// and *every* participant of a JaaS room counts), so the tenant is reserved for
+// the one flow where the embedded panel matters most and the head-count is
+// lowest — one-on-one calls. Everything else stays on the free public instance.
 //
-// The fallback is not a leftover: local dev, CI and every e2e run have no JaaS
-// credentials, and the five-minute embed limit is irrelevant there. It also
-// means a broken/expired key never leaves the app unable to create a meeting —
-// the link degrades to one that anybody can still open in a tab.
-export function generateMeetingLink(): string {
+//   inviteeCount === 1  → JaaS room, when the tenant is configured
+//                         (organizer + exactly one invitee = a 1:1 call)
+//   anything else       → https://meet.jit.si/<room>
+//                         (group/bulk links, and `null` for flows like
+//                         recurring series whose audience is derived from
+//                         membership later and can grow over time)
+//
+// The free fallback is not a leftover: local dev, CI and every e2e run have no
+// JaaS credentials. It also means a broken/expired key never leaves the app
+// unable to create a meeting — the link degrades to one that anybody can still
+// open in a tab. The runtime counterpart (an existing 8x8.vc room failing) is
+// handled client-side via freeMeetingFallbackLink in @/lib/meetingLink.
+export function generateMeetingLink(opts: { inviteeCount: number | null }): string {
   const room = generateMeetingRoomName();
-  const config = jaasConfig();
+  const config = opts.inviteeCount === 1 ? jaasConfig() : null;
   return config ? jaasRoomUrl(config, room) : `https://meet.jit.si/${room}`;
 }

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,24 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.81.0-beta',
+    date: '2026-08-19',
+    highlights: {
+      en: [
+        'Video calls got smarter about hosting: one-on-one meetings run on our dedicated call service (no time limits in the embedded panel), while group meetings and recurring series use the free Jitsi server — so the paid allowance is spent only where it matters.',
+        'If an embedded call ever fails to start, the meeting panel now offers "Continue in the free room": the same room on the free server, so everyone still meets in one place with no interruption.',
+      ],
+      tr: [
+        'Görüntülü aramalarda akıllı yönlendirme: birebir görüşmeler özel arama servisimizde çalışıyor (gömülü panelde süre sınırı yok), grup toplantıları ve tekrarlayan seriler ise ücretsiz Jitsi sunucusunu kullanıyor — ücretli kota yalnızca gerektiği yerde harcanıyor.',
+        'Gömülü bir arama başlatılamazsa toplantı paneli artık "Ücretsiz odada devam et" seçeneği sunuyor: aynı oda ücretsiz sunucuda da açılıyor, böylece herkes kesintisiz aynı görüşmede buluşuyor.',
+      ],
+      de: [
+        'Videoanrufe werden jetzt klüger geroutet: Einzelgespräche laufen über unseren dedizierten Anrufdienst (ohne Zeitlimit im eingebetteten Panel), Gruppentermine und wiederkehrende Serien nutzen den freien Jitsi-Server — das bezahlte Kontingent wird nur dort verbraucht, wo es zählt.',
+        'Falls ein eingebetteter Anruf nicht startet, bietet das Meeting-Panel jetzt „Im freien Raum fortfahren“: derselbe Raum auf dem freien Server, sodass alle ohne Unterbrechung im selben Gespräch landen.',
+      ],
+    },
+  },
+  {
     version: '0.80.0-beta',
     date: '2026-08-19',
     highlights: {


### PR DESCRIPTION
> **Önizleme ortamı:** https://crm-pr1257.ersah.in (topic-preview.yml, her push'ta güncellenir)

## Summary

JaaS'ın ücretsiz katmanı 25 MAU ve bir `8x8.vc` odasının **her katılımcısı** kotadan düşüyor (Activity sayfası ilk ayda 4/25'i gösteriyor). Bu PR hibrit stratejiye geçiriyor: **birebir görüşmeler JaaS'ta kalır** (gömülü panel, süre limiti yok), **toplu/grup linkler ve tekrarlayan seriler her zaman ücretsiz `meet.jit.si`'ye gider** — artı, JaaS araması başlatılamazsa kesintiyi önleyen bir **ücretsiz oda fallback'i**.

- Yönlendirme tek noktada: `generateMeetingLink({ inviteeCount })` — `1` → JaaS (tenant yapılandırılmışsa), diğer her şey ve `null` (seriler: katılımcı kümesi üyelikten türetiliyor) → `meet.jit.si`. Dört üretim yolu da sayıyı geçirir (instant, scheduled, request-accept, series).
- Fallback: JaaS oda adı ücretsiz sunucuda birebir çalışır → `freeMeetingFallbackLink()` `8x8.vc/<appId>/<oda>` linkinden `https://meet.jit.si/<oda>` türetir (yalnızca kendi ürettiğimiz linkler; yapıştırılan Zoom/Meet URL'lerine asla). Gömülü JaaS araması başlatılamazsa (tenant çökük, MAU bloğu, token reddi) panel **"Ücretsiz odada devam et"** düğmesini gösterir — açınca linki de panoya kopyalar, geçen herkes aynı odada buluşur. `JAAS_*`'ı silmek üretim-anı kill-switch olarak kalır.
- CSP/Permissions-Policy değişmedi (iki host da zaten izinli); **yeni env değişkeni yok**.
- Adversarial review'un doğruladığı 4 bulgu (kopyalama affordance'ı + 3 doküman/yorum tutarlılığı) ikinci commit'te düzeltildi.

Closes #1256

## Changes

- `src/lib/meetingRoom.ts` — `generateMeetingLink()` artık `{ inviteeCount: number | null }` alıyor; JaaS yalnızca `inviteeCount === 1` iken.
- `src/app/api/meetings/instant/route.ts`, `meetings/route.ts`, `meeting-requests/[id]/route.ts`, `meeting-series/route.ts` — dört çağrı noktası davetli sayısını geçiriyor.
- `src/lib/meetingLink.ts` — `freeMeetingFallbackLink()` (strict `parseJaasMeetingLink` üstüne kurulu) + güncellenen host yorumları.
- `src/components/meeting/MeetingLauncher.tsx` — fallback görünümüne "Ücretsiz odada devam et" (açarken linki kopyalar, `data-testid="meeting-free-fallback"`).
- `src/i18n/dictionaries.ts` — `meetings.instant.freeRoomHint` / `openFreeRoom` (EN/TR/DE, key parity yeşil).
- `e2e/meeting-link-hybrid.unit.spec.ts` — unit-tarzı spec (@smoke): CI'ın env'siz tarayıcı süiti JaaS dalını hiç göremediği için yönlendirme kuralı ve fallback türetmesi burada test ediliyor (sahte `JAAS_*` env, imzalama yok).
- `docs/video-calls-jaas.md`, `.env.example`, `next.config.js` yorumu — hibrit tablo + fallback bölümü.
- `package.json` 0.81.0-beta, `CHANGELOG.md`, `src/lib/releaseNotes.ts` (EN/TR/DE), `docs/agent-experience.md` retrospektifi.

## Verification

- [x] `npm run lint` + `npx tsc --noEmit` clean
- [x] `npm run test:e2e` passing (or CI green) — yeni unit spec 7/7 lokalde geçti; `npm run build` + `npm run check:i18n` yeşil; tam süit CI'da
- [x] Tested the change manually / added an e2e test — `e2e/meeting-link-hybrid.unit.spec.ts` (@smoke)

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JUtQyqhswanTNKpiKKSNMq