### PR TITLE
docs: retrospective addendum from the #1274 merge round

### DIFF
--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -3825,7 +3825,20 @@ timeout'una takılıyor (5 context + on-demand derleme; CI production build'de s
 ve requisitions'ın eşzamanlı PATCH testi tek çekirdekte serileşip 409 üretmeyebiliyor.
 İkisini de CI'da doğrulayın, yerelde kırmızı diye kurcalamayın.
 
-## 2026-08-23 — #1261 hotfix'i ve katkıcı PR inceleme turu (Claude Code oturumu)
+### Ek — merge turunda çıkan iki ders (PR #1274)
+
+**CodeQL, test dosyasındaki yorum-temizleyen regex'i bile HTML sanitizasyonu sayıyor**
+(`js/incomplete-multi-character-sanitization` + `js/bad-tag-filter`, ikisi de "high").
+React SSR'ın metin ayırıcılarını assertion öncesi temizlerken `replace(/<!--.*?-->/g, '')`
+değil, literal `replaceAll('<!-- -->', '')` kullanın — davranış aynı, tarayıcı kalıbı
+görmüyor ve alarm PR'ı bloke etmiyor. Alert'i "test kodu, kapat" diye dismiss etmeye
+çalışmaktansa kalıbı ortadan kaldırmak hem hızlı hem kalıcı.
+
+**PR ortasında main'i merge etmek, o arada merge olmuş PR'ların taze spec kırıklarını da
+ithal eder.** #692 journey tracker'ı /portal'dan /portal/journey'ye taşımıştı; merge'ten
+sonra journey.spec strict-mode ihlaliyle patladı — benim 11'imle ilgisi yoktu ama benim
+koşumda kırmızıydı. Merge sonrası "önceki koşu yeşildi" güvencesi taşınmaz: tam suite'i
+merge'lenmiş head üzerinde yeniden tetikleyin (workflow_dispatch ücretsiz ve ~8 dk).
 
 **Bir PR'ı yeniden işlemeye başlamadan önce MERGED mi diye bak — ve bitince bir daha bak.**
 #1261'i incelerken (rebase + iki bug düzeltmesi) başka bir oturum PR'ı çoktan merge etmişti;


### PR DESCRIPTION
## Summary

Two reusable lessons that emerged during PR #1274's merge round, after its retrospective entry was already written — appended as an addendum to the same 2026-08-23 entry in `docs/agent-experience.md`:

- **CodeQL flags comment-matching regexes as HTML sanitization even in e2e specs** (`js/incomplete-multi-character-sanitization` + `js/bad-tag-filter`, both high, PR-blocking). Normalize React SSR text separators with a literal `replaceAll('<!-- -->', '')` instead — same behavior, no scanner pattern.
- **Merging main mid-PR imports fresh spec breakage** from PRs that landed meanwhile (#692's portal restructure broke `journey.spec` on the merged head). The pre-merge green doesn't carry over — re-dispatch the full suite on the merged head.

## Verification

- [x] Docs-only change (one markdown file); no fragment needed per releases/README.md.

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGJJumac7jfL5iqoTt96GY)_