### PR TITLE
feat: add mentor assignment capacity warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.81.0-beta] - 2026-08-19
+
+### Added
+- **Mentor capacity/availability warnings on assignment** (#942). Building on #941's
+  `getMentorAvailability()`, the three places an admin puts a mentee with a mentor now
+  surface the mentor's current load and ask for confirmation before assigning one who's
+  full or not currently accepting new mentees: direct assignment (`POST /api/mentorship`,
+  used by `AssignMentorInline` on `/admin/candidates` and the assign form on
+  `/admin/mentorship`), approving a mentee's mentorship request
+  (`PUT /api/admin/mentorship-requests`), and pre-linking a mentor on an invite
+  (`POST /api/invite`, `/admin/invite`). Advisory only — capacity/availability never
+  blocks an assignment, only the existing plan-relation limit does; a full or paused
+  mentor stays selectable everywhere, never hidden or disabled. `GET
+  /api/users?view=mentorAvailability` is the new shared picker source (batched active-
+  mentee counts, no N+1), and `formatMentorAvailability()`
+  (`src/lib/mentorAvailabilityLabel.ts`) renders the same "3 / 4 · Available" label in
+  all four pickers. E2E coverage: `mentor-assign-confirm`, `mentorship-request-approve-
+  confirm`, `invite-mentor-confirm`, `mentor-picker-availability`, and extensions to
+  `mentorship-direct-assign`, `mentorship-request` and `invitations`.
+
 ## [0.80.1-beta] - 2026-08-19
 
 ### Fixed

--- a/e2e/invitations.spec.ts
+++ b/e2e/invitations.spec.ts
@@ -44,3 +44,124 @@ test('invitations persist, can be resent and cancelled', async ({ page }) => {
     await cleanupByEmail(adminEmail);
   }
 });
