### PR TITLE
fix(duplicates): merge 500 vermeden tamamlansın — audit taşması + kırık dosya linkleri (#841 hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ version is shown in the sidebar footer of every page (links to the
 [user-facing release notes](src/lib/releaseNotes.ts), rendered at
 `/release-notes`) and in the landing-page footer.
 
+## [0.84.1-beta] - 2026-08-23
+
+### Fixed
+- **Duplicate merge no longer 500s after committing** (#841 hotfix). `AuditLog.detail`
+  is a default VARCHAR(191); the `USER_MERGE` detail carries per-relation move counts
+  as JSON and overflowed it, so the audit insert threw P2000 AFTER `mergeUsers` had
+  committed — the admin saw a 500 for a merge that had succeeded, no audit row was
+  written, and a retry hit `not_found` because the absorbed user was already gone.
+  (Caught by running `e2e/duplicate-merge.spec.ts`, which is not in the smoke set the
+  PR gate runs.) The column is now `@db.Text` (lossless widen, passes the schema
+  guard), and the post-commit audit/activity writes can no longer turn a committed,
+  irreversible merge into an error response.
+- **Merged profiles no longer point at the deleted user's files** (#841 hotfix).
+  `cvUrl`/`avatarUrl` embed the user id (`/api/cv/<id>`, `/api/avatar/<id>`); the
+  verbatim copy-if-empty left the primary linking to the absorbed id (404 after the
+  delete). The URLs are now rewritten against the primary's own id whenever a file
+  row moved.
+
 ## [0.84.0-beta] - 2026-08-19
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internship-crm",
-  "version": "0.84.0-beta",
+  "version": "0.84.1-beta",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "author": "Mehmet Erşahin",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1830,7 +1830,10 @@ model AuditLog {
   actorId   String // who performed the action (e.g. the admin)
   action    String // e.g. IMPERSONATE_START / IMPERSONATE_STOP
   targetId  String? // affected user, when applicable
-  detail    String?
+  // @db.Text: a USER_MERGE detail carries per-relation move counts as JSON,
+  // which overflows the default VARCHAR(191) and turned a committed merge
+  // into a 500 with no audit row (P2000).
+  detail    String?  @db.Text
   createdAt DateTime @default(now())
 
   @@index([actorId])

--- a/src/app/api/admin/duplicates/merge/route.ts
+++ b/src/app/api/admin/duplicates/merge/route.ts
@@ -74,27 +74,34 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Merge failed' }, { status: 500 });
   }
 
+  // The merge is already committed — from here on, a logging failure must not
+  // turn a successful (and irreversible) merge into a 500 the admin retries
+  // against an id that no longer exists.
   const totalMoved = Object.values(result.counts).reduce((sum, n) => sum + n, 0);
-  await prisma.auditLog.create({
-    data: {
+  try {
+    await prisma.auditLog.create({
+      data: {
+        actorId: session.user.id,
+        action: 'USER_MERGE',
+        targetId: primaryId,
+        detail: JSON.stringify({ duplicateId, duplicateEmail: result.duplicateEmail, counts: result.counts }),
+      },
+    });
+    await logActivity({
+      action: 'user.merge',
+      level: 'warning',
       actorId: session.user.id,
-      action: 'USER_MERGE',
+      actorEmail: session.user.email ?? null,
+      targetType: 'user',
       targetId: primaryId,
-      detail: JSON.stringify({ duplicateId, duplicateEmail: result.duplicateEmail, counts: result.counts }),
-    },
-  });
-  await logActivity({
-    action: 'user.merge',
-    level: 'warning',
-    actorId: session.user.id,
-    actorEmail: session.user.email ?? null,
-    targetType: 'user',
-    targetId: primaryId,
-    // The duplicate row no longer exists — this line is the durable record of
-    // which account was absorbed and how much history moved with it.
-    detail: `absorbed ${result.duplicateEmail} (${totalMoved} rows moved)`,
-    request,
-  });
+      // The duplicate row no longer exists — this line is the durable record of
+      // which account was absorbed and how much history moved with it.
+      detail: `absorbed ${result.duplicateEmail} (${totalMoved} rows moved)`,
+      request,
+    });
+  } catch (error) {
+    console.error('USER_MERGE committed but writing its audit trail failed:', error);
+  }
 
   return NextResponse.json({ ok: true, counts: result.counts });
   });

