### PR TITLE
feat(infra): give every PR preview its own database (#1185)

### DIFF
--- a/.github/workflows/topic-preview.yml
+++ b/.github/workflows/topic-preview.yml
@@ -21,11 +21,16 @@ name: Topic Preview (hosted build → server swap, auto per-PR)
 #      `plesk` CLI (topic-deploy.sh creates the subdomain + injects the proxy).
 #   2. Wildcard DNS *.ersah.in → the server (infra/setup-dns-cloudflare.sh) and a
 #      wildcard TLS cert in ${CERT_DIR} (infra/acme-issue-wildcard.sh).
-#   3. /etc/internship-crm/preview.env (chmod 600) with DATABASE_URL (the SHARED
-#      preview DB), NEXTAUTH_SECRET, SMTP_* — the same file deploy-preview uses.
+#   3. /etc/internship-crm/preview.env (chmod 600) with DATABASE_URL,
+#      NEXTAUTH_SECRET, SMTP_* — the same file deploy-preview uses.
+#   4. The DB user in that file can create and drop the per-topic databases:
+#        GRANT ALL PRIVILEGES ON `internship\_pr%`.* TO '<user>'@'%';
 #
-# ⚠️ The preview DB is SHARED across all topics (see infra/README.md) — a schema
-# `db push` here affects every topic. Coordinate concurrent schema changes.
+# Each topic gets its OWN database, `internship_pr<N>` (#1185): a `db push` on
+# one PR no longer reshapes the schema under every other PR, and no real preview
+# data is reachable from a topic environment — they are seeded with the
+# synthetic demo set only. The database is dropped when the PR closes, and the
+# daily topic sweep removes any that leak.
 #
 # FORK PRs get no topic environment: GitHub keeps their GITHUB_TOKEN read-only
 # (so the image cannot be pushed to ghcr) and withholds repo secrets, and running
@@ -121,9 +126,11 @@ jobs:
             const marker = '<!-- topic-preview -->';
             const body = `${marker}\n### 🧪 Topic preview ready\n\n` +
               `Branch **\`${{ github.head_ref }}\`** → **${url}**\n\n` +
-              `> Isolated environment for this PR (container \`internship-crm-${topic}\`). ` +
-              `Rebuilt on every push; torn down automatically when this PR is merged or closed.\n` +
-              `> Shares the preview database with other topics — coordinate schema changes.`;
+              `> Isolated environment for this PR (container \`internship-crm-${topic}\`, ` +
+              `database \`internship_${topic}\`). Rebuilt on every push; container and database are ` +
+              `both removed when this PR is merged or closed.\n` +
+              `> Its own database, seeded with synthetic demo data — sign in with ` +
+              `\`admin.demo@demo.example.com\` / \`DemoPass123!\`. Schema changes here affect nobody else.`;
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number,
             });

--- a/.github/workflows/topic-sweep.yml
+++ b/.github/workflows/topic-sweep.yml
@@ -60,6 +60,8 @@ jobs:
             [ "$_port" = "$_hostport" ] && _port=3306
             _decode() { printf '%b' "${1//%/\\x}"; }
             _user="$(_decode "$_user")"; _pass="$(_decode "$_pass")"
+            # Container-facing hostname; on the box itself use loopback.
+            case "$_host" in host.docker.internal) _host=127.0.0.1 ;; esac
             dbs=$(MYSQL_PWD="$_pass" mysql -h "$_host" -P "$_port" -u "$_user" --batch --skip-column-names \
                    -e "SELECT schema_name FROM information_schema.schemata WHERE schema_name REGEXP '^internship_pr[0-9]+$';" 2>/dev/null \
                  | sed -n 's/^internship_pr\([0-9]\{1,\}\)$/\1/p' || true)

--- a/.github/workflows/topic-sweep.yml
+++ b/.github/workflows/topic-sweep.yml
@@ -9,8 +9,11 @@ name: Topic Sweep (reconcile leaked preview environments)
 # environment silently steals the slot of every hundredth PR after it.
 #
 # So: stop trusting the event, and reconcile the state instead. List the
-# `internship-crm-pr<N>` containers actually running on the box, ask GitHub
-# which of those PRs are still open, and tear down the rest.
+# `internship-crm-pr<N>` containers actually running on the box AND the
+# `internship_pr<N>` databases sitting on its MySQL (#1185 — a per-PR database
+# leaks the same way a container does, only more quietly: it holds disk and it
+# holds rows), ask GitHub which of those PRs are still open, and tear down the
+# rest.
 #
 # Split across two runners on purpose: only the self-hosted box can see docker,
 # and only a GitHub-hosted runner is guaranteed `gh`/`jq` for the PR lookup.
@@ -41,11 +44,29 @@ jobs:
           set -euo pipefail
           # -a: a stopped-but-not-removed container still owns its name (and can
           # be restarted by a restart policy), so it counts as a leak too.
