### PR TITLE
feat(comms): e-mail delivery failure visibility — derived health, alerts, hourly check (#1190)

### DIFF
--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -3869,3 +3869,34 @@ ediyor; `version.ts` ve `releaseNotes.ts` oradan besleniyor. Deploy sonrası can
 health `version` alanı taban değil türetilmiş numarayı gösterir (0.85.0 taban + minor fragment
 → 0.86.0-beta gözlendi). Sürüm iddialarını test ederken package.json'a değil
 `scripts/release-derive.cjs` ile hesaplanan değere assert et (version-release-notes.spec böyle).
+
+## 2026-08-23 — Backlog-bitirme oturumu, 2. kısım (#1272, #937-#939, #1190)
+
+**MariaDB bu konteynerde boşta kalınca ölüyor** — `prisma db push`/spec'ler "Can't reach
+database" ya da sessizce eski şemayla devam ediyor. Her doğrulama zincirinin ilk adımı
+`service mariadb status || service mariadb start` olmalı. Sinsi biçimi: db push'un kendisi
+sessizce başarısız olmuşsa spec "column does not exist" ile düşer — bağlantı hatası değil,
+şema kaymasıdır; yeniden push et.
+
+**`ActivityLog.detail` ve tüm çıplak `String?` alanlar MySQL'de VARCHAR(191)** — #1268'in
+AuditLog dersi genelleşti: JSON payload yazan her logging çağrısı sığdırmayı kendisi
+garantilemeli (`.slice(0, 191)` + uzun alt alanları önceden kırp). P2000 logActivity içinde
+yutulur, kayıt sessizce kaybolur — tam da alarm kaydı gibi kaybolmaması gereken yerde.
+
+**E-posta sağlığı türetilmiş veri olarak kuruldu (#1190):** ayrı bir "son durum" markörü
+yerine EmailLog defterinden hesapla (`getEmailHealth`) — defter her denemede yazıldığı için
+sağlık gerçeklikten sapamaz. Alarm zinciri katmanlı: kalıcı sinyal ActivityLog satırı,
+best-effort sinyal ALERT_EMAIL_TO'ya `ops-alert` kategorili mail (kendi kategorisini
+denetlemez → özyineleme yok), tekrar bastırma in-memory 6h (restart sonrası bir fazla alarm,
+kaçan alarmdan iyidir).
+
+**Playwright'ta `page.request` oturum çerezini taşır** — "anonim çağrı" assert'i için ayrı
+`request` fixture'ını kullan (çerezsiz). Admin oturumuyla açık page.request, token'sız
+/api/health çağrısında bile detay görür (maySeeDetail admin oturumunu kabul ediyor) ve
+"anonim görmemeli" testini yanlış düşürür.
+
+**e2e'de global durum varsayma:** EmailLog gibi paylaşılan defterlere assert yazarken paralel
+spec'lerin araya satır sokabileceğini hesaba kat — eşitlik yerine alt sınır (`>=`), koşullu
+assert (cron cevabındaki anlık görüntüye göre) ve temizlenmeyen kalıcı kanıt satırı
+(in-memory dedupe yüzünden ikinci koşuda alarm atılmaz; ilk koşunun ActivityLog satırına
+`count >= 1` assert et, satırı silme).

--- a/e2e/email-health.spec.ts
+++ b/e2e/email-health.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect } from '@playwright/test';
+import { E2E_HEALTH_TOKEN } from '../playwright.config';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+// E-mail delivery failure visibility (#1190): health is DERIVED from the
+// EmailLog ledger (#1194) — last success, failures since, attempts in 24h —
+// and surfaced on /api/admin/email-health, the /api/health detail view and an
+// hourly check that writes an `email.health_alert` ActivityLog row when the
+// channel looks dead. Recipient addresses must never leak into any of it.
+const local = !process.env.BASE_URL;
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('derived email health: counters, PII scrubbing, health endpoints, stale alert', async ({ page, request }) => {
+  test.skip(!local, 'seeds EmailLog rows directly — local DB only');
+
+  const adminEmail = uniqueEmail('emailhealth-admin');
+  await seedUser(adminEmail, 'AdminPass123', 'ADMIN', 'EmailHealth Admin');
+
+  // The channel's story: one success 7h ago, then three failures — the last
+  // one echoing the recipient's address, as SMTP rejections do.
+  const failTo = uniqueEmail('emailhealth-victim');
+  const sevenHoursAgo = new Date(Date.now() - 7 * 60 * 60 * 1000);
+  const seeded: string[] = [];
+  const mkLog = async (status: 'SENT' | 'FAILED', createdAt: Date, error?: string) => {
+    const row = await prisma.emailLog.create({
+      data: { to: failTo, subject: 'e2e email health probe', category: 'e2e-health', status, error: error ?? null, createdAt },
+    });
+    seeded.push(row.id);
+  };
+  await mkLog('SENT', sevenHoursAgo);
+  await mkLog('FAILED', new Date(Date.now() - 3 * 60 * 1000), 'Connection refused');
+  await mkLog('FAILED', new Date(Date.now() - 2 * 60 * 1000), 'Connection refused');
+  await mkLog('FAILED', new Date(Date.now() - 1 * 60 * 1000), `550 Recipient ${failTo} rejected`);
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', 'AdminPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    // 1) Admin endpoint: counters derived from the ledger, error scrubbed.
+    // Other specs run in parallel and also write EmailLog rows, so the
+    // assertions are lower bounds, not exact equality.
+    const adminRes = await page.request.get('/api/admin/email-health');
+    expect(adminRes.status()).toBe(200);
+    const adminHealth = (await adminRes.json()).email;
+    expect(adminHealth.failuresSinceOk).toBeGreaterThanOrEqual(3);
+    expect(adminHealth.attempts24h).toBeGreaterThanOrEqual(3);
+    expect(adminHealth.lastErrorAt).not.toBeNull();
+    // The recipient's address never leaves the server — scrubbed at read time.
+    expect(adminHealth.lastError).toContain('<redacted>');
+    expect(JSON.stringify(adminHealth)).not.toContain('@e2e.local');
+
+    // 2) /api/health detail view carries the same block (token-gated).
+    const healthRes = await page.request.get('/api/health', {
+      headers: { 'X-Health-Token': E2E_HEALTH_TOKEN },
+    });
+    expect(healthRes.status()).toBe(200);
+    const healthBody = await healthRes.json();
+    expect(healthBody.email).toBeTruthy();
+    expect(healthBody.email.failuresSinceOk).toBeGreaterThanOrEqual(3);
+    expect(JSON.stringify(healthBody.email)).not.toContain('@e2e.local');
+
+    // …and an anonymous caller still sees liveness only, no delivery detail.
+    // The `request` fixture carries no browser cookies — page.request would
+    // ride the admin session, which legitimately sees the detail view.
+    const anonRes = await request.get('/api/health');
+    expect((await anonRes.json()).email).toBeUndefined();
+
+    // 3) The hourly check, run on demand: with the last success 7h old and
+    // failures since, the channel is stale → a durable ActivityLog alert.
+    const cronRes = await page.request.get('/api/cron?job=email-health');
+    expect(cronRes.ok()).toBeTruthy();
+    const cronHealth = (await cronRes.json()).email;
+    const wasStale =
+      (!cronHealth.lastOkAt || Date.parse(cronHealth.lastOkAt) < Date.now() - 6 * 60 * 60 * 1000) &&
+      cronHealth.attempts24h > 0 &&
+      cronHealth.failuresSinceOk > 0;
+    if (wasStale) {
+      // Not cleaned up on purpose: the alert is in-memory-deduped for 6h, so a
+      // rerun against a long-lived dev server must still find the earlier row.
+      const alerts = await prisma.activityLog.count({ where: { action: 'email.health_alert' } });
+      expect(alerts).toBeGreaterThanOrEqual(1);
+    }
+    // A parallel spec can insert a fresh SENT row and un-stale the ledger
+    // (email-hardening does); then the alert legitimately does not fire and
+    // only the derived numbers above are asserted.
+
+    // 4) The admin settings page shows the derived line.
+    await page.goto('/admin/settings');
+    await expect(page.getByTestId('email-delivery-health')).toBeVisible();
+  } finally {
+    await prisma.emailLog.deleteMany({ where: { id: { in: seeded } } });
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/releases/unreleased/email-delivery-health.json
+++ b/releases/unreleased/email-delivery-health.json
@@ -1,0 +1,9 @@
+{
+  "bump": "minor",
+  "changelog": "- **Email delivery health (#1190)**: delivery health (last success, failures since, attempts in 24h) is now derived from the `EmailLog` ledger and surfaced on the admin settings page, `/api/admin/email-health` and the token-gated `/api/health` detail view. An hourly check writes a durable `email.health_alert` activity entry and sends a best-effort ops email (`ALERT_EMAIL_TO`) after 3 consecutive failures or when the last success goes stale while attempts continue. Error text is scrubbed of recipient addresses before it leaves the server.",
+  "notes": {
+    "en": ["Email delivery problems no longer stay silent: the settings page shows the last successful delivery and failures since, and admins are alerted when sending keeps failing."],
+    "tr": ["E-posta gönderim sorunları artık sessiz kalmıyor: ayarlar sayfası son başarılı gönderimi ve o zamandan beri olan hataları gösteriyor; gönderim sürekli başarısız olursa yöneticiler uyarılıyor."],
+    "de": ["E-Mail-Zustellprobleme bleiben nicht mehr unbemerkt: Die Einstellungsseite zeigt die letzte erfolgreiche Zustellung und die Fehler seitdem; Admins werden gewarnt, wenn der Versand wiederholt fehlschlägt."]
+  }
+}

--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -56,8 +56,19 @@ export default function AdminSettingsPage() {
     byCategory: { category: string; transport: string; count: number }[];
   } | null>(null);
 
+  // Derived delivery health (#1190): last success / failures since, computed
+  // server-side from the same EmailLog ledger the table below shows.
+  const [emailHealth, setEmailHealth] = useState<{
+    lastOkAt: string | null;
+    lastErrorAt: string | null;
+    lastError: string | null;
+    failuresSinceOk: number;
+    attempts24h: number;
+  } | null>(null);
+
   const loadEmailLog = useCallback(() => {
     fetch('/api/admin/email-log?limit=25').then((r) => (r.ok ? r.json() : null)).then((d) => d && setEmailLog(d)).catch(() => {});
+    fetch('/api/admin/email-health').then((r) => (r.ok ? r.json() : null)).then((d) => d?.email && setEmailHealth(d.email)).catch(() => {});
   }, []);
 
   useEffect(() => {
@@ -293,6 +304,27 @@ export default function AdminSettingsPage() {
                 .replace('{p}', String(emailLog.last24h.primary))
                 .replace('{b}', String(emailLog.last24h.bulk))}
             </p>
+          )}
+
+          {/* Delivery health (#1190): when did a mail last actually go out, and
+              has anything failed since. Amber at 1-2 failures, red from 3 (the
+              threshold that also fires the ops alert). */}
+          {emailHealth && (
+            <div className="text-sm" data-testid="email-delivery-health">
+              <span className="text-gray-600 dark:text-gray-300">
+                {emailHealth.lastOkAt
+                  ? t.settings.deliveryLastOk.replace('{t}', new Date(emailHealth.lastOkAt).toLocaleString())
+                  : t.settings.deliveryNeverOk}
+              </span>
+              {emailHealth.failuresSinceOk > 0 ? (
+                <span className={emailHealth.failuresSinceOk >= 3 ? 'text-red-600 dark:text-red-400' : 'text-amber-600 dark:text-amber-400'}>
+                  {' · '}
+                  {t.settings.deliveryFailures.replace('{n}', String(emailHealth.failuresSinceOk))}
+                </span>
+              ) : (
+                emailHealth.lastOkAt && <span className="text-green-600 dark:text-green-400"> · {t.settings.deliveryHealthy}</span>
+              )}
+            </div>
           )}
 
           <div className="flex flex-col sm:flex-row gap-2">

--- a/src/app/api/admin/email-health/route.ts
+++ b/src/app/api/admin/email-health/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { getEmailHealth } from '@/lib/emailHealth';
+
+// Admin view of the e-mail delivery health (#1190) — the settings page shows
+// "last successful e-mail" from this. Same derived, PII-scrubbed shape as the
+// /api/health detail block, but reachable with a normal admin session instead
+// of the health token.
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  return NextResponse.json({ email: await getEmailHealth() });
+}

--- a/src/app/api/cron/route.ts
+++ b/src/app/api/cron/route.ts
@@ -12,6 +12,7 @@ import {
   sendWeeklyAnalyticsReport,
   sendWeeklyReportReminders,
   sendWeeklyMissingDocumentReminders,
+  runEmailHealthCheck,
 } from '@/services/emailService';
 import { expireOffers } from '@/lib/offerNotify';
 
@@ -26,6 +27,9 @@ export async function GET(request: Request) {
     const job = new URL(request.url).searchParams.get('job');
     if (job === 'weekly-reports') {
       return NextResponse.json({ message: 'Weekly report reminders ran', weeklyReports: await sendWeeklyReportReminders() });
+    }
+    if (job === 'email-health') {
+      return NextResponse.json({ message: 'Email health check ran', email: await runEmailHealthCheck() });
     }
     if (job === 'missing-documents') {
       const missingDocuments = await sendWeeklyMissingDocumentReminders();

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from 'next-auth';
 import { timingSafeEqual } from 'crypto';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { getEmailHealth } from '@/lib/emailHealth';
 import { APP_VERSION, GIT_SHA } from '@/lib/version';
 import { verifySmtpConnection } from '@/services/emailService';
 
@@ -92,6 +93,9 @@ export async function GET(request: Request) {
       db,
       smtp,
       ...(smtpError ? { smtpError } : {}),
+      // Delivery health (#1190), derived from the EmailLog ledger — recipient
+      // addresses are scrubbed in the lib, so nothing here carries PII.
+      email: await getEmailHealth(),
       uptimeMs: Math.round(process.uptime() * 1000),
       responseMs: Date.now() - started,
       timestamp: new Date().toISOString(),

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -2137,6 +2137,10 @@ const en = {
     bulkChannelFailed: 'Bulk channel unreachable',
     bulkTag: 'bulk',
     quotaToday: 'Last 24 hours: {p} via the primary channel (this is what counts against a relay quota), {b} via the bulk channel.',
+    deliveryLastOk: 'Last successful delivery: {t}',
+    deliveryNeverOk: 'No successful delivery recorded yet',
+    deliveryFailures: '{n} failed attempt(s) since the last success — an alert goes to the ops address after 3 in a row.',
+    deliveryHealthy: 'no failures since',
   },
   checklist: {
     title: 'Get started',
@@ -4918,6 +4922,10 @@ const tr: Dict = {
     bulkChannelFailed: 'Toplu kanala ulaşılamıyor',
     bulkTag: 'toplu',
     quotaToday: 'Son 24 saat: {p} birincil kanaldan (relay kotasından düşen bu), {b} toplu kanaldan.',
+    deliveryLastOk: 'Son başarılı gönderim: {t}',
+    deliveryNeverOk: 'Henüz başarılı bir gönderim kaydedilmedi',
+    deliveryFailures: 'Son başarılı gönderimden bu yana {n} başarısız deneme — art arda 3 denemeden sonra ops adresine uyarı gider.',
+    deliveryHealthy: 'o zamandan beri hata yok',
   },
   checklist: {
     title: 'Başlayalım',
@@ -7697,6 +7705,10 @@ const de: Dict = {
     bulkChannelFailed: 'Bulk-Kanal nicht erreichbar',
     bulkTag: 'Bulk',
     quotaToday: 'Letzte 24 Stunden: {p} über den primären Kanal (das zählt gegen ein Relay-Kontingent), {b} über den Bulk-Kanal.',
+    deliveryLastOk: 'Letzte erfolgreiche Zustellung: {t}',
+    deliveryNeverOk: 'Noch keine erfolgreiche Zustellung aufgezeichnet',
+    deliveryFailures: '{n} fehlgeschlagene(r) Versuch(e) seit dem letzten Erfolg — nach 3 in Folge geht eine Warnung an die Ops-Adresse.',
+    deliveryHealthy: 'seitdem keine Fehler',
   },
   checklist: {
     title: 'Loslegen',

--- a/src/lib/emailHealth.ts
+++ b/src/lib/emailHealth.ts
@@ -1,0 +1,47 @@
+import { prisma } from '@/lib/prisma';
+
+// E-mail delivery health (#1190), DERIVED from the EmailLog ledger (#1194)
+// instead of a separate last-state marker — the log is written on every
+// attempt, so the two can never drift apart. Server-only.
+//
+// PII rule: the health surface never carries a recipient. EmailLog.error can
+// echo the address (SMTP rejections often do), so error text is scrubbed of
+// anything address-shaped before it leaves this module.
+
+export interface EmailHealth {
+  // Latest successful delivery, or null when none was ever recorded.
+  lastOkAt: string | null;
+  lastErrorAt: string | null;
+  // Sanitized error class/message of the latest failure — never an address.
+  lastError: string | null;
+  // FAILED attempts recorded after the latest success (all-time when there
+  // has never been a success). 0 means the channel looks healthy.
+  failuresSinceOk: number;
+  // Real attempts (SENT + FAILED) in the last 24h; SKIPPED rows are an
+  // unconfigured-SMTP marker, not an attempt.
+  attempts24h: number;
+}
+
+export function sanitizeEmailError(error: string | null | undefined): string | null {
+  if (!error) return null;
+  return error.replace(/[\w.+-]+@[\w.-]+/g, '<redacted>').slice(0, 300);
+}
+
+export async function getEmailHealth(): Promise<EmailHealth> {
+  const dayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+  const [lastOk, lastFail, attempts24h] = await Promise.all([
+    prisma.emailLog.findFirst({ where: { status: 'SENT' }, orderBy: { createdAt: 'desc' }, select: { createdAt: true } }),
+    prisma.emailLog.findFirst({ where: { status: 'FAILED' }, orderBy: { createdAt: 'desc' }, select: { createdAt: true, error: true } }),
+    prisma.emailLog.count({ where: { status: { in: ['SENT', 'FAILED'] }, createdAt: { gt: dayAgo } } }),
+  ]);
+  const failuresSinceOk = await prisma.emailLog.count({
+    where: { status: 'FAILED', ...(lastOk ? { createdAt: { gt: lastOk.createdAt } } : {}) },
+  });
+  return {
+    lastOkAt: lastOk?.createdAt.toISOString() ?? null,
+    lastErrorAt: lastFail?.createdAt.toISOString() ?? null,
+    lastError: sanitizeEmailError(lastFail?.error),
+    failuresSinceOk,
+    attempts24h,
+  };
+}

--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -4,6 +4,8 @@ import { randomUUID } from 'node:crypto';
 import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 import { logger } from '@/lib/logger';
+import { getEmailHealth, type EmailHealth } from '@/lib/emailHealth';
+import { logActivity } from '@/lib/activity';
 import { notify } from '@/lib/notify';
 import { markReadUrl } from '@/lib/emailActionToken';
 import { getSetting } from '@/lib/settings';
@@ -188,6 +190,66 @@ async function recordEmail(
   }
 }
 
+// ── E-mail delivery health alerts (#1190) ───────────────────────────────────
+// The channel's own failures must not stay silent, but the alert also travels
+// by e-mail — so the alert is best-effort and the durable signals are the
+// ActivityLog row and /api/health. In-memory dedupe (6h) is deliberate: after
+// a restart one extra alert beats a missed one.
+const EMAIL_ALERT_CATEGORY = 'ops-alert';
+const EMAIL_ALERT_MIN_FAILURES = 3;
+const EMAIL_ALERT_INTERVAL_MS = 6 * 60 * 60 * 1000;
+let lastEmailAlertAt = 0;
+
+async function alertEmailHealth(reason: 'consecutive_failures' | 'stale', health: EmailHealth) {
+  if (Date.now() - lastEmailAlertAt < EMAIL_ALERT_INTERVAL_MS) return;
+  lastEmailAlertAt = Date.now();
+  // ActivityLog.detail is VARCHAR(191) — an oversized JSON is silently lost
+  // (P2000, the #1268 lesson), so the error is pre-trimmed and the whole
+  // payload capped.
+  const detail = JSON.stringify({
+    reason,
+    failuresSinceOk: health.failuresSinceOk,
+    lastOkAt: health.lastOkAt,
+    lastError: health.lastError?.slice(0, 80) ?? null,
+  }).slice(0, 191);
+  // The durable record — visible even when the alert e-mail below cannot leave.
+  await logActivity({ level: 'error', action: 'email.health_alert', targetType: 'email', detail });
+  const alertTo = process.env.ALERT_EMAIL_TO;
+  if (!alertTo) return;
+  try {
+    await sendEmail({
+      to: alertTo,
+      subject: `[CRM] E-mail delivery ${reason === 'stale' ? 'stalled' : 'failing'} — ${health.failuresSinceOk} failures since last success`,
+      html: `<p>E-mail delivery health alert (<b>${reason}</b>).</p><ul><li>Failures since last success: ${health.failuresSinceOk}</li><li>Last success: ${health.lastOkAt ?? 'never'}</li><li>Last error: ${health.lastError ?? '-'}</li></ul><p>Watch /api/health (detail view) for the live state.</p>`,
+      category: EMAIL_ALERT_CATEGORY,
+    });
+  } catch (e) {
+    logger.error('Email health alert could not be delivered', { error: String(e) });
+  }
+}
+
+// Fired after every FAILED attempt (never for the alert channel itself — the
+// alert failing must not re-trigger the alert).
+async function maybeAlertEmailFailures(category?: string) {
+  if (category === EMAIL_ALERT_CATEGORY) return;
+  try {
+    const health = await getEmailHealth();
+    if (health.failuresSinceOk >= EMAIL_ALERT_MIN_FAILURES) await alertEmailHealth('consecutive_failures', health);
+  } catch (e) {
+    logger.error('Email health evaluation failed', { error: String(e) });
+  }
+}
+
+// Hourly check (#1190 item 4): the last success is older than 6h while real
+// attempts kept happening — the queue is trying and nothing gets through.
+export async function runEmailHealthCheck(): Promise<EmailHealth> {
+  const health = await getEmailHealth();
+  const sixHoursAgo = Date.now() - 6 * 60 * 60 * 1000;
+  const stale = (!health.lastOkAt || new Date(health.lastOkAt).getTime() < sixHoursAgo) && health.attempts24h > 0 && health.failuresSinceOk > 0;
+  if (stale) await alertEmailHealth('stale', health);
+  return health;
+}
+
 export async function sendEmail({
   to,
   subject,
@@ -257,6 +319,7 @@ export async function sendEmail({
     const message = e instanceof Error ? e.message : String(e);
     logger.error('Email send failed', { to, subject, category, transport, error: message });
     await recordEmail(to, subject, category, 'FAILED', transport, message);
+    void maybeAlertEmailFailures(category).catch(() => {});
     throw e;
   }
 
@@ -2294,6 +2357,17 @@ export function initCronJobs() {
     }
   });
   scheduledTasks.set('analytics-report', analyticsTask);
+
+  // Hourly e-mail delivery health check (#1190) — alerts when sends keep
+  // failing or the last success goes stale while attempts continue.
+  const emailHealthTask = cron.schedule('5 * * * *', async () => {
+    try {
+      await runEmailHealthCheck();
+    } catch (e) {
+      logger.error('Email health cron failed', { error: String(e) });
+    }
+  });
+  scheduledTasks.set('email-health', emailHealthTask);
 
   // Missing mandatory documents — Mondays 08:30, offset from the other weekly jobs.
   const documentTask = cron.schedule('30 8 * * 1', async () => {


### PR DESCRIPTION
# Summary

E-mail delivery problems no longer stay silent (#1190, parent story #1189). Delivery health — **last successful delivery, failures since, attempts in the last 24h** — is now *derived* from the `EmailLog` ledger (#1194) in `src/lib/emailHealth.ts`: the log is written on every attempt, so health can never drift from what actually happened.

**Surfaces**
- `GET /api/admin/email-health` — admin-session view, feeds the settings page.
- `/api/health` detail view (HEALTH_TOKEN / admin gated) gains an `email` block for uptime monitoring.
- Admin settings → E-mail health card shows a status line: last successful delivery, amber at 1–2 failures since, red from 3 (EN/TR/DE).

**Alerts**
- After **3 consecutive failures** (evaluated on every FAILED send) or when the last success is **>6h stale while attempts continue** (hourly cron `5 * * * *`, on demand via `/api/cron?job=email-health`), a durable `email.health_alert` ActivityLog row is written and a best-effort ops e-mail goes to `ALERT_EMAIL_TO`.
- The alert e-mail uses category `ops-alert` and is guarded against self-recursion (an alert failing to send never re-triggers the alert); in-memory 6h dedupe — after a restart one extra alert beats a missed one.

**PII**: recipient addresses are scrubbed from error text before it leaves the server (`sanitizeEmailError`), and the ActivityLog `detail` payload is capped below VARCHAR(191) (the #1268 lesson).

Closes #1190

# Changes

- `src/lib/emailHealth.ts` (new): `getEmailHealth()` + `sanitizeEmailError()`.
- `src/services/emailService.ts`: alert machinery, FAILED-send hook, `runEmailHealthCheck()`, hourly cron registration.
- `src/app/api/admin/email-health/route.ts` (new): ADMIN-only health endpoint.
- `src/app/api/health/route.ts`: `email` block in the gated detail view.
- `src/app/api/cron/route.ts`: `?job=email-health` branch.
- `src/app/admin/settings/page.tsx`: delivery-health status line in the E-mail health card.
- `src/i18n/dictionaries.ts`: 4 new `settings.*` keys ×3 locales.
- `e2e/email-health.spec.ts` (new): seeds a 7h-old success + 3 failures (one echoing the recipient address); asserts derived counters, `<redacted>` scrubbing on both endpoints, anonymous callers see no detail, the stale alert writes the ActivityLog row, and the settings line renders.
- `releases/unreleased/email-delivery-health.json`: minor bump fragment with EN/TR/DE notes.

# Verification

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (pre-existing warning only)
- [x] `npm run check:i18n` — 2802 keys × 3 locales OK
- [x] `npm run check:release-fragments` OK (→ 0.88.0-beta)
- [x] `npm run build` clean
- [x] Local e2e: `email-health.spec.ts` green; regression `health.spec.ts`, `admin-settings.spec.ts`, `cron-jobs.spec.ts`, `email-channels.spec.ts` all green (7/7)

# Contributor terms (IP)

- [x] I have read and accept the contributor terms in CONTRIBUTING.md (§ Contributor terms (IP)), including the copyright assignment to Mehmet Erşahin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VeSYkGngKpYG4KWsJ7Ph2Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeSYkGngKpYG4KWsJ7Ph2Z)_