### PR TITLE
fix(ui): telefon genişliğinde bozuk satır düzenleri + mobil düzen denetimi (#1305)

### DIFF
--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -10,6 +10,56 @@ Newest entries on top.
 
 ---
 
+## 2026-08-24 — Telefon genişliğinde düzen denetimi: sıkışan satırlar sayfa taşması yapmaz (#1305)
+
+**"Yatay kaydırma var mı" kuralı bu hataların çoğunu KAÇIRIYOR.** Bildirilen bozukluk
+(/admin/mentors'ta mentor adının "E·" olarak görünmesi) hiçbir yerde sayfayı genişletmiyordu:
+`justify-between` satırda `flex-shrink-0` bir aksiyon kümesi kimlik sütununu **18px**'e
+sıkıştırıyordu. Yakalayan kural: **bir kutunun kendi içeriğini yatay taşırması**
+(`el.scrollWidth > el.clientWidth + 4`) ve **daralmış metin** (`clientWidth < 110` iken
+içerik daha geniş). Bu iki kural `e2e/mobile-layout-audit.spec.ts`'te; `mobile-responsive`
+spec'inin eski iki kuralı (sayfa kaydırması + form alanı genişliği) yeterli değildi.
+
+**Kaçınılması gereken iki yanlış pozitif** (aksi hâlde denetim gürültüden kullanılamaz):
+`overflow-x-auto` bir ata içindeki geniş tablo (kaydırılabilir → bozuk değil) ve **negatif
+yatay margin'li çocuk** (`-mx-2 px-2` hover zeminleri kart padding'ine taşar; scrollWidth'i
+tasarımca büyütür). `sr-only` yardımcıları da 1px'tir.
+
+**Tarama TR ve DE ile yapılmalı.** `/admin/analytics`, `/admin/companies`, `/admin/support`
+İngilizce'de sığıyor, Almanca'da taşıyor — biri sayfayı 51px yatay kaydırmaya sokuyordu.
+Locale'i `document.cookie = 'locale=de;path=/'` ile zorla (i18n-coverage.spec deseni);
+kullanıcı tercihi yerine çerez kazanır.
+
+**Tekrarlayan düzeltme desenleri:** (1) satırı telefonda dikey yığ (`flex-col sm:flex-row`),
+(2) aksiyon kümesini sar (`flex-wrap`), (3) metin bloğuna `min-w-0` + `truncate` ver,
+(4) `<input>`'a `min-w-0` (input varsayılan içsel genişliğinin altına inmez, komşu butonu
+kutudan atar), (5) sabit `w-56`/`w-48` etiket sütunlarını telefonda `w-1/2 sm:w-56` yap.
+Marka satırında `truncate`'i **satıra değil isme** koy: satırı kırpmak beta rozetini yarıdan
+kesiyordu ("Internship CRM BI"). `BrandWordmark` bunun için `oneLine` prop'u aldı — kenar
+çubuğunda isim iki satıra sarabilir, mobil barda kısalır.
+
+**JSX yorumu ekleme tuzağı:** `.map((x) => (` veya bir ternary'nin `) : (` kolundan hemen
+sonra `{/* ... */}` koymak "Expected '</', got ..." sözdizimi hatası verir (iki komşu düğüm).
+Yorumu ya açılan etiketin İÇİNE ya da `map` çağrısının üstüne koy. `tsc --noEmit` bunu
+yakalar; dev sunucusu 500 döner.
+
+**Playwright bu konteynerde:** kurulu build `chromium-1194`, Playwright 1.62 ise
+`chromium_headless_shell-1234` arıyor. Çalışan yol: repoya **commit edilmeyen**
+`playwright.local.config.ts` (repo config'ini import edip
+`use.launchOptions.executablePath = '/opt/pw-browsers/chromium'` ekler) ve
+`npx playwright test --config=playwright.local.config.ts`. Config dosyası repo dışında
+(/tmp) olursa `test.afterAll() did not expect to be called here` hatası verir — repo kökünde
+tut. Ayrıca kendi spec'ini **düzeltmeyi geri alıp** koştur (`git stash push <dosya>`): benim
+denetimim ilk hâlde iki `spills` satırıyla düştü, yani boş test değil.
+
+**Yükleme durumu denetimi bozar:** `networkidle` bu kabuklarda hiç gelmiyor (TimezoneSync +
+sidebar prefetch), o yüzden `.animate-pulse` sayısının 0'a düşmesini bekle — iskelet
+üzerinden ölçüm alırsan sayfa "temiz" görünür. Aynı `page` içinde ikinci bir kullanıcıya
+`signInAndSettle` ile geçmek /mentor/mentees'i kalıcı iskelette bıraktı; rol başına ayrı
+`test()` (yani ayrı page fixture) hem hızlı hem güvenilir.
+
+---
+
 ## 2026-08-24 — Ticari SAST raporunu triyaj etmek: 25 bulgu, 25 yanlış pozitif, 2 kaçırılmış gerçek (#1294)
 
 **Bu tarayıcı `where: { field: variable }` desenini ORM'den ve veritabanı tipinden bağımsız