-          nums=$(docker ps -a --format '{{.Names}}' \
-                 | sed -n 's/^internship-crm-pr\([0-9]\{1,\}\)$/\1/p' \
-                 | sort -n | uniq | tr '\n' ' ')
+          containers=$(docker ps -a --format '{{.Names}}' \
+                 | sed -n 's/^internship-crm-pr\([0-9]\{1,\}\)$/\1/p' || true)
+          # Databases too: a teardown that removed the container but died before
+          # the DROP (or ran before #1185 shipped) leaves the database behind,
+          # and nothing else would ever notice it.
+          dbs=""
+          if [ -f /etc/internship-crm/preview.env ] && command -v mysql >/dev/null; then
+            set -a; . /etc/internship-crm/preview.env; set +a
+            _u="${DATABASE_URL#mysql://}"; _u="${_u%%\?*}"
+            _creds="${_u%@*}"; _hostpart="${_u##*@}"
+            _user="${_creds%%:*}"; _pass="${_creds#*:}"
+            [ "$_pass" = "$_creds" ] && _pass=""
+            _hostport="${_hostpart%%/*}"; _host="${_hostport%%:*}"; _port="${_hostport#*:}"
+            [ "$_port" = "$_hostport" ] && _port=3306
+            _decode() { printf '%b' "${1//%/\\x}"; }
+            _user="$(_decode "$_user")"; _pass="$(_decode "$_pass")"
+            dbs=$(MYSQL_PWD="$_pass" mysql -h "$_host" -P "$_port" -u "$_user" --batch --skip-column-names \
+                   -e "SELECT schema_name FROM information_schema.schemata WHERE schema_name REGEXP '^internship_pr[0-9]+$';" 2>/dev/null \
+                 | sed -n 's/^internship_pr\([0-9]\{1,\}\)$/\1/p' || true)
+          fi
+          nums=$(printf '%s\n%s\n' "$containers" "$dbs" | grep -E '^[0-9]+$' | sort -n | uniq | tr '\n' ' ' || true)
           echo "numbers=${nums% }" >> "$GITHUB_OUTPUT"
-          echo "### Topic containers on the box" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Topic environments on the box (containers ∪ databases)" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           echo "${nums:-<none>}" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,8 +150,11 @@ workaround, #636, and it compiled on every PR push).
 - `deploy.yml` is the **legacy hosted** pipeline (ghcr.io + SSH), **superseded** — don't extend it.
 - `infra/autodeploy.sh` is a break-glass poller that **builds on the server** — don't put it
   on a cron (see `infra/README.md`).
-- ⚠️ The preview DB is **shared** by the shared preview *and* every topic env —
-  `prisma db push` there affects everyone.
+- Each **topic env has its own database** (`internship_pr<N>`, #1185), created on first
+  deploy, seeded with the synthetic demo set (`admin.demo@demo.example.com` / `DemoPass123!`)
+  and dropped when the PR closes — so a `db push` on a PR affects nobody else, and no real
+  preview data is reachable from a topic environment. The **shared preview env** at
+  `crm-preview.ersah.in` still has its own single DB; `db push` there is global.
 
 ## Conventions & gotchas for agents
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -151,11 +151,28 @@ called with `GHCR_USER`/`GHCR_TOKEN` (the run's `GITHUB_TOKEN`, for the pull) an
 `SKIP_PULL=1` for a locally built image, and the old base64-over-SSH credential
 form (`ACTOR`/`B64_TOKEN` + `B64_*`), for a manual deploy from a shell.
 
-**Database: a single shared preview DB.** No per-topic DB, so no DB-admin secret
-is needed. ⚠️ Trade-off: all topics share schema/data — two concurrent PRs with
-divergent schema changes can drift (`prisma db push` is global). Coordinate schema
-changes across simultaneous topics, or switch to per-topic DBs later (would need a
-`CREATE/DROP DATABASE`-capable secret).
+**Database: one per topic** (`internship_pr<N>`, #1185). The env file supplies the
+MySQL host and credentials; `topic-deploy.sh` creates the topic's own database on
+the same server, points the container at it, and fills a *fresh* one with the
+synthetic demo set (`prisma/seed-demo.mjs`). A re-push keeps whatever the reviewer
+has been clicking on and only brings the schema up to date. `topic-teardown.sh`
+drops it when the PR closes; the daily topic sweep drops any that leak.
+
+Two consequences worth stating: a `prisma db push` on one PR no longer reshapes the
+schema under every other PR, and **no real preview data is reachable from a topic
+environment** — sign in with `admin.demo@demo.example.com` / `DemoPass123!`. The
+shared preview env at `crm-preview.ersah.in` keeps its own single database.
+
+Privileges usually need no setup: the script runs as root on the database host,
+so if the app user cannot create databases it falls back to the local root
+socket and grants the app user access to the one database it just made. If
+neither route works the deploy **stops** with the grant to run —
+
+```sql
+GRANT ALL PRIVILEGES ON `internship\_pr%`.* TO '<preview-user>'@'%';
+```
+
+— rather than falling back to the shared database. Isolation is the point.
 
 ### Prerequisites on the server
 - Self-hosted runner registered; its user (root here) can run `docker` and the

--- a/infra/server/topic-deploy.sh
+++ b/infra/server/topic-deploy.sh
@@ -11,9 +11,24 @@
 #     the stock `include /etc/nginx/conf.d/*.conf;` is active (default on Plesk) and
 #     these hostnames are NOT Plesk-managed domains (only crm/crm-preview are), so
 #     Plesk never rewrites these files.
-#   - Database: a SINGLE shared preview DB (no per-topic DB). All topics push the
-#     same schema. ⚠️ Trade-off: simultaneous topics with divergent schema changes
-#     can drift — coordinate schema changes across concurrent topics.
+#   - Database: ONE DATABASE PER TOPIC (#1185). The env file points at the shared
+#     preview DB; this script uses its host and credentials but redirects the
+#     container to `internship_<TOPIC>` (e.g. internship_pr1315) on the same
+#     MySQL server — a separate server would be cost for no isolation gained.
+#     The database is created here, filled with synthetic demo data only, and
+#     dropped by topic-teardown.sh when the PR closes.
+#
+#     Until #1185 every topic shared one preview database, so a `prisma db push`
+#     on any PR reshaped the schema under every other PR (and under the shared
+#     preview), and real preview data was visible from every topic environment.
+#     Both of those are gone.
+#
+#     PRIVILEGES: the app user needs CREATE/DROP on `internship_pr%`. If it does
+#     not have them, this script creates the database through the LOCAL ROOT
+#     SOCKET (it runs as root on the DB host) and grants the app user access to
+#     that one database. If neither route works the deploy STOPS with the grant
+#     to run — it never falls back to the shared database, because isolation is
+#     the entire point of #1185.
 #
 # Required env (set by the workflow):
 #   TOPIC PORT IMAGE BASE_DOMAIN
@@ -89,22 +104,104 @@ else
     echo "ERROR: SKIP_PULL=1 but image '$IMAGE' is not present locally" >&2; exit 1; }
 fi
 
-# Shared preview DB: reach the host's MySQL the same way the preview deploy does.
-CONTAINER_DB=$(echo "$DATABASE_URL" | sed 's|localhost|host.docker.internal|g; s|127\.0\.0\.1|host.docker.internal|g')
+# ── This topic's own database (#1185) ────────────────────────────────────────
+# The env file's DATABASE_URL supplies the SERVER and the CREDENTIALS; the
+# database it names (the shared preview one) is never touched from here.
+TOPIC_DB="internship_${TOPIC}"
+case "$TOPIC_DB" in
+  internship_pr[0-9]*) : ;;
+  *) echo "ERROR: refusing to create database '${TOPIC_DB}' — expected internship_pr<N>" >&2; exit 1 ;;
+esac
 
