### PR TITLE
feat(meetings): participants can declare a meeting over + live JaaS room info on the banner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -153,6 +153,14 @@ JAAS_APP_ID=
 JAAS_API_KEY_ID=
 JAAS_PRIVATE_KEY=
 
+# Optional — live room info on the dashboard banner ("n in the call"). Generate
+# any long random string, put it here AND in the JaaS console as a webhook to
+#   https://<host>/api/webhooks/jaas?secret=<value>
+# subscribed to ROOM_CREATED / ROOM_DESTROYED / PARTICIPANT_JOINED /
+# PARTICIPANT_LEFT. Unset = the endpoint answers 404 and the banner shows no
+# live line — the feature simply stays off.
+JAAS_WEBHOOK_SECRET=
+
 # Optional — multi-tenancy (#543). When "true", every tenant-scoped Prisma query
 # is auto-isolated to the request's organization (see docs/tenant-isolation.md).
 # Leave unset/false to keep the app single-tenant (default). Do NOT enable in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,35 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.82.0-beta] - 2026-08-19
+
+### Added
+- **Participants can declare a meeting over, and the banner can show who is really
+  in the call.** The dashboard's "meeting in progress" strip used to sit there for
+  the whole assumed 60-minute window even when everyone had hung up, reading as
+  "they are still talking". Now:
+  - Any participant can mark the running meeting as over (`POST
+    /api/meetings/[id]/end`) from a button on the banner — the strip then
+    disappears for **every** participant, not just the clicker. Untouched, the
+    banner still times out after the assumed hour exactly as before. Works for
+    one-off `Meeting` rows, for multi-mentee meetings (all sibling rows sharing
+    the room link are ended together), and for recurring-series occurrences that
+    have no `Meeting` row (composite `<seriesId>:<ISO>` ids, marked in the new
+    `MeetingOccurrenceEnd` table). Ending is participant-only, start-gated
+    (a future meeting can't be hidden), and deliberately has no undo.
+  - Optional live room info from JaaS: a new webhook receiver
+    (`/api/webhooks/jaas`, enabled by `JAAS_WEBHOOK_SECRET`; subscribe the tenant
+    to ROOM_CREATED / ROOM_DESTROYED / PARTICIPANT_JOINED / PARTICIPANT_LEFT)
+    keeps a per-room `MeetingRoomState`, and the banner shows "n in the call"
+    with real names while the room is active. Display-only: room lifecycle never
+    auto-ends a meeting (rooms die whenever the last person drops, including
+    someone popping in early). Unset secret = endpoint answers 404, feature off —
+    the default in dev, CI and un-provisioned deployments.
+  - Schema: `Meeting.endedAt` / `Meeting.endedById`, new `MeetingOccurrenceEnd`
+    and `MeetingRoomState` models (additive `db push`).
+  - E2E: `e2e/meeting-end.spec.ts` (end flow tagged `@smoke`, sibling-row fanout,
+    occurrence ids, outsider 404, webhook feed end-to-end).
+
 ## [0.81.0-beta] - 2026-08-19
 
 ### Changed

--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -3738,3 +3738,36 @@ kurmadan hızlı bir doğrulama yolu.
 dalına `--force-with-lease` push ile PR numarasını korumak en temiz yol çıktı. Kapsam dışı
 hunk'ları (agent-experience.md) ve kaza silmelerini (EN `projects.demo` anahtarı —
 `check:i18n` bunu yakalar) bu aşamada ayıkla.
+
+## 2026-08-19 — Toplantı "bitti" işareti + JaaS canlı oda bilgisi (#1259, 0.81.0-beta)
+
+**Banner'daki "id" her zaman bir Meeting satırı değil.** `getUpcomingMeeting` seri
+tekrarlarını `<seriesId>:<ISO>` bileşik id'siyle uçuşta sentezliyor; bu id'ye durum
+yazan her yeni endpoint iki şekli de kabul etmek zorunda (ilk `:`'dan böl — cuid'de
+iki nokta yok). Kalıcı işaret için `MeetingSeriesReminder` ile aynı anahtar şekli
+(`@@unique([seriesId, occurrenceAt])`) birebir uydu; ayrıca gönderilen ISO'nun
+kuralın *gerçek* bir tekrarı olduğunu `seriesOccurrences` ile ±1 dk pencerede doğrulat,
+yoksa URL'e yazılan rastgele timestamp'ler tabloya çöp satır olarak girer.
+
+**Relation-bağlamlı bir toplantı N ayrı Meeting satırıdır** (davetli ilişki başına bir
+satır, aynı `meetLink`i paylaşırlar). "Bitti" gibi toplantı-düzeyi bir durum tek satıra
+yazılırsa diğer davetliler görmeye devam eder — fan-out anahtarı `(meetLink, scheduledAt)`
+ikilisi (link olay başına rastgele/eşsiz olduğu için güvenli kimlik).
+
+**Playwright pinli tarayıcı build'i eskisinden farklı bir dizin *düzeni* isteyebilir.**
+`/opt/pw-browsers`'ta 1194 var, pin 1234 istiyordu; dizini symlink'lemek yetmedi çünkü
+yeni sürüm `chrome-headless-shell-linux64/chrome-headless-shell` yolunu arıyor, eskisi
+`chrome-linux/headless_shell`. Çözüm: beklenen düzeni mkdir'le kur, binary'yi tek tek
+symlink'le, `INSTALLATION_COMPLETE` + `DEPENDENCIES_VALIDATED` dosyalarını `touch`la.
+
+**Webhook secret'ını query param olarak da kabul et** (`?secret=` — `x-webhook-secret`
+header'ına ek): JaaS konsolu her planda özel header alanı sunmuyor; URL'i zaten operatör
+yazdığı için sözleşme bizim tarafta kalıyor. Yapılandırılmamış secret = 404 (endpoint yok
+gibi), yanlış secret = 401 — inbound-email (#870) ile aynı desen, e2e'de
+`playwright.config.ts` webServer env'ine sabit test secret'ı ekleyerek test edilir.
+
+**ROOM_DESTROYED ≠ toplantı bitti.** Jitsi odası son kişi çıkınca ölür — erken girip
+çıkan tek kişi bile odayı yaratıp yok eder. Webhook beslemesini yalnızca gösterim
+(canlı katılımcı sayısı/isimleri) için kullan; "bitti" kararını katılımcıya bırak.
+Bayat state'e karşı da (serilerin `fixedLink`'i aynı odayı her hafta yeniden kullanır)
+`updatedAt` tazelik eşiği koy.

