### PR TITLE
feat(release): sürüm çakışması cehennemine kalıcı çözüm — releases/ fragment sistemi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,10 @@ jobs:
       - run: npx tsc --noEmit
       - name: i18n parity (EN/TR/DE)
         run: npm run check:i18n
+      # A malformed release fragment must fail in the PR that adds it, not in
+      # next.config.js during the deploy build (#1275).
+      - name: release fragments are well-formed (#1275)
+        run: npm run check:release-fragments
       - name: auth path reads only the columns it needs (#1150)
         run: npm run check:auth-reads
       # A renamed route would silently drop out of the demo's write blocklist,

--- a/.github/workflows/release-compact.yml
+++ b/.github/workflows/release-compact.yml
@@ -1,0 +1,78 @@
+name: Compact release fragments
+
+# #1275 — the other half of the release-fragment system (releases/README.md).
+# PRs only ADD files under releases/unreleased/; this workflow periodically
+# folds them into the three canonical files (package.json version, CHANGELOG.md,
+# src/lib/releaseNotes.ts) and deletes them — through a NORMAL pull request, so
+# branch protection and the PR checks stay in force (a bot cannot push to main
+# directly here: classic protection requires status checks on every push).
+#
+# Between a merge and this compaction, the app already shows the right version:
+# next.config.js derives it from base+fragments at build time — so a delayed
+# compaction is harmless.
+#
+# TOKEN NOTE: the repo secret RELEASE_BOT_TOKEN (a maintainer's fine-grained
+# PAT — this repo only, contents + pull-requests: write) is effectively
+# REQUIRED for the scheduled path, twice over: the org setting forbids the
+# default GITHUB_TOKEN from creating PRs at all, and even where allowed, a
+# GITHUB_TOKEN-created PR would not trigger the required checks (GitHub's
+# recursion guard), so auto-merge could never fire. Without the secret this
+# workflow fails at the PR step — harmless: compaction can lag indefinitely
+# (builds derive the version from base+fragments), and any maintainer or agent
+# session can run `node scripts/release-compact.mjs` and open the PR normally.
+
+on:
+  schedule:
+    # Daily, in the quiet hours between the 03:00 UTC e2e-full run and the
+    # first European work pushes.
+    - cron: '45 4 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: release-compact
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  compact:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Push the bot branch with the PAT too (not only the PR creation), so
+          # the branch's own push-triggered workflows run as well.
+          token: ${{ secrets.RELEASE_BOT_TOKEN || github.token }}
+
+      - name: Compact fragments
+        id: compact
+        run: |
+          set -euo pipefail
+          if ! ls releases/unreleased/*.json >/dev/null 2>&1; then
+            echo "nothing to compact"; echo "changed=0" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          node scripts/release-compact.mjs
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "changed=1" >> "$GITHUB_OUTPUT"
+
+      - name: Open the compaction PR
+        if: steps.compact.outputs.changed == '1'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.compact.outputs.version }}
+        run: |
+          set -euo pipefail
+          BRANCH="bot/release-compact-${VERSION}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add -A
+          git commit -m "chore(release): compact fragments into ${VERSION} (#1275)"
+          git push -u origin "$BRANCH"
+          gh pr create \
+            --title "chore(release): compact fragments into ${VERSION}" \
+            --body "Scheduled compaction (#1275): folds the pending \`releases/unreleased/\` fragments into \`package.json\`, \`CHANGELOG.md\` and \`src/lib/releaseNotes.ts\`, then deletes them. The displayed version does not change — builds already derived \`${VERSION}\` from base+fragments; this only makes the canonical files match it."
+          gh pr merge "$BRANCH" --squash --auto

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,20 +211,22 @@ workaround, #636, and it compiled on every PR push).
 - **Feature catalogue**: when a user-visible feature ships, add/update its entry in
   `src/lib/features.ts` (+ `featureCatalog` i18n block) — the landing cards and the `/features`
   page are both fed from that single source. Same discipline as CHANGELOG/releaseNotes.
-- **Versioning (maintainer instruction, 2026-07-20): bump the version + changelog on EVERY
-  shipped change**, not just notable batches — the maintainer tracks "what changed / what's
-  live" from the version. For each user-visible PR: bump `package.json` `version` (semver —
-  patch for fixes/small tweaks, minor for features), add a `CHANGELOG.md` entry (developer-
-  facing, Keep a Changelog format), and add a matching `src/lib/releaseNotes.ts` entry (user-
-  facing, EN/TR/DE, rendered at `/release-notes`, linked from the sidebar version footer). The
-  app version is read from `package.json` at build time (`src/lib/version.ts`); the git SHA is
-  baked into the Docker image via a build arg — no other wiring is needed. (Trivial non-user-
-  facing changes — pure docs, CI config — don't need a bump.)
-  **Versioning checklist — do ALL of these before the final commit of every user-visible PR:**
-  1. Bump `package.json` → `"version"` (patch `0.x.y` → `0.x.y+1`, or minor for large features).
-  2. Add a `## [x.y.z] - YYYY-MM-DD` section to `CHANGELOG.md` (developer-facing, Keep a Changelog).
-  3. Prepend an entry to `RELEASE_NOTES` in `src/lib/releaseNotes.ts` (user-facing EN/TR/DE strings).
-  Missing any one of these three is a checklist failure — reviewers will call it out.
+- **Versioning (maintainer instruction, 2026-07-20; mechanism reworked 2026-08-23, #1275):
+  every shipped change is versioned** — the maintainer tracks "what changed / what's live"
+  from the version. But PRs **never edit** `package.json`'s version, `CHANGELOG.md` or
+  `src/lib/releaseNotes.ts` directly anymore: those three changed on the same lines in every
+  PR, so parallel PRs always conflicted and raced for the same number.
+  **Versioning checklist — ONE step per shipped PR:** add a file
+  `releases/unreleased/<kebab-slug>.json` with `bump` (`minor` for features, `patch` for
+  fixes), `changelog` (developer-facing Keep-a-Changelog bullet, markdown) and — for
+  user-visible changes — `notes` with EN/TR/DE user-facing highlight strings (all three or
+  none). Full format + rationale: [releases/README.md](releases/README.md). Trivial
+  non-user-facing changes (pure docs, CI config) still need no fragment.
+  The displayed version is derived at build time from base+fragments (`next.config.js` →
+  `src/lib/version.ts`), so it is correct immediately after every merge; a scheduled workflow
+  (`release-compact.yml`) later folds fragments into the canonical files through a normal PR.
+  `npm run check:release-fragments` validates fragments in CI. A shipped change without a
+  fragment is a checklist failure — reviewers will call it out.
 - **E2E locator pitfalls** (hit repeatedly): `AdminNav` renders its own sidebar
   `input[type="search"]` filter box present on every admin page — an unscoped
   `input[type="search"]` selector in a new test will hit that instead of a page-level search

--- a/e2e/version-release-notes.spec.ts
+++ b/e2e/version-release-notes.spec.ts
@@ -2,7 +2,13 @@ import { test, expect } from '@playwright/test';
 import { readFileSync } from 'fs';
 import path from 'path';
 
-const pkg = JSON.parse(readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'));
+const repoRoot = path.join(__dirname, '..');
+const pkg = JSON.parse(readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+// The footer shows the DERIVED version: base plus pending release fragments
+// (#1275) — compute the expectation with the same code next.config.js uses.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const release = require(path.join(repoRoot, 'scripts', 'release-derive.cjs'));
+pkg.version = release.deriveVersion(pkg.version, release.readFragments(repoRoot));
 
 test('landing footer shows the app version linking to release notes', async ({ page }) => {
   await page.goto('/');

--- a/next.config.js
+++ b/next.config.js
@@ -67,8 +67,26 @@ const securityHeaders = [
   { key: 'Strict-Transport-Security', value: 'max-age=63072000; includeSubDomains; preload' },
 ];
 
+// Release fragments (#1275): the version shown to users is BASE (package.json)
+// plus the pending fragments under releases/unreleased/, derived here at build
+// time and inlined via env. PRs never edit package.json/CHANGELOG/releaseNotes
+// directly — see releases/README.md; a scheduled workflow later compacts the
+// fragments into those canonical files through a normal PR.
+const pkg = require('./package.json');
+const release = require('./scripts/release-derive.cjs');
+const releaseFragments = release.readFragments(__dirname);
+releaseFragments.forEach(release.validateFragment);
+const derivedVersion = release.deriveVersion(pkg.version, releaseFragments);
+const unreleasedHighlights = release.unreleasedHighlights(releaseFragments);
+
 const nextConfig = {
   reactStrictMode: true,
+  env: {
+    APP_DERIVED_VERSION: derivedVersion,
+    // One synthetic RELEASE_NOTES entry for everything not yet compacted, or
+    // '' when no pending fragment carries user-facing notes.
+    APP_UNRELEASED_NOTES: unreleasedHighlights ? JSON.stringify(unreleasedHighlights) : '',
+  },
   // pdf-parse/mammoth pull in Node-only deps (pdfjs) — keep them out of the
   // webpack server bundle so they load as plain CJS at runtime.
   // imapflow/mailparser are Node-only too (net/tls, iconv) and are used by the

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "next lint",
     "check:demo-blocklist": "node scripts/check-demo-blocklist.mjs",
     "check:i18n": "node --experimental-strip-types scripts/check-i18n.ts",
+    "check:release-fragments": "node scripts/check-release-fragments.mjs",
     "check:auth-reads": "node scripts/check-auth-reads.mjs",
     "db:check-json": "node prisma/backfill-json-columns.mjs",
     "test:e2e": "playwright test",

--- a/releases/README.md
+++ b/releases/README.md
@@ -1,0 +1,49 @@
+# Release fragments (#1275)
+
+**PRs no longer edit `package.json`'s version, `CHANGELOG.md`, or
+`src/lib/releaseNotes.ts`.** Those three files changed on the same lines in
+every PR, so any two open PRs conflicted textually *and* raced for the same
+version number — every parallel PR needed a manual rebase + renumber.
+
+Instead, a PR **adds one new file** under `releases/unreleased/` (new files
+never conflict):
+
+```json
+{
+  "bump": "minor",
+  "changelog": "- **Mentees can own projects** (#1222). ProjectOwnerType gains MENTEE; resolveOwner verifies the role.",
+  "notes": {
+    "en": ["Projects can now be owned by a mentee."],
+    "tr": ["Projelerin sahibi artık bir mentee olabilir."],
+    "de": ["Projekte können jetzt einem Mentee gehören."]
+  }
+}
+```
+
+- **Filename**: short kebab-case slug, e.g. `mentee-project-owner.json`.
+- **`bump`**: `minor` for features, `patch` for fixes/tweaks (semver, as before).
+- **`changelog`**: developer-facing Keep-a-Changelog bullet(s), markdown.
+- **`notes`**: user-facing highlights for `/release-notes` — all three of
+  EN/TR/DE or none. Omit the field for changes users don't see.
+- Trivial non-user-facing changes (pure docs, CI config) still need **no**
+  fragment at all, same as before.
+
+## How the version stays correct
+
+- `next.config.js` reads the fragments at **build time** and derives the real
+  version (base from `package.json`, +minor/+patch per fragment, sorted by
+  filename) plus one synthetic release-notes entry. The sidebar footer,
+  `/api/health`, and `/release-notes` all show the derived version immediately
+  after a merge deploys.
+- A scheduled workflow (`release-compact.yml`, daily 04:45 UTC + manual
+  `workflow_dispatch`) folds pending fragments into the three canonical files
+  with the real date and deletes them — via a **normal PR** that passes the
+  usual checks, so branch protection stays intact. That PR is the only thing
+  that ever edits the version line again.
+- `npm run check:release-fragments` (in CI) fails a PR whose fragment is
+  malformed or missing a locale.
+
+## For agents & reviewers
+
+The old three-file versioning checklist is replaced by: **does the PR that
+ships a change carry a fragment?** One file, no numbering, no rebase churn.

--- a/releases/unreleased/release-fragment-system.json
+++ b/releases/unreleased/release-fragment-system.json
@@ -1,0 +1,15 @@
+{
+  "bump": "minor",
+  "changelog": "- **Release fragments end the version-collision churn** (#1275). PRs no longer edit `package.json`'s version, `CHANGELOG.md` or `src/lib/releaseNotes.ts` — they add one JSON fragment under `releases/unreleased/` (new files cannot conflict). The displayed version is derived at build time from base+fragments (`next.config.js` → `APP_DERIVED_VERSION`), `/release-notes` shows pending notes as a synthetic entry, `check:release-fragments` validates fragments in CI, and the scheduled `release-compact.yml` folds them into the canonical files through a normal PR. This very entry is the first fragment.",
+  "notes": {
+    "en": [
+      "Release notes now appear the moment a change goes live: the version number and the what's-new page update with every deployment instead of waiting for a manual bookkeeping step."
+    ],
+    "tr": [
+      "Sürüm notları artık bir değişiklik yayına girdiği anda görünüyor: sürüm numarası ve yenilikler sayfası, elle yapılan bir kayıt adımını beklemek yerine her dağıtımla birlikte güncelleniyor."
+    ],
+    "de": [
+      "Versionshinweise erscheinen jetzt in dem Moment, in dem eine Änderung live geht: Versionsnummer und Neuigkeiten-Seite aktualisieren sich mit jedem Deployment, statt auf einen manuellen Pflegeschritt zu warten."
+    ]
+  }
+}

--- a/scripts/check-release-fragments.mjs
+++ b/scripts/check-release-fragments.mjs
@@ -1,0 +1,23 @@
+// CI gate for release fragments (#1275): every releases/unreleased/*.json must
+// parse, match the schema, and carry all three locales when it has user-facing
+// notes. Run via `npm run check:release-fragments` (wired into ci.yml next to
+// check:i18n). A malformed fragment must fail HERE, in the PR that adds it —
+// not in next.config.js during the deploy build.
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { readFragments, validateFragment, deriveVersion } = require('./release-derive.cjs');
+const pkg = require('../package.json');
+
+const fragments = readFragments(process.cwd());
+try {
+  fragments.forEach(validateFragment);
+  const version = deriveVersion(pkg.version, fragments);
+  console.log(
+    fragments.length === 0
+      ? `release fragments OK — none pending (version stays ${pkg.version})`
+      : `release fragments OK — ${fragments.length} pending: ${fragments.map((f) => f.file).join(', ')} → ${version}`
+  );
+} catch (error) {
+  console.error(`XX ${error.message}`);
+  process.exit(1);
+}

--- a/scripts/release-compact.mjs
+++ b/scripts/release-compact.mjs
@@ -1,0 +1,76 @@
+// Fold the pending release fragments into the three canonical files (#1275):
+//   package.json          -> version = base + fragments
+//   CHANGELOG.md          -> one new section from the fragments' changelog text
+//   src/lib/releaseNotes.ts -> one new entry from the fragments' notes (if any)
+// then delete the fragments. Run by .github/workflows/release-compact.yml on a
+// schedule (the result goes through a NORMAL pull request — branch protection
+// stays intact), or by hand:  node scripts/release-compact.mjs
+//
+// Idempotent by construction: no fragments -> exit 0 without touching anything.
+import { readFileSync, writeFileSync, unlinkSync } from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { FRAGMENT_DIR, readFragments, validateFragment, deriveVersion, unreleasedHighlights } = require('./release-derive.cjs');
+
+const root = process.cwd();
+const fragments = readFragments(root);
+if (fragments.length === 0) {
+  console.log('no pending fragments — nothing to compact');
+  process.exit(0);
+}
+fragments.forEach(validateFragment);
+
+const pkgPath = path.join(root, 'package.json');
+const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+const version = deriveVersion(pkg.version, fragments);
+const date = new Date().toISOString().slice(0, 10);
+
+// 1. package.json — replace exactly the version line, preserving formatting.
+const pkgRaw = readFileSync(pkgPath, 'utf8');
+const pkgNext = pkgRaw.replace(`"version": "${pkg.version}"`, `"version": "${version}"`);
+if (pkgNext === pkgRaw) throw new Error(`could not find "version": "${pkg.version}" in package.json`);
+writeFileSync(pkgPath, pkgNext);
+
+// 2. CHANGELOG.md — one section, fragment bullets in filename order.
+const clPath = path.join(root, 'CHANGELOG.md');
+const cl = readFileSync(clPath, 'utf8');
+const anchor = cl.indexOf('## [');
+if (anchor === -1) throw new Error('CHANGELOG.md has no "## [" section to anchor on');
+const bullets = fragments.map((f) => f.changelog.trim()).join('\n');
+const section = `## [${version}] - ${date}\n\n${bullets}\n\n`;
+writeFileSync(clPath, cl.slice(0, anchor) + section + cl.slice(anchor));
+
+// 3. src/lib/releaseNotes.ts — one entry when any fragment carries notes.
+const highlights = unreleasedHighlights(fragments);
+if (highlights) {
+  const rnPath = path.join(root, 'src', 'lib', 'releaseNotes.ts');
+  const rn = readFileSync(rnPath, 'utf8');
+  const rnAnchor = 'export const RELEASE_NOTES: ReleaseNote[] = [\n';
+  const i = rn.indexOf(rnAnchor);
+  if (i === -1) throw new Error('releaseNotes.ts anchor not found');
+  const list = (arr) => arr.map((s) => `        ${JSON.stringify(s)},`).join('\n');
+  const entry = `  {
+    version: '${version}',
+    date: '${date}',
+    highlights: {
+      en: [
+${list(highlights.en)}
+      ],
+      tr: [
+${list(highlights.tr)}
+      ],
+      de: [
+${list(highlights.de)}
+      ],
+    },
+  },
+`;
+  const at = i + rnAnchor.length;
+  writeFileSync(rnPath, rn.slice(0, at) + entry + rn.slice(at));
+}
+
+// 4. Consume the fragments.
+for (const f of fragments) unlinkSync(path.join(root, FRAGMENT_DIR, f.file));
+
+console.log(`compacted ${fragments.length} fragment(s) -> ${version} (${date})${highlights ? ' with release notes' : ''}`);

--- a/scripts/release-derive.cjs
+++ b/scripts/release-derive.cjs
@@ -1,0 +1,96 @@
+// Shared release-fragment logic (#1275). Used from three places, so it lives
+// in one file with no dependencies:
+//   - next.config.js       -> derive the build's version + unreleased notes
+//   - scripts/release-compact.mjs -> fold fragments into the canonical files
+//   - e2e/version-release-notes.spec.ts -> compute the expected footer version
+//
+// A "fragment" is releases/unreleased/<slug>.json:
+//   {
+//     "bump": "minor" | "patch",
+//     "changelog": "- **Title** (#issue). Developer-facing markdown bullet.",
+//     "notes": { "en": ["..."], "tr": ["..."], "de": ["..."] }   // optional
+//   }
+// PRs only ever ADD such files — they never touch package.json, CHANGELOG.md
+// or src/lib/releaseNotes.ts, so parallel PRs cannot collide on version
+// numbers or conflict on the same lines (see releases/README.md).
+
+const { readFileSync, readdirSync, existsSync } = require('node:fs');
+const path = require('node:path');
+
+const FRAGMENT_DIR = path.join('releases', 'unreleased');
+const LOCALES = ['en', 'tr', 'de'];
+
+/** All fragments, sorted by filename for a deterministic version. */
+function readFragments(repoRoot) {
+  const dir = path.join(repoRoot, FRAGMENT_DIR);
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter((f) => f.endsWith('.json'))
+    .sort()
+    .map((file) => ({
+      file,
+      ...JSON.parse(readFileSync(path.join(dir, file), 'utf8')),
+    }));
+}
+
+/** Throws with a readable message when a fragment is malformed. */
+function validateFragment(fragment) {
+  const where = fragment.file || '(inline)';
+  if (!['minor', 'patch'].includes(fragment.bump)) {
+    throw new Error(`${where}: "bump" must be "minor" or "patch"`);
+  }
+  if (typeof fragment.changelog !== 'string' || !fragment.changelog.trim()) {
+    throw new Error(`${where}: "changelog" must be a non-empty string`);
+  }
+  if (fragment.notes !== undefined) {
+    for (const locale of LOCALES) {
+      const list = fragment.notes?.[locale];
+      if (!Array.isArray(list) || list.length === 0 || list.some((s) => typeof s !== 'string' || !s.trim())) {
+        throw new Error(`${where}: "notes.${locale}" must be a non-empty array of strings (all of ${LOCALES.join('/')} are required together)`);
+      }
+    }
+    const extra = Object.keys(fragment.notes).filter((k) => !LOCALES.includes(k));
+    if (extra.length) throw new Error(`${where}: unknown notes locale(s): ${extra.join(', ')}`);
+  }
+  const known = ['file', 'bump', 'changelog', 'notes'];
+  const unknown = Object.keys(fragment).filter((k) => !known.includes(k));
+  if (unknown.length) throw new Error(`${where}: unknown field(s): ${unknown.join(', ')}`);
+}
+
+/**
+ * Apply fragments to a base semver (suffix like "-beta" is preserved):
+ * each minor fragment bumps the minor and resets patch; each patch fragment
+ * bumps the patch. Deterministic: fragments are pre-sorted by filename.
+ */
+function deriveVersion(baseVersion, fragments) {
+  const m = baseVersion.match(/^(\d+)\.(\d+)\.(\d+)(-.*)?$/);
+  if (!m) throw new Error(`unparseable base version: ${baseVersion}`);
+  let [major, minor, patch] = [Number(m[1]), Number(m[2]), Number(m[3])];
+  const suffix = m[4] ?? '';
+  for (const fragment of fragments) {
+    if (fragment.bump === 'minor') {
+      minor += 1;
+      patch = 0;
+    } else {
+      patch += 1;
+    }
+  }
+  return `${major}.${minor}.${patch}${suffix}`;
+}
+
+/**
+ * The user-facing notes of all fragments that carry any, merged in fragment
+ * order — the shape of one RELEASE_NOTES highlights entry, or null when no
+ * fragment has notes.
+ */
+function unreleasedHighlights(fragments) {
+  const withNotes = fragments.filter((f) => f.notes);
+  if (withNotes.length === 0) return null;
+  const highlights = { en: [], tr: [], de: [] };
+  for (const fragment of withNotes) {
+    for (const locale of LOCALES) highlights[locale].push(...fragment.notes[locale]);
+  }
+  return highlights;
+}
+
+module.exports = { FRAGMENT_DIR, LOCALES, readFragments, validateFragment, deriveVersion, unreleasedHighlights };

--- a/src/app/for-companies/page.tsx
+++ b/src/app/for-companies/page.tsx
@@ -4,7 +4,7 @@ import { getServerDictionary } from '@/i18n/server';
 import { CompanyInquiryForm } from '@/components/CompanyInquiryForm';
 import { PublicShell } from '@/components/landing/PublicShell';
 import { GITHUB_URL } from '@/components/landing/links';
-import { RELEASE_NOTES } from '@/lib/releaseNotes';
+import { getAllReleaseNotes } from '@/lib/releaseNotes';
 
 export const dynamic = 'force-dynamic';
 
@@ -27,7 +27,7 @@ export default async function ForCompaniesPage() {
     { t: L.audCompany6T, d: L.audCompany6D },
   ];
 
-  const releaseCount = RELEASE_NOTES.length;
+  const releaseCount = getAllReleaseNotes().length;
   const proof = [
     { t: L.trans1T, d: L.trans1D, icon: Code2 },
     { t: L.trans2T.replace('{n}', String(releaseCount)), d: L.trans2D, icon: ScrollText },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,7 +14,7 @@ import { getServerDictionary } from '@/i18n/server';
 import { PublicShell } from '@/components/landing/PublicShell';
 import { GITHUB_URL } from '@/components/landing/links';
 import { TawkChat } from '@/components/TawkChat';
-import { RELEASE_NOTES } from '@/lib/releaseNotes';
+import { getAllReleaseNotes } from '@/lib/releaseNotes';
 
 export default async function HomePage() {
   // Only decode a session when one could exist — this is the most-hit page in
@@ -91,7 +91,7 @@ export default async function HomePage() {
 
   // Only claims a stranger can check without an account. The version count is
   // read from the release notes rather than typed in, so it cannot go stale.
-  const releaseCount = RELEASE_NOTES.length;
+  const releaseCount = getAllReleaseNotes().length;
   const transparency = [
     { t: L.trans1T, d: L.trans1D, icon: Code2 },
     { t: L.trans2T.replace('{n}', String(releaseCount)), d: L.trans2D, icon: ScrollText },

--- a/src/app/release-notes/page.tsx
+++ b/src/app/release-notes/page.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import { GraduationCap, Sparkles } from 'lucide-react';
 import { getServerDictionary } from '@/i18n/server';
-import { RELEASE_NOTES } from '@/lib/releaseNotes';
+import { getAllReleaseNotes } from '@/lib/releaseNotes';
 import { APP_VERSION, GIT_SHA } from '@/lib/version';
 import { PublicShell } from '@/components/landing/PublicShell';
 
@@ -21,7 +21,7 @@ export default async function ReleaseNotesPage() {
         </div>
 
         <div className="space-y-6">
-          {RELEASE_NOTES.map((r) => (
+          {getAllReleaseNotes().map((r) => (
             <div key={r.version} className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-800 p-6">
               <div className="flex items-baseline justify-between mb-3">
                 <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">v{r.version}</h2>

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -4,11 +4,34 @@
 // notable release; bump APP_VERSION in package.json to match.
 
 import type { Locale } from '@/i18n/config';
+import { APP_VERSION } from '@/lib/version';
 
 export interface ReleaseNote {
   version: string;
   date: string; // ISO date (release day)
   highlights: Record<Locale, string[]>;
+}
+
+// Release fragments (#1275): PRs ship user-facing notes as files under
+// releases/unreleased/ instead of editing this array (see releases/README.md).
+// next.config.js merges pending fragment notes into APP_UNRELEASED_NOTES at
+// build time; here they become one synthetic entry carrying the derived
+// version, so /release-notes and the landing count stay correct between a
+// merge and the scheduled compaction PR that folds fragments into this file.
+function unreleasedEntry(): ReleaseNote | null {
+  const raw = process.env.APP_UNRELEASED_NOTES;
+  if (!raw) return null;
+  try {
+    return { version: APP_VERSION, date: '', highlights: JSON.parse(raw) };
+  } catch {
+    return null;
+  }
+}
+
+/** Canonical entries plus the pending (not yet compacted) one, newest first. */
+export function getAllReleaseNotes(): ReleaseNote[] {
+  const pending = unreleasedEntry();
+  return pending ? [pending, ...RELEASE_NOTES] : RELEASE_NOTES;
 }
 
 export const RELEASE_NOTES: ReleaseNote[] = [

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,8 +1,11 @@
 import pkg from '../../package.json';
 
-// package.json is a static JSON import — Next.js inlines its contents into
-// the compiled server bundle at build time, so this needs no runtime file
-// access. GIT_SHA is baked into the Docker image at build time (see
-// Dockerfile / .github/workflows/deploy.yml); 'dev' locally.
-export const APP_VERSION: string = pkg.version;
+// The displayed version is BASE (package.json) plus any pending release
+// fragments, derived in next.config.js at build time and inlined here via env
+// (#1275) — so it is correct even before the scheduled compaction PR folds the
+// fragments into package.json. The package.json fallback covers contexts that
+// run without the Next build (scripts, tests importing this module directly).
+// GIT_SHA is baked into the Docker image at build time (see Dockerfile /
+// deploy workflows); 'dev' locally.
+export const APP_VERSION: string = process.env.APP_DERIVED_VERSION || pkg.version;
 export const GIT_SHA: string = (process.env.GIT_SHA || 'dev').slice(0, 7);


### PR DESCRIPTION
## Özet

Closes #1275. Bu haftaki her PR'ın elle rebase + yeniden numaralandırma istemesinin kök nedeni: üç dosya (package.json sürüm satırı, CHANGELOG başı, releaseNotes başı) her PR'da **aynı satırlardan** değişiyordu.

**Yeni kural — PR başına tek adım:** `releases/unreleased/<slug>.json` ekle (`{bump, changelog, notes{en,tr,de}?}`). Yeni dosyalar asla çakışmaz; numarayı kimse elle seçmez. Format: [releases/README.md](releases/README.md).

## Nasıl çalışıyor

- **Build anında türetme:** `next.config.js` taban + fragment'lardan sürümü hesaplar (`APP_DERIVED_VERSION`) ve bekleyen notları tek sentetik girdiye çevirir (`APP_UNRELEASED_NOTES`). Footer, `/api/health` ve `/release-notes` her merge'ün deploy'unda **anında doğru** sürümü gösterir — sıkıştırmanın gecikmesi tasarım gereği zararsız.
- **Zamanlanmış sıkıştırma:** `release-compact.yml` (günlük 04:45 UTC + manuel) fragment'ları gerçek tarihle üç kanonik dosyaya katlar ve siler — **normal bir PR ile** (branch protection ve check'ler aynen geçerli). Script idempotent; scratch kopyada uçtan uca ve ikinci-koşu-no-op olarak doğrulandı.
- **CI kapısı:** `check:release-fragments` bozuk/eksik-dilli fragment'ı onu ekleyen PR'da düşürür (deploy build'inde değil).
- **Dogfood:** bu PR ilk fragment'ı taşıyor → görünen sürüm 0.85.0-beta (e2e `version-release-notes` spec'i türetmeyle güncellendi ve lokalde geçti).

## Doğrulama

- `check:release-fragments` ✓ ("1 pending → 0.85.0-beta")
- Sıkıştırma kuru çalışması: package.json → 0.85.0-beta, CHANGELOG bölümü, releaseNotes girdisi, fragment silindi; 2. koşu no-op ✓
- `tsc` + lint temiz; `e2e/version-release-notes.spec.ts` lokalde geçti (footer türetilmiş sürümü gösteriyor) ✓
- CLAUDE.md versiyonlama bölümü tek-adım kurala güncellendi ✓

## ⚠️ Maintainer'dan tek adım (2 dk): `RELEASE_BOT_TOKEN`

Zamanlanmış sıkıştırmanın otonom olması için **fine-grained PAT** gerekiyor (Settings → Developer settings → Fine-grained tokens: yalnız bu repo, izinler **Contents: RW + Pull requests: RW**) → repo secret **RELEASE_BOT_TOKEN**. İki sebep: (1) org ayarı `GITHUB_TOKEN`'ın PR açmasını yasaklıyor (org düzeyinde; benim token'ım `admin:org` kapsamı olmadığı için açamadım), (2) açabilse bile GitHub'ın özyineleme koruması yüzünden o PR'da required check'ler hiç koşmazdı. Secret gelene kadar: fragment sistemi tam çalışır, sıkıştırmayı herhangi bir oturum `node scripts/release-compact.mjs` + normal PR ile yapar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)