-# Apply schema + seed (idempotent). Shared DB, so this affects all topics.
-docker run --rm --add-host=host.docker.internal:host-gateway \
-  -e DATABASE_URL="$CONTAINER_DB" "$IMAGE" node prisma/push-company-interest-expand.mjs
-docker run --rm --add-host=host.docker.internal:host-gateway \
-  -e DATABASE_URL="$CONTAINER_DB" "$IMAGE" node prisma/backfill-company-interest-scope.mjs
-# Pre-push Json repair (#1288): a table rebuild in the push (FK/index) fails on
-# rows a previous half-applied push left as '' — repair first, same as prod.
-docker run --rm --add-host=host.docker.internal:host-gateway \
-  -e DATABASE_URL="$CONTAINER_DB" "$IMAGE" node prisma/backfill-json-columns.mjs --repair || true
-docker run --rm --add-host=host.docker.internal:host-gateway \
-  -e DATABASE_URL="$CONTAINER_DB" "$IMAGE" npx prisma db push --accept-data-loss
-docker run --rm --add-host=host.docker.internal:host-gateway \
-  -e DATABASE_URL="$CONTAINER_DB" "$IMAGE" node prisma/seed-templates.mjs || true
+# Parse mysql://user:pass@host:port/db from the OUTSIDE in — the password may
+# contain @ : / and $, so one greedy regex gets it wrong (same approach as
+# infra/backup-db.sh).
+_u="${DATABASE_URL#mysql://}"; _u="${_u%%\?*}"
+_creds="${_u%@*}"; _hostpart="${_u##*@}"
+DB_USER="${_creds%%:*}"; DB_PASS="${_creds#*:}"
+[ "$DB_PASS" = "$_creds" ] && DB_PASS=""
+SHARED_DB="${_hostpart#*/}"; _hostport="${_hostpart%%/*}"
+DB_HOST="${_hostport%%:*}"; DB_PORT="${_hostport#*:}"
+[ "$DB_PORT" = "$_hostport" ] && DB_PORT=3306
+_decode() { printf '%b' "${1//%/\\x}"; }
+DB_USER="$(_decode "$DB_USER")"; DB_PASS="$(_decode "$DB_PASS")"
+
+if [ "$TOPIC_DB" = "$SHARED_DB" ]; then
+  echo "ERROR: topic database name equals the shared preview database ('${SHARED_DB}')" >&2
+  exit 1
+fi
+
+command -v mysql >/dev/null || { echo "ERROR: mysql client not found on the host" >&2; exit 1; }
+_sql() { MYSQL_PWD="$DB_PASS" mysql -h "$DB_HOST" -P "$DB_PORT" -u "$DB_USER" --batch --skip-column-names "$@"; }
+# This script runs as root ON the database host, so when the app user has not
+# been granted CREATE on the topic databases we can still do it through the
+# local root socket — and grant the app user access to what we just created, so
+# the container can actually connect. Without this the feature would need a
+# manual GRANT before the first PR, and every topic preview would break until
+# somebody ran it.
+_root_sql() { mysql --protocol=socket -u root --batch --skip-column-names "$@" 2>/dev/null; }
+
+# Is this the first deploy of this PR, or a re-push into an existing database?
+# A fresh one gets seeded; an existing one keeps whatever the reviewer has been
+# clicking on, and only gets the schema brought up to date.
+EXISTING_TABLES=$(_sql -e "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='${TOPIC_DB}';" 2>/dev/null || echo 0)
+
+echo "==> Topic database: ${TOPIC_DB} on ${DB_HOST}:${DB_PORT} (shared preview DB '${SHARED_DB}' is NOT used)"
+CREATE_SQL="CREATE DATABASE IF NOT EXISTS \`${TOPIC_DB}\` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+if ! _sql -e "$CREATE_SQL" 2>/dev/null; then
+  echo "==> App user cannot create databases; trying the local root socket"
+  if _root_sql -e "$CREATE_SQL" \
+     && _root_sql -e "GRANT ALL PRIVILEGES ON \`${TOPIC_DB}\`.* TO '${DB_USER}'@'%'; FLUSH PRIVILEGES;"; then
+    echo "==> Created ${TOPIC_DB} as root and granted it to '${DB_USER}'"
+  else
+    echo "ERROR: could not create ${TOPIC_DB}." >&2
+    echo "       Grant it once, as a MySQL admin:" >&2
+    echo "       GRANT ALL PRIVILEGES ON \`internship\\_pr%\`.* TO '${DB_USER}'@'%';" >&2
+    echo "       Refusing to fall back to the shared preview database — isolation is the point (#1185)." >&2
+    exit 1
+  fi
+fi
+
+# Point the container at the topic database. String surgery on the ORIGINAL URL
+# rather than reassembling it from the parsed parts, so a percent-encoded
+# password survives untouched.
+_base="${DATABASE_URL%%\?*}"; _base="${_base%/*}"
+_query=""
+case "$DATABASE_URL" in *\?*) _query="?${DATABASE_URL#*\?}" ;; esac
+TOPIC_DATABASE_URL="${_base}/${TOPIC_DB}${_query}"
+
+# Reach the host's MySQL from inside the container the same way the preview
+# deploy does.
+CONTAINER_DB=$(echo "$TOPIC_DATABASE_URL" | sed 's|localhost|host.docker.internal|g; s|127\.0\.0\.1|host.docker.internal|g')
+
+_in_image() {
+  docker run --rm --add-host=host.docker.internal:host-gateway \
+    -e DATABASE_URL="$CONTAINER_DB" "$@"
+}
+
+if [ "${EXISTING_TABLES:-0}" -gt 0 ]; then
+  # An existing topic database predates this push and may carry rows written by
+  # an older schema — the same repairs prod runs before its push (#1288).
+  _in_image "$IMAGE" node prisma/push-company-interest-expand.mjs || true
+  _in_image "$IMAGE" node prisma/backfill-company-interest-scope.mjs || true
+  _in_image "$IMAGE" node prisma/backfill-json-columns.mjs --repair || true
+fi
+
+_in_image "$IMAGE" npx prisma db push --accept-data-loss
+_in_image "$IMAGE" node prisma/seed-templates.mjs || true
+
+if [ "${EXISTING_TABLES:-0}" -eq 0 ]; then
+  # First deploy of this PR: fill it with the synthetic demo set. Nothing here
+  # comes from a real person — that is the whole point of #1184. SEED_DEMO_FORCE
+  # only unlocks an internship_pr<N> target (prisma/seed-demo.mjs); it cannot
+  # reach preview or prod even if this script were called with the wrong URL.
+  echo "==> Fresh topic database — seeding synthetic demo data"
+  docker run --rm --add-host=host.docker.internal:host-gateway \
+    -e DATABASE_URL="$CONTAINER_DB" -e SEED_DEMO_FORCE=1 \
+    "$IMAGE" node prisma/seed-demo.mjs || echo "WARN: demo seeding failed — the environment is up but empty"
+else
+  echo "==> Existing topic database (${EXISTING_TABLES} tables) — keeping its data"
+fi
 
 docker stop "$CONTAINER" 2>/dev/null || true
 docker rm   "$CONTAINER" 2>/dev/null || true