--- a/e2e/meeting-end.spec.ts
+++ b/e2e/meeting-end.spec.ts
@@ -1,0 +1,255 @@
+import { test, expect } from '@playwright/test';
+import crypto from 'crypto';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { signInAndSettle } from './helpers/auth';
+import { E2E_JAAS_WEBHOOK_SECRET } from '../playwright.config';
+
+/**
+ * "The meeting is over" (participant-declared) + live room info.
+ *
+ * The dashboard strip used to sit on "in progress" for the whole assumed hour
+ * even when everyone had hung up after twenty minutes. Now any participant can
+ * declare the meeting over — POST /api/meetings/[id]/end — and the strip
+ * disappears for *everyone* (the shared endpoint stops returning it). And when
+ * the JaaS webhook feed is configured, the strip shows who is actually in the
+ * room (/api/webhooks/jaas → MeetingRoomState).
+ */
+
+const password = 'MeetingEndPass123!';
+const minutesFromNow = (m: number) => new Date(Date.now() + m * 60 * 1000);
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+async function seedPair(prefix: string) {
+  const mentorEmail = uniqueEmail(`${prefix}-mentor`);
+  const menteeEmail = uniqueEmail(`${prefix}-mentee`);
+  const mentor = await seedUser(mentorEmail, password, 'MENTOR', 'End Mentor');
+  const mentee = await seedUser(menteeEmail, password, 'MENTEE', 'End Mentee');
+  const relation = await prisma.mentorshipRelation.create({
+    data: { mentorId: mentor.id, menteeId: mentee.id },
+  });
+  return { mentorEmail, menteeEmail, mentor, mentee, relation };
+}
+
+async function seedMeeting(relationId: string, scheduledAt: Date, title: string, meetLink?: string) {
+  return prisma.meeting.create({
+    data: {
+      relationId,
+      title,
+      scheduledAt,
+      meetLink: meetLink ?? 'https://meet.example.com/end-room',
+      rsvpToken: `e2e-${Math.random().toString(36).slice(2)}`,
+      createdById: 'e2e',
+    },
+  });
+}
+
+test('any participant can declare a running meeting over — and it is gone for everyone', { tag: '@smoke' }, async ({ page }) => {
+  const { mentorEmail, menteeEmail, mentee, relation } = await seedPair('endnow');
+  const meeting = await seedMeeting(relation.id, minutesFromNow(-10), 'Retro running');
+
+  try {
+    // The mentee (a participant, not the organizer) ends it from the banner.
+    await signInAndSettle(page, menteeEmail, password, '/portal');
+    const banner = page.getByTestId('upcoming-meeting-banner');
+    await expect(banner).toContainText('Retro running', { timeout: 20_000 });
+
+    page.once('dialog', (dialog) => void dialog.accept());
+    await banner.getByTestId('upcoming-meeting-end').click();
+    // The hook refreshes right after the POST — the strip vanishes without a reload.
+    await expect(page.getByTestId('upcoming-meeting-banner')).toHaveCount(0, { timeout: 20_000 });
+
+    // Hidden server-side for every participant, not just the marker's client.
+    const res = await page.request.get('/api/meetings/upcoming');
+    expect((await res.json()).meeting).toBeNull();
+    const row = await prisma.meeting.findUnique({ where: { id: meeting.id } });
+    expect(row?.endedAt).not.toBeNull();
+    expect(row?.endedById).toBe(mentee.id);
+  } finally {
+    await prisma.meeting.deleteMany({ where: { relationId: relation.id } });
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(menteeEmail);
+  }
+});
+
+test('a meeting that has not started cannot be ended — no button, and the API refuses', async ({ page }) => {
+  const { mentorEmail, menteeEmail, relation } = await seedPair('endsoon');
+  const meeting = await seedMeeting(relation.id, minutesFromNow(20), 'Kickoff ahead');
+
+  try {
+    await signInAndSettle(page, mentorEmail, password, '/mentor');
+    const banner = page.getByTestId('upcoming-meeting-banner');
+    await expect(banner).toContainText('Kickoff ahead', { timeout: 20_000 });
+    // Not ongoing → the end button is not offered…
+    await expect(banner.getByTestId('upcoming-meeting-end')).toHaveCount(0);
+    // …and hiding the button is not the authorization: the endpoint refuses too.
+    const res = await page.request.post(`/api/meetings/${meeting.id}/end`);
+    expect(res.status()).toBe(409);
+    expect((await prisma.meeting.findUnique({ where: { id: meeting.id } }))?.endedAt).toBeNull();
+  } finally {
+    await prisma.meeting.deleteMany({ where: { relationId: relation.id } });
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(menteeEmail);
+  }
+});
+
+test('ending one relation row of a multi-mentee meeting hides the siblings too', async ({ page }) => {
+  // A relation-context meeting invites N relations as N Meeting rows sharing
+  // one room link — ending it as one mentee must end it for the other as well.
+  const { mentorEmail, menteeEmail, relation } = await seedPair('endsib');
+  const otherEmail = uniqueEmail('endsib-mentee2');
+  const other = await seedUser(otherEmail, password, 'MENTEE', 'End Sibling');
+  const mentor = await prisma.user.findUnique({ where: { email: mentorEmail } });
+  const relation2 = await prisma.mentorshipRelation.create({
+    data: { mentorId: mentor!.id, menteeId: other.id },
+  });
+  const startedAt = minutesFromNow(-5);
+  const sharedLink = `https://meet.example.com/shared-${crypto.randomBytes(4).toString('hex')}`;
+  await seedMeeting(relation.id, startedAt, 'Group sync', sharedLink);
+  const siblingRow = await seedMeeting(relation2.id, startedAt, 'Group sync', sharedLink);
+
+  try {
+    await signInAndSettle(page, menteeEmail, password, '/portal');
+    await expect(page.getByTestId('upcoming-meeting-banner')).toContainText('Group sync', { timeout: 20_000 });
+    page.once('dialog', (dialog) => void dialog.accept());
+    await page.getByTestId('upcoming-meeting-end').click();
+    await expect(page.getByTestId('upcoming-meeting-banner')).toHaveCount(0, { timeout: 20_000 });
+
+    const sibling = await prisma.meeting.findUnique({ where: { id: siblingRow.id } });
+    expect(sibling?.endedAt).not.toBeNull();
+  } finally {
+    await prisma.meeting.deleteMany({ where: { relationId: { in: [relation.id, relation2.id] } } });
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(otherEmail);
+  }
+});
+
+test('a recurring occurrence (no Meeting row) can be ended through its composite id', async ({ page }) => {
+  const ownerEmail = uniqueEmail('endseries-owner');
+  const memberEmail = uniqueEmail('endseries-member');
+  const owner = await seedUser(ownerEmail, password, 'MENTOR', 'End Series Owner');
+  const member = await seedUser(memberEmail, password, 'MENTEE', 'End Series Member');
+
+  const project = await prisma.project.create({
+    data: {
+      name: 'End Series Project',
+      ownerType: 'MENTOR',
+      ownerUserId: owner.id,
+      members: {
+        create: [
+          { userId: owner.id, role: 'OWNER' },
+          { userId: member.id, role: 'MENTEE', functionalRole: 'DEVELOPER' },
+        ],
+      },
+    },
+  });
+
+  // A rule whose occurrence started 10 minutes ago, pinned to UTC like the
+  // upcoming-meeting spec does since #1110.
+  const target = minutesFromNow(-10);
+  const hhmm = `${String(target.getUTCHours()).padStart(2, '0')}:${String(target.getUTCMinutes()).padStart(2, '0')}`;
+  const series = await prisma.meetingSeries.create({
+    data: {
+      projectId: project.id,
+      title: 'Daily standup',
+      daysOfWeek: [0, 1, 2, 3, 4, 5, 6],
+      timeOfDay: hhmm,
+      timeZone: 'UTC',
+      fixedLink: 'https://meet.example.com/end-series-room',
+      createdById: owner.id,
+    },
+  });
+
+  try {
+    await signInAndSettle(page, memberEmail, password, '/portal');
+    const before = await page.request.get('/api/meetings/upcoming');
+    const upcoming = (await before.json()).meeting;
+    expect(upcoming?.title).toBe('Daily standup');
+    expect(String(upcoming.id)).toContain(':'); // synthesized: `<seriesId>:<ISO>`
+
+    const end = await page.request.post(`/api/meetings/${encodeURIComponent(upcoming.id)}/end`);
+    expect(end.ok()).toBeTruthy();
+
+    const after = await page.request.get('/api/meetings/upcoming');
+    expect((await after.json()).meeting).toBeNull();
+
+    const mark = await prisma.meetingOccurrenceEnd.findFirst({ where: { seriesId: series.id } });
+    expect(mark?.endedById).toBe(member.id);
+  } finally {
+    await prisma.meetingOccurrenceEnd.deleteMany({ where: { seriesId: series.id } });
+    await prisma.meetingSeriesReminder.deleteMany({ where: { seriesId: series.id } });
+    await prisma.meetingSeries.delete({ where: { id: series.id } }).catch(() => {});
+    await prisma.projectMember.deleteMany({ where: { projectId: project.id } });
+    await prisma.conversation.deleteMany({ where: { projectId: project.id } });
+    await prisma.project.delete({ where: { id: project.id } }).catch(() => {});
+    await cleanupByEmail(ownerEmail);
+    await cleanupByEmail(memberEmail);
+  }
+});
+
+test('an outsider cannot end someone else’s meeting', async ({ page }) => {
+  const { mentorEmail, menteeEmail, relation } = await seedPair('endforeign');
+  const outsiderEmail = uniqueEmail('endforeign-outsider');
+  await seedUser(outsiderEmail, password, 'MENTEE', 'End Outsider');
+  const meeting = await seedMeeting(relation.id, minutesFromNow(-10), 'Private sync');
+
+  try {
+    await signInAndSettle(page, outsiderEmail, password, '/portal');
+    const res = await page.request.post(`/api/meetings/${meeting.id}/end`);
+    // Missing and not-yours answer the same, so the id space stays opaque.
+    expect(res.status()).toBe(404);
+    expect((await prisma.meeting.findUnique({ where: { id: meeting.id } }))?.endedAt).toBeNull();
+  } finally {
+    await prisma.meeting.deleteMany({ where: { relationId: relation.id } });
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(outsiderEmail);
+  }
+});
+
+test('the JaaS webhook feed puts live participants on the banner', async ({ page, request }) => {
+  const { mentorEmail, menteeEmail, relation } = await seedPair('endlive');
+  const room = `InternshipCRM-e2e-${crypto.randomBytes(6).toString('hex')}`;
+  const appId = 'vpaas-magic-cookie-e2etenant';
+  await seedMeeting(relation.id, minutesFromNow(-10), 'Live check', `https://8x8.vc/${appId}/${room}`);
+
+  const hook = (eventType: string, data?: Record<string, unknown>) =>
+    request.post(`/api/webhooks/jaas?secret=${E2E_JAAS_WEBHOOK_SECRET}`, {
+      data: { eventType, fqn: `${appId}/${room}`, data },
+    });
+
+  try {
+    // The secret is the gate: without it nothing is accepted.
+    const unauthorized = await request.post('/api/webhooks/jaas', {
+      data: { eventType: 'ROOM_CREATED', fqn: `${appId}/${room}` },
+    });
+    expect(unauthorized.status()).toBe(401);
+
+    expect((await hook('ROOM_CREATED')).ok()).toBeTruthy();
+    expect((await hook('PARTICIPANT_JOINED', { participantId: 'p1', name: 'Ayşe Mentor' })).ok()).toBeTruthy();
+    expect((await hook('PARTICIPANT_JOINED', { participantId: 'p2', name: 'Deniz Mentee' })).ok()).toBeTruthy();
+
+    await signInAndSettle(page, mentorEmail, password, '/mentor');
+    const live = page.getByTestId('upcoming-meeting-live');
+    await expect(live).toBeVisible({ timeout: 20_000 });
+    await expect(live).toContainText('2');
+    await expect(live).toContainText('Ayşe Mentor');
+
+    // One leaves → the endpoint reports one; the room dying → nothing at all.
+    expect((await hook('PARTICIPANT_LEFT', { participantId: 'p1' })).ok()).toBeTruthy();
+    let res = await page.request.get('/api/meetings/upcoming');
+    expect((await res.json()).meeting?.live).toEqual({ count: 1, names: ['Deniz Mentee'] });
+
+    expect((await hook('ROOM_DESTROYED')).ok()).toBeTruthy();
+    res = await page.request.get('/api/meetings/upcoming');
+    expect((await res.json()).meeting?.live).toBeNull();
+  } finally {
+    await prisma.meetingRoomState.deleteMany({ where: { room } });
+    await prisma.meeting.deleteMany({ where: { relationId: relation.id } });
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(menteeEmail);
+  }
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.81.0-beta",
+  "version": "0.82.0-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "author": "Mehmet Erşahin",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,6 +20,9 @@ export const E2E_HEALTH_TOKEN = 'e2e-health-token';
 // the shape production actually runs (secret required AND supplied) instead of
 // the lenient path.
 export const E2E_INBOUND_SECRET = 'e2e-inbound-secret';
+// Shared with e2e/meeting-end.spec.ts. Unset, /api/webhooks/jaas answers 404
+// to everything and the live-room assertions would be vacuous.
+export const E2E_JAAS_WEBHOOK_SECRET = 'e2e-jaas-webhook-secret';
 
 export default defineConfig({
   testDir: './e2e',
@@ -59,6 +62,7 @@ export default defineConfig({
           // assertions about what an anonymous caller may see would be vacuous.
           HEALTH_TOKEN: E2E_HEALTH_TOKEN,
           INBOUND_SECRET: E2E_INBOUND_SECRET,
+          JAAS_WEBHOOK_SECRET: E2E_JAAS_WEBHOOK_SECRET,
         },
       },
 });

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1545,6 +1545,11 @@ model Meeting {
   createdAt      DateTime   @default(now())
   // Null for manually scheduled meetings; set for auto-generated series instances.
   seriesId       String?
+  // "This meeting is over" — set when any participant marks it ended, which
+  // hides the dashboard banner for everyone instead of letting the assumed
+  // 60-minute window run out. Null = never marked; the window still applies.
+  endedAt        DateTime?
+  endedById      String?
 
   relation     MentorshipRelation? @relation(fields: [relationId], references: [id], onDelete: Cascade)
   project      Project?            @relation(fields: [projectId], references: [id], onDelete: Cascade)
@@ -1581,6 +1586,7 @@ model MeetingSeries {
   project   Project?                @relation(fields: [projectId], references: [id], onDelete: SetNull)
   meetings  Meeting[]
   reminders MeetingSeriesReminder[]
+  ends      MeetingOccurrenceEnd[]
 
   @@index([projectId])
 }
@@ -1605,6 +1611,38 @@ model MeetingSeriesReminder {
   series MeetingSeries @relation(fields: [seriesId], references: [id], onDelete: Cascade)
 
   @@unique([seriesId, occurrenceAt, lead])
+}
+
+// "This occurrence is over" for a series occurrence that has no Meeting row —
+// the dashboard banner synthesizes those on the fly (src/lib/upcomingMeeting.ts),
+// so the end mark needs its own home, keyed the same way as the reminders above.
+// Occurrences that DO have a generated Meeting row get both marks (the row's
+// endedAt and one of these), so every viewer's representation is covered.
+model MeetingOccurrenceEnd {
+  id           String   @id @default(cuid())
+  seriesId     String
+  occurrenceAt DateTime
+  endedById    String
+  endedAt      DateTime @default(now())
+
+  series MeetingSeries @relation(fields: [seriesId], references: [id], onDelete: Cascade)
+
+  @@unique([seriesId, occurrenceAt])
+}
+
+// Live state of one JaaS video room, fed by the tenant's webhooks
+// (/api/webhooks/jaas, enabled by JAAS_WEBHOOK_SECRET). Purely informational:
+// the dashboard banner shows "n in the call" while the room is active. Keyed by
+// the bare room name (unguessable, unique per meeting; a series' fixedLink
+// reuses one room, so readers must also check freshness via updatedAt).
+model MeetingRoomState {
+  id           String   @id @default(cuid())
+  room         String   @unique
+  active       Boolean  @default(false)
+  // JSON array of { id, name } for everyone currently in the room.
+  participants Json
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
 }
 
 // Audit trail of pipeline stage changes for a mentorship.

--- a/src/app/api/meetings/[id]/end/route.ts
+++ b/src/app/api/meetings/[id]/end/route.ts
@@ -1,0 +1,153 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { withTenantScope } from '@/lib/orgContext';
+import { enforceRateLimit } from '@/lib/rateLimit';
+import { prisma } from '@/lib/prisma';
+import { loadAccessibleMeeting } from '@/lib/meetingAccess';
+import { seriesOccurrences } from '@/lib/meetingSeriesOccurrences';
+
+// POST — a participant says "this meeting is over" and the dashboard banner
+// disappears for everyone, instead of sitting on "in progress" until the
+// assumed 60-minute window (src/lib/upcomingMeeting.ts) runs out and being
+// read as "they are still talking".
+//
+// Any participant may do it — whoever is in the call knows better than the
+// clock — and it only ever *ends* a meeting: there is no un-end, because the
+// banner would have died on its own within the hour anyway.
+//
+// Two id shapes, matching what /api/meetings/upcoming hands out:
+//   - a Meeting row's cuid;
+//   - `<seriesId>:<ISO instant>` for a recurring occurrence the banner
+//     synthesized on the fly (no Meeting row exists to carry the mark).
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const limited = enforceRateLimit(request, 'meeting-end', { limit: 15, windowMs: 60_000 });
+  if (limited) return limited;
+
+  const { id: rawId } = await params;
+  let id = rawId;
+  try {
+    id = decodeURIComponent(rawId);
+  } catch {
+    /* keep the raw segment — a lone % is not worth a 500 */
+  }
+
+  return await withTenantScope(session, async () => {
+    const now = new Date();
+    const colon = id.indexOf(':');
+    return colon > 0
+      ? await endSeriesOccurrence(session.user, id.slice(0, colon), id.slice(colon + 1), now)
+      : await endMeetingRow(session.user, id, now);
+  });
+}
+
+async function endMeetingRow(user: { id: string; role: string }, meetingId: string, now: Date) {
+  // Same participation rule as notes and call tokens; missing and not-yours
+  // answer the same, so the id space stays opaque.
+  const accessible = await loadAccessibleMeeting(user, meetingId);
+  if (!accessible) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+  const row = await prisma.meeting.findUnique({
+    where: { id: meetingId },
+    select: { scheduledAt: true, seriesId: true, endedAt: true, meetLink: true },
+  });
+  if (!row) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  // A link-only meeting (no time) is never "in progress", and a future one is
+  // not endable — otherwise one click would silently cancel the announcement
+  // everyone else is still waiting for.
+  if (!row.scheduledAt || row.scheduledAt > now) {
+    return NextResponse.json({ error: 'Meeting has not started' }, { status: 409 });
+  }
+
+  if (!row.endedAt) {
+    await prisma.meeting.update({
+      where: { id: meetingId },
+      data: { endedAt: now, endedById: user.id },
+    });
+    // A relation-context meeting writes one row per invited relation, all
+    // sharing the (unguessable, per-event) room link — one participant ending
+    // it must hide every sibling row too, or the other invitees keep seeing a
+    // meeting that is over.
+    if (row.meetLink) {
+      await prisma.meeting.updateMany({
+        where: { meetLink: row.meetLink, scheduledAt: row.scheduledAt, endedAt: null },
+        data: { endedAt: now, endedById: user.id },
+      });
+    }
+    // Generated from a recurring rule → also mark the occurrence itself, so
+    // viewers who see the synthesized occurrence (not this row) lose it too.
+    if (row.seriesId) {
+      await prisma.meetingOccurrenceEnd.upsert({
+        where: { seriesId_occurrenceAt: { seriesId: row.seriesId, occurrenceAt: row.scheduledAt } },
+        update: {},
+        create: { seriesId: row.seriesId, occurrenceAt: row.scheduledAt, endedById: user.id },
+      });
+    }
+  }
+  return NextResponse.json({ ok: true });
+}
+
+async function endSeriesOccurrence(user: { id: string; role: string }, seriesId: string, iso: string, now: Date) {
+  const occurrenceAt = new Date(iso);
+  if (Number.isNaN(occurrenceAt.getTime())) {
+    return NextResponse.json({ error: 'Invalid occurrence' }, { status: 400 });
+  }
+
+  const series = await prisma.meetingSeries.findUnique({
+    where: { id: seriesId },
+    select: { id: true, projectId: true, createdById: true, daysOfWeek: true, timeOfDay: true, timeZone: true },
+  });
+  if (!series) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+  // Who counts as a participant mirrors who the banner shows it to
+  // (src/lib/upcomingMeeting.ts): project members, people whose active
+  // mentorship carries the project, the rule's creator, and admins.
+  let allowed = user.role === 'ADMIN' || series.createdById === user.id;
+  if (!allowed && series.projectId) {
+    const member = await prisma.projectMember.findUnique({
+      where: { projectId_userId: { projectId: series.projectId, userId: user.id } },
+      select: { id: true },
+    });
+    allowed = member !== null;
+    if (!allowed) {
+      const relation = await prisma.mentorshipRelation.findFirst({
+        where: {
+          projectId: series.projectId,
+          status: 'ACTIVE',
+          OR: [{ mentorId: user.id }, { menteeId: user.id }],
+        },
+        select: { id: true },
+      });
+      allowed = relation !== null;
+    }
+  }
+  if (!allowed) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+  // Endable = actually started, recently — and a real occurrence of the rule,
+  // not an arbitrary timestamp someone typed into the URL.
+  if (occurrenceAt > now || now.getTime() - occurrenceAt.getTime() > 24 * 60 * 60 * 1000) {
+    return NextResponse.json({ error: 'Meeting has not started' }, { status: 409 });
+  }
+  const minuteBefore = new Date(occurrenceAt.getTime() - 60 * 1000);
+  const minuteAfter = new Date(occurrenceAt.getTime() + 60 * 1000);
+  const real = seriesOccurrences(series.daysOfWeek, series.timeOfDay, minuteBefore, minuteAfter, series.timeZone).some(
+    (d) => d.getTime() === occurrenceAt.getTime()
+  );
+  if (!real) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+  await prisma.meetingOccurrenceEnd.upsert({
+    where: { seriesId_occurrenceAt: { seriesId, occurrenceAt } },
+    update: {},
+    create: { seriesId, occurrenceAt, endedById: user.id },
+  });
+  // If the reminder cron already materialized this occurrence as Meeting rows,
+  // mark those too — other members may be looking at the row, not the rule.
+  await prisma.meeting.updateMany({
+    where: { seriesId, scheduledAt: occurrenceAt, endedAt: null },
+    data: { endedAt: now, endedById: user.id },
+  });
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/webhooks/jaas/route.ts
+++ b/src/app/api/webhooks/jaas/route.ts
@@ -1,0 +1,147 @@
+import { NextResponse } from 'next/server';
+import { timingSafeEqual } from 'crypto';
+import { z } from 'zod';
+import type { Prisma } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+import { jaasConfig, JAAS_APP_ID_PREFIX } from '@/lib/jaas';
+
+// POST — event feed from the JaaS tenant (console → Webhooks). This is what
+// turns the dashboard banner's guess ("assumed to run 60 minutes") into real
+// information: who is actually in the room right now.
+//
+// Setup: in the JaaS console point a webhook at
+//   https://<host>/api/webhooks/jaas?secret=<JAAS_WEBHOOK_SECRET>
+// and subscribe to ROOM_CREATED, ROOM_DESTROYED, PARTICIPANT_JOINED and
+// PARTICIPANT_LEFT. Unset env = endpoint answers 404, exactly as if the
+// feature did not exist — local dev, CI and un-provisioned deployments.
+//
+// The state written here is display-only (MeetingRoomState → the banner's
+// "n in the call" line). It deliberately does NOT auto-end meetings: rooms are
+// created and destroyed whenever the last participant drops, including someone
+// popping in early and leaving, so "room destroyed" is not "meeting over" —
+// that call stays with the participants (POST /api/meetings/[id]/end).
+
+const schema = z.object({
+  eventType: z.string().min(1).max(64),
+  // "vpaas-magic-cookie-…/RoomName" — which tenant room the event is about.
+  fqn: z.string().max(400).optional(),
+  data: z.record(z.unknown()).optional(),
+});
+
+/** Everyone currently in a room; capped so a hostile feed can't grow a row unboundedly. */
+const MAX_PARTICIPANTS = 100;
+
+function secretOk(request: Request): { ok: boolean; configured: boolean } {
+  const expected = process.env.JAAS_WEBHOOK_SECRET?.trim();
+  if (!expected) return { ok: false, configured: false };
+  // The console offers no custom-header field on every plan, so the secret may
+  // ride in the URL instead; both spellings are ours, not JaaS-defined.
+  const got = request.headers.get('x-webhook-secret') || new URL(request.url).searchParams.get('secret') || '';
+  try {
+    return {
+      ok: got.length === expected.length && timingSafeEqual(Buffer.from(got), Buffer.from(expected)),
+      configured: true,
+    };
+  } catch {
+    return { ok: false, configured: true };
+  }
+}
+
+// The room name out of an fqn, with the same strictness as
+// parseJaasMeetingLink: only our own tenant's rooms get state rows.
+function roomFromFqn(fqn: string | undefined): string | null {
+  if (!fqn) return null;
+  const parts = fqn.split('/').filter(Boolean);
+  if (parts.length !== 2) return null;
+  const [appId, room] = parts;
+  if (!appId.startsWith(JAAS_APP_ID_PREFIX)) return null;
+  // When the signing config is present, a foreign tenant's events are noise.
+  const config = jaasConfig();
+  if (config && appId !== config.appId) return null;
+  if (!/^[A-Za-z0-9._-]{1,120}$/.test(room)) return null;
+  return room;
+}
+
+interface RoomParticipant {
+  id: string;
+  name: string;
+}
+
+function participantFrom(data: Record<string, unknown> | undefined): RoomParticipant | null {
+  if (!data) return null;
+  const id = [data.participantId, data.participantJid, data.id]
+    .map((v) => (typeof v === 'string' ? v.trim() : ''))
+    .find(Boolean);
+  if (!id) return null;
+  const name = typeof data.name === 'string' ? data.name.trim().slice(0, 120) : '';
+  return { id: id.slice(0, 200), name };
+}
+
+function asParticipants(raw: unknown): RoomParticipant[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(
+    (p): p is RoomParticipant =>
+      !!p && typeof p === 'object' && typeof (p as RoomParticipant).id === 'string'
+  );
+}
+
+export async function POST(request: Request) {
+  const secret = secretOk(request);
+  // Unconfigured = the endpoint does not exist; wrong secret = 401.
+  if (!secret.configured) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  if (!secret.ok) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const parsed = schema.safeParse(await request.json().catch(() => ({})));
+  if (!parsed.success) return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+
+  const room = roomFromFqn(parsed.data.fqn);
+  // Events we don't track (recordings, dial-in, …) and foreign rooms are
+  // acknowledged and dropped — a webhook that errors gets retried or disabled.
+  if (!room) return NextResponse.json({ ok: true, ignored: true });
+
+  switch (parsed.data.eventType) {
+    case 'ROOM_CREATED':
+      await prisma.meetingRoomState.upsert({
+        where: { room },
+        update: { active: true, participants: [] },
+        create: { room, active: true, participants: [] },
+      });
+      break;
+    case 'ROOM_DESTROYED':
+      await prisma.meetingRoomState.upsert({
+        where: { room },
+        update: { active: false, participants: [] },
+        create: { room, active: false, participants: [] },
+      });
+      break;
+    case 'PARTICIPANT_JOINED': {
+      const joined = participantFrom(parsed.data.data);
+      if (!joined) break;
+      const state = await prisma.meetingRoomState.findUnique({ where: { room }, select: { participants: true } });
+      const list = asParticipants(state?.participants).filter((p) => p.id !== joined.id);
+      list.push(joined);
+      await prisma.meetingRoomState.upsert({
+        where: { room },
+        update: { active: true, participants: list.slice(-MAX_PARTICIPANTS) as unknown as Prisma.InputJsonValue },
+        create: { room, active: true, participants: [joined] as unknown as Prisma.InputJsonValue },
+      });
+      break;
+    }
+    case 'PARTICIPANT_LEFT': {
+      const left = participantFrom(parsed.data.data);
+      if (!left) break;
+      const state = await prisma.meetingRoomState.findUnique({ where: { room }, select: { participants: true } });
+      if (!state) break;
+      const list = asParticipants(state.participants).filter((p) => p.id !== left.id);
+      await prisma.meetingRoomState.update({
+        where: { room },
+        data: { participants: list as unknown as Prisma.InputJsonValue },
+      });
+      break;
+    }
+    default:
+      return NextResponse.json({ ok: true, ignored: true });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/components/UpcomingMeetingBanner.tsx
+++ b/src/components/UpcomingMeetingBanner.tsx
@@ -1,20 +1,36 @@
 'use client';
 
-import { CalendarClock, Video } from 'lucide-react';
+import { useState } from 'react';
+import { CalendarClock, CheckCircle2, Users, Video } from 'lucide-react';
 import { useT, useLocale } from '@/i18n/client';
 import { formatDateTime } from '@/lib/relativeTime';
-import { useUpcomingMeeting } from '@/hooks/useUpcomingMeeting';
+import { endUpcomingMeeting, useUpcomingMeeting } from '@/hooks/useUpcomingMeeting';
 
 // The dashboard's "you have a meeting" strip (#51 follow-up): appears half an
 // hour before the start and stays for as long as the meeting is running, with the
 // join link right in it. Nothing is rendered when there is no such meeting, so the
 // dashboard is unchanged the rest of the time.
+//
+// While it is running, any participant can declare it over — the strip then
+// disappears for everyone instead of implying "still talking" for the rest of
+// the assumed hour. When the JaaS webhook feed is configured the strip also
+// shows who is actually in the room right now.
 export function UpcomingMeetingBanner() {
   const t = useT();
   const locale = useLocale();
   const { meeting } = useUpcomingMeeting();
+  const [ending, setEnding] = useState(false);
 
   if (!meeting) return null;
+
+  const markEnded = async () => {
+    // A one-click action that hides the banner for every participant deserves
+    // one explicit "are you sure" — there is no undo.
+    if (!window.confirm(t.upcomingMeeting.markEndedConfirm)) return;
+    setEnding(true);
+    await endUpcomingMeeting(meeting.id);
+    setEnding(false);
+  };
 
   const when = meeting.ongoing
     ? t.upcomingMeeting.inProgress
@@ -41,9 +57,30 @@ export function UpcomingMeetingBanner() {
             {meeting.projectName ? `${meeting.projectName} · ` : ''}
             {formatDateTime(meeting.startsAt, locale)}
           </p>
+          {meeting.live && meeting.live.count > 0 && (
+            <p
+              data-testid="upcoming-meeting-live"
+              className={`mt-0.5 flex items-center gap-1 text-sm ${meeting.ongoing ? 'text-green-700' : 'text-blue-700'}`}
+            >
+              <Users className="h-3.5 w-3.5 flex-shrink-0" />
+              {t.upcomingMeeting.liveParticipants.replace('{n}', String(meeting.live.count))}
+              {meeting.live.names.length > 0 ? `: ${meeting.live.names.join(', ')}` : ''}
+            </p>
+          )}
         </div>
       </div>
-      <div className="sm:ml-auto">
+      <div className="flex flex-col gap-2 sm:ml-auto sm:flex-row sm:items-center">
+        {meeting.ongoing && (
+          <button
+            type="button"
+            onClick={markEnded}
+            disabled={ending}
+            data-testid="upcoming-meeting-end"
+            className="inline-flex w-full items-center justify-center gap-1.5 rounded-lg border border-green-300 px-4 py-2 text-sm font-medium text-green-700 hover:bg-green-100 disabled:opacity-50 sm:w-auto dark:border-green-700 dark:hover:bg-green-900/40"
+          >
+            <CheckCircle2 className="h-4 w-4" /> {t.upcomingMeeting.markEnded}
+          </button>
+        )}
         {meeting.meetLink ? (
           <a
             href={meeting.meetLink}

--- a/src/hooks/useUpcomingMeeting.ts
+++ b/src/hooks/useUpcomingMeeting.ts
@@ -19,6 +19,8 @@ export interface UpcomingMeeting {
   minutesUntilStart: number;
   projectId: string | null;
   projectName: string | null;
+  /** Who is in the video room right now — null when unknown (no JaaS webhook feed). */
+  live: { count: number; names: string[] } | null;
 }
 
 const POLL_MS = 60_000;
@@ -44,6 +46,22 @@ async function refresh() {
   }
   loaded = true;
   subscribers.forEach((fn) => fn(current));
+}
+
+// "This meeting is over" — any participant may say so, and the banner then
+// disappears for *everyone* (the server hides it from the shared endpoint).
+// The local store refreshes immediately so the marker sees it vanish at once;
+// other participants pick it up on their next poll. Errors are swallowed: the
+// worst case is the banner living out its assumed window, exactly as before.
+export async function endUpcomingMeeting(id: string): Promise<boolean> {
+  try {
+    const res = await fetch(`/api/meetings/${encodeURIComponent(id)}/end`, { method: 'POST' });
+    if (!res.ok) return false;
+    await refresh();
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export function useUpcomingMeeting() {

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -1435,6 +1435,9 @@ const en = {
     join: 'Join',
     joinAria: 'Join the meeting',
     noLink: 'No meeting link — ask the organiser.',
+    markEnded: 'Meeting is over',
+    markEndedConfirm: 'Mark this meeting as over? The banner disappears for every participant.',
+    liveParticipants: '{n} in the call',
   },
   menteeOnboarding: {
     title: 'Onboarding',
@@ -4142,6 +4145,9 @@ const tr: Dict = {
     join: 'Katıl',
     joinAria: 'Toplantıya katıl',
     noLink: 'Toplantı linki yok — düzenleyene sor.',
+    markEnded: 'Toplantı bitti',
+    markEndedConfirm: 'Toplantı bitti olarak işaretlensin mi? Bu şerit tüm katılımcılar için kaybolur.',
+    liveParticipants: 'Görüşmede {n} kişi var',
   },
   menteeOnboarding: {
     title: 'Onboarding',
@@ -6845,6 +6851,9 @@ const de: Dict = {
     join: 'Teilnehmen',
     joinAria: 'Am Treffen teilnehmen',
     noLink: 'Kein Meeting-Link — frag die Organisatorin.',
+    markEnded: 'Treffen ist vorbei',
+    markEndedConfirm: 'Dieses Treffen als beendet markieren? Der Hinweis verschwindet für alle Teilnehmenden.',
+    liveParticipants: '{n} im Gespräch',
   },
   menteeOnboarding: {
     title: 'Onboarding',

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,24 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.82.0-beta',
+    date: '2026-08-19',
+    highlights: {
+      en: [
+        'Meeting over? Say so: while a meeting is running, any participant can mark it as over from the dashboard strip — it then disappears for everyone at once, instead of showing "in progress" for the rest of the assumed hour.',
+        'The meeting strip can now show who is really in the video call ("2 in the call: …") when the video tenant’s live feed is connected — real names, live, not a guess.',
+      ],
+      tr: [
+        'Toplantı bitti mi? Söyleyin: toplantı sürerken katılımcılardan herhangi biri panodaki şeritten toplantıyı bitti olarak işaretleyebilir — şerit varsayılan bir saatin geri kalanında "devam ediyor" göstermek yerine herkes için aynı anda kaybolur.',
+        'Toplantı şeridi, görüntülü görüşme kiracısının canlı akışı bağlıysa görüşmede gerçekten kimlerin olduğunu da gösterebiliyor ("Görüşmede 2 kişi var: …") — tahmin değil, gerçek isimlerle canlı bilgi.',
+      ],
+      de: [
+        'Treffen vorbei? Sag es: Während ein Treffen läuft, kann jede teilnehmende Person es über den Hinweis auf dem Dashboard als beendet markieren — der Hinweis verschwindet dann sofort für alle, statt für den Rest der angenommenen Stunde "läuft" anzuzeigen.',
+        'Der Meeting-Hinweis kann jetzt zeigen, wer wirklich im Videoanruf ist („2 im Gespräch: …“), wenn der Live-Feed des Video-Tenants angebunden ist — echte Namen, live, keine Vermutung.',
+      ],
+    },
+  },
+  {
     version: '0.81.0-beta',
     date: '2026-08-19',
     highlights: {

--- a/src/lib/upcomingMeeting.ts
+++ b/src/lib/upcomingMeeting.ts
@@ -1,5 +1,6 @@
 import { prisma } from '@/lib/prisma';
 import { parseDaysOfWeek, seriesOccurrences } from '@/lib/meetingSeriesOccurrences';
+import { parseJaasMeetingLink } from '@/lib/meetingLink';
 
 // "There is a meeting about to start / happening right now" (#51 follow-up).
 //
@@ -13,7 +14,8 @@ import { parseDaysOfWeek, seriesOccurrences } from '@/lib/meetingSeriesOccurrenc
 //      carrying that project.
 //
 // A meeting has no end time in the schema, so "still going" is a fixed window
-// after the start (MEETING_DURATION_MINUTES).
+// after the start (MEETING_DURATION_MINUTES) — unless a participant marked it
+// ended (Meeting.endedAt / MeetingOccurrenceEnd), which hides it for everyone.
 
 /** How long a meeting is assumed to run — the join link stays offered this long. */
 export const MEETING_DURATION_MINUTES = 60;
@@ -32,7 +34,14 @@ export interface UpcomingMeeting {
   minutesUntilStart: number;
   projectId: string | null;
   projectName: string | null;
+  /** Who is in the JaaS room right now — null when unknown (no webhook feed). */
+  live: { count: number; names: string[] } | null;
 }
+
+/** How long webhook-fed room state is trusted before it counts as stale — a
+ * series' fixedLink reuses one room across occurrences, so an `active` row from
+ * a missed ROOM_DESTROYED must not haunt next week's banner. */
+const ROOM_STATE_FRESH_MS = 3 * 60 * 60 * 1000;
 
 interface Candidate {
   id: string;
@@ -57,6 +66,8 @@ export async function getUpcomingMeeting(userId: string, now = new Date()): Prom
     prisma.meeting.findMany({
       where: {
         scheduledAt: { gte: windowStart, lte: windowEnd },
+        // Marked over by a participant — gone for everyone, not just the marker.
+        endedAt: null,
         // A Meeting row hangs off a relation, a project or a conversation (#1051);
         // whichever it is, the user is expected there if they are on that side of it.
         OR: [
@@ -115,9 +126,19 @@ export async function getUpcomingMeeting(userId: string, now = new Date()): Prom
         project: { select: { name: true } },
       },
     });
+    // Occurrence-level end marks: a synthesized occurrence has no Meeting row to
+    // carry `endedAt`, so its mark lives in its own table (same key shape as
+    // MeetingSeriesReminder). Ending a generated Meeting row writes both marks,
+    // so this one check covers every viewer's representation of the event.
+    const ends = await prisma.meetingOccurrenceEnd.findMany({
+      where: { seriesId: { in: series.map((s) => s.id) }, occurrenceAt: { gte: windowStart, lte: windowEnd } },
+      select: { seriesId: true, occurrenceAt: true },
+    });
+    const endedOccurrences = new Set(ends.map((e) => `${e.seriesId}:${e.occurrenceAt.toISOString()}`));
     for (const s of series) {
       if (parseDaysOfWeek(s.daysOfWeek).length === 0) continue;
       for (const when of seriesOccurrences(s.daysOfWeek, s.timeOfDay, windowStart, windowEnd, s.timeZone)) {
+        if (endedOccurrences.has(`${s.id}:${when.toISOString()}`)) continue;
         candidates.push({
           id: `${s.id}:${when.toISOString()}`,
           title: s.title,
@@ -165,5 +186,27 @@ export async function getUpcomingMeeting(userId: string, now = new Date()): Prom
     minutesUntilStart: Math.max(0, Math.ceil((startsAt.getTime() - now.getTime()) / 60000)),
     projectId: pick.projectId,
     projectName: pick.projectName,
+    live: await liveRoomState(pick.meetLink, now),
   };
+}
+
+// Who is in the meeting's JaaS room right now, per the webhook feed
+// (/api/webhooks/jaas). Null whenever nothing trustworthy is known — no JaaS
+// link, no webhook configured, room idle, or state stale — and the banner then
+// says nothing rather than guessing.
+async function liveRoomState(meetLink: string | null, now: Date): Promise<UpcomingMeeting['live']> {
+  const ref = parseJaasMeetingLink(meetLink);
+  if (!ref) return null;
+  const state = await prisma.meetingRoomState.findUnique({
+    where: { room: ref.room },
+    select: { active: true, participants: true, updatedAt: true },
+  });
+  if (!state?.active) return null;
+  if (now.getTime() - state.updatedAt.getTime() > ROOM_STATE_FRESH_MS) return null;
+  const list = Array.isArray(state.participants) ? state.participants : [];
+  const names = list
+    .map((p) => (p && typeof p === 'object' && 'name' in p && typeof p.name === 'string' ? p.name.trim() : ''))
+    .filter(Boolean);
+  // Count the anonymous too: an entry with no usable name is still a person.
+  return { count: list.length, names };
 }


### PR DESCRIPTION
## Summary

The dashboard's "meeting in progress" strip sits on an assumed 60-minute window, so it keeps saying **"Toplantı devam ediyor"** long after everyone hung up — which reads as "they're still talking". Now **any participant can declare the meeting over** from the banner, and it disappears **for every participant at once**; if nobody clicks, the old 60-minute window applies unchanged. On top of that, when the JaaS tenant's webhook feed is connected, the banner shows **who is actually in the call right now** ("Görüşmede 2 kişi var: …") — real names instead of a clock-based guess.

Closes #1259

## Changes

- **`POST /api/meetings/[id]/end`** — participant-only (same access rule as notes/call tokens; outsiders get an opaque 404), start-gated (a future meeting can't be hidden, 409), no undo. Fans out to sibling `Meeting` rows sharing the room link (relation-context meetings are one row per invitee), and covers synthesized recurring occurrences via `<seriesId>:<ISO>` composite ids — validated against the rule, marked in the new `MeetingOccurrenceEnd` table.
- **`getUpcomingMeeting`** excludes ended meetings/occurrences server-side, so the shared endpoint hides them from everyone (banner *and* header join pill).
- **Banner UI**: "Toplantı bitti" button while ongoing (confirm dialog) + live participant line; EN/TR/DE strings.
- **`/api/webhooks/jaas`** (new, optional): enabled by `JAAS_WEBHOOK_SECRET` (unset = 404, feature off — dev/CI default); timing-safe secret via header or `?secret=`; ingests ROOM_CREATED/DESTROYED, PARTICIPANT_JOINED/LEFT into `MeetingRoomState`. Display-only — room lifecycle never auto-ends a meeting (rooms die whenever the last person drops, incl. someone popping in early), and a freshness window guards against stale state on series `fixedLink` rooms.
- **Schema** (additive `db push`): `Meeting.endedAt`/`endedById`, `MeetingOccurrenceEnd`, `MeetingRoomState`.
- **Versioning**: `0.82.0-beta` + CHANGELOG + release notes (EN/TR/DE). (Originally `0.81.0-beta`; renumbered during the rebase because `main` took 0.81.0 with #1256/#1257 while this PR was open.)

To turn the live feed on in prod: set `JAAS_WEBHOOK_SECRET` and point a JaaS console webhook at `https://crm.ersah.in/api/webhooks/jaas?secret=<value>` with the four room/participant events (see `.env.example`).

## Verification

- [x] `npm run lint` + `npx tsc --noEmit` clean
- [x] `npm run test:e2e` passing (or CI green) — new `e2e/meeting-end.spec.ts` 6/6 locally (end flow tagged `@smoke`, no-start 409, sibling fanout, composite occurrence ids, outsider 404, webhook feed end-to-end incl. wrong-secret 401), plus `upcoming-meeting.spec.ts` regression 4/4 against a local MariaDB; re-validated after the 0.82.0 rebase (6/6, i18n 2725 keys OK, tsc/lint clean)
- [x] Tested the change manually / added an e2e test

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BtJKB9d4jjwKuz5CZMbe73