--- a/src/lib/mergeUsers.ts
+++ b/src/lib/mergeUsers.ts
@@ -135,8 +135,10 @@ const COPY_IF_EMPTY = [
   'university',
   'department',
   'graduationYear',
-  'cvUrl',
-  'avatarUrl',
+  // NOT cvUrl/avatarUrl: those are /api/cv/<id> // /api/avatar/<id> paths that
+  // embed the DUPLICATE's user id — copying them verbatim leaves the primary
+  // pointing at a deleted user (404). Section 2 moves the file rows and
+  // section 5 rewrites the URLs against the primary's own id.
   'displayName',
   'bio',
   'linkedinUrl',
@@ -208,6 +210,7 @@ export async function mergeUsers(input: { primaryId: string; duplicateId: string
 
       // AvatarFile / CvFile: userId @unique, one row per user. Keep the
       // primary's when both exist (dup's is removed by the final cascade).
+      const movedFiles: Record<'avatarFile' | 'cvFile', boolean> = { avatarFile: false, cvFile: false };
       for (const model of ['avatarFile', 'cvFile'] as const) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const delegate = (tx as any)[model];
@@ -215,6 +218,7 @@ export async function mergeUsers(input: { primaryId: string; duplicateId: string
         if (!primaryHas) {
           const moved = await delegate.updateMany({ where: { userId: duplicateId }, data: { userId: primaryId } });
           add(counts, model, moved.count);
+          movedFiles[model] = moved.count > 0;
         }
       }
 
@@ -515,6 +519,10 @@ export async function mergeUsers(input: { primaryId: string; duplicateId: string
       const union = (a: unknown, b: unknown): string[] => [
         ...new Set([...(Array.isArray(a) ? a : []), ...(Array.isArray(b) ? b : [])].map(String)),
       ];
+      // The file rows moved in section 2 — point the URLs at the PRIMARY's id
+      // (the duplicate's /api/…/<id> path dies with the row below).
+      if (movedFiles.avatarFile && !primary.avatarUrl) data.avatarUrl = `/api/avatar/${primaryId}`;
+      if (movedFiles.cvFile && !primary.cvUrl) data.cvUrl = `/api/cv/${primaryId}`;
       data.skills = union(primary.skills, duplicate.skills) as unknown as Prisma.InputJsonValue;
       data.languages = union(primary.languages, duplicate.languages) as unknown as Prisma.InputJsonValue;
       const levels = {

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -13,6 +13,21 @@ export interface ReleaseNote {
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    version: '0.84.1-beta',
+    date: '2026-08-23',
+    highlights: {
+      en: [
+        'Merging duplicate candidate records now completes cleanly: the merge no longer reports an error after it already succeeded, the audit trail records every merge, and the merged profile keeps a working CV and photo.',
+      ],
+      tr: [
+        'Mükerrer aday kayıtlarını birleştirme artık temiz tamamlanıyor: birleştirme başarıyla bittiği hâlde hata göstermiyor, her birleştirme denetim kaydına geçiyor ve birleşen profilin özgeçmişi ile fotoğrafı çalışır durumda kalıyor.',
+      ],
+      de: [
+        'Das Zusammenführen doppelter Kandidatendatensätze läuft jetzt sauber durch: Es meldet keinen Fehler mehr, nachdem es bereits erfolgreich war, jede Zusammenführung landet im Prüfprotokoll, und das zusammengeführte Profil behält funktionierenden Lebenslauf und Foto.',
+      ],
+    },
+  },
+  {
     version: '0.84.0-beta',
     date: '2026-08-19',
     highlights: {


### PR DESCRIPTION
## Özet

#1261 merge edildikten sonra dalında yakaladığım ama merge'e yetişemeyen **iki gerçek bug'ın** hotfix'i — ikisi de şu an main'de (dolayısıyla prod'da) canlı:

### 1. Merge, başarıyla commit edildikten SONRA 500 dönüyor (asıl kritik)

`AuditLog.detail` varsayılan VARCHAR(191); `USER_MERGE` detayı ilişki-başına taşıma sayaçlarını JSON olarak taşıyor ve **kolona sığmıyor** (P2000). Audit insert'i `mergeUsers` **commit edildikten sonra** patlıyor: admin başarılı bir merge için 500 görüyor, audit satırı yazılmıyor, retry `not_found` yiyor (emilen kullanıcı çoktan silinmiş). `e2e/duplicate-merge.spec.ts`'i lokalde koşturunca yakalandı — bu spec smoke setinde olmadığı için PR gate'i hiç çalıştırmıyor.

**Düzeltme:** kolon `@db.Text` (kayıpsız genişletme — `MODIFY ... NULL` olduğu için schema-guard'ın yıkıcı desenine girmiyor) + commit-sonrası audit/activity yazımları try/catch'e alındı: log arızası, geri alınamaz bir merge'i asla hata cevabına çeviremez.

### 2. Birleşen profil, silinen kullanıcının dosyalarına işaret ediyor

`cvUrl`/`avatarUrl` kullanıcı id'sini gömer (`/api/cv/<id>`). `COPY_IF_EMPTY` bunları birebir kopyaladığı için primary, silinmiş duplicate id'sine bakan kırık linkle kalıyordu (dosya satırları zaten doğru taşınıyordu). Artık dosya taşındığında URL'ler primary'nin kendi id'siyle yeniden yazılıyor; ham URL alanları birebir kopya listesinden çıkarıldı.

## Doğrulama

- `e2e/duplicate-merge.spec.ts` + `duplicate-detection.unit.spec.ts`: lokal **17/17 passed** (fix öncesi merge testi P2000 ile kırmızıydı).
- FK kapsama denetimi elle yapıldı: şemadaki User'a bakan tüm ilişkiler mergeUsers'ın re-point/dedupe/bilinçli-düşürme kümesiyle eşleşiyor (yalnızca reset/verify token'ları ve SSO grant'leri bilinçli olarak satırla birlikte gidiyor) — ayrı bulgu çıkmadı.
- `tsc`, lint, `check:i18n` (2761 anahtar) temiz.

## Versiyonlama

`package.json` → **0.84.1-beta**, CHANGELOG, releaseNotes (EN/TR/DE).

Ref #841 · follow-up to #1261

🤖 Generated with [Claude Code](https://claude.com/claude-code)