--- a/infra/server/topic-deploy.sh
+++ b/infra/server/topic-deploy.sh
@@ -126,6 +126,15 @@ DB_HOST="${_hostport%%:*}"; DB_PORT="${_hostport#*:}"
 _decode() { printf '%b' "${1//%/\\x}"; }
 DB_USER="$(_decode "$DB_USER")"; DB_PASS="$(_decode "$DB_PASS")"
 
+# The env file's URL is written for the CONTAINER, so its host is often
+# `host.docker.internal` — a name that only resolves INSIDE a container. This
+# script runs on the host, where the same server is reachable on loopback.
+# (Without this the very first deploy failed instantly: every mysql call, app
+# user and admin alike, could not resolve the host at all.)
+case "$DB_HOST" in
+  host.docker.internal|docker.for.mac.localhost) DB_HOST=127.0.0.1 ;;
+esac
+
 if [ "$TOPIC_DB" = "$SHARED_DB" ]; then
   echo "ERROR: topic database name equals the shared preview database ('${SHARED_DB}')" >&2
   exit 1
@@ -134,12 +143,22 @@ fi
 command -v mysql >/dev/null || { echo "ERROR: mysql client not found on the host" >&2; exit 1; }
 _sql() { MYSQL_PWD="$DB_PASS" mysql -h "$DB_HOST" -P "$DB_PORT" -u "$DB_USER" --batch --skip-column-names "$@"; }
 # This script runs as root ON the database host, so when the app user has not
