### PR TITLE
fix(register): assign the tenant at creation time (#1272)

### DIFF
--- a/e2e/register-org.spec.ts
+++ b/e2e/register-org.spec.ts
@@ -1,0 +1,75 @@
+// #1272 — registration must assign the tenant at creation time. Before this,
+// every account was created org-less and fail-closed org scoping (#1227)
+// 403'd invited COMPANY users' portals until the next deploy's backfill.
+import { test, expect } from '@playwright/test';
+import { prisma, uniqueEmail, cleanupByEmail } from './helpers/db';
+
+const PASSWORD = 'RegisterOrg123!';
+const emails: string[] = [];
+let orgId = '';
+
+test.beforeAll(async () => {
+  const org = await prisma.organization.upsert({
+    where: { slug: 'default' },
+    update: {},
+    create: { slug: 'default', name: 'Default Organization' },
+    select: { id: true },
+  });
+  orgId = org.id;
+});
+
+test.afterAll(async () => {
+  for (const e of emails) await cleanupByEmail(e);
+  await prisma.$disconnect();
+});
+
+test('invited registration inherits the invitation’s org immediately', async ({ request }) => {
+  const email = uniqueEmail('invited-org');
+  emails.push(email);
+  const invite = await prisma.invitationToken.create({
+    data: {
+      token: `org-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      email,
+      role: 'MENTEE',
+      expiresAt: new Date(Date.now() + 86_400_000),
+      orgId,
+    },
+  });
+  const res = await request.post('/api/register', {
+    data: { token: invite.token, email, password: PASSWORD, fullName: 'Invited OrgUser' },
+  });
+  expect(res.status()).toBe(201);
+  const user = await prisma.user.findUnique({ where: { email }, select: { orgId: true } });
+  expect(user?.orgId).toBe(orgId);
+});
+
+test('token-less self-registration gets the default org, not null', async ({ request }) => {
+  const email = uniqueEmail('selfreg-org');
+  emails.push(email);
+  const res = await request.post('/api/register', {
+    data: { email, password: PASSWORD, fullName: 'SelfReg OrgUser' },
+  });
+  expect(res.status()).toBe(201);
+  const user = await prisma.user.findUnique({ where: { email }, select: { orgId: true } });
+  expect(user?.orgId).toBe(orgId);
+});
+
+test('a legacy invitation without an org still registers (falls back to default org)', async ({ request }) => {
+  const email = uniqueEmail('legacy-invite-org');
+  emails.push(email);
+  const invite = await prisma.invitationToken.create({
+    data: {
+      token: `org-legacy-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      email,
+      role: 'MENTEE',
+      expiresAt: new Date(Date.now() + 86_400_000),
+      // orgId deliberately unset — pre-#1272 rows look like this
+    },
+  });
+  const res = await request.post('/api/register', {
+    data: { token: invite.token, email, password: PASSWORD, fullName: 'Legacy Invite OrgUser' },
+  });
+  expect(res.status()).toBe(201);
+  const user = await prisma.user.findUnique({ where: { email }, select: { orgId: true } });
+  expect(user?.orgId).toBe(orgId);
+});

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1674,6 +1674,11 @@ model InvitationToken {
   used         Boolean   @default(false)
   createdAt    DateTime  @default(now())
   expiresAt    DateTime
+  // The inviter's tenant, captured at invite time (#1272) so registration can
+  // assign the org immediately instead of leaving the account org-less until
+  // the next deploy's backfill (fail-closed org scoping 403s COMPANY reads in
+  // that window). Nullable: pre-existing rows predate the column.
+  orgId        String?
   // Who sent the invitation (#51). Nullable: pre-existing rows have no inviter,
   // and the seeder/system can invite without a user. Drives two things on
   // registration — the new account's `referredById`, and the automatic

--- a/prisma/seed-demo.mjs
+++ b/prisma/seed-demo.mjs
@@ -200,6 +200,20 @@ async function main() {
     console.log(`created relation: ${m.fullName} → ${mentor.fullName} (${m.stage})`);
   }
 
+  // Org backfill (#1272): the demo box reseeds between deploys, so without
+  // this the freshly created org-less rows 403 the COMPANY demo account
+  // (fail-closed org scoping, #1227) until the next deploy's backfill runs.
+  const defaultOrg = await prisma.organization.upsert({
+    where: { slug: 'default' },
+    update: {},
+    create: { slug: 'default', name: 'Default Organization' },
+    select: { id: true },
+  });
+  for (const model of ['user', 'source', 'cohort', 'company', 'project', 'mentorshipRelation']) {
+    await prisma[model].updateMany({ where: { orgId: null }, data: { orgId: defaultOrg.id } });
+  }
+  console.log('backfilled default org onto demo rows');
+
   console.log(`\nDemo seed complete. All demo accounts share the password: ${PASSWORD}`);
   console.log(`Demo accounts use the @${DEMO_DOMAIN} domain — no real PII involved.`);
 }

--- a/releases/unreleased/register-org-assignment.json
+++ b/releases/unreleased/register-org-assignment.json
@@ -1,0 +1,9 @@
+{
+  "bump": "patch",
+  "changelog": "- **Registration assigns the tenant at creation time (#1272).** Invited users inherit the inviter's org (carried on `InvitationToken.orgId`, set at invite time); token-less self-registration gets the default org via the new `defaultOrgId()` helper — the same upsert the deploy backfill uses. Previously every account was created org-less, so fail-closed org scoping (#1227) 403'd an invited COMPANY user's portal until the next deploy ran the backfill. The demo seeder now backfills the default org onto its rows too, so the demo company account survives demo resets between deploys.",
+  "notes": {
+    "en": ["Invited company users see their candidates immediately after registering — previously the portal could stay empty until the next deployment."],
+    "tr": ["Davet edilen şirket kullanıcıları kayıttan hemen sonra adaylarını görüyor — önceden portal bir sonraki dağıtıma kadar boş kalabiliyordu."],
+    "de": ["Eingeladene Unternehmensnutzer sehen ihre Kandidaten sofort nach der Registrierung — zuvor konnte das Portal bis zum nächsten Deployment leer bleiben."]
+  }
+}

--- a/src/app/api/invite/route.ts
+++ b/src/app/api/invite/route.ts
@@ -147,6 +147,7 @@ export async function POST(request: Request) {
           role,
           expiresAt,
           invitedById: session.user.id,
+          orgId: resolveOrgId(session),
           mentorId,
           menteeId,
           projectId,

--- a/src/app/api/register/route.ts
+++ b/src/app/api/register/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { enforceRateLimit } from '@/lib/rateLimit';
 import bcrypt from 'bcryptjs';
 import { prisma } from '@/lib/prisma';
+import { defaultOrgId } from '@/lib/defaultOrg';
 import { z } from 'zod';
 import { createEmailVerificationToken } from '@/lib/emailVerification';
 import { sendVerificationEmail } from '@/services/emailService';
@@ -71,6 +72,7 @@ export async function POST(request: Request) {
     // Set from the invitation (its sender) or from a referral code, and written
     // onto the new account so "who brought this person in" is answerable later.
     let referredById: string | null = null;
+    let invitedOrgId: string | null = null;
     let autoLink: { mentorId?: string | null; menteeId?: string | null; projectId?: string | null } = {};
 
     if (token) {
@@ -89,6 +91,7 @@ export async function POST(request: Request) {
       }
       role = invitation.role;
       referredById = invitation.invitedById;
+      invitedOrgId = invitation.orgId;
       autoLink = { mentorId: invitation.mentorId, menteeId: invitation.menteeId, projectId: invitation.projectId };
     } else {
       // An open registration may still carry a referral link.
@@ -117,8 +120,15 @@ export async function POST(request: Request) {
 
     const timezone = isValidTimeZone(parsed.data.timezone) ? parsed.data.timezone : null;
 
+    // Assign the tenant at creation time (#1272): invited users inherit the
+    // inviter's org (carried on the InvitationToken), everyone else gets the
+    // default org — the same one the deploy backfill would assign. Without
+    // this, fail-closed org scoping (#1227) 403s an invited COMPANY user's
+    // portal until the next deploy runs the backfill.
+    const orgId = invitedOrgId ?? (await defaultOrgId());
+
     const user = await prisma.user.create({
-      data: { email, password: hashedPassword, fullName, role, skills: [], emailVerified, isActive: !selfRegistered, pendingApproval: pending, consentAt: new Date(), referredById, timezone },
+      data: { email, password: hashedPassword, fullName, role, skills: [], emailVerified, isActive: !selfRegistered, pendingApproval: pending, consentAt: new Date(), referredById, timezone, orgId },
       select: { id: true, email: true, fullName: true, role: true, createdAt: true, orgId: true },
     });
 

--- a/src/lib/defaultOrg.ts
+++ b/src/lib/defaultOrg.ts
@@ -1,0 +1,20 @@
+import { prisma } from '@/lib/prisma';
+
+// The organization the deploy-time backfill (prisma/seed.mjs) would assign.
+// Registration uses this so no account is ever created org-less (#1272):
+// fail-closed org scoping (#1227) 403s COMPANY reads in the window between
+// registering and the next deploy's backfill. Same upsert as the seeder, so
+// the two can never disagree about which org is "the default".
+let cachedId: string | null = null;
+
+export async function defaultOrgId(): Promise<string> {
+  if (cachedId) return cachedId;
+  const org = await prisma.organization.upsert({
+    where: { slug: 'default' },
+    update: {},
+    create: { slug: 'default', name: 'Default Organization' },
+    select: { id: true },
+  });
+  cachedId = org.id;
+  return cachedId;
+}


### PR DESCRIPTION
## Summary

Every account was created with `orgId: null`; the default-org backfill only runs at deploy time. Since #1227, COMPANY reads of `/api/mentorship` fail closed without an org — so an admin invites a COMPANY user, they register, and their portal answers `403 organization_required` **until the next deploy**. Registration now assigns the tenant at creation time, exactly along the lines #1272 suggested.

Closes #1272

## Changes

- **`InvitationToken.orgId`** (nullable, additive `db push`): the inviter's tenant, captured at invite time via `resolveOrgId(session)` in `/api/invite` — the invite email already resolved it, now the token carries it.
- **`/api/register`**: invited users inherit the invitation's org; token-less self-registration (and legacy org-less invitations) fall back to the default org via the new **`src/lib/defaultOrg.ts`** — the exact same `slug: 'default'` upsert `prisma/seed.mjs`'s backfill uses (module-cached), so the register path and the deploy backfill can never disagree about which org is "the default". This closes the gap for **every** role, not just COMPANY.
- **`prisma/seed-demo.mjs`**: backfills the default org onto demo rows — the demo box reseeds between deploys, so its COMPANY account (`prisma/seed-demo.mjs:109`, created org-less) hit the same 403 after every reset.
- **`e2e/register-org.spec.ts`** (3 tests, all green locally against a real MariaDB): invited registration inherits the invitation's org · token-less self-registration gets the default org (not null) · a legacy pre-#1272 invitation without an org still registers and falls back to the default org.
- **Release fragment** (`releases/unreleased/register-org-assignment.json`) per the new #1276 system — no version-trio edits.

## Verification

- [x] `npm run lint` + `npx tsc --noEmit` clean
- [x] `npm run test:e2e` passing (or CI green) — the new spec 3/3 green locally against a seeded MariaDB; full suite compile-checked (614 tests / 296 files); `check:release-fragments` green (derives 0.86.0-beta)
- [x] Tested the change manually / added an e2e test — `npx prisma validate` green; schema change is additive (nullable column), safe for `db push`

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VeSYkGngKpYG4KWsJ7Ph2Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeSYkGngKpYG4KWsJ7Ph2Z)_