--- a/e2e/mobile-layout-audit.spec.ts
+++ b/e2e/mobile-layout-audit.spec.ts
@@ -1,0 +1,229 @@
+import { test, expect, type Page } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { signInAndSettle, gotoSettled } from './helpers/auth';
+
+/**
+ * Phone-width layout audit across the role shells (#1305).
+ *
+ * The bug that prompted this: on /admin/mentors the two Turkish action labels
+ * ("Uzmanlığı düzenle" + "Pasifleştir") sat in a `flex-shrink-0` column opposite
+ * the mentor's identity, so on a 360px phone the name/email column was squeezed
+ * to ~18px — the row showed "E·" and the expertise chips ran under the buttons.
+ * Nothing overflowed the *page*, so the existing sideways-scroll check missed it.
+ *
+ * Four mechanical rules, in the order they catch things:
+ *   1. the page must not scroll sideways;
+ *   2. nothing visible may reach past the right edge of the screen (unless it
+ *      lives in a container that scrolls horizontally — a wide table inside
+ *      `overflow-x-auto` is reachable, not broken);
+ *   3. no box may spill its own content sideways — that is how a squeezed row
+ *      announces itself even when the page still fits;
+ *   4. a truncating text box narrower than 110px is not readable; the buttons
+ *      next to it are what pushed it there.
+ *
+ * The audit runs in Turkish and German because those dictionaries carry the
+ * longest labels — several of the rows this spec covers fit in English and only
+ * break once translated.
+ */
+
+const PHONE = { width: 360, height: 800 };
+// Narrower than this and a truncated label stops carrying information.
+const MIN_TEXT_WIDTH = 110;
+
+async function setLocale(page: Page, locale: 'tr' | 'de') {
+  // Same trick as i18n-coverage.spec: the cookie wins over the user preference,
+  // and it needs an origin to be set on, hence the navigation first.
+  await page.goto('/auth/signin');
+  await page.evaluate((l) => { document.cookie = `locale=${l};path=/`; }, locale);
+}
+
+/** Let the client-side lists land before measuring a half-empty page. */
+async function settle(page: Page) {
+  await page.getByTestId('account-menu-button').waitFor({ state: 'visible', timeout: 20_000 });
+  // Every list on these pages renders SkeletonRows while it fetches; waiting for
+  // the last one to go is more reliable than `networkidle`, which these shells
+  // never reach (see helpers/auth.ts).
+  await expect
+    .poll(async () => page.locator('.animate-pulse').count(), { timeout: 20_000 })
+    .toBe(0);
+}
+
+async function auditLayout(page: Page) {
+  return page.evaluate((minTextWidth) => {
+    const problems: string[] = [];
+    const viewport = window.innerWidth;
+    // 1px of slack: sub-pixel rounding on scaled layouts is not an overflow.
+    if (document.documentElement.scrollWidth > viewport + 1) {
+      problems.push(`page scrolls sideways: ${document.documentElement.scrollWidth}px > ${viewport}px`);
+    }
+
+    const describe = (el: Element) => {
+      const testId = el.getAttribute('data-testid');
+      const cls = (el.getAttribute('class') || '').split(' ').slice(0, 4).join('.');
+      return `${el.tagName.toLowerCase()}${testId ? `[${testId}]` : ''}${cls ? `.${cls}` : ''}`;
+    };
+
+    for (const el of Array.from(document.querySelectorAll('body *'))) {
+      const rect = el.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0) continue;
+      const style = getComputedStyle(el);
+      if (style.visibility === 'hidden' || Number(style.opacity) === 0) continue;
+      // Screen-reader-only helpers are a 1px box by design.
+      if (/(^|\s)sr-only(\s|$)/.test(el.getAttribute('class') || '')) continue;
+
+      let inScroller = false;
+      for (let a = el.parentElement; a && a !== document.body; a = a.parentElement) {
+        if (/auto|scroll/.test(getComputedStyle(a).overflowX)) { inScroller = true; break; }
+      }
+
+      if (rect.right > viewport + 1 && style.position !== 'fixed' && !inScroller) {
+        problems.push(`${describe(el)} reaches ${Math.round(rect.right)}px, past the ${viewport}px screen`);
+      }
+
+      // A child pulled out with a negative margin (row hover backgrounds bleeding
+      // into the card padding) widens scrollWidth on purpose.
+      const negativeMargin = Array.from(el.children).some((c) => {
+        const cs = getComputedStyle(c);
+        return parseFloat(cs.marginLeft) < 0 || parseFloat(cs.marginRight) < 0;
+      });
+      const spills =
+        el.scrollWidth > el.clientWidth + 4 &&
+        el.clientWidth > 0 &&
+        !negativeMargin &&
+        !/auto|scroll/.test(style.overflowX) &&
+        style.overflow !== 'hidden' &&
+        // Text scrolling inside a form control is normal.
+        !['INPUT', 'SELECT', 'TEXTAREA'].includes(el.tagName);
+      if (spills) {
+        problems.push(`${describe(el)} spills its content: ${el.clientWidth}px box, ${el.scrollWidth}px content`);
+      }
+
+      const text = (el.textContent || '').trim();
+      const isLeaf = !Array.from(el.children).some((c) => (c.textContent || '').trim().length > 0);
+      if (
+        isLeaf &&
+        text.length > 3 &&
+        el.clientWidth > 0 &&
+        el.clientWidth < minTextWidth &&
+        el.scrollWidth > el.clientWidth + 6 &&
+        !/auto|scroll/.test(style.overflowX)
+      ) {
+        problems.push(`${describe(el)} is ${el.clientWidth}px wide for "${text.slice(0, 30)}"`);
+      }
+    }
+    return [...new Set(problems)];
+  }, MIN_TEXT_WIDTH);
+}
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('phone width: the admin rows keep the person identifiable', { tag: '@smoke' }, async ({ page }) => {
+  const adminEmail = uniqueEmail('mobile-audit-admin');
+  const mentorEmail = uniqueEmail('mobile-audit-mentor-with-a-long-address');
+  const pw = 'MobileAudit123!';
+  await seedUser(adminEmail, pw, 'ADMIN', 'Mobile Audit Admin');
+  const mentor = await seedUser(mentorEmail, pw, 'MENTOR', 'Mobile Audit Mentor (Mentor)');
+  // Expertise chips are part of the squeezed row, and an over-capacity mentor
+  // also renders the warning badge next to the actions.
+  await prisma.user.update({
+    where: { id: mentor.id },
+    data: { skills: ['TypeScript', 'Next.js', 'Data Engineering'], mentorCapacity: 2 },
+  });
+
+  try {
+    await page.setViewportSize(PHONE);
+    await setLocale(page, 'tr');
+    await signInAndSettle(page, adminEmail, pw, '/admin');
+
+    for (const path of ['/admin', '/admin/mentors', '/admin/activity']) {
+      await gotoSettled(page, path);
+      await settle(page);
+      expect(await auditLayout(page), `${path} at ${PHONE.width}px (tr)`).toEqual([]);
+    }
+
+    // The seeded mentor is actually identifiable, not truncated to an initial.
+    await gotoSettled(page, '/admin/mentors');
+    await settle(page);
+    await expect(page.getByText(mentorEmail)).toBeVisible();
+
+    // A dialog is where a cramped row hides: nothing measures a form that is
+    // not open yet.
+    await page.getByRole('button', { name: /Uzmanlığı düzenle/i }).first().click();
+    await expect(page.getByRole('button', { name: /^Kaydet$/i })).toBeVisible();
+    expect(await auditLayout(page), 'the expertise dialog at 360px (tr)').toEqual([]);
+  } finally {
+    await prisma.activityLog.deleteMany({ where: { actorEmail: { in: [adminEmail, mentorEmail] } } });
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});
+
+test('phone width: the admin screens stay inside the viewport in German', async ({ page }) => {
+  const adminEmail = uniqueEmail('mobile-sweep-admin');
+  const pw = 'MobileAudit123!';
+  await seedUser(adminEmail, pw, 'ADMIN', 'Mobile Sweep Admin');
+
+  try {
+    await page.setViewportSize(PHONE);
+    // German: the longest labels in the three dictionaries. /admin/analytics and
+    // /admin/support only overflowed once translated.
+    await setLocale(page, 'de');
+    await signInAndSettle(page, adminEmail, pw, '/admin');
+
+    for (const path of [
+      '/admin/users',
+      '/admin/candidates',
+      '/admin/companies',
+      '/admin/mentorship',
+      '/admin/analytics',
+      '/admin/support',
+    ]) {
+      await gotoSettled(page, path);
+      await settle(page);
+      expect(await auditLayout(page), `${path} at ${PHONE.width}px (de)`).toEqual([]);
+    }
+  } finally {
+    await prisma.activityLog.deleteMany({ where: { actorEmail: adminEmail } });
+    await cleanupByEmail(adminEmail);
+  }
+});
+
+test('phone width: the mentor screens stay inside the viewport in German', async ({ page }) => {
+  const mentorEmail = uniqueEmail('mobile-sweep-mentor');
+  const menteeEmail = uniqueEmail('mobile-sweep-mentee-with-a-long-address');
+  const pw = 'MobileAudit123!';
+  const mentor = await seedUser(mentorEmail, pw, 'MENTOR', 'Mobile Sweep Mentor');
+  const mentee = await seedUser(menteeEmail, pw, 'MENTEE', 'Mobile Sweep Mentee');
+  // A mentee card carries the identity block, the chips and the three actions —
+  // the row that clipped "view details" at the card edge.
+  await prisma.user.update({
+    where: { id: mentee.id },
+    data: {
+      skills: ['React', 'JavaScript'],
+      university: 'Orta Doğu Teknik Üniversitesi',
+      department: 'Bilgisayar Mühendisliği',
+    },
+  });
+  const relation = await prisma.mentorshipRelation.create({
+    data: { mentorId: mentor.id, menteeId: mentee.id },
+  });
+
+  try {
+    await page.setViewportSize(PHONE);
+    await setLocale(page, 'de');
+    await signInAndSettle(page, mentorEmail, pw, '/mentor');
+
+    for (const path of ['/mentor', '/mentor/mentees', '/mentor/analytics']) {
+      await gotoSettled(page, path);
+      await settle(page);
+      expect(await auditLayout(page), `${path} at ${PHONE.width}px (de)`).toEqual([]);
+    }
+  } finally {
+    await prisma.mentorshipRelation.delete({ where: { id: relation.id } }).catch(() => {});
+    await prisma.activityLog.deleteMany({ where: { actorEmail: mentorEmail } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+  }
+});

--- a/releases/unreleased/mobile-row-layouts.json
+++ b/releases/unreleased/mobile-row-layouts.json
@@ -1,0 +1,9 @@
+{
+  "bump": "patch",
+  "changelog": "- **Phone-width row layouts (#1305)**: rows whose action cluster was pinned `flex-shrink-0` opposite the identity column now stack or wrap on a phone — `/admin/mentors` (the name/email column was squeezed to ~18px, chips ran under the buttons), `/admin/activity` (actor cut to `adm…`), `/mentor/mentees` (the third action clipped at the card edge), `/company` and the funnel/aging/stat rows on `/admin` + `/admin/analytics` + `/mentor/analytics`. The mobile top bar now truncates the brand *name* instead of the whole row, so the beta badge is no longer cut in half. `/admin/analytics`, `/admin/companies` and `/admin/support` also stopped pushing the page into horizontal scroll in German. New `e2e/mobile-layout-audit.spec.ts` audits four mechanical rules (no sideways scroll, nothing past the right edge, no box spilling its own content, no text box under 110px) across admin/mentor screens at 360px in Turkish and German; the reported-screens test is tagged `@smoke`.",
+  "notes": {
+    "en": ["Phone layouts fixed: mentor, activity-log and mentee rows no longer squeeze the name and e-mail away, and the beta badge is no longer clipped."],
+    "tr": ["Telefon görünümü düzeltildi: mentor, aktivite günlüğü ve mentee satırları artık isim ile e-postayı sıkıştırmıyor, beta rozeti de kırpılmıyor."],
+    "de": ["Telefon-Layouts korrigiert: In Mentor-, Aktivitäts- und Mentee-Zeilen werden Name und E-Mail nicht mehr zusammengedrückt, und das Beta-Abzeichen wird nicht mehr abgeschnitten."]
+  }
+}

--- a/src/app/admin/activity/page.tsx
+++ b/src/app/admin/activity/page.tsx
@@ -84,10 +84,17 @@ export default function AdminActivityPage() {
         ) : (
           <div className="divide-y divide-gray-50">
             {items.map((e) => (
-              <div key={e.id} className="flex items-center gap-3 py-2.5 text-sm">
+              // Phone: level + action + timestamp on the first line, the actor
+              // (and detail) on its own full-width line below. On one line the
+              // actor column was squeezed to ~46px — "admin@example.com" showed
+              // as "adm…", which is the only part of the row that identifies who
+              // did it (#1305). `sm:order-last` keeps the desktop order
+              // level · action · actor · ip · date.
+              <div key={e.id} className="flex flex-wrap items-center gap-x-3 gap-y-1 py-2.5 text-sm sm:flex-nowrap">
                 <Badge variant={LEVEL_VARIANT[e.level]} className="flex-shrink-0">{e.level}</Badge>
                 <span className="font-medium text-gray-900 flex-shrink-0">{e.action}</span>
-                <span className="text-gray-500 truncate flex-1">
+                <span data-testid="activity-date" className="ml-auto text-xs text-gray-400 flex-shrink-0 sm:ml-0 sm:order-last">{formatDateTime(e.createdAt, locale)}</span>
+                <span className="w-full min-w-0 truncate text-gray-500 sm:w-auto sm:flex-1">
                   {e.actorEmail || '—'}{e.detail ? ` · ${e.detail}` : ''}
                 </span>
                 {e.ip && (
@@ -98,7 +105,6 @@ export default function AdminActivityPage() {
                     {e.ip}
                   </span>
                 )}
-                <span data-testid="activity-date" className="text-xs text-gray-400 flex-shrink-0">{formatDateTime(e.createdAt, locale)}</span>
               </div>
             ))}
           </div>

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -167,7 +167,10 @@ export default function AdminAnalyticsPage() {
           <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.analytics.title}</h1>
           <p className="text-gray-500 mt-1">{t.analytics.subtitle}</p>
         </div>
-        <div className="flex items-center gap-2 no-print">
+        {/* Up to five controls: on a phone (and in German, where the labels are
+            longest) they have to wrap, or the row pushed the whole page 51px
+            wider than the screen (#1305). */}
+        <div className="flex flex-wrap items-center gap-2 no-print">
           <Select
             aria-label={t.analytics.dateRange}
             className="w-auto"
@@ -284,7 +287,9 @@ export default function AdminAnalyticsPage() {
               const n = data.funnel[s.key] || 0;
               return (
                 <div key={s.key} className="flex items-center gap-2 text-sm">
-                  <span className="w-48 truncate text-gray-600 flex-shrink-0">{s.label}</span>
+                  {/* Half the row on a phone, a fixed 192px from `sm` up — the
+                      fixed width left the bar a few pixels wide (#1305). */}
+                  <span className="w-1/2 sm:w-48 truncate text-gray-600 flex-shrink-0">{s.label}</span>
                   <div className="flex-1 bg-gray-100 rounded h-4 overflow-hidden">
                     <div className="bg-blue-500 h-full" style={{ width: `${(n / maxFunnel) * 100}%` }} />
                   </div>
@@ -377,10 +382,13 @@ export default function AdminAnalyticsPage() {
               <p className="text-sm text-gray-400">—</p>
             ) : (
               <div className="divide-y divide-gray-50 dark:divide-gray-800">
+                {/* The stats string is unbreakable, so on a phone the stage name
+                    gets its own line instead of being squeezed to ~35px
+                    ("100 · Erstkontakt" → "100 …", #1305). */}
                 {aging.stageAging.map((s) => (
-                  <div key={s.pipelineStatus} className="flex items-center justify-between py-2 text-sm">
-                    <span className="truncate">{label(s.pipelineStatus)}</span>
-                    <span className="text-gray-500 flex-shrink-0">
+                  <div key={s.pipelineStatus} className="flex flex-col items-start gap-0.5 py-2 text-sm sm:flex-row sm:items-center sm:justify-between sm:gap-2">
+                    <span className="max-w-full truncate">{label(s.pipelineStatus)}</span>
+                    <span className="text-gray-500 sm:flex-shrink-0">
                       {t.analytics.aging.avg} {s.avgDays}{t.analytics.aging.days} · {t.analytics.aging.median} {s.medianDays}{t.analytics.aging.days} · {s.count} {t.analytics.aging.candidates}
                     </span>
                   </div>

--- a/src/app/admin/companies/page.tsx
+++ b/src/app/admin/companies/page.tsx
@@ -127,7 +127,9 @@ export default function CompaniesPage() {
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-8">
+      {/* Wraps on a phone: "Unternehmen hinzufügen" next to the title pushed the
+          button 9px past the content column in German (#1305). */}
+      <div className="flex flex-wrap items-start justify-between gap-3 mb-8">
         <div>
           <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.companiesPage.title}</h1>
           <p className="text-gray-500 mt-1">{t.companiesPage.subtitle}</p>

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -41,7 +41,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
 
   return (
     <ResponsiveShell
-      brand={<BrandWordmark />}
+      brand={<BrandWordmark oneLine />}
       headerExtra={<GlobalSearch />}
       sidebar={
         <aside className="w-64 h-full bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-800 flex flex-col">

--- a/src/app/admin/mentors/page.tsx
+++ b/src/app/admin/mentors/page.tsx
@@ -148,7 +148,12 @@ export default function MentorsPage() {
               const cap = m.mentorCapacity;
               const atCapacity = cap != null && cap > 0 && m._count.mentorRelations >= cap;
               return (
-                <div key={m.id} className="flex items-start justify-between gap-3 py-3">
+                // Phone: the identity block gets the full width and the actions wrap
+                // below it. Side by side, the Turkish action labels ("Uzmanlığı
+                // düzenle" + "Pasifleştir") left the name/email column ~18px wide,
+                // so the mentor was unidentifiable and the expertise chips ran
+                // under the buttons (#1305).
+                <div key={m.id} className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-2 sm:gap-3 py-3">
                   <div className="flex items-start gap-3 min-w-0">
                     <div className="w-9 h-9 bg-green-100 rounded-full flex items-center justify-center flex-shrink-0">
                       <span className="text-green-700 font-semibold text-sm">{m.fullName?.[0] || 'M'}</span>
@@ -173,12 +178,12 @@ export default function MentorsPage() {
                       )}
                     </div>
                   </div>
-                  <div className="flex flex-col items-end gap-2 flex-shrink-0">
+                  <div className="flex flex-wrap items-center gap-2 sm:flex-col sm:flex-nowrap sm:items-end sm:flex-shrink-0">
                     <Badge variant={atCapacity ? 'warning' : 'info'} className="flex items-center gap-1">
                       <Users className="h-3 w-3" />
                       {m._count.mentorRelations}{cap != null ? `/${cap}` : ''} {t.mentors.mentee}
                     </Badge>
-                    <div className="flex items-center gap-2">
+                    <div className="flex flex-wrap items-center gap-2">
                       <Button variant="outline" size="sm" onClick={() => openEdit(m)}>
                         <Pencil className="h-3.5 w-3.5" />
                         {t.mentors.editExpertise}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -155,7 +155,10 @@ export default async function AdminDashboard() {
                     href={`/admin/candidates?status=${s.key}`}
                     className="flex items-center gap-3 rounded-lg px-1 py-0.5 hover:bg-blue-50 transition-colors"
                   >
-                    <span className="text-xs text-gray-600 w-56 flex-shrink-0 truncate">{s.label}</span>
+                    {/* The label is a fixed 224px from `sm` up; on a phone that
+                        left no room for the bar (and pushed the count 6px out of
+                        the card), so there it takes half the row instead (#1305). */}
+                    <span className="text-xs text-gray-600 w-1/2 sm:w-56 flex-shrink-0 truncate">{s.label}</span>
                     <div className="flex-1 bg-gray-100 rounded-full h-2.5 overflow-hidden">
                       <div
                         className="bg-blue-500 h-full rounded-full"

--- a/src/app/admin/support/page.tsx
+++ b/src/app/admin/support/page.tsx
@@ -174,7 +174,9 @@ export default function AdminSupportPage() {
       </div>
       <p className="text-gray-500 mb-6">{a.subtitle}</p>
 
-      <div className="flex gap-2 mb-4" data-testid="support-filters">
+      {/* Filter chips wrap: in German the four labels ran 14px past the screen
+          and put the whole page into horizontal scroll (#1305). */}
+      <div className="flex flex-wrap gap-2 mb-4" data-testid="support-filters">
         {FILTERS.map((f) => (
           <button
             key={f.value || 'all'}

--- a/src/app/company/layout.tsx
+++ b/src/app/company/layout.tsx
@@ -30,7 +30,7 @@ export default async function CompanyLayout({ children }: { children: React.Reac
 
   return (
     <ResponsiveShell
-      brand={<BrandWordmark />}
+      brand={<BrandWordmark oneLine />}
       sidebar={
         <aside className="w-64 h-full bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-800 flex flex-col">
           <div className="p-6 border-b border-gray-200">

--- a/src/app/company/page.tsx
+++ b/src/app/company/page.tsx
@@ -79,9 +79,12 @@ export default function CompanyOverviewPage() {
               <Link
                 key={r.id}
                 href={`/company/candidates/${r.mentee.id}`}
-                className="flex items-center justify-between gap-3 py-3 hover:bg-gray-50 dark:hover:bg-gray-800/60 -mx-2 px-2 rounded-lg transition-colors"
+                className="flex flex-col items-start gap-1 py-3 hover:bg-gray-50 dark:hover:bg-gray-800/60 -mx-2 px-2 rounded-lg transition-colors sm:flex-row sm:items-center sm:justify-between sm:gap-3"
               >
-                <div className="min-w-0">
+                {/* Phone: the stage badge moves under the candidate, otherwise it
+                    took two thirds of the row and the university/mentor line was
+                    cut to "İTÜ · Mentor: …" (#1305). */}
+                <div className="min-w-0 max-w-full">
                   <p className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">{r.mentee.fullName}</p>
                   <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
                     {r.mentee.university ? `${r.mentee.university} · ` : ''}

--- a/src/app/mentor/analytics/page.tsx
+++ b/src/app/mentor/analytics/page.tsx
@@ -22,13 +22,15 @@ interface MentorAnalytics {
 function StatCard({ icon: Icon, value, label, color }: { icon: React.ElementType; value: string | number; label: string; color: string }) {
   return (
     <Card>
-      <div className="flex items-center gap-4">
+      {/* Two of these sit side by side on a phone: without `min-w-0` the text
+          block refuses to shrink and the label runs out of the card (#1305). */}
+      <div className="flex items-center gap-3 sm:gap-4">
         <div className={`w-12 h-12 ${color} rounded-xl flex items-center justify-center flex-shrink-0`}>
           <Icon className="h-6 w-6 text-white" />
         </div>
-        <div>
+        <div className="min-w-0">
           <p className="text-2xl font-bold text-gray-900 dark:text-gray-100">{value}</p>
-          <p className="text-sm text-gray-500 dark:text-gray-400">{label}</p>
+          <p className="text-sm text-gray-500 dark:text-gray-400 break-words">{label}</p>
         </div>
       </div>
     </Card>
@@ -127,18 +129,22 @@ export default function MentorAnalyticsPage() {
                     {ma.goalsTitle}
                   </CardTitle>
                 </CardHeader>
-                <div className="grid grid-cols-3 gap-3 text-center">
-                  <div className="rounded-lg bg-gray-50 dark:bg-gray-800 p-3">
+                {/* Three tiles across a 360px phone leave ~60px per label, which
+                    is narrower than a single Turkish word ("Tamamlandı") — tighter
+                    padding plus `break-words` keeps every label inside its tile
+                    whatever the language (#1305). */}
+                <div className="grid grid-cols-3 gap-2 sm:gap-3 text-center">
+                  <div className="rounded-lg bg-gray-50 dark:bg-gray-800 p-2 sm:p-3">
                     <p className="text-2xl font-bold text-gray-900 dark:text-gray-100">{data.goals.total}</p>
-                    <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">{ma.goalsTotal}</p>
+                    <p className="text-xs text-gray-500 dark:text-gray-400 mt-1 break-words">{ma.goalsTotal}</p>
                   </div>
-                  <div className="rounded-lg bg-amber-50 dark:bg-amber-950/30 p-3">
+                  <div className="rounded-lg bg-amber-50 dark:bg-amber-950/30 p-2 sm:p-3">
                     <p className="text-2xl font-bold text-amber-700 dark:text-amber-300">{data.goals.open}</p>
-                    <p className="text-xs text-amber-600 dark:text-amber-400 mt-1">{ma.goalsOpen}</p>
+                    <p className="text-xs text-amber-600 dark:text-amber-400 mt-1 break-words">{ma.goalsOpen}</p>
                   </div>
-                  <div className="rounded-lg bg-green-50 dark:bg-green-950/30 p-3">
+                  <div className="rounded-lg bg-green-50 dark:bg-green-950/30 p-2 sm:p-3">
                     <p className="text-2xl font-bold text-green-700 dark:text-green-300">{data.goals.done}</p>
-                    <p className="text-xs text-green-600 dark:text-green-400 mt-1">{ma.goalsDone}</p>
+                    <p className="text-xs text-green-600 dark:text-green-400 mt-1 break-words">{ma.goalsDone}</p>
                   </div>
                 </div>
               </Card>

--- a/src/app/mentor/layout.tsx
+++ b/src/app/mentor/layout.tsx
@@ -44,7 +44,7 @@ export default async function MentorLayout({ children }: { children: React.React
 
   return (
     <ResponsiveShell
-      brand={<BrandWordmark />}
+      brand={<BrandWordmark oneLine />}
       headerExtra={<GlobalSearch />}
       sidebar={
         <aside className="w-64 h-full bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-800 flex flex-col">

--- a/src/app/mentor/mentees/page.tsx
+++ b/src/app/mentor/mentees/page.tsx
@@ -80,12 +80,15 @@ export default function MenteesPage() {
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           {relations.map((rel) => (
             <Card key={rel.id}>
-              <div className="flex items-start justify-between mb-4">
-                <div>
-                  <h3 className="font-semibold text-gray-900 text-lg">{rel.mentee.fullName}</h3>
-                  <p className="text-sm text-gray-500">{rel.mentee.email}</p>
+              <div className="flex items-start justify-between gap-2 mb-4">
+                {/* `min-w-0` + `truncate`: a long address ran out of the card,
+                    because the text block would not shrink next to the status
+                    badge (#1305). */}
+                <div className="min-w-0">
+                  <h3 className="font-semibold text-gray-900 text-lg truncate">{rel.mentee.fullName}</h3>
+                  <p className="text-sm text-gray-500 truncate">{rel.mentee.email}</p>
                 </div>
-                <StatusBadge status={rel.status} />
+                <div className="flex-shrink-0"><StatusBadge status={rel.status} /></div>
               </div>
 
               <div className="space-y-2 mb-4">
@@ -111,9 +114,11 @@ export default function MenteesPage() {
                 </div>
               )}
 
-              <div className="flex items-center justify-between gap-2">
+              {/* Wraps on a phone: interaction count + three actions did not fit a
+                  360px card, so "Detayları gör" was clipped at the card edge (#1305). */}
+              <div className="flex flex-wrap items-center justify-between gap-2">
                 <Badge variant="default">{rel._count.interactions} {t.mentor.interactions}</Badge>
-                <div className="flex items-center gap-2">
+                <div className="flex flex-wrap items-center gap-2">
                   <StartMeetingButton
                     target={{ relationIds: [rel.id] }}
                     defaultTitle={t.meetings.instant.defaultWith.replace('{name}', rel.mentee.fullName)}

--- a/src/app/portal/layout.tsx
+++ b/src/app/portal/layout.tsx
@@ -55,7 +55,7 @@ export default async function PortalLayout({ children }: { children: React.React
 
   return (
     <ResponsiveShell
-      brand={<BrandWordmark />}
+      brand={<BrandWordmark oneLine />}
       sidebar={
         <aside className="w-64 h-full bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-800 flex flex-col">
         <div className="p-6 border-b border-gray-200">

--- a/src/app/source/layout.tsx
+++ b/src/app/source/layout.tsx
@@ -23,7 +23,7 @@ export default async function SourceLayout({ children }: { children: React.React
 
   return (
     <ResponsiveShell
-      brand={<BrandWordmark />}
+      brand={<BrandWordmark oneLine />}
       sidebar={
         <aside className="w-64 h-full bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-800 flex flex-col">
           <div className="p-6 border-b border-gray-200">

--- a/src/components/ApplyLinkBox.tsx
+++ b/src/components/ApplyLinkBox.tsx
@@ -26,7 +26,9 @@ export function ApplyLinkBox() {
           readOnly
           value={url}
           onFocus={(e) => e.target.select()}
-          className="flex-1 px-3 py-2 border border-blue-200 rounded-lg text-sm bg-white text-gray-700"
+          // `min-w-0`: an <input> refuses to shrink below its default intrinsic
+          // width, which pushed the copy button out of the box on a phone (#1305).
+          className="flex-1 min-w-0 px-3 py-2 border border-blue-200 rounded-lg text-sm bg-white text-gray-700"
         />
         <button
           onClick={() => {

--- a/src/components/BrandWordmark.tsx
+++ b/src/components/BrandWordmark.tsx
@@ -8,18 +8,22 @@ import { getOrgBranding } from '@/lib/orgBranding';
 // back to the product default ("Internship CRM") when the org has no branding or
 // there's no org, so single-tenant chrome is unchanged. Self-resolving server
 // component so layouts can drop it in with no prop threading.
-export async function BrandWordmark({ className }: { className?: string }) {
+export async function BrandWordmark({ className, oneLine = false }: { className?: string; oneLine?: boolean }) {
   const session = await getServerSession(authOptions);
   const brand = await getOrgBranding(session?.user?.orgId);
   return (
-    <span className={`flex items-center gap-2 ${className ?? ''}`}>
+    <span className={`flex items-center gap-2 ${oneLine ? 'min-w-0' : ''} ${className ?? ''}`}>
       {brand.logoUrl ? (
         // eslint-disable-next-line @next/next/no-img-element -- tenant logo is an arbitrary external/stored URL
-        <img src={brand.logoUrl} alt={brand.name} className="h-7 w-auto max-w-[150px] object-contain" />
+        <img src={brand.logoUrl} alt={brand.name} className="h-7 w-auto max-w-[150px] flex-shrink-0 object-contain" />
       ) : (
-        <GraduationCap className="h-7 w-7 text-blue-600" />
+        <GraduationCap className="h-7 w-7 flex-shrink-0 text-blue-600" />
       )}
-      <span className="font-bold text-gray-900 dark:text-gray-100">{brand.name}</span>
+      {/* `oneLine` (the mobile top bar) truncates the *name* when the row runs
+          out of room. That bar used to truncate the whole row instead, which cut
+          the beta badge in half — a 360px phone read "Internship CRM BI" (#1305).
+          Everywhere else the name may wrap, which loses nothing. */}
+      <span className={`font-bold text-gray-900 dark:text-gray-100 ${oneLine ? 'truncate' : ''}`}>{brand.name}</span>
     </span>
   );
 }

--- a/src/components/ResponsiveShell.tsx
+++ b/src/components/ResponsiveShell.tsx
@@ -30,10 +30,13 @@ export function ResponsiveShell({
       {/* Mobile top bar */}
       <div className="lg:hidden sticky top-0 z-30 flex items-center justify-between bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-800 h-14 px-4">
         {/* The wordmark truncates instead of pushing the bar wider than the screen:
-            brand + badge + three icon buttons did not fit a 320px phone (#936). */}
-        <div className="flex items-center min-w-0 truncate">
-          {brand ?? <span className="font-bold text-gray-900 dark:text-gray-100">InternshipCRM</span>}
-          <BetaBadge className="ml-2" />
+            brand + badge + three icon buttons did not fit a 320px phone (#936).
+            The truncation happens *inside* the wordmark (`oneLine`, see
+            BrandWordmark) — truncating this row clipped the badge itself, so a
+            360px phone read "Internship CRM BI" (#1305). */}
+        <div className="flex items-center min-w-0">
+          {brand ?? <span className="font-bold text-gray-900 dark:text-gray-100 truncate">InternshipCRM</span>}
+          <BetaBadge className="ml-2 flex-shrink-0" />
         </div>
         <div className="flex items-center gap-1 flex-shrink-0">
           {/* Only visible while a meeting is actually running (#51 follow-up). */}


### PR DESCRIPTION
## Summary

Aksiyon kümesini kimlik sütununun karşısına `flex-shrink-0` ile sabitleyen satırlar telefonda o sütunu yok ediyordu. Bildirilen ekran **/admin/mentors**: mentor'un adı ve e-postası ~18px'e sıkışıp "E·" oluyor, uzmanlık çipleri butonların altından taşıyordu. Sayfa yatay kaymadığı için mevcut "yana kayıyor mu" kontrolü bunu hiç görmüyordu.

360px'te, hem Türkçe hem Almanca ile taranıp düzeltildi (59 rota, admin + mentor + mentee + şirket + herkese açık sayfalar).

Closes #1305

## Changes

- **/admin/mentors** — satır telefonda dikey yığılıyor, aksiyonlar sarıyor.
- **/admin/activity** — birinci satır seviye + aksiyon + zaman, aktör kendi tam genişlikli satırında (önce `adm…` olarak kırpılıyordu).
- **/mentor/mentees** — kart aksiyon satırı sarıyor ("Detayları gör" artık kart kenarında kırpılmıyor); kimlik bloğu `min-w-0` + `truncate`.
- **/company** — aşama rozeti telefonda adayın altına iniyor.
- **Mobil üst bar** — `truncate` artık satırda değil marka *adında*: beta rozeti yarıdan kesilmiyor ("Internship CRM BI"). `BrandWordmark` bunun için `oneLine` prop'u aldı; kenar çubuğunda isim eskisi gibi iki satıra sarabiliyor.
- **/admin, /admin/analytics, /mentor/analytics** — sabit genişlikli etiket sütunları (`w-56`/`w-48`) telefonda yarım satır; bölünemeyen istatistik metni kendi satırında; istatistik kartları daralabiliyor.
- **/admin/analytics, /admin/companies, /admin/support** — başlık aksiyonları ve filtre çipleri sarıyor: Almanca'da sayfayı yatay kaydırmaya sokuyorlardı (biri 51px).
- **ApplyLinkBox** — salt-okunur input'a `min-w-0` (input varsayılan içsel genişliğinin altına inmediği için kopyala butonunu kutudan atıyordu).
- **`e2e/mobile-layout-audit.spec.ts`** (yeni) — 360px'te dört mekanik kural: sayfa yana kaymaz, hiçbir görünür öğe sağ kenarı geçmez, hiçbir kutu kendi içeriğini taşırmaz, kırpan metin kutusu 110px'in altına inmez. İki meşru istisna dışlanıyor: yatay kaydırılabilir bir ata içindeki içerik (`overflow-x-auto` tablolar) ve negatif margin'le dışarı çekilen çocuklar (`-mx-2 px-2` hover zeminleri). Bildirilen ekranlar `@smoke`; Almanca admin + mentor taramaları tam süitte koşuyor.
- Sürüm fragment'ı: `releases/unreleased/mobile-row-layouts.json` (patch).
- `docs/agent-experience.md` — oturum retrospektifi.

## Verification

- [x] `npm run lint` + `npx tsc --noEmit` clean
- [x] `npm run test:e2e` passing (or CI green) — yeni spec (3 test) + ilgili mevcut spec'ler yeşil: `beta-badge`, `mobile*`, `users-responsive`, `activity-log`, `mentors`, `analytics`, `analytics-aging`, `admin-support`, `mentor-attention-queue`, `mentor-dashboard-name-links`, `a11y*` (31 passed; `admin-support` bir kez bilinen flake verip retry'da geçti)
- [x] Tested the change manually / added an e2e test — lokal MariaDB + demo seed üzerinde 360/390px ekran görüntüleriyle doğrulandı; masaüstü (1280px) düzenleri değişmedi. Düzeltme geri alındığında yeni `@smoke` testi iki `spills` bulgusuyla düşüyor, yani boş bir test değil.

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.


---
_Generated by [Claude Code](https://claude.ai/code/session_019AFacrQq9yHvm4gDyNEALn)_