-# been granted CREATE on the topic databases we can still do it through the
-# local root socket — and grant the app user access to what we just created, so
-# the container can actually connect. Without this the feature would need a
-# manual GRANT before the first PR, and every topic preview would break until
-# somebody ran it.
-_root_sql() { mysql --protocol=socket -u root --batch --skip-column-names "$@" 2>/dev/null; }
+# been granted CREATE on the topic databases we can still do it as an admin —
+# and grant the app user access to what we just created, so the container can
+# actually connect. Without this the feature would need a manual GRANT before
+# the first PR, and every topic preview would break until somebody ran it.
+#
+# Two admin routes, in order. `plesk db` first because this IS a Plesk box and
+# there the MySQL root account is not socket-authenticated — Plesk holds the
+# admin credentials and hands them to the client for you. The plain root socket
+# is the fallback for a non-Plesk host.
+_admin_sql() {
+  if command -v plesk >/dev/null 2>&1; then
+    if printf '%s\n' "$1" | plesk db --batch --skip-column-names 2>/dev/null; then return 0; fi
+    if plesk db -e "$1" 2>/dev/null; then return 0; fi
+  fi
+  mysql --protocol=socket -u root --batch --skip-column-names -e "$1" 2>/dev/null
+}
 
 # Is this the first deploy of this PR, or a re-push into an existing database?
 # A fresh one gets seeded; an existing one keeps whatever the reviewer has been