+
+// #942: a MENTEE invite may pre-link a mentor (`mentorId`) — advisory only,
+// mirrors POST /api/mentorship and the request-approval endpoint's use of
+// getMentorAvailability(). Never blocks: the invitation is created either way.
+test('inviting a mentee with an at-capacity mentor pre-linked still creates the invite, with a mentor_at_capacity warning', async ({ page }) => {
+  const adminEmail = uniqueEmail('inv-cap-admin');
+  await seedUser(adminEmail, 'AdminPass123', 'ADMIN', 'Inv Cap Admin');
+  const mentor = await seedUser(uniqueEmail('inv-cap-mentor'), 'x', 'MENTOR', 'Inv Cap Mentor');
+  const existingMentee = await seedUser(uniqueEmail('inv-cap-existing-mentee'), 'x', 'MENTEE', 'Inv Cap Existing Mentee');
+  await prisma.user.update({ where: { id: mentor.id }, data: { mentorCapacity: 1 } });
+  await prisma.mentorshipRelation.create({
+    data: { mentorId: mentor.id, menteeId: existingMentee.id, orgId: existingMentee.orgId, status: 'ACTIVE', startDate: new Date() },
+  });
+  const inviteeEmail = uniqueEmail('inv-cap-invitee');
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', 'AdminPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    const sent = await page.request.post('/api/invite', {
+      data: { email: inviteeEmail, role: 'MENTEE', mentorId: mentor.id },
+    });
+    expect(sent.status()).toBe(201);
+    const body = await sent.json();
+    expect(body.warnings).toEqual(['mentor_at_capacity']);
+
+    const token = await prisma.invitationToken.findFirst({ where: { email: inviteeEmail } });
+    expect(token?.mentorId).toBe(mentor.id);
+  } finally {
+    await prisma.invitationToken.deleteMany({ where: { email: inviteeEmail } });
+    await prisma.mentorshipRelation.deleteMany({ where: { mentorId: mentor.id } });
+    await cleanupByEmail(mentor.email);
+    await cleanupByEmail(existingMentee.email);
+    await cleanupByEmail(adminEmail);
+  }
+});
+
+test('inviting a mentee with a not-accepting mentor pre-linked still creates the invite, with a mentor_not_accepting warning', async ({ page }) => {
+  const adminEmail = uniqueEmail('inv-acc-admin');
+  await seedUser(adminEmail, 'AdminPass123', 'ADMIN', 'Inv Acc Admin');
+  const mentor = await seedUser(uniqueEmail('inv-acc-mentor'), 'x', 'MENTOR', 'Inv Acc Mentor');
+  await prisma.user.update({ where: { id: mentor.id }, data: { mentorCapacity: 10, acceptingMentees: false } });
+  const inviteeEmail = uniqueEmail('inv-acc-invitee');
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', 'AdminPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    const sent = await page.request.post('/api/invite', {
+      data: { email: inviteeEmail, role: 'MENTEE', mentorId: mentor.id },
+    });
+    expect(sent.status()).toBe(201);
+    const body = await sent.json();
+    expect(body.warnings).toEqual(['mentor_not_accepting']);
+
+    const token = await prisma.invitationToken.findFirst({ where: { email: inviteeEmail } });
+    expect(token?.mentorId).toBe(mentor.id);
+  } finally {
+    await prisma.invitationToken.deleteMany({ where: { email: inviteeEmail } });
+    await cleanupByEmail(mentor.email);
+    await cleanupByEmail(adminEmail);
+  }
+});
+
+test('inviting a mentee with an available mentor pre-linked creates the invite with no warnings', async ({ page }) => {
+  const adminEmail = uniqueEmail('inv-avail-admin');
+  await seedUser(adminEmail, 'AdminPass123', 'ADMIN', 'Inv Avail Admin');
+  const mentor = await seedUser(uniqueEmail('inv-avail-mentor'), 'x', 'MENTOR', 'Inv Avail Mentor');
+  await prisma.user.update({ where: { id: mentor.id }, data: { mentorCapacity: 5, acceptingMentees: true } });
+  const inviteeEmail = uniqueEmail('inv-avail-invitee');
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', 'AdminPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    const sent = await page.request.post('/api/invite', {
+      data: { email: inviteeEmail, role: 'MENTEE', mentorId: mentor.id },
+    });
+    expect(sent.status()).toBe(201);
+    const body = await sent.json();
+    expect(body.warnings).toEqual([]);
+
+    const token = await prisma.invitationToken.findFirst({ where: { email: inviteeEmail } });
+    expect(token?.mentorId).toBe(mentor.id);
+  } finally {
+    await prisma.invitationToken.deleteMany({ where: { email: inviteeEmail } });
+    await cleanupByEmail(mentor.email);
+    await cleanupByEmail(adminEmail);
+  }
+});
+
+test('inviting without a mentor pre-linked creates the invite with no warnings', async ({ page }) => {
+  const adminEmail = uniqueEmail('inv-none-admin');
+  await seedUser(adminEmail, 'AdminPass123', 'ADMIN', 'Inv None Admin');
+  const inviteeEmail = uniqueEmail('inv-none-invitee');
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', 'AdminPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    const sent = await page.request.post('/api/invite', { data: { email: inviteeEmail, role: 'MENTOR' } });
+    expect(sent.status()).toBe(201);
+    const body = await sent.json();
+    expect(body.warnings).toEqual([]);
+  } finally {
+    await prisma.invitationToken.deleteMany({ where: { email: inviteeEmail } });
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/e2e/invite-mentor-confirm.spec.ts
+++ b/e2e/invite-mentor-confirm.spec.ts
@@ -1,0 +1,146 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { acceptConfirmDialog, cancelConfirmDialog, confirmDialog } from './helpers/confirm';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// #942: /admin/invite's "connect to this mentor" picker (a MENTEE invite may
+// pre-link a mentor — the mentorship is created the moment the invitee
+// registers, see register/route.ts) must ask for confirmation before sending
+// an invite that pre-links a mentor whose availability.status is
+// at_capacity/not_accepting — same gate, same ConfirmDialog copy as the
+// direct-assignment and request-approval flows. An available mentor skips
+// the dialog, and cancelling must never send the POST.
+
+async function signInAsAdmin(page: import('@playwright/test').Page, email: string, pw: string) {
+  await page.goto('/auth/signin');
+  await page.fill('input[type="email"], input[name="email"]', email);
+  await page.fill('input[type="password"]', pw);
+  await page.click('button[type="submit"]');
+  await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+}
+
+test('inviting a mentee with an available mentor pre-linked skips the dialog and sends directly', async ({ page }) => {
+  const adminEmail = uniqueEmail('imc-avail-admin');
+  const mentorEmail = uniqueEmail('imc-avail-mentor');
+  const inviteeEmail = uniqueEmail('imc-avail-invitee');
+  const pw = 'InvitePass123';
+  await seedUser(adminEmail, pw, 'ADMIN', 'IMC Avail Admin');
+  const mentor = await seedUser(mentorEmail, pw, 'MENTOR', 'IMC Avail Mentor');
+  await prisma.user.update({ where: { id: mentor.id }, data: { mentorCapacity: 5, acceptingMentees: true } });
+
+  try {
+    await signInAsAdmin(page, adminEmail, pw);
+    await page.goto('/admin/invite');
+
+    await page.fill('input[type="email"]', inviteeEmail);
+    await page.getByLabel('Connect to this mentor (optional)').selectOption(mentor.id);
+
+    const postRequest = page.waitForRequest((r) => r.method() === 'POST' && r.url().includes('/api/invite'), { timeout: 10_000 });
+    await page.getByRole('button', { name: 'Send Invitation' }).click();
+    await postRequest;
+    await expect(confirmDialog(page)).toHaveCount(0);
+
+    await expect(async () => {
+      const token = await prisma.invitationToken.findFirst({ where: { email: inviteeEmail } });
+      expect(token).toBeTruthy();
+      expect(token?.mentorId).toBe(mentor.id);
+    }).toPass({ timeout: 10_000 });
+  } finally {
+    await prisma.invitationToken.deleteMany({ where: { email: inviteeEmail } });
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});
+
+test('inviting a mentee with an at-capacity mentor pre-linked asks for confirmation; cancel sends no request, confirm sends the invite', async ({ page }) => {
+  const adminEmail = uniqueEmail('imc-cap-admin');
+  const mentorEmail = uniqueEmail('imc-cap-mentor');
+  const existingMenteeEmail = uniqueEmail('imc-cap-existing-mentee');
+  const inviteeEmail = uniqueEmail('imc-cap-invitee');
+  const pw = 'InvitePass123';
+  await seedUser(adminEmail, pw, 'ADMIN', 'IMC Cap Admin');
+  const mentor = await seedUser(mentorEmail, pw, 'MENTOR', 'IMC Cap Mentor');
+  const existingMentee = await seedUser(existingMenteeEmail, pw, 'MENTEE', 'IMC Cap Existing Mentee');
+  await prisma.user.update({ where: { id: mentor.id }, data: { mentorCapacity: 1 } });
+  await prisma.mentorshipRelation.create({
+    data: { mentorId: mentor.id, menteeId: existingMentee.id, orgId: existingMentee.orgId, status: 'ACTIVE', startDate: new Date() },
+  });
+
+  try {
+    await signInAsAdmin(page, adminEmail, pw);
+    await page.goto('/admin/invite');
+
+    await page.fill('input[type="email"]', inviteeEmail);
+    await page.getByLabel('Connect to this mentor (optional)').selectOption(mentor.id);
+
+    // Cancel: the dialog opens but no POST leaves the page, and no invitation
+    // token is created.
+    const noRequestYet = page
+      .waitForRequest((r) => r.method() === 'POST' && r.url().includes('/api/invite'), { timeout: 2_000 })
+      .catch(() => null);
+    await page.getByRole('button', { name: 'Send Invitation' }).click();
+    await expect(confirmDialog(page)).toBeVisible();
+    await expect(page.locator('#confirm-dialog-message')).toContainText('capacity');
+    expect(await noRequestYet).toBeNull();
+    await cancelConfirmDialog(page);
+    expect(await prisma.invitationToken.findFirst({ where: { email: inviteeEmail } })).toBeNull();
+    // The form's selections survived the cancel.
+    await expect(page.locator('input[type="email"]')).toHaveValue(inviteeEmail);
+    await expect(page.getByLabel('Connect to this mentor (optional)')).toHaveValue(mentor.id);
+
+    // Confirm: the same POST now runs and the invitation is created.
+    const postRequest = page.waitForRequest((r) => r.method() === 'POST' && r.url().includes('/api/invite'), { timeout: 10_000 });
+    await page.getByRole('button', { name: 'Send Invitation' }).click();
+    await acceptConfirmDialog(page);
+    await postRequest;
+
+    await expect(async () => {
+      const token = await prisma.invitationToken.findFirst({ where: { email: inviteeEmail } });
+      expect(token).toBeTruthy();
+      expect(token?.mentorId).toBe(mentor.id);
+    }).toPass({ timeout: 10_000 });
+  } finally {
+    await prisma.invitationToken.deleteMany({ where: { email: inviteeEmail } });
+    await cleanupByEmail(existingMenteeEmail);
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});
+
+test('inviting a mentee with a not-accepting mentor pre-linked asks for confirmation and sends the invite on confirm', async ({ page }) => {
+  const adminEmail = uniqueEmail('imc-acc-admin');
+  const mentorEmail = uniqueEmail('imc-acc-mentor');
+  const inviteeEmail = uniqueEmail('imc-acc-invitee');
+  const pw = 'InvitePass123';
+  await seedUser(adminEmail, pw, 'ADMIN', 'IMC Acc Admin');
+  const mentor = await seedUser(mentorEmail, pw, 'MENTOR', 'IMC Acc Mentor');
+  await prisma.user.update({ where: { id: mentor.id }, data: { mentorCapacity: 10, acceptingMentees: false } });
+
+  try {
+    await signInAsAdmin(page, adminEmail, pw);
+    await page.goto('/admin/invite');
+
+    await page.fill('input[type="email"]', inviteeEmail);
+    await page.getByLabel('Connect to this mentor (optional)').selectOption(mentor.id);
+
+    const postRequest = page.waitForRequest((r) => r.method() === 'POST' && r.url().includes('/api/invite'), { timeout: 10_000 });
+    await page.getByRole('button', { name: 'Send Invitation' }).click();
+    await expect(confirmDialog(page)).toBeVisible();
+    await expect(page.locator('#confirm-dialog-message')).toContainText('not accepting');
+    await acceptConfirmDialog(page);
+    await postRequest;
+
+    await expect(async () => {
+      const token = await prisma.invitationToken.findFirst({ where: { email: inviteeEmail } });
+      expect(token).toBeTruthy();
+      expect(token?.mentorId).toBe(mentor.id);
+    }).toPass({ timeout: 10_000 });
+  } finally {
+    await prisma.invitationToken.deleteMany({ where: { email: inviteeEmail } });
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/e2e/mentor-assign-confirm.spec.ts
+++ b/e2e/mentor-assign-confirm.spec.ts
@@ -1,0 +1,200 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { acceptConfirmDialog, cancelConfirmDialog, confirmDialog } from './helpers/confirm';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// #942: the two direct admin assignment flows — the inline picker on
+// /admin/candidates (AssignMentorInline.tsx) and the assign form on
+// /admin/mentorship — must ask for confirmation before assigning a mentor
+// whose availability.status (from GET /api/users?view=mentorAvailability) is
+// at_capacity or not_accepting. An available mentor skips the dialog
+// entirely, and cancelling must never send the POST.
+
+async function signInAsAdmin(page: import('@playwright/test').Page, email: string, pw: string) {
+  await page.goto('/auth/signin');
+  await page.fill('input[type="email"], input[name="email"]', email);
+  await page.fill('input[type="password"]', pw);
+  await page.click('button[type="submit"]');
+  await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+}
+
+test('assigning an available mentor from the candidates picker skips the dialog and assigns directly', async ({ page }) => {
+  const adminEmail = uniqueEmail('mac-avail-admin');
+  const mentorEmail = uniqueEmail('mac-avail-mentor');
+  const menteeEmail = uniqueEmail('mac-avail-mentee');
+  const pw = 'AssignPass123';
+  await seedUser(adminEmail, pw, 'ADMIN', 'MAC Avail Admin');
+  const mentor = await seedUser(mentorEmail, pw, 'MENTOR', 'MAC Avail Mentor');
+  const mentee = await seedUser(menteeEmail, pw, 'MENTEE', 'MAC Avail Mentee');
+  await prisma.user.update({ where: { id: mentor.id }, data: { mentorCapacity: 5, acceptingMentees: true } });
+
+  try {
+    await signInAsAdmin(page, adminEmail, pw);
+    await page.goto('/admin/candidates');
+    const card = page.getByTestId(`candidate-card-${mentee.id}`);
+    await expect(card).toBeVisible({ timeout: 10_000 });
+
+    const postRequest = page.waitForRequest((r) => r.method() === 'POST' && r.url().includes('/api/mentorship'), { timeout: 10_000 });
+    await card.locator('select').selectOption(mentor.id);
+    await card.getByRole('button', { name: 'Assign', exact: true }).click();
+    await postRequest;
+    await expect(confirmDialog(page)).toHaveCount(0);
+
+    await expect(async () => {
+      const relation = await prisma.mentorshipRelation.findFirst({ where: { mentorId: mentor.id, menteeId: mentee.id } });
+      expect(relation).toBeTruthy();
+    }).toPass({ timeout: 10_000 });
+  } finally {
+    await prisma.mentorshipRelation.deleteMany({ where: { mentorId: mentor.id, menteeId: mentee.id } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});
+
+test('assigning an at-capacity mentor from the candidates picker asks for confirmation; cancel sends no request, confirm assigns', async ({ page }) => {
+  const adminEmail = uniqueEmail('mac-cap-admin');
+  const mentorEmail = uniqueEmail('mac-cap-mentor');
+  const existingMenteeEmail = uniqueEmail('mac-cap-existing-mentee');
+  const newMenteeEmail = uniqueEmail('mac-cap-new-mentee');
+  const pw = 'AssignPass123';
+  await seedUser(adminEmail, pw, 'ADMIN', 'MAC Cap Admin');
+  const mentor = await seedUser(mentorEmail, pw, 'MENTOR', 'MAC Cap Mentor');
+  const existingMentee = await seedUser(existingMenteeEmail, pw, 'MENTEE', 'MAC Cap Existing Mentee');
+  const newMentee = await seedUser(newMenteeEmail, pw, 'MENTEE', 'MAC Cap New Mentee');
+  await prisma.user.update({ where: { id: mentor.id }, data: { mentorCapacity: 1 } });
+  await prisma.mentorshipRelation.create({
+    data: { mentorId: mentor.id, menteeId: existingMentee.id, orgId: existingMentee.orgId, status: 'ACTIVE', startDate: new Date() },
+  });
+
+  try {
+    await signInAsAdmin(page, adminEmail, pw);
+    await page.goto('/admin/candidates');
+    const card = page.getByTestId(`candidate-card-${newMentee.id}`);
+    await expect(card).toBeVisible({ timeout: 10_000 });
+    await card.locator('select').selectOption(mentor.id);
+
+    // Cancel: the dialog opens but no POST leaves the page, and the relation
+    // is never created.
+    const noRequestYet = page
+      .waitForRequest((r) => r.method() === 'POST' && r.url().includes('/api/mentorship'), { timeout: 2_000 })
+      .catch(() => null);
+    await card.getByRole('button', { name: 'Assign', exact: true }).click();
+    await expect(confirmDialog(page)).toBeVisible();
+    await expect(page.locator('#confirm-dialog-message')).toContainText('capacity');
+    expect(await noRequestYet).toBeNull();
+    await cancelConfirmDialog(page);
+    const afterCancel = await prisma.mentorshipRelation.findFirst({ where: { mentorId: mentor.id, menteeId: newMentee.id } });
+    expect(afterCancel).toBeNull();
+
+    // Confirm: the same POST now runs and the relation is created.
+    const postRequest = page.waitForRequest((r) => r.method() === 'POST' && r.url().includes('/api/mentorship'), { timeout: 10_000 });
+    await card.getByRole('button', { name: 'Assign', exact: true }).click();
+    await acceptConfirmDialog(page);
+    await postRequest;
+
+    await expect(async () => {
+      const relation = await prisma.mentorshipRelation.findFirst({ where: { mentorId: mentor.id, menteeId: newMentee.id } });
+      expect(relation).toBeTruthy();
+    }).toPass({ timeout: 10_000 });
+  } finally {
+    await prisma.mentorshipRelation.deleteMany({ where: { mentorId: mentor.id } });
+    await cleanupByEmail(newMenteeEmail);
+    await cleanupByEmail(existingMenteeEmail);
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});
+
+test('assigning a not-accepting mentor from the candidates picker asks for confirmation and assigns on confirm', async ({ page }) => {
+  const adminEmail = uniqueEmail('mac-acc-admin');
+  const mentorEmail = uniqueEmail('mac-acc-mentor');
+  const menteeEmail = uniqueEmail('mac-acc-mentee');
+  const pw = 'AssignPass123';
+  await seedUser(adminEmail, pw, 'ADMIN', 'MAC Acc Admin');
+  const mentor = await seedUser(mentorEmail, pw, 'MENTOR', 'MAC Acc Mentor');
+  const mentee = await seedUser(menteeEmail, pw, 'MENTEE', 'MAC Acc Mentee');
+  await prisma.user.update({ where: { id: mentor.id }, data: { mentorCapacity: 10, acceptingMentees: false } });
+
+  try {
+    await signInAsAdmin(page, adminEmail, pw);
+    await page.goto('/admin/candidates');
+    const card = page.getByTestId(`candidate-card-${mentee.id}`);
+    await expect(card).toBeVisible({ timeout: 10_000 });
+    await card.locator('select').selectOption(mentor.id);
+
+    const postRequest = page.waitForRequest((r) => r.method() === 'POST' && r.url().includes('/api/mentorship'), { timeout: 10_000 });
+    await card.getByRole('button', { name: 'Assign', exact: true }).click();
+    await expect(confirmDialog(page)).toBeVisible();
+    await expect(page.locator('#confirm-dialog-message')).toContainText('not accepting');
+    await acceptConfirmDialog(page);
+    await postRequest;
+
+    await expect(async () => {
+      const relation = await prisma.mentorshipRelation.findFirst({ where: { mentorId: mentor.id, menteeId: mentee.id } });
+      expect(relation).toBeTruthy();
+    }).toPass({ timeout: 10_000 });
+  } finally {
+    await prisma.mentorshipRelation.deleteMany({ where: { mentorId: mentor.id, menteeId: mentee.id } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});
+
+test('the /admin/mentorship assign form asks for confirmation before assigning an at-capacity mentor', async ({ page }) => {
+  const adminEmail = uniqueEmail('mac-form-admin');
+  const mentorEmail = uniqueEmail('mac-form-mentor');
+  const existingMenteeEmail = uniqueEmail('mac-form-existing-mentee');
+  const newMenteeEmail = uniqueEmail('mac-form-new-mentee');
+  const pw = 'AssignPass123';
+  await seedUser(adminEmail, pw, 'ADMIN', 'MAC Form Admin');
+  const mentor = await seedUser(mentorEmail, pw, 'MENTOR', 'MAC Form Mentor');
+  const existingMentee = await seedUser(existingMenteeEmail, pw, 'MENTEE', 'MAC Form Existing Mentee');
+  const newMentee = await seedUser(newMenteeEmail, pw, 'MENTEE', 'MAC Form New Mentee');
+  await prisma.user.update({ where: { id: mentor.id }, data: { mentorCapacity: 1 } });
+  await prisma.mentorshipRelation.create({
+    data: { mentorId: mentor.id, menteeId: existingMentee.id, orgId: existingMentee.orgId, status: 'ACTIVE', startDate: new Date() },
+  });
+
+  try {
+    await signInAsAdmin(page, adminEmail, pw);
+    await page.goto('/admin/mentorship');
+    await page.getByRole('button', { name: 'Assign mentorship' }).click();
+
+    await page.getByLabel('Mentor').selectOption(mentor.id);
+    await page.getByLabel('Mentee').selectOption(newMentee.id);
+
+    // Cancel first: no request, mentorship modal stays open, relation not created.
+    const noRequestYet = page
+      .waitForRequest((r) => r.method() === 'POST' && r.url().includes('/api/mentorship'), { timeout: 2_000 })
+      .catch(() => null);
+    await page.getByRole('button', { name: 'Assign', exact: true }).click();
+    await expect(confirmDialog(page)).toBeVisible();
+    expect(await noRequestYet).toBeNull();
+    await cancelConfirmDialog(page);
+    const afterCancel = await prisma.mentorshipRelation.findFirst({ where: { mentorId: mentor.id, menteeId: newMentee.id } });
+    expect(afterCancel).toBeNull();
+    // The underlying assign form is still open and the selection survived.
+    await expect(page.getByLabel('Mentor')).toHaveValue(mentor.id);
+
+    const postRequest = page.waitForRequest((r) => r.method() === 'POST' && r.url().includes('/api/mentorship'), { timeout: 10_000 });
+    await page.getByRole('button', { name: 'Assign', exact: true }).click();
+    await acceptConfirmDialog(page);
+    await postRequest;
+
+    await expect(async () => {
+      const relation = await prisma.mentorshipRelation.findFirst({ where: { mentorId: mentor.id, menteeId: newMentee.id } });
+      expect(relation).toBeTruthy();
+    }).toPass({ timeout: 10_000 });
+  } finally {
+    await prisma.mentorshipRelation.deleteMany({ where: { mentorId: mentor.id } });
+    await cleanupByEmail(newMenteeEmail);
+    await cleanupByEmail(existingMenteeEmail);
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/e2e/mentor-picker-availability.spec.ts
+++ b/e2e/mentor-picker-availability.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// #942: GET /api/users?view=mentorAvailability feeds the two admin mentor
+// pickers (AssignMentorInline, /admin/mentorship's assign form). A mentor at
+// capacity or with acceptingMentees=false must still be returned — never
+// dropped from the list — with correct activeMenteeCount/availability so the
+// UI can label (not block) the option. See src/lib/mentorAvailability.ts.
+test('mentor availability picker view returns at-capacity, not-accepting and available mentors alike', async ({ page }) => {
+  const adminEmail = uniqueEmail('mpa-admin');
+  const fullMentorEmail = uniqueEmail('mpa-full-mentor');
+  const pausedMentorEmail = uniqueEmail('mpa-paused-mentor');
+  const openMentorEmail = uniqueEmail('mpa-open-mentor');
+  const existingMenteeEmail = uniqueEmail('mpa-existing-mentee');
+  const pw = 'AssignPass123';
+
+  await seedUser(adminEmail, pw, 'ADMIN', 'MPA Admin');
+  const fullMentor = await seedUser(fullMentorEmail, pw, 'MENTOR', 'MPA Full Mentor');
+  const pausedMentor = await seedUser(pausedMentorEmail, pw, 'MENTOR', 'MPA Paused Mentor');
+  const openMentor = await seedUser(openMentorEmail, pw, 'MENTOR', 'MPA Open Mentor');
+  const existingMentee = await seedUser(existingMenteeEmail, pw, 'MENTEE', 'MPA Existing Mentee');
+
+  await prisma.user.update({ where: { id: fullMentor.id }, data: { mentorCapacity: 1 } });
+  await prisma.mentorshipRelation.create({
+    data: { mentorId: fullMentor.id, menteeId: existingMentee.id, orgId: existingMentee.orgId, status: 'ACTIVE', startDate: new Date() },
+  });
+  await prisma.user.update({ where: { id: pausedMentor.id }, data: { mentorCapacity: 10, acceptingMentees: false } });
+  await prisma.user.update({ where: { id: openMentor.id }, data: { mentorCapacity: 5, acceptingMentees: true } });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', pw);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    const res = await page.request.get('/api/users?view=mentorAvailability');
+    expect(res.ok()).toBeTruthy();
+    const body = await res.json();
+    type Row = { id: string; activeMenteeCount: number; availability: { status: string; capacityKnown: boolean } };
+    const byId = new Map((body.users as Row[]).map((u) => [u.id, u]));
+
+    const full = byId.get(fullMentor.id);
+    expect(full).toBeTruthy();
+    expect(full!.activeMenteeCount).toBe(1);
+    expect(full!.availability.status).toBe('at_capacity');
+    expect(full!.availability.capacityKnown).toBe(true);
+
+    const paused = byId.get(pausedMentor.id);
+    expect(paused).toBeTruthy();
+    expect(paused!.activeMenteeCount).toBe(0);
+    expect(paused!.availability.status).toBe('not_accepting');
+
+    const open = byId.get(openMentor.id);
+    expect(open).toBeTruthy();
+    expect(open!.activeMenteeCount).toBe(0);
+    expect(open!.availability.status).toBe('available');
+  } finally {
+    await prisma.mentorshipRelation.deleteMany({ where: { mentorId: fullMentor.id } });
+    await cleanupByEmail(existingMenteeEmail);
+    await cleanupByEmail(openMentorEmail);
+    await cleanupByEmail(pausedMentorEmail);
+    await cleanupByEmail(fullMentorEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/e2e/mentorship-direct-assign.spec.ts
+++ b/e2e/mentorship-direct-assign.spec.ts
@@ -52,3 +52,125 @@ test('admin directly assigns a mentor to a mentee and both are notified in-app',
     await cleanupByEmail(adminEmail);
   }
 });
+
+// #942: the assignment still goes through when the mentor is over/at capacity
+// or has switched acceptingMentees off — these are advisory warnings on the
+// 201 response, never a block. See src/lib/mentorAvailability.ts.
+test('assigning a mentor already at capacity still succeeds, with a mentor_at_capacity warning', async ({ page }) => {
+  const adminEmail = uniqueEmail('cap-admin');
+  const mentorEmail = uniqueEmail('cap-mentor');
+  const existingMenteeEmail = uniqueEmail('cap-existing-mentee');
+  const newMenteeEmail = uniqueEmail('cap-new-mentee');
+  const pw = 'AssignPass123';
+  await seedUser(adminEmail, pw, 'ADMIN', 'Cap Admin');
+  const mentor = await seedUser(mentorEmail, pw, 'MENTOR', 'Cap Mentor');
+  const existingMentee = await seedUser(existingMenteeEmail, pw, 'MENTEE', 'Cap Existing Mentee');
+  const newMentee = await seedUser(newMenteeEmail, pw, 'MENTEE', 'Cap New Mentee');
+
+  // Capacity of 1, already filled by one ACTIVE relation.
+  await prisma.user.update({ where: { id: mentor.id }, data: { mentorCapacity: 1 } });
+  await prisma.mentorshipRelation.create({
+    data: { mentorId: mentor.id, menteeId: existingMentee.id, orgId: existingMentee.orgId, status: 'ACTIVE', startDate: new Date() },
+  });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', pw);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    const res = await page.request.post('/api/mentorship', {
+      data: { mentorId: mentor.id, menteeId: newMentee.id },
+    });
+    expect(res.status()).toBe(201);
+    const body = await res.json();
+    expect(body.warnings).toEqual(['mentor_at_capacity']);
+
+    const relation = await prisma.mentorshipRelation.findFirst({
+      where: { mentorId: mentor.id, menteeId: newMentee.id },
+    });
+    expect(relation).toBeTruthy();
+  } finally {
+    await prisma.mentorshipRelation.deleteMany({ where: { mentorId: mentor.id } });
+    await cleanupByEmail(newMenteeEmail);
+    await cleanupByEmail(existingMenteeEmail);
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});
+
+test('assigning a mentor with acceptingMentees=false still succeeds, with a mentor_not_accepting warning', async ({ page }) => {
+  const adminEmail = uniqueEmail('acc-admin');
+  const mentorEmail = uniqueEmail('acc-mentor');
+  const menteeEmail = uniqueEmail('acc-mentee');
+  const pw = 'AssignPass123';
+  await seedUser(adminEmail, pw, 'ADMIN', 'Acc Admin');
+  const mentor = await seedUser(mentorEmail, pw, 'MENTOR', 'Acc Mentor');
+  const mentee = await seedUser(menteeEmail, pw, 'MENTEE', 'Acc Mentee');
+
+  // Plenty of capacity, but the mentor has explicitly paused new assignments.
+  await prisma.user.update({ where: { id: mentor.id }, data: { mentorCapacity: 10, acceptingMentees: false } });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', pw);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    const res = await page.request.post('/api/mentorship', {
+      data: { mentorId: mentor.id, menteeId: mentee.id },
+    });
+    expect(res.status()).toBe(201);
+    const body = await res.json();
+    expect(body.warnings).toEqual(['mentor_not_accepting']);
+
+    const relation = await prisma.mentorshipRelation.findFirst({
+      where: { mentorId: mentor.id, menteeId: mentee.id },
+    });
+    expect(relation).toBeTruthy();
+  } finally {
+    await prisma.mentorshipRelation.deleteMany({ where: { mentorId: mentor.id, menteeId: mentee.id } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});
+
+test('assigning an available mentor succeeds with no warnings', async ({ page }) => {
+  const adminEmail = uniqueEmail('avail-admin');
+  const mentorEmail = uniqueEmail('avail-mentor');
+  const menteeEmail = uniqueEmail('avail-mentee');
+  const pw = 'AssignPass123';
+  await seedUser(adminEmail, pw, 'ADMIN', 'Avail Admin');
+  const mentor = await seedUser(mentorEmail, pw, 'MENTOR', 'Avail Mentor');
+  const mentee = await seedUser(menteeEmail, pw, 'MENTEE', 'Avail Mentee');
+
+  await prisma.user.update({ where: { id: mentor.id }, data: { mentorCapacity: 5, acceptingMentees: true } });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', pw);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    const res = await page.request.post('/api/mentorship', {
+      data: { mentorId: mentor.id, menteeId: mentee.id },
+    });
+    expect(res.status()).toBe(201);
+    const body = await res.json();
+    expect(body.warnings).toEqual([]);
+
+    const relation = await prisma.mentorshipRelation.findFirst({
+      where: { mentorId: mentor.id, menteeId: mentee.id },
+    });
+    expect(relation).toBeTruthy();
+  } finally {
+    await prisma.mentorshipRelation.deleteMany({ where: { mentorId: mentor.id, menteeId: mentee.id } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/e2e/mentorship-request-approve-confirm.spec.ts
+++ b/e2e/mentorship-request-approve-confirm.spec.ts
@@ -1,0 +1,169 @@
+import { test, expect } from '@playwright/test';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { signInAsFreshUser } from './helpers/auth';
+import { acceptConfirmDialog, cancelConfirmDialog, confirmDialog } from './helpers/confirm';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// #942: the admin request queue (MentorshipRequestQueue, rendered on
+// /admin/mentorship) must ask for confirmation before approving a request
+// with a mentor whose availability.status is at_capacity/not_accepting —
+// same gate, same ConfirmDialog copy as the direct-assignment flows
+// (mentor-assign-confirm.spec.ts). An available mentor skips the dialog, and
+// cancelling must never send the PUT.
+
+async function seedPendingRequest(page: import('@playwright/test').Page, menteeEmail: string, pw: string, fullName: string) {
+  const mentee = await seedUser(menteeEmail, pw, 'MENTEE', fullName);
+  await prisma.user.update({ where: { id: mentee.id }, data: { university: 'Test University', skills: ['React'] } });
+  const pdf = readFileSync(path.join(__dirname, 'fixtures', 'sample-cv.pdf'));
+  await prisma.cvFile.create({
+    data: { userId: mentee.id, filename: 'cv.pdf', contentType: 'application/pdf', size: pdf.length, data: pdf },
+  });
+  await page.goto('/auth/signin');
+  await page.fill('input[type="email"], input[name="email"]', menteeEmail);
+  await page.fill('input[type="password"]', pw);
+  await page.click('button[type="submit"]');
+  await page.waitForURL((u) => u.pathname.startsWith('/portal'), { timeout: 20_000 });
+  const created = await page.request.post('/api/mentorship-requests', { data: {} });
+  expect(created.status()).toBe(201);
+  const requestId = (await created.json()).request.id as string;
+  return { mentee, requestId };
+}
+
+test('approving a request with an available mentor skips the dialog and approves directly', async ({ page }) => {
+  const adminEmail = uniqueEmail('rac-avail-admin');
+  const mentorEmail = uniqueEmail('rac-avail-mentor');
+  const menteeEmail = uniqueEmail('rac-avail-mentee');
+  const pw = 'RequestPass123';
+  await seedUser(adminEmail, pw, 'ADMIN', 'RAC Avail Admin');
+  const mentor = await seedUser(mentorEmail, pw, 'MENTOR', 'RAC Avail Mentor');
+  await prisma.user.update({ where: { id: mentor.id }, data: { mentorCapacity: 5, acceptingMentees: true } });
+
+  const { mentee, requestId } = await seedPendingRequest(page, menteeEmail, pw, 'RAC Avail Mentee');
+
+  try {
+    await signInAsFreshUser(page, adminEmail, pw, '/admin');
+    await page.goto('/admin/mentorship');
+
+    const row = page.getByTestId(`request-${requestId}`);
+    await expect(row).toBeVisible({ timeout: 10_000 });
+
+    const putRequest = page.waitForRequest((r) => r.method() === 'PUT' && r.url().includes('/api/admin/mentorship-requests'), { timeout: 10_000 });
+    await row.locator('select').selectOption(mentor.id);
+    await row.getByRole('button', { name: 'Approve', exact: true }).click();
+    await putRequest;
+    await expect(confirmDialog(page)).toHaveCount(0);
+
+    await expect(async () => {
+      const relation = await prisma.mentorshipRelation.findFirst({ where: { menteeId: mentee.id, mentorId: mentor.id, status: 'ACTIVE' } });
+      expect(relation).toBeTruthy();
+    }).toPass({ timeout: 10_000 });
+  } finally {
+    await prisma.mentorshipRequest.deleteMany({ where: { id: requestId } });
+    await prisma.mentorshipRelation.deleteMany({ where: { mentorId: mentor.id, menteeId: mentee.id } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});
+
+test('approving a request with an at-capacity mentor asks for confirmation; cancel sends no request, confirm approves', async ({ page }) => {
+  const adminEmail = uniqueEmail('rac-cap-admin');
+  const mentorEmail = uniqueEmail('rac-cap-mentor');
+  const menteeEmail = uniqueEmail('rac-cap-mentee');
+  const existingMenteeEmail = uniqueEmail('rac-cap-existing-mentee');
+  const pw = 'RequestPass123';
+  await seedUser(adminEmail, pw, 'ADMIN', 'RAC Cap Admin');
+  const mentor = await seedUser(mentorEmail, pw, 'MENTOR', 'RAC Cap Mentor');
+  const existingMentee = await seedUser(existingMenteeEmail, pw, 'MENTEE', 'RAC Cap Existing Mentee');
+  await prisma.user.update({ where: { id: mentor.id }, data: { mentorCapacity: 1 } });
+  await prisma.mentorshipRelation.create({
+    data: { mentorId: mentor.id, menteeId: existingMentee.id, orgId: existingMentee.orgId, status: 'ACTIVE', startDate: new Date() },
+  });
+
+  const { mentee, requestId } = await seedPendingRequest(page, menteeEmail, pw, 'RAC Cap Mentee');
+
+  try {
+    await signInAsFreshUser(page, adminEmail, pw, '/admin');
+    await page.goto('/admin/mentorship');
+
+    const row = page.getByTestId(`request-${requestId}`);
+    await expect(row).toBeVisible({ timeout: 10_000 });
+    await row.locator('select').selectOption(mentor.id);
+
+    // Cancel: the dialog opens but no PUT leaves the page, and the relation is
+    // never created.
+    const noRequestYet = page
+      .waitForRequest((r) => r.method() === 'PUT' && r.url().includes('/api/admin/mentorship-requests'), { timeout: 2_000 })
+      .catch(() => null);
+    await row.getByRole('button', { name: 'Approve', exact: true }).click();
+    await expect(confirmDialog(page)).toBeVisible();
+    await expect(page.locator('#confirm-dialog-message')).toContainText('capacity');
+    expect(await noRequestYet).toBeNull();
+    await cancelConfirmDialog(page);
+    const afterCancel = await prisma.mentorshipRequest.findUnique({ where: { id: requestId } });
+    expect(afterCancel?.status).toBe('PENDING');
+    expect(await prisma.mentorshipRelation.findFirst({ where: { menteeId: mentee.id } })).toBeNull();
+
+    // Confirm: the same PUT now runs and the relation is created.
+    const putRequest = page.waitForRequest((r) => r.method() === 'PUT' && r.url().includes('/api/admin/mentorship-requests'), { timeout: 10_000 });
+    await row.getByRole('button', { name: 'Approve', exact: true }).click();
+    await acceptConfirmDialog(page);
+    await putRequest;
+
+    await expect(async () => {
+      const relation = await prisma.mentorshipRelation.findFirst({ where: { menteeId: mentee.id, mentorId: mentor.id, status: 'ACTIVE' } });
+      expect(relation).toBeTruthy();
+    }).toPass({ timeout: 10_000 });
+  } finally {
+    await prisma.mentorshipRequest.deleteMany({ where: { id: requestId } });
+    await prisma.mentorshipRelation.deleteMany({ where: { mentorId: mentor.id } });
+    await cleanupByEmail(existingMenteeEmail);
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});
+
+test('approving a request with a not-accepting mentor asks for confirmation and approves on confirm', async ({ page }) => {
+  const adminEmail = uniqueEmail('rac-acc-admin');
+  const mentorEmail = uniqueEmail('rac-acc-mentor');
+  const menteeEmail = uniqueEmail('rac-acc-mentee');
+  const pw = 'RequestPass123';
+  await seedUser(adminEmail, pw, 'ADMIN', 'RAC Acc Admin');
+  const mentor = await seedUser(mentorEmail, pw, 'MENTOR', 'RAC Acc Mentor');
+  await prisma.user.update({ where: { id: mentor.id }, data: { mentorCapacity: 10, acceptingMentees: false } });
+
+  const { mentee, requestId } = await seedPendingRequest(page, menteeEmail, pw, 'RAC Acc Mentee');
+
+  try {
+    await signInAsFreshUser(page, adminEmail, pw, '/admin');
+    await page.goto('/admin/mentorship');
+
+    const row = page.getByTestId(`request-${requestId}`);
+    await expect(row).toBeVisible({ timeout: 10_000 });
+    await row.locator('select').selectOption(mentor.id);
+
+    const putRequest = page.waitForRequest((r) => r.method() === 'PUT' && r.url().includes('/api/admin/mentorship-requests'), { timeout: 10_000 });
+    await row.getByRole('button', { name: 'Approve', exact: true }).click();
+    await expect(confirmDialog(page)).toBeVisible();
+    await expect(page.locator('#confirm-dialog-message')).toContainText('not accepting');
+    await acceptConfirmDialog(page);
+    await putRequest;
+
+    await expect(async () => {
+      const relation = await prisma.mentorshipRelation.findFirst({ where: { menteeId: mentee.id, mentorId: mentor.id, status: 'ACTIVE' } });
+      expect(relation).toBeTruthy();
+    }).toPass({ timeout: 10_000 });
+  } finally {
+    await prisma.mentorshipRequest.deleteMany({ where: { id: requestId } });
+    await prisma.mentorshipRelation.deleteMany({ where: { mentorId: mentor.id, menteeId: mentee.id } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/e2e/mentorship-request.spec.ts
+++ b/e2e/mentorship-request.spec.ts
@@ -201,6 +201,187 @@ test('admin approves a mentorship request and both mentor and mentee are notifie
   }
 });
 
+// #942: approving a request still succeeds when the picked mentor is at
+// capacity or not accepting — these are advisory warnings on the response,
+// mirroring POST /api/mentorship (direct assignment). See
+// src/lib/mentorAvailability.ts.
+test('approving a request with a mentor at capacity still succeeds, with a mentor_at_capacity warning', async ({ browser }) => {
+  const menteeEmail = uniqueEmail('req-cap-mentee');
+  const adminEmail = uniqueEmail('req-cap-admin');
+  const mentorEmail = uniqueEmail('req-cap-mentor');
+  const existingMenteeEmail = uniqueEmail('req-cap-existing-mentee');
+  const pw = 'RequestPass123';
+  const mentee = await seedUser(menteeEmail, pw, 'MENTEE', 'Req Cap Mentee');
+  await prisma.user.update({ where: { id: mentee.id }, data: { university: 'Test University', skills: ['React'] } });
+  const pdf = readFileSync(path.join(__dirname, 'fixtures', 'sample-cv.pdf'));
+  await prisma.cvFile.create({
+    data: { userId: mentee.id, filename: 'cv.pdf', contentType: 'application/pdf', size: pdf.length, data: pdf },
+  });
+  await seedUser(adminEmail, pw, 'ADMIN', 'Req Cap Admin');
+  const mentor = await seedUser(mentorEmail, pw, 'MENTOR', 'Req Cap Mentor');
+  const existingMentee = await seedUser(existingMenteeEmail, pw, 'MENTEE', 'Req Cap Existing Mentee');
+  await prisma.user.update({ where: { id: mentor.id }, data: { mentorCapacity: 1 } });
+  await prisma.mentorshipRelation.create({
+    data: { mentorId: mentor.id, menteeId: existingMentee.id, orgId: existingMentee.orgId, status: 'ACTIVE', startDate: new Date() },
+  });
+
+  const menteeCtx = await browser.newContext();
+  const adminCtx = await browser.newContext();
+  let requestId = '';
+  try {
+    const menteePage = await menteeCtx.newPage();
+    await menteePage.goto('/auth/signin');
+    await menteePage.fill('input[type="email"], input[name="email"]', menteeEmail);
+    await menteePage.fill('input[type="password"]', pw);
+    await menteePage.click('button[type="submit"]');
+    await menteePage.waitForURL((u) => u.pathname.startsWith('/portal'), { timeout: 20_000 });
+
+    const created = await menteePage.request.post('/api/mentorship-requests', { data: {} });
+    expect(created.status()).toBe(201);
+    requestId = (await created.json()).request.id;
+
+    const adminPage = await adminCtx.newPage();
+    await adminPage.goto('/auth/signin');
+    await adminPage.fill('input[type="email"], input[name="email"]', adminEmail);
+    await adminPage.fill('input[type="password"]', pw);
+    await adminPage.click('button[type="submit"]');
+    await adminPage.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    const approve = await adminPage.request.put('/api/admin/mentorship-requests', {
+      data: { requestId, action: 'approve', mentorId: mentor.id },
+    });
+    expect(approve.status()).toBe(200);
+    const body = await approve.json();
+    expect(body.warnings).toEqual(['mentor_at_capacity']);
+
+    const relation = await prisma.mentorshipRelation.findFirst({ where: { menteeId: mentee.id, mentorId: mentor.id, status: 'ACTIVE' } });
+    expect(relation).toBeTruthy();
+  } finally {
+    await menteeCtx.close();
+    await adminCtx.close();
+    if (requestId) await prisma.mentorshipRequest.deleteMany({ where: { id: requestId } });
+    await prisma.mentorshipRelation.deleteMany({ where: { mentorId: mentor.id } });
+    await cleanupByEmail(existingMenteeEmail);
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});
+
+test('approving a request with a mentor who has acceptingMentees=false still succeeds, with a mentor_not_accepting warning', async ({ browser }) => {
+  const menteeEmail = uniqueEmail('req-acc-mentee');
+  const adminEmail = uniqueEmail('req-acc-admin');
+  const mentorEmail = uniqueEmail('req-acc-mentor');
+  const pw = 'RequestPass123';
+  const mentee = await seedUser(menteeEmail, pw, 'MENTEE', 'Req Acc Mentee');
+  await prisma.user.update({ where: { id: mentee.id }, data: { university: 'Test University', skills: ['React'] } });
+  const pdf = readFileSync(path.join(__dirname, 'fixtures', 'sample-cv.pdf'));
+  await prisma.cvFile.create({
+    data: { userId: mentee.id, filename: 'cv.pdf', contentType: 'application/pdf', size: pdf.length, data: pdf },
+  });
+  await seedUser(adminEmail, pw, 'ADMIN', 'Req Acc Admin');
+  const mentor = await seedUser(mentorEmail, pw, 'MENTOR', 'Req Acc Mentor');
+  await prisma.user.update({ where: { id: mentor.id }, data: { mentorCapacity: 10, acceptingMentees: false } });
+
+  const menteeCtx = await browser.newContext();
+  const adminCtx = await browser.newContext();
+  let requestId = '';
+  try {
+    const menteePage = await menteeCtx.newPage();
+    await menteePage.goto('/auth/signin');
+    await menteePage.fill('input[type="email"], input[name="email"]', menteeEmail);
+    await menteePage.fill('input[type="password"]', pw);
+    await menteePage.click('button[type="submit"]');
+    await menteePage.waitForURL((u) => u.pathname.startsWith('/portal'), { timeout: 20_000 });
+
+    const created = await menteePage.request.post('/api/mentorship-requests', { data: {} });
+    expect(created.status()).toBe(201);
+    requestId = (await created.json()).request.id;
+
+    const adminPage = await adminCtx.newPage();
+    await adminPage.goto('/auth/signin');
+    await adminPage.fill('input[type="email"], input[name="email"]', adminEmail);
+    await adminPage.fill('input[type="password"]', pw);
+    await adminPage.click('button[type="submit"]');
+    await adminPage.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    const approve = await adminPage.request.put('/api/admin/mentorship-requests', {
+      data: { requestId, action: 'approve', mentorId: mentor.id },
+    });
+    expect(approve.status()).toBe(200);
+    const body = await approve.json();
+    expect(body.warnings).toEqual(['mentor_not_accepting']);
+
+    const relation = await prisma.mentorshipRelation.findFirst({ where: { menteeId: mentee.id, mentorId: mentor.id, status: 'ACTIVE' } });
+    expect(relation).toBeTruthy();
+  } finally {
+    await menteeCtx.close();
+    await adminCtx.close();
+    if (requestId) await prisma.mentorshipRequest.deleteMany({ where: { id: requestId } });
+    await prisma.mentorshipRelation.deleteMany({ where: { mentorId: mentor.id } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});
+
+test('approving a request with an available mentor succeeds with no warnings', async ({ browser }) => {
+  const menteeEmail = uniqueEmail('req-avail-mentee');
+  const adminEmail = uniqueEmail('req-avail-admin');
+  const mentorEmail = uniqueEmail('req-avail-mentor');
+  const pw = 'RequestPass123';
+  const mentee = await seedUser(menteeEmail, pw, 'MENTEE', 'Req Avail Mentee');
+  await prisma.user.update({ where: { id: mentee.id }, data: { university: 'Test University', skills: ['React'] } });
+  const pdf = readFileSync(path.join(__dirname, 'fixtures', 'sample-cv.pdf'));
+  await prisma.cvFile.create({
+    data: { userId: mentee.id, filename: 'cv.pdf', contentType: 'application/pdf', size: pdf.length, data: pdf },
+  });
+  await seedUser(adminEmail, pw, 'ADMIN', 'Req Avail Admin');
+  const mentor = await seedUser(mentorEmail, pw, 'MENTOR', 'Req Avail Mentor');
+  await prisma.user.update({ where: { id: mentor.id }, data: { mentorCapacity: 5, acceptingMentees: true } });
+
+  const menteeCtx = await browser.newContext();
+  const adminCtx = await browser.newContext();
+  let requestId = '';
+  try {
+    const menteePage = await menteeCtx.newPage();
+    await menteePage.goto('/auth/signin');
+    await menteePage.fill('input[type="email"], input[name="email"]', menteeEmail);
+    await menteePage.fill('input[type="password"]', pw);
+    await menteePage.click('button[type="submit"]');
+    await menteePage.waitForURL((u) => u.pathname.startsWith('/portal'), { timeout: 20_000 });
+
+    const created = await menteePage.request.post('/api/mentorship-requests', { data: {} });
+    expect(created.status()).toBe(201);
+    requestId = (await created.json()).request.id;
+
+    const adminPage = await adminCtx.newPage();
+    await adminPage.goto('/auth/signin');
+    await adminPage.fill('input[type="email"], input[name="email"]', adminEmail);
+    await adminPage.fill('input[type="password"]', pw);
+    await adminPage.click('button[type="submit"]');
+    await adminPage.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    const approve = await adminPage.request.put('/api/admin/mentorship-requests', {
+      data: { requestId, action: 'approve', mentorId: mentor.id },
+    });
+    expect(approve.status()).toBe(200);
+    const body = await approve.json();
+    expect(body.warnings).toEqual([]);
+
+    const relation = await prisma.mentorshipRelation.findFirst({ where: { menteeId: mentee.id, mentorId: mentor.id, status: 'ACTIVE' } });
+    expect(relation).toBeTruthy();
+  } finally {
+    await menteeCtx.close();
+    await adminCtx.close();
+    if (requestId) await prisma.mentorshipRequest.deleteMany({ where: { id: requestId } });
+    await prisma.mentorshipRelation.deleteMany({ where: { mentorId: mentor.id, menteeId: mentee.id } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});
+
 // #668: rejecting a request should notify the mentee and must not create a relation.
 test('admin rejects a mentorship request and the mentee is notified with no relation created', async ({ page }) => {
   const menteeEmail = uniqueEmail('reject-mentee');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.80.1-beta",
+  "version": "0.81.0-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "author": "Mehmet Erşahin",

--- a/src/app/admin/candidates/page.tsx
+++ b/src/app/admin/candidates/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useSession } from 'next-auth/react';
 import { SavedViews } from '@/components/SavedViews';
 import { AssignMentorInline } from '@/components/admin/AssignMentorInline';
+import type { MentorAvailability } from '@/lib/mentorAvailability';
 import { EmptyState } from '@/components/EmptyState';
 import Link from "next/link";
 import { useT } from "@/i18n/client";
@@ -52,7 +53,9 @@ export default function CandidatesPage() {
   const stages = useResolvedStages();
   const label = useStageLabel();
   const { data: session } = useSession();
-  const [mentors, setMentors] = useState<{ id: string; fullName: string }[]>([]);
+  const [mentors, setMentors] = useState<
+    { id: string; fullName: string; mentorCapacity: number | null; activeMenteeCount: number; availability: MentorAvailability }[]
+  >([]);
   const [candidates, setCandidates] = useState<Candidate[]>([]);
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(1);
@@ -154,14 +157,32 @@ export default function CandidatesPage() {
       .then((r) => (r.ok ? r.json() : { sources: [] }))
       .then((d) => setSources(d.sources ?? []))
       .catch(() => {});
-    // Mentors available to assign a candidate to (admins can mentor too).
-    fetch('/api/users')
+    // Mentors available to assign a candidate to (admins can mentor too), with
+    // capacity/availability so AssignMentorInline can label each option (#942).
+    // Full or paused mentors are kept in the list, never dropped or disabled —
+    // getMentorAvailability() is only advisory here.
+    fetch('/api/users?view=mentorAvailability')
       .then((r) => (r.ok ? r.json() : { users: [] }))
       .then((d) =>
         setMentors(
-          ((d.users ?? []) as { id: string; fullName: string; role: string }[])
+          (
+            (d.users ?? []) as {
+              id: string;
+              fullName: string;
+              role: string;
+              mentorCapacity: number | null;
+              activeMenteeCount: number;
+              availability: MentorAvailability;
+            }[]
+          )
             .filter((u) => u.role === 'MENTOR' || u.role === 'ADMIN')
-            .map((u) => ({ id: u.id, fullName: u.fullName }))
+            .map((u) => ({
+              id: u.id,
+              fullName: u.fullName,
+              mentorCapacity: u.mentorCapacity,
+              activeMenteeCount: u.activeMenteeCount,
+              availability: u.availability,
+            }))
         )
       )
       .catch(() => {});

--- a/src/app/admin/invite/page.tsx
+++ b/src/app/admin/invite/page.tsx
@@ -9,10 +9,13 @@ import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Input } from '@/components/ui/Input';
 import { Button } from '@/components/ui/Button';
 import { Select } from '@/components/ui/Select';
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { Badge, RoleBadge } from '@/components/ui/Badge';
 import { Send, Mail, Copy, Check, CheckCircle2, Circle } from 'lucide-react';
 import { useT, useLocale } from '@/i18n/client';
 import { formatDate, formatDateTime } from '@/lib/relativeTime';
+import { formatMentorAvailability } from '@/lib/mentorAvailabilityLabel';
+import type { MentorAvailability } from '@/lib/mentorAvailability';
 
 const inviteSchema = z.object({
   email: z.string().email('Invalid email'),
@@ -89,17 +92,38 @@ export default function InvitePage() {
     }
   };
 
-  // Pickers for the auto-connect fields.
-  const [mentors, setMentors] = useState<{ id: string; fullName: string }[]>([]);
+  // Pickers for the auto-connect fields. The mentor picker carries
+  // capacity/availability (#942) so the admin can see load before pre-linking
+  // a mentor to a MENTEE invite; the mentee picker only ever needs a name.
+  const [mentors, setMentors] = useState<
+    { id: string; fullName: string; mentorCapacity: number | null; activeMenteeCount: number; availability: MentorAvailability }[]
+  >([]);
   const [mentees, setMentees] = useState<{ id: string; fullName: string }[]>([]);
   const [projects, setProjects] = useState<{ id: string; name: string }[]>([]);
   useEffect(() => {
-    fetch('/api/users?view=picker')
+    fetch('/api/users?view=mentorAvailability')
       .then((r) => (r.ok ? r.json() : { users: [] }))
       .then((d) => {
-        const users = (d.users ?? []) as { id: string; fullName: string; role: string }[];
-        setMentors(users.filter((u) => u.role === 'MENTOR' || u.role === 'ADMIN'));
-        setMentees(users.filter((u) => u.role === 'MENTEE'));
+        const users = (d.users ?? []) as {
+          id: string;
+          fullName: string;
+          role: string;
+          mentorCapacity: number | null;
+          activeMenteeCount: number;
+          availability: MentorAvailability;
+        }[];
+        setMentors(
+          users
+            .filter((u) => u.role === 'MENTOR' || u.role === 'ADMIN')
+            .map((u) => ({
+              id: u.id,
+              fullName: u.fullName,
+              mentorCapacity: u.mentorCapacity,
+              activeMenteeCount: u.activeMenteeCount,
+              availability: u.availability,
+            }))
+        );
+        setMentees(users.filter((u) => u.role === 'MENTEE').map((u) => ({ id: u.id, fullName: u.fullName })));
       })
       .catch(() => {});
     fetch('/api/projects')
@@ -121,7 +145,13 @@ export default function InvitePage() {
 
   const watchedRole = watch('role');
 
-  const onSubmit = handleSubmit(async (data) => {
+  // Does the actual POST — called either directly (available mentor, or no
+  // mentor picked at all) or after the confirmation dialog is accepted
+  // (at_capacity/not_accepting). The response's `warnings` (#942) are
+  // accepted defensively and otherwise ignored: the confirmation already
+  // happened client-side before this ran, so a second dialog off the same
+  // warning would just be a duplicate.
+  const sendInvite = async (data: InviteData) => {
     setLoading(true);
     setError('');
     setSuccess('');
@@ -159,7 +189,35 @@ export default function InvitePage() {
     } finally {
       setLoading(false);
     }
+  };
+
+  // Held for confirmation (#942) when a MENTEE invite pre-links a mentor
+  // whose server-reported availability.status is at_capacity/not_accepting —
+  // read straight off the `mentors` list already fetched from
+  // /api/users?view=mentorAvailability, never recomputed here.
+  const [pendingInvite, setPendingInvite] = useState<{ data: InviteData; status: 'at_capacity' | 'not_accepting' } | null>(null);
+
+  // Gate before sendInvite: only interrupts with a dialog when the invite
+  // pre-links a mentor (role MENTEE + mentorId chosen) whose availability is
+  // at_capacity/not_accepting. Everything else — no mentor picked, or one
+  // that's available — goes straight through, same as before #942.
+  const onSubmit = handleSubmit((data) => {
+    if (data.role === 'MENTEE' && data.mentorId) {
+      const status = mentors.find((m) => m.id === data.mentorId)?.availability?.status;
+      if (status === 'at_capacity' || status === 'not_accepting') {
+        setPendingInvite({ data, status });
+        return;
+      }
+    }
+    sendInvite(data);
   });
+
+  const confirmInvite = () => {
+    if (!pendingInvite) return;
+    const { data } = pendingInvite;
+    setPendingInvite(null);
+    sendInvite(data);
+  };
 
   return (
     <div>
@@ -209,7 +267,16 @@ export default function InvitePage() {
             {watchedRole === 'MENTEE' && (
               <Select
                 label={t.invite.connectMentor}
-                options={[{ value: '', label: '—' }, ...mentors.map((m) => ({ value: m.id, label: m.fullName }))]}
+                // Full or paused mentors stay in the list and stay selectable
+                // (#942) — the capacity/status suffix is advisory only, never
+                // a filter or a disable.
+                options={[
+                  { value: '', label: '—' },
+                  ...mentors.map((m) => ({
+                    value: m.id,
+                    label: `${m.fullName} · ${formatMentorAvailability(m, t.mentorAvailability)}`,
+                  })),
+                ]}
                 {...register('mentorId')}
               />
             )}
@@ -326,6 +393,16 @@ export default function InvitePage() {
           )}
         </Card>
       </div>
+
+      <ConfirmDialog
+        open={pendingInvite !== null}
+        message={pendingInvite?.status === 'at_capacity' ? t.assignMentor.confirmAtCapacity : t.assignMentor.confirmNotAccepting}
+        cancelLabel={t.common.cancel}
+        confirmLabel={t.assignMentor.confirmAnyway}
+        loading={loading}
+        onConfirm={confirmInvite}
+        onCancel={() => setPendingInvite(null)}
+      />
     </div>
   );
 }

--- a/src/app/admin/mentorship/page.tsx
+++ b/src/app/admin/mentorship/page.tsx
@@ -6,19 +6,26 @@ import { useState, useEffect, useCallback } from 'react';
 import { Card } from '@/components/ui/Card';
 import { Badge, StatusBadge } from '@/components/ui/Badge';
 import { Button } from '@/components/ui/Button';
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { MentorshipRequestQueue } from '@/components/admin/MentorshipRequestQueue';
 import { Select } from '@/components/ui/Select';
 import { SavedViews } from '@/components/SavedViews';
 import { SkeletonRows } from '@/components/ui/Skeleton';
 import { BookOpen, Plus } from 'lucide-react';
 import { formatDate } from '@/lib/relativeTime';
+import { formatMentorAvailability } from '@/lib/mentorAvailabilityLabel';
+import type { MentorAvailability } from '@/lib/mentorAvailability';
 
-// The assign dropdowns only ever show a name, so this asks the API for the
-// `picker` field set — no email/phone/university in the response (#855).
+// The assign dropdowns show a name plus capacity/availability (#942), so this
+// asks the API for the `mentorAvailability` field set — still no email/phone/
+// university in the response (#855).
 interface User {
   id: string;
   fullName: string;
   role: string;
+  mentorCapacity: number | null;
+  activeMenteeCount: number;
+  availability: MentorAvailability;
 }
 
 interface Company {
@@ -62,6 +69,11 @@ export default function MentorshipPage() {
   const [statusFilter, setStatusFilter] = useState<'ALL' | 'ACTIVE' | 'COMPLETED'>('ALL');
   const [page, setPage] = useState(1);
   const PAGE_SIZE = 20;
+  // Confirmation held for a picked mentor whose server-reported
+  // availability.status is at_capacity/not_accepting (#942) — read straight
+  // off the `mentors` list already fetched from /api/users?view=mentorAvailability,
+  // never recomputed here.
+  const [pendingConfirm, setPendingConfirm] = useState<'at_capacity' | 'not_accepting' | null>(null);
 
   const fetchRelations = useCallback(async () => {
     setLoading(true);
@@ -85,7 +97,7 @@ export default function MentorshipPage() {
   const fetchPickers = async () => {
     try {
       const [usersRes, companiesRes] = await Promise.all([
-        fetch('/api/users?view=picker'),
+        fetch('/api/users?view=mentorAvailability'),
         fetch('/api/companies'),
       ]);
       const [usersData, companiesData] = await Promise.all([usersRes.json(), companiesRes.json()]);
@@ -148,6 +160,28 @@ export default function MentorshipPage() {
     }
   };
 
+  // Gate before handleCreate (#942): interrupts with a confirmation dialog
+  // only when the picked mentor's own availability.status is at_capacity/
+  // not_accepting. An available mentor — or a picker that failed to load
+  // availability at all — goes straight through, same as before #942.
+  const submitCreate = () => {
+    if (!formData.mentorId || !formData.menteeId) {
+      setFormError(t.mentorships.mentorMenteeRequired);
+      return;
+    }
+    const status = mentors.find((m) => m.id === formData.mentorId)?.availability?.status;
+    if (status === 'at_capacity' || status === 'not_accepting') {
+      setPendingConfirm(status);
+      return;
+    }
+    handleCreate();
+  };
+
+  const confirmCreate = () => {
+    setPendingConfirm(null);
+    handleCreate();
+  };
+
   const handleComplete = async (id: string) => {
     await fetch(`/api/mentorship/${id}`, {
       method: 'PUT',
@@ -175,9 +209,14 @@ export default function MentorshipPage() {
     role === expected
       ? ''
       : ` · ${role === 'ADMIN' ? t.modeSwitch.admin : role === 'MENTOR' ? t.modeSwitch.mentor : t.modeSwitch.mentee}`;
+  // Full or paused mentors stay in the list and stay selectable (#942) — the
+  // capacity/status suffix is advisory only, never a filter or a disable.
   const mentorOptions = mentors
     .filter((m) => m.id !== formData.menteeId)
-    .map((m) => ({ value: m.id, label: m.fullName + roleSuffix(m.role, 'MENTOR') }));
+    .map((m) => ({
+      value: m.id,
+      label: `${m.fullName}${roleSuffix(m.role, 'MENTOR')} · ${formatMentorAvailability(m, t.mentorAvailability)}`,
+    }));
   const menteeOptions = mentees
     .filter((m) => m.id !== formData.mentorId)
     .map((m) => ({ value: m.id, label: m.fullName + roleSuffix(m.role, 'MENTEE') }));
@@ -239,11 +278,21 @@ export default function MentorshipPage() {
             </div>
             <div className="flex justify-end gap-3 mt-6">
               <Button variant="outline" onClick={() => setShowForm(false)}>{t.common.cancel}</Button>
-              <Button onClick={handleCreate} loading={submitting}>{t.mentorships.assignSubmit}</Button>
+              <Button onClick={submitCreate} loading={submitting}>{t.mentorships.assignSubmit}</Button>
             </div>
           </div>
         </div>
       )}
+
+      <ConfirmDialog
+        open={pendingConfirm !== null}
+        message={pendingConfirm === 'at_capacity' ? t.assignMentor.confirmAtCapacity : t.assignMentor.confirmNotAccepting}
+        cancelLabel={t.common.cancel}
+        confirmLabel={t.assignMentor.confirmAnyway}
+        loading={submitting}
+        onConfirm={confirmCreate}
+        onCancel={() => setPendingConfirm(null)}
+      />
 
       {/* Search + status filter */}
       <div className="flex flex-wrap items-center gap-2 mb-4">

--- a/src/app/api/admin/mentorship-requests/route.ts
+++ b/src/app/api/admin/mentorship-requests/route.ts
@@ -8,6 +8,7 @@ import { notify } from '@/lib/notify';
 import { emailAllowed } from '@/lib/notificationPrefs';
 import { sendMentorshipDecisionEmail, sendMenteeAssignedEmail } from '@/services/emailService';
 import { checkActiveRelationLimitForMentee, planLimitError } from '@/lib/planGate';
+import { getMentorAvailability } from '@/lib/mentorAvailability';
 import { withTenantScope } from '@/lib/orgContext';
 
 // Admin queue for mentee mentorship requests (#590): list PENDING requests,
@@ -90,6 +91,8 @@ export async function PUT(request: Request) {
         orgId: true,
         emailNotifications: true,
         notificationPrefs: true,
+        mentorCapacity: true,
+        acceptingMentees: true,
       },
     });
     if (!mentor || !mentor.isActive || (mentor.role !== 'MENTOR' && mentor.role !== 'ADMIN')) {
@@ -105,6 +108,25 @@ export async function PUT(request: Request) {
     if (!gate.allowed) {
       return NextResponse.json(planLimitError(gate), { status: 403 });
     }
+
+    // Capacity/availability warning (#942): advisory only, mirrors POST
+    // /api/mentorship (direct assignment) — same getMentorAvailability()
+    // helper, same "count ACTIVE relations *before* this new one" semantics.
+    // Never blocks the approval; only the plan gate above can do that.
+    const activeMenteeCount = await prisma.mentorshipRelation.count({
+      where: { mentorId, status: 'ACTIVE' },
+    });
+    const availability = getMentorAvailability({
+      mentorCapacity: mentor.mentorCapacity,
+      activeMenteeCount,
+      acceptingMentees: mentor.acceptingMentees,
+    });
+    const warnings: string[] =
+      availability.status === 'at_capacity'
+        ? ['mentor_at_capacity']
+        : availability.status === 'not_accepting'
+          ? ['mentor_not_accepting']
+          : [];
 
     const [relation] = await prisma.$transaction([
       prisma.mentorshipRelation.create({ data: { mentorId, menteeId: req.menteeId, orgId: gate.orgId } }),
@@ -153,7 +175,7 @@ export async function PUT(request: Request) {
       detail: `approved · mentor ${mentorId}`,
       request,
     });
-    return NextResponse.json({ ok: true, relationId: relation.id });
+    return NextResponse.json({ ok: true, relationId: relation.id, warnings });
   }
 
   await prisma.mentorshipRequest.update({

--- a/src/app/api/invite/route.ts
+++ b/src/app/api/invite/route.ts
@@ -7,6 +7,7 @@ import { sendInvitationEmail } from '@/services/emailService';
 import { resolveOrgId } from '@/lib/orgScope';
 import { withTenantScope } from '@/lib/orgContext';
 import { isProjectOwner } from '@/lib/projectAccess';
+import { getMentorAvailability } from '@/lib/mentorAvailability';
 import { z } from 'zod';
 import crypto from 'crypto';
 
@@ -71,11 +72,34 @@ export async function POST(request: Request) {
         mentorId = parsed.data.mentorId || null;
         menteeId = parsed.data.menteeId || null;
       }
+      // Capacity/availability warning (#942): advisory only, mirrors POST
+      // /api/mentorship and the request-approval endpoint's use of
+      // getMentorAvailability(). The MentorshipRelation itself isn't created
+      // yet here — that happens at registration (register/route.ts) — this
+      // just warns the admin up front about the mentor they're pre-linking.
+      let warnings: string[] = [];
       if (mentorId) {
-        const mentor = await prisma.user.findUnique({ where: { id: mentorId }, select: { role: true, isActive: true } });
+        const mentor = await prisma.user.findUnique({
+          where: { id: mentorId },
+          select: { role: true, isActive: true, mentorCapacity: true, acceptingMentees: true },
+        });
         if (!mentor?.isActive || (mentor.role !== 'MENTOR' && mentor.role !== 'ADMIN')) {
           return NextResponse.json({ error: 'The chosen mentor is not an active mentor' }, { status: 400 });
         }
+        const activeMenteeCount = await prisma.mentorshipRelation.count({
+          where: { mentorId, status: 'ACTIVE' },
+        });
+        const availability = getMentorAvailability({
+          mentorCapacity: mentor.mentorCapacity,
+          activeMenteeCount,
+          acceptingMentees: mentor.acceptingMentees,
+        });
+        warnings =
+          availability.status === 'at_capacity'
+            ? ['mentor_at_capacity']
+            : availability.status === 'not_accepting'
+              ? ['mentor_not_accepting']
+              : [];
       }
       if (menteeId) {
         const mentee = await prisma.user.findUnique({ where: { id: menteeId }, select: { role: true, isActive: true } });
@@ -159,6 +183,7 @@ export async function POST(request: Request) {
           invitationId: invitation.id,
           registerUrl,
           emailSent,
+          warnings,
         },
         { status: 201 }
       );

--- a/src/app/api/mentorship/route.ts
+++ b/src/app/api/mentorship/route.ts
@@ -5,6 +5,7 @@ import { prisma } from '@/lib/prisma';
 import { z } from 'zod';
 import { dispatchWebhook } from '@/lib/webhooks';
 import { checkActiveRelationLimit, planLimitError } from '@/lib/planGate';
+import { getMentorAvailability } from '@/lib/mentorAvailability';
 import { withTenantScope } from '@/lib/orgContext';
 import { scopeForRole, logScopeDenial } from '@/lib/authzScope';
 import { notify } from '@/lib/notify';
@@ -182,6 +183,26 @@ export async function POST(request: Request) {
       return NextResponse.json(planLimitError(gate), { status: 403 });
     }
 
+    // Capacity/availability warning (#942): advisory only, never blocking — the
+    // plan gate above is the only thing that can refuse the assignment. Counted
+    // *before* this new relation is created, so it reflects the mentor's load
+    // going into the assignment, not after it. Single source of truth for the
+    // derivation: getMentorAvailability() (#941).
+    const activeMenteeCount = await prisma.mentorshipRelation.count({
+      where: { mentorId, status: 'ACTIVE' },
+    });
+    const availability = getMentorAvailability({
+      mentorCapacity: mentor.mentorCapacity,
+      activeMenteeCount,
+      acceptingMentees: mentor.acceptingMentees,
+    });
+    const warnings: string[] =
+      availability.status === 'at_capacity'
+        ? ['mentor_at_capacity']
+        : availability.status === 'not_accepting'
+          ? ['mentor_not_accepting']
+          : [];
+
     const relation = await prisma.mentorshipRelation.create({
       data: {
         mentorId,
@@ -232,7 +253,7 @@ export async function POST(request: Request) {
       }
     }
 
-    return NextResponse.json({ relation }, { status: 201 });
+    return NextResponse.json({ relation, warnings }, { status: 201 });
     });
   } catch (error) {
     console.error('Create mentorship error:', error);

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { withTenantScope } from '@/lib/orgContext';
 import { accountState } from '@/lib/accountState';
+import { getMentorAvailability } from '@/lib/mentorAvailability';
 import type { Prisma } from '@prisma/client';
 
 // Field sets, narrowest first (#855). The admin list used to return every
@@ -26,6 +27,16 @@ const SELECTS = {
     emailVerified: true,
     pendingApproval: true,
     password: true,
+  },
+  // Admin mentor pickers (#942): a name plus what's needed to derive
+  // availability. `activeMenteeCount` and `availability` are computed below,
+  // not selected — see the mentorAvailability branch in GET.
+  mentorAvailability: {
+    id: true,
+    fullName: true,
+    role: true,
+    mentorCapacity: true,
+    acceptingMentees: true,
   },
 } as const;
 
@@ -108,7 +119,8 @@ export async function GET(request: Request) {
 
       const { searchParams } = new URL(request.url);
       const view = searchParams.get('view');
-      const select = view === 'picker' || view === 'directory' ? SELECTS[view] : FULL_SELECT;
+      const select =
+        view === 'picker' || view === 'directory' || view === 'mentorAvailability' ? SELECTS[view] : FULL_SELECT;
 
       const roleParam = searchParams.get('role');
       const role = ROLES.find((r) => r === roleParam);
@@ -121,6 +133,38 @@ export async function GET(request: Request) {
       if (status === 'archived') where.isActive = false;
       if (search) {
         where.OR = [{ fullName: { contains: search } }, { email: { contains: search } }];
+      }
+
+      // Mentor picker with capacity/availability (#942): same `where` filters
+      // as everything else here, but the response needs two computed fields no
+      // Prisma `select` can produce — activeMenteeCount and the availability
+      // derived from it. One groupBy covers every returned mentor's ACTIVE
+      // count instead of a query per mentor. Full list, like `picker`/
+      // `directory` — a picker dropdown has no use for pagination.
+      if (view === 'mentorAvailability') {
+        const users = await prisma.user.findMany({ where, select: SELECTS.mentorAvailability, orderBy: { fullName: 'asc' } });
+        const counts = users.length
+          ? await prisma.mentorshipRelation.groupBy({
+              by: ['mentorId'],
+              where: { mentorId: { in: users.map((u) => u.id) }, status: 'ACTIVE' },
+              _count: { _all: true },
+            })
+          : [];
+        const activeCountByMentorId = new Map(counts.map((c) => [c.mentorId, c._count._all]));
+        return NextResponse.json({
+          users: users.map((u) => {
+            const activeMenteeCount = activeCountByMentorId.get(u.id) ?? 0;
+            return {
+              ...u,
+              activeMenteeCount,
+              availability: getMentorAvailability({
+                mentorCapacity: u.mentorCapacity,
+                activeMenteeCount,
+                acceptingMentees: u.acceptingMentees,
+              }),
+            };
+          }),
+        });
       }
 
       // Pagination is opt-in — applied only when `page` is passed, the same

--- a/src/components/admin/AssignMentorInline.tsx
+++ b/src/components/admin/AssignMentorInline.tsx
@@ -3,11 +3,20 @@
 import { useState } from 'react';
 import { Sparkles } from 'lucide-react';
 import { Button } from '@/components/ui/Button';
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { useT } from '@/i18n/client';
+import { formatMentorAvailability } from '@/lib/mentorAvailabilityLabel';
+import type { MentorAvailability } from '@/lib/mentorAvailability';
 
 interface MentorOption {
   id: string;
   fullName: string;
+  // Capacity/availability (#942) — optional so callers that only have a bare
+  // {id, fullName} picker (no /api/users?view=mentorAvailability fetch) still
+  // satisfy this type; the label is simply omitted for those.
+  mentorCapacity?: number | null;
+  activeMenteeCount?: number;
+  availability?: MentorAvailability;
 }
 
 interface Suggestion {
@@ -39,6 +48,11 @@ export function AssignMentorInline({
   const [suggesting, setSuggesting] = useState(false);
   const [suggestion, setSuggestion] = useState<Suggestion | null>(null);
   const [aiUsed, setAiUsed] = useState(false);
+  // Assignment held for confirmation (#942) when the picked mentor's server-
+  // reported availability.status is at_capacity/not_accepting — never
+  // recomputed on the client, just read off the mentor object the caller
+  // already fetched from /api/users?view=mentorAvailability.
+  const [pendingAssign, setPendingAssign] = useState<{ mentorId: string; status: 'at_capacity' | 'not_accepting' } | null>(null);
 
   // Mentor suggestion (#533): rule-based ranking, AI-deepened with a rationale
   // when the AI gate allows — otherwise the top rule-based match, no rationale.
@@ -68,8 +82,12 @@ export function AssignMentorInline({
     }
   };
 
-  const assign = async (mentorId: string) => {
-    if (!mentorId) return;
+  // Does the actual POST — called either directly (available mentor) or after
+  // the confirmation dialog is accepted (at_capacity/not_accepting). The
+  // response's `warnings` (#942) are accepted defensively and otherwise
+  // ignored here: the confirmation already happened client-side before this
+  // ran, so a second dialog off the same warning would just be a duplicate.
+  const doAssign = async (mentorId: string) => {
     setBusy(true);
     setErr('');
     try {
@@ -89,6 +107,28 @@ export function AssignMentorInline({
     } finally {
       setBusy(false);
     }
+  };
+
+  // Entry point for both "Assign to me" and the dropdown "Assign" button.
+  // Gates on the mentor's own availability.status from the server — never
+  // recomputed here — and only interrupts with a dialog for at_capacity/
+  // not_accepting; an available mentor (or one with no availability info at
+  // all) is assigned immediately, same as before #942.
+  const assign = (mentorId: string) => {
+    if (!mentorId) return;
+    const status = mentors.find((m) => m.id === mentorId)?.availability?.status;
+    if (status === 'at_capacity' || status === 'not_accepting') {
+      setPendingAssign({ mentorId, status });
+      return;
+    }
+    doAssign(mentorId);
+  };
+
+  const confirmAssign = () => {
+    if (!pendingAssign) return;
+    const { mentorId } = pendingAssign;
+    setPendingAssign(null);
+    doAssign(mentorId);
   };
 
   // Other mentors (exclude self — self is the dedicated button).
@@ -112,7 +152,16 @@ export function AssignMentorInline({
         >
           <option value="">{a.chooseMentor}</option>
           {others.map((m) => (
-            <option key={m.id} value={m.id}>{m.fullName}</option>
+            <option key={m.id} value={m.id}>
+              {/* Full or paused mentors stay selectable (#942) — the label is
+                  advisory, never a restriction. */}
+              {m.availability
+                ? `${m.fullName} · ${formatMentorAvailability(
+                    { mentorCapacity: m.mentorCapacity ?? null, activeMenteeCount: m.activeMenteeCount ?? 0, availability: m.availability },
+                    t.mentorAvailability
+                  )}`
+                : m.fullName}
+            </option>
           ))}
         </select>
         <Button size="sm" variant="outline" loading={busy} disabled={!choice} onClick={() => assign(choice)}>
@@ -134,6 +183,15 @@ export function AssignMentorInline({
         </p>
       )}
       {err && <p className="text-xs text-red-600 mt-1.5">{err}</p>}
+      <ConfirmDialog
+        open={pendingAssign !== null}
+        message={pendingAssign?.status === 'at_capacity' ? a.confirmAtCapacity : a.confirmNotAccepting}
+        cancelLabel={t.common.cancel}
+        confirmLabel={a.confirmAnyway}
+        loading={busy}
+        onConfirm={confirmAssign}
+        onCancel={() => setPendingAssign(null)}
+      />
     </div>
   );
 }

--- a/src/components/admin/MentorshipRequestQueue.tsx
+++ b/src/components/admin/MentorshipRequestQueue.tsx
@@ -4,7 +4,10 @@ import { useCallback, useEffect, useState } from 'react';
 import { Inbox } from 'lucide-react';
 import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { useT } from '@/i18n/client';
+import { formatMentorAvailability } from '@/lib/mentorAvailabilityLabel';
+import type { MentorAvailability } from '@/lib/mentorAvailability';
 
 interface RequestRow {
   id: string;
@@ -14,17 +17,36 @@ interface RequestRow {
   mentee: { id: string; fullName: string; email: string; university?: string | null; skills: string[] };
 }
 
+interface MentorOption {
+  id: string;
+  fullName: string;
+  // Capacity/availability (#942) — optional so a caller with only a bare
+  // {id, fullName} picker still satisfies this type; the label/confirmation
+  // gate are simply skipped for those. The one real caller today
+  // (/admin/mentorship) already fetches these via
+  // /api/users?view=mentorAvailability, same list it feeds the direct-assign
+  // pickers, so no extra request is made here.
+  mentorCapacity?: number | null;
+  activeMenteeCount?: number;
+  availability?: MentorAvailability;
+}
+
 // Admin queue for mentee mentorship requests (#590). Hidden while empty.
 export function MentorshipRequestQueue({ mentors, onApproved }: {
-  mentors: { id: string; fullName: string }[];
+  mentors: MentorOption[];
   onApproved: () => void;
 }) {
   const t = useT();
   const q = t.mentorshipRequests;
+  const a = t.assignMentor;
   const [rows, setRows] = useState<RequestRow[]>([]);
   const [choices, setChoices] = useState<Record<string, string>>({});
   const [busy, setBusy] = useState<string | null>(null);
   const [err, setErr] = useState('');
+  // Approval held for confirmation (#942) when the picked mentor's server-
+  // reported availability.status is at_capacity/not_accepting — same gate as
+  // the direct-assignment flows, reusing their ConfirmDialog copy.
+  const [pendingApprove, setPendingApprove] = useState<{ requestId: string; status: 'at_capacity' | 'not_accepting' } | null>(null);
 
   const load = useCallback(() => {
     fetch('/api/admin/mentorship-requests')
@@ -34,6 +56,11 @@ export function MentorshipRequestQueue({ mentors, onApproved }: {
   }, []);
   useEffect(() => { load(); }, [load]);
 
+  // Does the actual PUT — called either directly (reject, or approve of an
+  // available mentor) or after the confirmation dialog is accepted. The
+  // response's `warnings` (#942) are accepted defensively and otherwise
+  // ignored: the confirmation already happened client-side before this ran,
+  // so a second dialog off the same warning would just be a duplicate.
   const decide = async (requestId: string, action: 'approve' | 'reject') => {
     setBusy(requestId);
     setErr('');
@@ -57,9 +84,33 @@ export function MentorshipRequestQueue({ mentors, onApproved }: {
     }
   };
 
+  // Entry point for the "Approve" button. Gates on the chosen mentor's
+  // availability.status from the server — never recomputed here — and only
+  // interrupts with a dialog for at_capacity/not_accepting; an available
+  // mentor (or one with no availability info at all) is approved
+  // immediately, same as before #942.
+  const approve = (requestId: string) => {
+    const mentorId = choices[requestId];
+    if (!mentorId) return;
+    const status = mentors.find((m) => m.id === mentorId)?.availability?.status;
+    if (status === 'at_capacity' || status === 'not_accepting') {
+      setPendingApprove({ requestId, status });
+      return;
+    }
+    decide(requestId, 'approve');
+  };
+
+  const confirmApprove = () => {
+    if (!pendingApprove) return;
+    const { requestId } = pendingApprove;
+    setPendingApprove(null);
+    decide(requestId, 'approve');
+  };
+
   if (rows.length === 0) return null;
 
   return (
+    <>
     <Card className="mb-6 border-blue-200 dark:border-blue-800" data-testid="request-queue">
       <CardHeader>
         <div className="flex items-center gap-2">
@@ -88,10 +139,19 @@ export function MentorshipRequestQueue({ mentors, onApproved }: {
               >
                 <option value="">{q.chooseMentor}</option>
                 {mentors.map((m) => (
-                  <option key={m.id} value={m.id}>{m.fullName}</option>
+                  <option key={m.id} value={m.id}>
+                    {/* Full or paused mentors stay selectable (#942) — the
+                        label is advisory, never a restriction. */}
+                    {m.availability
+                      ? `${m.fullName} · ${formatMentorAvailability(
+                          { mentorCapacity: m.mentorCapacity ?? null, activeMenteeCount: m.activeMenteeCount ?? 0, availability: m.availability },
+                          t.mentorAvailability
+                        )}`
+                      : m.fullName}
+                  </option>
                 ))}
               </select>
-              <Button size="sm" loading={busy === r.id} disabled={!choices[r.id]} onClick={() => decide(r.id, 'approve')}>
+              <Button size="sm" loading={busy === r.id} disabled={!choices[r.id]} onClick={() => approve(r.id)}>
                 {q.approve}
               </Button>
               <Button size="sm" variant="outline" loading={busy === r.id} onClick={() => decide(r.id, 'reject')}>
@@ -102,5 +162,15 @@ export function MentorshipRequestQueue({ mentors, onApproved }: {
         ))}
       </div>
     </Card>
+    <ConfirmDialog
+      open={pendingApprove !== null}
+      message={pendingApprove?.status === 'at_capacity' ? a.confirmAtCapacity : a.confirmNotAccepting}
+      cancelLabel={t.common.cancel}
+      confirmLabel={a.confirmAnyway}
+      loading={busy === pendingApprove?.requestId}
+      onConfirm={confirmApprove}
+      onCancel={() => setPendingApprove(null)}
+    />
+    </>
   );
 }

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -166,6 +166,21 @@ const en = {
     sharedSkills: 'shared skills',
     ruleBased: 'rule-based',
     noSuggestion: 'No available mentor to suggest.',
+    // Confirmation dialog (#942) shown before assigning a mentor whose
+    // availability.status is at_capacity/not_accepting — advisory, not a block.
+    confirmAtCapacity: 'This mentor appears to be at capacity. Assign anyway?',
+    confirmNotAccepting: 'This mentor has indicated they are not accepting new mentees. Assign anyway?',
+    confirmAnyway: 'Assign anyway',
+  },
+  // Capacity/status suffix shown next to a mentor's name in an admin picker
+  // (#942) — see src/lib/mentorAvailabilityLabel.ts. Advisory only: a mentor
+  // at capacity or not accepting is still selectable, never hidden or disabled.
+  mentorAvailability: {
+    available: 'Available',
+    atCapacity: 'At capacity',
+    notAccepting: 'Not accepting',
+    capacityNotSet: 'Capacity not set',
+    activeCount: '{active} / {capacity}',
   },
   offline: { title: 'You are offline', body: 'Check your connection and try again. Some pages you have visited may still work.' },
   common: {
@@ -2881,6 +2896,16 @@ const tr: Dict = {
     sharedSkills: 'ortak yetenekler',
     ruleBased: 'kural tabanlı',
     noSuggestion: 'Önerilecek uygun mentör yok.',
+    confirmAtCapacity: 'Bu mentor kapasitesini doldurmuş görünüyor. Yine de atamak istiyor musunuz?',
+    confirmNotAccepting: 'Bu mentor yeni mentee kabul etmediğini belirtmiş. Yine de atamak istiyor musunuz?',
+    confirmAnyway: 'Yine de ata',
+  },
+  mentorAvailability: {
+    available: 'Uygun',
+    atCapacity: 'Kapasite dolu',
+    notAccepting: 'Mentee almıyor',
+    capacityNotSet: 'Kapasite belirtilmemiş',
+    activeCount: '{active} / {capacity}',
   },
   offline: { title: 'Çevrimdışısın', body: 'Bağlantını kontrol edip tekrar dene. Daha önce ziyaret ettiğin bazı sayfalar yine de çalışabilir.' },
   common: {
@@ -5581,6 +5606,16 @@ const de: Dict = {
     sharedSkills: 'gemeinsame Fähigkeiten',
     ruleBased: 'regelbasiert',
     noSuggestion: 'Kein verfügbarer Mentor zum Vorschlagen.',
+    confirmAtCapacity: 'Dieser Mentor scheint seine Kapazität erreicht zu haben. Trotzdem zuweisen?',
+    confirmNotAccepting: 'Dieser Mentor hat angegeben, aktuell keine neuen Mentees anzunehmen. Trotzdem zuweisen?',
+    confirmAnyway: 'Trotzdem zuweisen',
+  },
+  mentorAvailability: {
+    available: 'Verfügbar',
+    atCapacity: 'Kapazität voll',
+    notAccepting: 'Nimmt nicht auf',
+    capacityNotSet: 'Kapazität nicht festgelegt',
+    activeCount: '{active} / {capacity}',
   },
   offline: { title: 'Du bist offline', body: 'Prüfe deine Verbindung und versuche es erneut. Bereits besuchte Seiten funktionieren womöglich weiter.' },
   common: {

--- a/src/lib/mentorAvailabilityLabel.ts
+++ b/src/lib/mentorAvailabilityLabel.ts
@@ -1,0 +1,44 @@
+// Shared "capacity · status" suffix for an admin mentor picker row (#942), e.g.
+// "3 / 4 · Available" or "Capacity not set · Not accepting". Two admin UIs
+// render this next to a mentor's name — AssignMentorInline.tsx (candidates
+// screen) and the assign form on /admin/mentorship — kept in one place so the
+// shape never drifts between them. Availability itself must still come from
+// getMentorAvailability() (src/lib/mentorAvailability.ts); this only formats it.
+
+import type { MentorAvailability } from './mentorAvailability';
+
+export interface MentorAvailabilityLabelInput {
+  mentorCapacity: number | null | undefined;
+  activeMenteeCount: number;
+  availability: Pick<MentorAvailability, 'status' | 'capacityKnown'>;
+}
+
+// Matches the shape of the `mentorAvailability` i18n block — passed in rather
+// than imported so this stays a plain, framework-free function the two React
+// call sites can each feed their own `t.mentorAvailability`.
+export interface MentorAvailabilityLabelStrings {
+  available: string;
+  atCapacity: string;
+  notAccepting: string;
+  capacityNotSet: string;
+  // '{active} / {capacity}', e.g. '3 / 4'.
+  activeCount: string;
+}
+
+export function formatMentorAvailability(
+  { mentorCapacity, activeMenteeCount, availability }: MentorAvailabilityLabelInput,
+  strings: MentorAvailabilityLabelStrings
+): string {
+  const capacityPart = availability.capacityKnown
+    ? strings.activeCount.replace('{active}', String(activeMenteeCount)).replace('{capacity}', String(mentorCapacity))
+    : strings.capacityNotSet;
+
+  const statusPart =
+    availability.status === 'at_capacity'
+      ? strings.atCapacity
+      : availability.status === 'not_accepting'
+        ? strings.notAccepting
+        : strings.available;
+
+  return `${capacityPart} · ${statusPart}`;
+}

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,21 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.81.0-beta',
+    date: '2026-08-19',
+    highlights: {
+      en: [
+        'When assigning a mentor — directly, by approving a mentorship request, or by pre-linking one on an invite — admins now see each mentor’s current load right in the picker, and get a confirmation prompt if that mentor is full or not currently accepting new mentees. It’s only a heads-up: the assignment still goes through if you confirm.',
+      ],
+      tr: [
+        'Bir mentor atarken — doğrudan, bir mentorluk talebini onaylayarak ya da bir davete önceden bağlayarak — adminler artık her mentörün mevcut yükünü seçicide görebiliyor; mentör doluysa veya şu anda yeni mentee almıyorsa bir onay istemi çıkıyor. Bu yalnızca bir bilgilendirme: onaylarsanız atama yine de gerçekleşiyor.',
+      ],
+      de: [
+        'Bei der Zuweisung eines Mentors — direkt, durch Genehmigung einer Mentoring-Anfrage oder durch Vorverknüpfung bei einer Einladung — sehen Admins jetzt die aktuelle Auslastung jedes Mentors direkt in der Auswahl und erhalten eine Bestätigungsabfrage, wenn dieser Mentor ausgelastet ist oder aktuell keine neuen Mentees aufnimmt. Es ist nur ein Hinweis: Die Zuweisung erfolgt trotzdem, wenn du bestätigst.',
+      ],
+    },
+  },
+  {
     version: '0.80.1-beta',
     date: '2026-08-19',
     highlights: {


### PR DESCRIPTION
Closes #942

## Summary
- Shows mentor capacity and availability during admin mentor assignment
- Warns when assigning a mentor who is at capacity or not accepting new mentees
- Keeps capacity warnings advisory so admins can still continue the assignment
- Adds the same warning flow to direct assignment, mentorship request approval, and invite pre-assignment
- Preserves existing blocking plan-limit behavior
- Adds EN/TR/DE translations and E2E coverage

## Validation
- npm run check:i18n ✅
- npx prisma generate ✅
- npx tsc --noEmit ✅
- git diff --check ✅

Database-dependent E2E tests will be validated in CI / preview environment.