### PR TITLE
test(e2e): guard the mentor-capacity sign-ins against the session race

### DIFF
--- a/e2e/mentor-capacity-gate.spec.ts
+++ b/e2e/mentor-capacity-gate.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { signInAndSettle, signInAsFreshUser } from './helpers/auth';
 
 // #1188: mentor capacity is BINDING on the public application link, and every
 // application waits for the mentor's accept/decline. Capacity counts active
@@ -101,11 +102,7 @@ test('mentor accepts an application: relation starts, applicant notified; declin
     const rejectUser = await prisma.user.findUniqueOrThrow({ where: { email: rejectEmail } });
 
     // Mentor signs in and decides from the applications inbox.
-    await page.goto('/auth/signin');
-    await page.fill('input[type="email"], input[name="email"]', mentorEmail);
-    await page.fill('input[type="password"]', PASSWORD);
-    await page.click('button[type="submit"]');
-    await page.waitForURL((u) => u.pathname.startsWith('/mentor'), { timeout: 20_000 });
+    await signInAndSettle(page, mentorEmail, PASSWORD, '/mentor');
     await page.goto('/mentor/applications');
 
     const acceptReq = await prisma.mentorshipRequest.findFirstOrThrow({ where: { menteeId: acceptUser.id } });
@@ -134,13 +131,12 @@ test('mentor accepts an application: relation starts, applicant notified; declin
     await seedUser(otherMentorEmail, PASSWORD, 'MENTOR', 'Other Mentor');
     try {
       const foreign = await prisma.mentorshipRequest.create({ data: { menteeId: rejectUser.id, preferredMentorId: mentor.id } });
-      await page.goto('/auth/signin');
-      await page.context().clearCookies();
-      await page.goto('/auth/signin');
-      await page.fill('input[type="email"], input[name="email"]', otherMentorEmail);
-      await page.fill('input[type="password"]', PASSWORD);
-      await page.click('button[type="submit"]');
-      await page.waitForURL((u) => u.pathname.startsWith('/mentor'), { timeout: 20_000 });
+      // Switching mentors mid-test needs the fresh-user guards: a blanket
+      // clearCookies() lets /api/auth/session re-issue the previous session, so
+      // /auth/signin redirects away mid-fill and the submit click resolves
+      // against the old dashboard (documented in helpers/auth.ts). This is what
+      // made the spec fail in the 2026-08-23 21:18 scheduled run.
+      await signInAsFreshUser(page, otherMentorEmail, PASSWORD, '/mentor');
       const attack = await page.request.put('/api/mentor/applications', {
         data: { requestId: foreign.id, action: 'accept' },
       });


### PR DESCRIPTION
## Summary

The scheduled full run of 2026-08-23 21:18 ([run 32667103191](https://github.com/21072026/Internship/actions/runs/32667103191)) failed 1/594 on `mentor-capacity-gate.spec.ts:142` (new in #1285). The next run on a later head passed, so it is a **latent flake, not a one-off** — and it is the same trap that took out `requisitions`, `announcement-edit-delete` and `document-requirements` in #1271:

The mentor-swap step did `goto('/auth/signin')` → blanket `clearCookies()` → `goto` again → unscoped `click('button[type="submit"]')`. `/api/auth/session` polling re-issues the previous session in that window, `/auth/signin` sees `authenticated` and redirects away mid-fill, and the submit click resolves against the old dashboard — timing-dependent, hence green on the next run.

## Changes

- First sign-in → `signInAndSettle` (waits for the shell to actually mount, not just the URL).
- The mentor swap → `signInAsFreshUser` (the documented guards in `e2e/helpers/auth.ts`: tear the old page down first, drop only the NextAuth cookie so the seeded consent state survives, and look the submit button up inside the sign-in form).

## Verification

- [x] `npx playwright test e2e/mentor-capacity-gate.spec.ts` → **4/4 green** locally against a dev server on the current schema.
- [x] Test-only change — no release fragment per releases/README.md.

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGJJumac7jfL5iqoTt96GY)_