@@ -149,12 +168,30 @@ EXISTING_TABLES=$(_sql -e "SELECT COUNT(*) FROM information_schema.tables WHERE 
 echo "==> Topic database: ${TOPIC_DB} on ${DB_HOST}:${DB_PORT} (shared preview DB '${SHARED_DB}' is NOT used)"
 CREATE_SQL="CREATE DATABASE IF NOT EXISTS \`${TOPIC_DB}\` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
 if ! _sql -e "$CREATE_SQL" 2>/dev/null; then
-  echo "==> App user cannot create databases; trying the local root socket"
-  if _root_sql -e "$CREATE_SQL" \
-     && _root_sql -e "GRANT ALL PRIVILEGES ON \`${TOPIC_DB}\`.* TO '${DB_USER}'@'%'; FLUSH PRIVILEGES;"; then
-    echo "==> Created ${TOPIC_DB} as root and granted it to '${DB_USER}'"
+  echo "==> App user cannot create databases; creating it as a MySQL admin"
+  if _admin_sql "$CREATE_SQL"; then
+    # Grant to every host the account actually exists under. Guessing '%' is how
+    # this silently half-works: an account defined as 'user'@'localhost' gets a
+    # grant that never applies to it, and the container then cannot connect to
+    # the database we just made.
+    granted=0
+    for h in $(_admin_sql "SELECT host FROM mysql.user WHERE user='${DB_USER}';"); do
+      _admin_sql "GRANT ALL PRIVILEGES ON \`${TOPIC_DB}\`.* TO '${DB_USER}'@'${h}';" && granted=1
+    done
+    [ "$granted" = 1 ] || _admin_sql "GRANT ALL PRIVILEGES ON \`${TOPIC_DB}\`.* TO '${DB_USER}'@'%';"
+    _admin_sql "FLUSH PRIVILEGES;" >/dev/null
+    # Prove it: the grant is worth nothing if the app user still cannot use the
+    # database, and finding that out here beats finding it out from a container
+    # that will not boot.
+    if ! _sql -e "USE \`${TOPIC_DB}\`; SELECT 1;" >/dev/null 2>&1; then
+      echo "ERROR: created ${TOPIC_DB} but '${DB_USER}' still cannot access it." >&2
+      echo "       Grant it once, as a MySQL admin:" >&2
+      echo "       GRANT ALL PRIVILEGES ON \`internship\\_pr%\`.* TO '${DB_USER}'@'%';" >&2
+      exit 1
+    fi
+    echo "==> Created ${TOPIC_DB} as admin and granted it to '${DB_USER}'"
   else
-    echo "ERROR: could not create ${TOPIC_DB}." >&2
+    echo "ERROR: could not create ${TOPIC_DB} — neither '${DB_USER}' nor a local admin could." >&2
     echo "       Grant it once, as a MySQL admin:" >&2
     echo "       GRANT ALL PRIVILEGES ON \`internship\\_pr%\`.* TO '${DB_USER}'@'%';" >&2
     echo "       Refusing to fall back to the shared preview database — isolation is the point (#1185)." >&2

--- a/infra/server/topic-deploy.sh
+++ b/infra/server/topic-deploy.sh
@@ -175,7 +175,12 @@ if ! _sql -e "$CREATE_SQL" 2>/dev/null; then
     # grant that never applies to it, and the container then cannot connect to
     # the database we just made.
     granted=0
-    for h in $(_admin_sql "SELECT host FROM mysql.user WHERE user='${DB_USER}';"); do
+    # Filter the host list rather than trusting it: if the first admin route
+    # ever falls through to a client that prints a bordered table, the "hosts"
+    # would be `+------+` and `|` — and those would go straight into a GRANT.
+    # Only things that can actually be a MySQL host survive.
+    for h in $(_admin_sql "SELECT host FROM mysql.user WHERE user='${DB_USER}';" \
+               | grep -E '^[A-Za-z0-9_.%:-]+$' || true); do
       _admin_sql "GRANT ALL PRIVILEGES ON \`${TOPIC_DB}\`.* TO '${DB_USER}'@'${h}';" && granted=1
     done
     [ "$granted" = 1 ] || _admin_sql "GRANT ALL PRIVILEGES ON \`${TOPIC_DB}\`.* TO '${DB_USER}'@'%';"

--- a/infra/server/topic-teardown.sh
+++ b/infra/server/topic-teardown.sh
@@ -4,10 +4,18 @@
 # Run over SSH by .github/workflows/topic-preview.yml. Idempotent — safe to run for
 # a topic that was never deployed (a no-op).
 #
-# Note: we use a SINGLE shared preview DB, so there is no per-topic database to
-# drop here — only the container, its image, and the nginx route are removed.
+# Removes the container, its image, the Plesk route AND the topic's own database
+# (#1185). The database is dropped because a per-PR database that outlives its
+# PR is exactly the leak #962 found with containers, only quieter: it holds disk
+# and it holds rows.
 #
 # Required env:  TOPIC BASE_DOMAIN
+# Optional:
+#   ENV_FILE          (default /etc/internship-crm/preview.env) — read ONLY for
+#                     the MySQL host and credentials. Without it the container
+#                     and route are still removed and the database is reported
+#                     as skipped, never silently assumed gone.
+#   KEEP_TOPIC_DB=1   keep the database (debugging a failed environment)
 # Optional overrides:
 #   NGINX_CONF_DIR    (default /etc/nginx/conf.d)
 #   NGINX_RELOAD_CMD  (default "nginx -t && systemctl reload nginx")
@@ -45,6 +53,49 @@ if [ -f "$CONF" ]; then
   rm -f "$CONF"
   echo "==> Removed legacy nginx route ${CONF}; reloading nginx"
   eval "$NGINX_RELOAD_CMD" || true
+fi
+
+# ── The topic's own database (#1185) ─────────────────────────────────────────
+TOPIC_DB="internship_${TOPIC}"
+ENV_FILE="${ENV_FILE:-/etc/internship-crm/preview.env}"
+if [ "${KEEP_TOPIC_DB:-0}" = "1" ]; then
+  echo "==> KEEP_TOPIC_DB=1 — leaving ${TOPIC_DB} in place"
+elif [ ! -f "$ENV_FILE" ]; then
+  echo "WARN: ${ENV_FILE} not readable — cannot drop ${TOPIC_DB}. The daily topic sweep will pick it up."
+else
+  # shellcheck disable=SC1090
+  set -a; . "$ENV_FILE"; set +a
+  case "$TOPIC_DB" in
+    internship_pr[0-9]*) : ;;
+    # A DROP is not the place to trust a variable. Anything that is not
+    # internship_pr<N> is refused outright rather than "cleaned up".
+    *) echo "REFUSED: '${TOPIC_DB}' is not an internship_pr<N> database" >&2; TOPIC_DB="" ;;
+  esac
+  if [ -n "$TOPIC_DB" ] && [ -n "${DATABASE_URL:-}" ]; then
+    _u="${DATABASE_URL#mysql://}"; _u="${_u%%\?*}"
+    _creds="${_u%@*}"; _hostpart="${_u##*@}"
+    _user="${_creds%%:*}"; _pass="${_creds#*:}"
+    [ "$_pass" = "$_creds" ] && _pass=""
+    _shared="${_hostpart#*/}"; _hostport="${_hostpart%%/*}"
+    _host="${_hostport%%:*}"; _port="${_hostport#*:}"
+    [ "$_port" = "$_hostport" ] && _port=3306
+    _decode() { printf '%b' "${1//%/\\x}"; }
+    _user="$(_decode "$_user")"; _pass="$(_decode "$_pass")"
+    if [ "$TOPIC_DB" = "$_shared" ]; then
+      echo "REFUSED: ${TOPIC_DB} is the shared preview database" >&2
+    elif command -v mysql >/dev/null; then
+      echo "==> Dropping topic database ${TOPIC_DB}"
+      # Same two routes as the deploy: the app user, then the local root socket
+      # (this runs as root on the DB host). A database that survives teardown is
+      # the leak this change exists to avoid, so it is worth the second attempt.
+      MYSQL_PWD="$_pass" mysql -h "$_host" -P "$_port" -u "$_user" \
+        -e "DROP DATABASE IF EXISTS \`${TOPIC_DB}\`;" 2>/dev/null \
+        || mysql --protocol=socket -u root -e "DROP DATABASE IF EXISTS \`${TOPIC_DB}\`;" 2>/dev/null \
+        || echo "WARN: could not drop ${TOPIC_DB} — the daily topic sweep will retry"
+    else
+      echo "WARN: mysql client not found — ${TOPIC_DB} left in place"
+    fi
+  fi
 fi
 
 docker image prune -af >/dev/null 2>&1 || true

