### PR TITLE
fix(deploy): repair poisoned Json columns before the schema push

### DIFF
--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -3913,3 +3913,25 @@ spec'lerin araya satır sokabileceğini hesaba kat — eşitlik yerine alt sın�
 assert (cron cevabındaki anlık görüntüye göre) ve temizlenmeyen kalıcı kanıt satırı
 (in-memory dedupe yüzünden ikinci koşuda alarm atılmaz; ilk koşunun ActivityLog satırına
 `count >= 1` assert et, satırı silme).
+
+## 2026-08-24 — Prod deploy'u kilitleyen Json+FK push'u (#1288)
+
+**MariaDB'de `ADD COLUMN ... CHECK(json_valid)` check'i DOĞRULAMAZ; sonraki FK/index
+adımının COPY rebuild'i DOĞRULAR.** #1281 aynı push'ta hem `preferredLanguages Json`
+(NOT NULL) hem yeni bir FK ekledi: AddColumn eski satırları sessizce `''` ile doldurup
+geçti (bilinen #1150/#1078 mekanizması — Prisma, Json `@default`'unu DDL'e yazmaz),
+AddForeignKey ise tabloyu yeniden yazarken check'e takıldı. Push yarıda kaldı, kolon
+`''` dolu kaldı ve HER yeniden deneme aynı yerde patladı — post-push çalışan
+`backfill-json-columns.mjs --repair` hiç sıraya giremedi. Çözüm: onarımı final
+push'un ÖNCESİNE de koymak (deploy-prod.sh + topic-deploy.sh) ve script'in COLUMNS
+listesine şemadaki YENİ Json kolonlarını eklemeyi unutmamak (7 kolon eksikti).
+
+**Tek satırlık lokal repro, prod log'undan daha öğretici.** Eski şemalı lokal
+MariaDB'ye 1 MentorshipRequest satırı ekleyip `db push` koşmak hatayı birebir üretti;
+düzeltme de aynı düzenekte uçtan uca doğrulandı (repair → push yeşil, FK yerinde).
+Prod'a hiç dokunmadan hem tanı hem kanıt.
+
+**Kalıcı önlem hâlâ açık:** populated bir tabloya "NOT NULL Json kolonu + rebuild
+tetikleyen değişiklik" aynı push'ta gelirse ilk deploy yine patlar (kolon henüz yokken
+pre-push repair işe yaramaz). Nullable-first ya da expand-script (#1227 deseni)
+konvansiyonu / schema-guard tespiti #1288'de tartışılıyor.

--- a/infra/deploy-prod.sh
+++ b/infra/deploy-prod.sh
@@ -326,6 +326,17 @@ run_tool node prisma/push-company-interest-expand.mjs
 log "backfill CompanyInterest deterministic scope keys"
 run_tool node prisma/backfill-company-interest-scope.mjs
 
+# ALSO before the push, not only after (#1288): when a previous half-applied
+# push has left a Json column filled with '' (the MariaDB longtext fill, see
+# the note below), the NEXT push can die before the post-push repair ever
+# runs — any step that rebuilds the table (AddForeignKey, index changes)
+# re-validates the json_valid() CHECK against the poisoned rows. That is
+# exactly how MentorshipRequest.preferredLanguages wedged the 2026-08-24 prod
+# deploy: the '' fill from the failed run's AddColumn step made every retry
+# fail at the AddForeignKey step. Repairing first makes the push re-runnable.
+log "repair invalid Json column values (pre-push, idempotent)"
+run_tool node prisma/backfill-json-columns.mjs --repair || true
+
 log "prisma db push (final contract phase)"
 run_tool npx prisma db push --accept-data-loss
 

--- a/infra/server/topic-deploy.sh
+++ b/infra/server/topic-deploy.sh
@@ -97,6 +97,10 @@ docker run --rm --add-host=host.docker.internal:host-gateway \
   -e DATABASE_URL="$CONTAINER_DB" "$IMAGE" node prisma/push-company-interest-expand.mjs
 docker run --rm --add-host=host.docker.internal:host-gateway \
   -e DATABASE_URL="$CONTAINER_DB" "$IMAGE" node prisma/backfill-company-interest-scope.mjs
+# Pre-push Json repair (#1288): a table rebuild in the push (FK/index) fails on
+# rows a previous half-applied push left as '' — repair first, same as prod.
+docker run --rm --add-host=host.docker.internal:host-gateway \
+  -e DATABASE_URL="$CONTAINER_DB" "$IMAGE" node prisma/backfill-json-columns.mjs --repair || true
 docker run --rm --add-host=host.docker.internal:host-gateway \
   -e DATABASE_URL="$CONTAINER_DB" "$IMAGE" npx prisma db push --accept-data-loss
 docker run --rm --add-host=host.docker.internal:host-gateway \

--- a/prisma/backfill-json-columns.mjs
+++ b/prisma/backfill-json-columns.mjs
@@ -34,6 +34,17 @@ const COLUMNS = [
   { table: 'MenteeOnboarding', column: 'steps', fallback: '{}' },
   { table: 'Evaluation', column: 'scores', fallback: '{}' },
   { table: 'MeetingSeries', column: 'daysOfWeek', fallback: '[]' },
+  { table: 'Notification', column: 'params', fallback: null },
+  { table: 'Announcement', column: 'translations', fallback: null },
+  // An empty labels object renders as the requirement key (requirementLabel()
+  // falls back key-ward), which is the honest display for a lost value.
+  { table: 'DocumentRequirement', column: 'labels', fallback: '{}' },
+  // The column whose '' fill killed the 2026-08-24 prod deploy: the same push
+  // added an FK on the table, and that rebuild re-validated json_valid().
+  { table: 'MentorshipRequest', column: 'preferredLanguages', fallback: '[]' },
+  { table: 'MeetingRoomState', column: 'participants', fallback: '[]' },
+  { table: 'Requisition', column: 'requiredSkills', fallback: '[]' },
+  { table: 'InterviewRequest', column: 'proposedSlots', fallback: null },
 ];
 
 const repair = process.argv.includes('--repair');


### PR DESCRIPTION
## Summary

The prod deploy of `3c726b0` failed ([run 32691989604](https://github.com/21072026/Internship/actions/runs/32691989604)) and **every retry will fail identically** until the poisoned rows are repaired. Production is up and healthy on the previous build (`5e38009`) — the failure happened before the container swap — but the last 4 merges are not live. Merging this PR redeploys main with the fix in place.

Closes #1288

## Root cause

#1281 added `MentorshipRequest.preferredLanguages Json @default("[]")` (NOT NULL) **and** a new FK in the same push. On MariaDB:
1. `AddColumn` silently filled existing rows with `''` (Prisma drops Json `@default` from DDL — the known #1150/#1078 mechanism) and did **not** validate the `json_valid()` CHECK;
2. the `AddForeignKey` step's COPY rebuild **did** validate it → `CONSTRAINT MentorshipRequest.preferredLanguages failed`, push dead, column left half-applied with `''` in every pre-existing row;
3. the existing safety net (`backfill-json-columns.mjs --repair`) runs **after** the final push, so it never ran — and this column wasn't in its COLUMNS list anyway.

## Changes

- **`infra/deploy-prod.sh` + `infra/server/topic-deploy.sh`**: run the Json repair **also before** the final contract push (kept after too). A wedged push becomes re-runnable; prod/preview/topic all get the same guard.
- **`prisma/backfill-json-columns.mjs`**: add the 7 Json columns missing from COLUMNS (`Notification.params`, `Announcement.translations`, `DocumentRequirement.labels`, `MentorshipRequest.preferredLanguages`, `MeetingRoomState.participants`, `Requisition.requiredSkills`, `InterviewRequest.proposedSlots`).
- Retrospective entry in `docs/agent-experience.md`.

The durable prevention (a new required Json column + rebuild-triggering change in one push will break the *first* deploy on any populated DB, before a repair can exist) is left open in #1288.

## Verification

- [x] Reproduced the exact error locally on MariaDB 10.11: one seeded `MentorshipRequest` row + `prisma db push` fails verbatim at `AddForeignKey` with `CONSTRAINT MentorshipRequest.preferredLanguages failed`.
- [x] With the fix: `backfill-json-columns.mjs --repair` resets the `''` row to `[]` (reported+repaired), the previously-failing push completes, and the `preferredMentorId` FK lands.
- [x] `bash -n` on both scripts; report-only mode converges to "All Json columns are valid."
- [x] Infra/tooling-only change — no release fragment per releases/README.md.

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGJJumac7jfL5iqoTt96GY)_