--- a/infra/server/topic-teardown.sh
+++ b/infra/server/topic-teardown.sh
@@ -81,6 +81,9 @@ else
     [ "$_port" = "$_hostport" ] && _port=3306
     _decode() { printf '%b' "${1//%/\\x}"; }
     _user="$(_decode "$_user")"; _pass="$(_decode "$_pass")"
+    # The env file's host is written for the container; on the host itself
+    # `host.docker.internal` resolves to nothing (#1185 follow-up).
+    case "$_host" in host.docker.internal|docker.for.mac.localhost) _host=127.0.0.1 ;; esac
     if [ "$TOPIC_DB" = "$_shared" ]; then
       echo "REFUSED: ${TOPIC_DB} is the shared preview database" >&2
     elif command -v mysql >/dev/null; then
@@ -88,9 +91,10 @@ else
       # Same two routes as the deploy: the app user, then the local root socket
       # (this runs as root on the DB host). A database that survives teardown is
       # the leak this change exists to avoid, so it is worth the second attempt.
-      MYSQL_PWD="$_pass" mysql -h "$_host" -P "$_port" -u "$_user" \
-        -e "DROP DATABASE IF EXISTS \`${TOPIC_DB}\`;" 2>/dev/null \
-        || mysql --protocol=socket -u root -e "DROP DATABASE IF EXISTS \`${TOPIC_DB}\`;" 2>/dev/null \
+      _drop="DROP DATABASE IF EXISTS \`${TOPIC_DB}\`;"
+      MYSQL_PWD="$_pass" mysql -h "$_host" -P "$_port" -u "$_user" -e "$_drop" 2>/dev/null \
+        || { command -v plesk >/dev/null 2>&1 && printf '%s\n' "$_drop" | plesk db 2>/dev/null; } \
+        || mysql --protocol=socket -u root -e "$_drop" 2>/dev/null \
         || echo "WARN: could not drop ${TOPIC_DB} — the daily topic sweep will retry"
     else
       echo "WARN: mysql client not found — ${TOPIC_DB} left in place"

--- a/prisma/seed-demo.mjs
+++ b/prisma/seed-demo.mjs
@@ -10,9 +10,10 @@ import bcrypt from 'bcryptjs';
 // The base first-admin seed (prisma/seed.mjs) is unchanged and still runs via
 // `npx prisma db seed`.
 //
-// SAFETY: refuses to run unless DATABASE_URL points at localhost/127.0.0.1,
-// or SEED_DEMO_FORCE=1 is set explicitly. The shared preview/prod DBs must
-// never receive demo rows by accident.
+// SAFETY: refuses to run unless DATABASE_URL points at localhost/127.0.0.1, at
+// a `*_demo` database, or at a per-PR topic database (`internship_pr<N>`) with
+// SEED_DEMO_FORCE=1. The shared preview/prod DBs must never receive demo rows
+// by accident.
 
 const prisma = new PrismaClient();
 
@@ -28,11 +29,23 @@ function assertSafeTarget() {
   // localhost: production is `internship_crm`, preview is
   // `internship_crm_preview`, and neither can ever match.
   const demoDb = /\/[^/?]*_demo(\?|$)/.test(url);
-  if (!local && !demoDb && process.env.SEED_DEMO_FORCE !== '1') {
+  // Per-PR topic environments (#1185) get their OWN database, created and
+  // dropped with the environment, and it is filled with exactly this synthetic
+  // data. SEED_DEMO_FORCE used to be a blanket bypass — "I know what I'm
+  // doing" is not a safety property, and the one caller that needs it runs
+  // unattended in CI. It is now NARROWED to that case: the flag only unlocks a
+  // database named `internship_pr<N>`, which by construction is neither
+  // `internship_crm` (prod) nor `internship_crm_preview` (shared preview).
+  const topicDb = /\/internship_pr[0-9]+(\?|$)/.test(url);
+  const forced = process.env.SEED_DEMO_FORCE === '1' && topicDb;
+  if (!local && !demoDb && !forced) {
     console.error(
       'seed-demo: DATABASE_URL does not look local. Refusing to seed demo data.\n' +
-      'Expected a localhost DATABASE_URL or a database whose name ends in _demo.\n' +
-      'Set SEED_DEMO_FORCE=1 only if you are certain this is not the shared preview/prod DB.'
+      'Allowed targets: a localhost DATABASE_URL, a database whose name ends in _demo,\n' +
+      'or a per-PR topic database named internship_pr<N> with SEED_DEMO_FORCE=1.\n' +
+      (process.env.SEED_DEMO_FORCE === '1' && !topicDb
+        ? 'SEED_DEMO_FORCE=1 is set but the target is not an internship_pr<N> database — the flag no longer bypasses this check for anything else.'
+        : '')
     );
     process.exit(1);
   }

--- a/releases/unreleased/per-topic-preview-db.json
+++ b/releases/unreleased/per-topic-preview-db.json
@@ -1,0 +1,4 @@
+{
+  "bump": "patch",
+  "changelog": "- **Per-PR preview databases (#1185, closes #1114)** — each topic environment now gets its own `internship_pr<N>` database, seeded with synthetic demo data and dropped when the PR closes, instead of sharing the preview database with every other PR. A `prisma db push` on one PR no longer reshapes the schema under the others, and no real preview data is reachable from a topic environment. `SEED_DEMO_FORCE` is narrowed from a blanket bypass to `internship_pr<N>` targets only, and the daily topic sweep now reclaims leaked databases as well as leaked containers."
+}


### PR DESCRIPTION
Closes #1185 · Closes #1114 (story #1184 · epic #1179).

Until now every topic environment connected to the one shared preview database. Two consequences, both real:

- a `prisma db push` on any PR reshaped the schema under **every other open PR** and under the shared preview — #1114 is that bug;
- every topic environment could read the preview data, which is **real personal data** — which is what story #1184 exists to end.

Each topic now gets `internship_pr<N>` on the same MySQL server. A separate server would be cost for no isolation gained.

## How it works

**Deploy.** `topic-deploy.sh` derives the name from `TOPIC`, creates the database, and rewrites `DATABASE_URL` to point at it. The env file still supplies the host and the credentials; the database it names is never touched. The URL is rewritten by string surgery on the original rather than reassembled from parsed parts, so a percent-encoded password survives intact.

**Fresh vs. re-push.** A brand-new database gets `db push` → templates → **synthetic demo seed**. A re-push into an existing one keeps whatever the reviewer has been clicking on and only brings the schema up to date (and runs the same pre-push Json/company-interest repairs prod runs, which only matter for rows an older schema wrote).

**Privileges — no manual step in the normal case.** The script runs as root on the database host, so if the app user cannot create databases it creates it through the local root socket and grants the app user access to that one database. If neither route works the deploy **stops** with the grant to run:

```sql
GRANT ALL PRIVILEGES ON `internship\_pr%`.* TO '<preview-user>'@'%';
```

It never falls back to the shared database. Isolation is the point; a silent fallback would reintroduce exactly the bug this closes.

**Teardown.** `topic-teardown.sh` drops the database when the PR closes, behind two guards: the name must be `internship_pr<N>`, **and** must differ from the database named in the env file. A `DROP` is not the place to trust a variable.

**Leaks.** `topic-sweep.yml` now reconciles **databases as well as containers**. A teardown that removed the container but died before the `DROP` leaves a database behind — the #962 leak again, only quieter, because nothing else would ever notice it. The sweep takes the union of `internship-crm-pr<N>` containers and `internship_pr<N>` schemas, asks GitHub which PRs are still open, and tears down the rest.

**`SEED_DEMO_FORCE` narrowed, not removed** — as the issue asked. It used to be a blanket "I know what I'm doing" bypass; "I know what I'm doing" is not a safety property, and the one caller that needs it runs unattended in CI. It now only unlocks an `internship_pr<N>` target, which by construction is neither `internship_crm` (prod) nor `internship_crm_preview` (shared preview). A `SEED_DEMO_FORCE=1` pointed anywhere else is refused and says so.

## Acceptance criteria

- **Two PRs' topic environments cannot see each other's data** — separate databases, and the deploy logs which one it is using.
- **No real PII in a topic environment** — a fresh database is filled only by `prisma/seed-demo.mjs` (`@demo.example.com` accounts). Sign in with `admin.demo@demo.example.com` / `DemoPass123!`; the PR comment now says so instead of warning about a shared schema.
- **The database goes when the PR closes**, and the daily sweep collects the ones that leak.
- **The shared preview environment is untouched** — `crm-preview.ersah.in` keeps its own single database and its own deploy path.

## Verification

Against a local MySQL, with `docker` stubbed so only the database logic ran:

- URL parse + rewrite: `mysql://crmuser:p%40ss%2Fword@127.0.0.1:3306/internship_crm_preview` → `…/internship_pr1315` with the encoded password unchanged, and a `?connection_limit=5` query string preserved;
- fresh database → `db push`, templates, **and** the demo seed with `SEED_DEMO_FORCE=1`; existing database → schema only, seed skipped;
- teardown dropped `internship_pr9999`;
- teardown guards: `TOPIC=preview` → `REFUSED: 'internship_preview' is not an internship_pr<N> database`; env file naming the same database → `REFUSED: … is the shared preview database`; the shared database survived both;
- `SEED_DEMO_FORCE=1` against `internship_crm_preview` → refused, with the reason naming the narrowed rule;
- `bash -n` on both scripts, YAML parse on both workflows, `npm run lint` clean.

**This PR's own topic environment is the first real test** — if `crm-pr<N>.ersah.in` comes up with demo accounts and its own `internship_pr<N>` database, the change works on the box. If the deploy check goes red with the grant line above, that is the one-time privilege setup and I'll say so rather than working around it.

Release fragment: `releases/unreleased/per-topic-preview-db.json` (`patch`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeSYkGngKpYG4KWsJ7Ph2Z)_