### PR TITLE
fix(ci): stop downloading actions on the self-hosted runner (#1239)

### DIFF
--- a/.github/workflows/backup-verify.yml
+++ b/.github/workflows/backup-verify.yml
@@ -48,7 +48,39 @@ jobs:
     outputs:
       report: ${{ steps.check.outputs.report }}
     steps:
-      - uses: actions/checkout@v7
+      # #1239 — NO `uses:` in a self-hosted job. Downloading an action archive
+      # from codeload.github.com answers 429 from this box's IP (the GitHub-hosted
+      # runners are unaffected), and it fails in "Set up job" — before a single
+      # line of repo code runs. That killed every topic preview and every deploy
+      # at the same point. Plain git over HTTPS is not throttled that way, and
+      # these jobs only ever needed the infra/ scripts.
+      - name: Fetch the repo (no action download)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FETCH_REF: ${{ github.sha }}
+          FETCH_DEPTH: '1'
+        run: |
+          set -euo pipefail
+          [ -d .git ] || git init -q .
+          git remote get-url origin >/dev/null 2>&1 \
+            || git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          # The token reaches git through a credential helper reading the
+          # environment, so it is never in argv (readable via `ps` on a shared box)
+          # and never written into .git/config.
+          HELPER='!f() { echo "username=x-access-token"; echo "password=$GH_TOKEN"; }; f'
+          if [ "$FETCH_DEPTH" = "0" ]; then
+            # Full history: the forward-only guard in deploy-prod.sh asks
+            # `git merge-base --is-ancestor` whether this commit predates the live
+            # one, and a shallow clone cannot answer that.
+            git -c credential.helper="$HELPER" fetch --no-tags --prune origin \
+              "+refs/heads/*:refs/remotes/origin/*"
+            git -c credential.helper="$HELPER" fetch --no-tags origin "$FETCH_REF"
+          else
+            git -c credential.helper="$HELPER" fetch --no-tags --depth="$FETCH_DEPTH" origin "$FETCH_REF"
+          fi
+          git checkout -q --force --detach FETCH_HEAD
+          git clean -qfdx
 
       - name: Backup freshness & integrity
         id: check

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -68,8 +68,39 @@ jobs:
       deploy: ${{ steps.gate.outputs.deploy }}
       sha: ${{ steps.gate.outputs.sha }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v7
+      # #1239 — NO `uses:` in a self-hosted job. Downloading an action archive
+      # from codeload.github.com answers 429 from this box's IP (the GitHub-hosted
+      # runners are unaffected), and it fails in "Set up job" — before a single
+      # line of repo code runs. That killed every topic preview and every deploy
+      # at the same point. Plain git over HTTPS is not throttled that way, and
+      # these jobs only ever needed the infra/ scripts.
+      - name: Fetch the repo (no action download)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FETCH_REF: ${{ github.sha }}
+          FETCH_DEPTH: '1'
+        run: |
+          set -euo pipefail
+          [ -d .git ] || git init -q .
+          git remote get-url origin >/dev/null 2>&1 \
+            || git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          # The token reaches git through a credential helper reading the
+          # environment, so it is never in argv (readable via `ps` on a shared box)
+          # and never written into .git/config.
+          HELPER='!f() { echo "username=x-access-token"; echo "password=$GH_TOKEN"; }; f'
+          if [ "$FETCH_DEPTH" = "0" ]; then
+            # Full history: the forward-only guard in deploy-prod.sh asks
+            # `git merge-base --is-ancestor` whether this commit predates the live
+            # one, and a shallow clone cannot answer that.
+            git -c credential.helper="$HELPER" fetch --no-tags --prune origin \
+              "+refs/heads/*:refs/remotes/origin/*"
+            git -c credential.helper="$HELPER" fetch --no-tags origin "$FETCH_REF"
+          else
+            git -c credential.helper="$HELPER" fetch --no-tags --depth="$FETCH_DEPTH" origin "$FETCH_REF"
+          fi
+          git checkout -q --force --detach FETCH_HEAD
+          git clean -qfdx
 
       - name: Decide whether a deploy is needed
         id: gate
@@ -155,10 +186,39 @@ jobs:
       contents: read
       packages: read
     steps:
-      - name: Checkout ${{ needs.gate.outputs.sha }}
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ needs.gate.outputs.sha }}
+      # #1239 — NO `uses:` in a self-hosted job. Downloading an action archive
+      # from codeload.github.com answers 429 from this box's IP (the GitHub-hosted
+      # runners are unaffected), and it fails in "Set up job" — before a single
+      # line of repo code runs. That killed every topic preview and every deploy
+      # at the same point. Plain git over HTTPS is not throttled that way, and
+      # these jobs only ever needed the infra/ scripts.
+      - name: Fetch the repo (no action download)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FETCH_REF: ${{ needs.gate.outputs.sha }}
+          FETCH_DEPTH: '1'
+        run: |
+          set -euo pipefail
+          [ -d .git ] || git init -q .
+          git remote get-url origin >/dev/null 2>&1 \
+            || git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          # The token reaches git through a credential helper reading the
+          # environment, so it is never in argv (readable via `ps` on a shared box)
+          # and never written into .git/config.
+          HELPER='!f() { echo "username=x-access-token"; echo "password=$GH_TOKEN"; }; f'
+          if [ "$FETCH_DEPTH" = "0" ]; then
+            # Full history: the forward-only guard in deploy-prod.sh asks
+            # `git merge-base --is-ancestor` whether this commit predates the live
+            # one, and a shallow clone cannot answer that.
+            git -c credential.helper="$HELPER" fetch --no-tags --prune origin \
+              "+refs/heads/*:refs/remotes/origin/*"
+            git -c credential.helper="$HELPER" fetch --no-tags origin "$FETCH_REF"
+          else
+            git -c credential.helper="$HELPER" fetch --no-tags --depth="$FETCH_DEPTH" origin "$FETCH_REF"
+          fi
+          git checkout -q --force --detach FETCH_HEAD
+          git clean -qfdx
 
       - name: Deploy
         env:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -76,8 +76,39 @@ jobs:
       deploy: ${{ steps.gate.outputs.deploy }}
       sha: ${{ steps.gate.outputs.sha }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v7
+      # #1239 — NO `uses:` in a self-hosted job. Downloading an action archive
+      # from codeload.github.com answers 429 from this box's IP (the GitHub-hosted
+      # runners are unaffected), and it fails in "Set up job" — before a single
+      # line of repo code runs. That killed every topic preview and every deploy
+      # at the same point. Plain git over HTTPS is not throttled that way, and
+      # these jobs only ever needed the infra/ scripts.
+      - name: Fetch the repo (no action download)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FETCH_REF: ${{ github.sha }}
+          FETCH_DEPTH: '1'
+        run: |
+          set -euo pipefail
+          [ -d .git ] || git init -q .
+          git remote get-url origin >/dev/null 2>&1 \
+            || git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          # The token reaches git through a credential helper reading the
+          # environment, so it is never in argv (readable via `ps` on a shared box)
+          # and never written into .git/config.
+          HELPER='!f() { echo "username=x-access-token"; echo "password=$GH_TOKEN"; }; f'
+          if [ "$FETCH_DEPTH" = "0" ]; then
+            # Full history: the forward-only guard in deploy-prod.sh asks
+            # `git merge-base --is-ancestor` whether this commit predates the live
+            # one, and a shallow clone cannot answer that.
+            git -c credential.helper="$HELPER" fetch --no-tags --prune origin \
+              "+refs/heads/*:refs/remotes/origin/*"
+            git -c credential.helper="$HELPER" fetch --no-tags origin "$FETCH_REF"
+          else
+            git -c credential.helper="$HELPER" fetch --no-tags --depth="$FETCH_DEPTH" origin "$FETCH_REF"
+          fi
+          git checkout -q --force --detach FETCH_HEAD
+          git clean -qfdx
 
       - name: Decide whether a deploy is needed
         id: gate
@@ -159,14 +190,39 @@ jobs:
       contents: read
       packages: read
     steps:
-      - name: Checkout ${{ needs.gate.outputs.sha }}
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ needs.gate.outputs.sha }}
-          # Full history: the forward-only guard in deploy-prod.sh asks
-          # `git merge-base --is-ancestor` whether this commit predates the live
-          # one, which a shallow clone can't answer.
-          fetch-depth: 0
+      # #1239 — NO `uses:` in a self-hosted job. Downloading an action archive
+      # from codeload.github.com answers 429 from this box's IP (the GitHub-hosted
+      # runners are unaffected), and it fails in "Set up job" — before a single
+      # line of repo code runs. That killed every topic preview and every deploy
+      # at the same point. Plain git over HTTPS is not throttled that way, and
+      # these jobs only ever needed the infra/ scripts.
+      - name: Fetch the repo (no action download)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FETCH_REF: ${{ needs.gate.outputs.sha }}
+          FETCH_DEPTH: '0'
+        run: |
+          set -euo pipefail
+          [ -d .git ] || git init -q .
+          git remote get-url origin >/dev/null 2>&1 \
+            || git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          # The token reaches git through a credential helper reading the
+          # environment, so it is never in argv (readable via `ps` on a shared box)
+          # and never written into .git/config.
+          HELPER='!f() { echo "username=x-access-token"; echo "password=$GH_TOKEN"; }; f'
+          if [ "$FETCH_DEPTH" = "0" ]; then
+            # Full history: the forward-only guard in deploy-prod.sh asks
+            # `git merge-base --is-ancestor` whether this commit predates the live
+            # one, and a shallow clone cannot answer that.
+            git -c credential.helper="$HELPER" fetch --no-tags --prune origin \
+              "+refs/heads/*:refs/remotes/origin/*"
+            git -c credential.helper="$HELPER" fetch --no-tags origin "$FETCH_REF"
+          else
+            git -c credential.helper="$HELPER" fetch --no-tags --depth="$FETCH_DEPTH" origin "$FETCH_REF"
+          fi
+          git checkout -q --force --detach FETCH_HEAD
+          git clean -qfdx
 
       - name: Deploy
         env:

--- a/.github/workflows/topic-preview.yml
+++ b/.github/workflows/topic-preview.yml
@@ -100,8 +100,39 @@ jobs:
           # of both and, checked on the box, of everything else.
           echo "port=$((3400 + PR % 100))" >> "$GITHUB_OUTPUT"
 
-      - name: Checkout
-        uses: actions/checkout@v7
+      # #1239 — NO `uses:` in a self-hosted job. Downloading an action archive
+      # from codeload.github.com answers 429 from this box's IP (the GitHub-hosted
+      # runners are unaffected), and it fails in "Set up job" — before a single
+      # line of repo code runs. That killed every topic preview and every deploy
+      # at the same point. Plain git over HTTPS is not throttled that way, and
+      # these jobs only ever needed the infra/ scripts.
+      - name: Fetch the repo (no action download)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FETCH_REF: ${{ github.event.pull_request.head.sha }}
+          FETCH_DEPTH: '1'
+        run: |
+          set -euo pipefail
+          [ -d .git ] || git init -q .
+          git remote get-url origin >/dev/null 2>&1 \
+            || git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          # The token reaches git through a credential helper reading the
+          # environment, so it is never in argv (readable via `ps` on a shared box)
+          # and never written into .git/config.
+          HELPER='!f() { echo "username=x-access-token"; echo "password=$GH_TOKEN"; }; f'
+          if [ "$FETCH_DEPTH" = "0" ]; then
+            # Full history: the forward-only guard in deploy-prod.sh asks
+            # `git merge-base --is-ancestor` whether this commit predates the live
+            # one, and a shallow clone cannot answer that.
+            git -c credential.helper="$HELPER" fetch --no-tags --prune origin \
+              "+refs/heads/*:refs/remotes/origin/*"
+            git -c credential.helper="$HELPER" fetch --no-tags origin "$FETCH_REF"
+          else
+            git -c credential.helper="$HELPER" fetch --no-tags --depth="$FETCH_DEPTH" origin "$FETCH_REF"
+          fi
+          git checkout -q --force --detach FETCH_HEAD
+          git clean -qfdx
 
       - name: Deploy topic environment
         env:
@@ -117,11 +148,24 @@ jobs:
           # No SKIP_PULL: the image comes from ghcr, built on the hosted runner.
           ./infra/server/topic-deploy.sh
 
-      - name: Comment topic URL on the PR
-        uses: actions/github-script@v9
+  # ── Say where it is (GitHub-hosted) ─────────────────────────────────────────
+  # Separate job on purpose (#1239): posting a comment needs GitHub, not the
+  # server, and every `uses:` inside a self-hosted job is an action archive this
+  # box has to download from codeload — which is exactly what 429s.
+  comment:
+    name: Comment topic URL on the PR
+    needs: deploy
+    if: >-
+      github.event.action != 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@v9
         with:
           script: |
-            const topic = '${{ steps.t.outputs.topic }}';
+            const topic = `pr${context.issue.number}`;
             const url = `https://crm-${topic}.${{ env.BASE_DOMAIN }}`;
             const marker = '<!-- topic-preview -->';
             const body = `${marker}\n### 🧪 Topic preview ready\n\n` +
@@ -149,8 +193,41 @@ jobs:
     if: github.event.action == 'closed'
     runs-on: self-hosted
     steps:
-      - name: Checkout
-        uses: actions/checkout@v7
+      # #1239 — NO `uses:` in a self-hosted job. Downloading an action archive
+      # from codeload.github.com answers 429 from this box's IP (the GitHub-hosted
+      # runners are unaffected), and it fails in "Set up job" — before a single
+      # line of repo code runs. That killed every topic preview and every deploy
+      # at the same point. Plain git over HTTPS is not throttled that way, and
+      # these jobs only ever needed the infra/ scripts.
+      - name: Fetch the repo (no action download)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # `github.sha` on a closed PR is the merge ref, which may already be
+          # gone; the base branch is always there and carries the same scripts.
+          FETCH_REF: ${{ github.event.pull_request.base.ref }}
+          FETCH_DEPTH: '1'
+        run: |
+          set -euo pipefail
+          [ -d .git ] || git init -q .
+          git remote get-url origin >/dev/null 2>&1 \
+            || git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          # The token reaches git through a credential helper reading the
+          # environment, so it is never in argv (readable via `ps` on a shared box)
+          # and never written into .git/config.
+          HELPER='!f() { echo "username=x-access-token"; echo "password=$GH_TOKEN"; }; f'
+          if [ "$FETCH_DEPTH" = "0" ]; then
+            # Full history: the forward-only guard in deploy-prod.sh asks
+            # `git merge-base --is-ancestor` whether this commit predates the live
+            # one, and a shallow clone cannot answer that.
+            git -c credential.helper="$HELPER" fetch --no-tags --prune origin \
+              "+refs/heads/*:refs/remotes/origin/*"
+            git -c credential.helper="$HELPER" fetch --no-tags origin "$FETCH_REF"
+          else
+            git -c credential.helper="$HELPER" fetch --no-tags --depth="$FETCH_DEPTH" origin "$FETCH_REF"
+          fi
+          git checkout -q --force --detach FETCH_HEAD
+          git clean -qfdx
 
       - name: Tear down
         env:

--- a/.github/workflows/topic-sweep.yml
+++ b/.github/workflows/topic-sweep.yml
@@ -118,7 +118,39 @@ jobs:
     if: needs.resolve.outputs.stale != ''
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@v7
+      # #1239 — NO `uses:` in a self-hosted job. Downloading an action archive
+      # from codeload.github.com answers 429 from this box's IP (the GitHub-hosted
+      # runners are unaffected), and it fails in "Set up job" — before a single
+      # line of repo code runs. That killed every topic preview and every deploy
+      # at the same point. Plain git over HTTPS is not throttled that way, and
+      # these jobs only ever needed the infra/ scripts.
+      - name: Fetch the repo (no action download)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FETCH_REF: ${{ github.sha }}
+          FETCH_DEPTH: '1'
+        run: |
+          set -euo pipefail
+          [ -d .git ] || git init -q .
+          git remote get-url origin >/dev/null 2>&1 \
+            || git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          # The token reaches git through a credential helper reading the
+          # environment, so it is never in argv (readable via `ps` on a shared box)
+          # and never written into .git/config.
+          HELPER='!f() { echo "username=x-access-token"; echo "password=$GH_TOKEN"; }; f'
+          if [ "$FETCH_DEPTH" = "0" ]; then
+            # Full history: the forward-only guard in deploy-prod.sh asks
+            # `git merge-base --is-ancestor` whether this commit predates the live
+            # one, and a shallow clone cannot answer that.
+            git -c credential.helper="$HELPER" fetch --no-tags --prune origin \
+              "+refs/heads/*:refs/remotes/origin/*"
+            git -c credential.helper="$HELPER" fetch --no-tags origin "$FETCH_REF"
+          else
+            git -c credential.helper="$HELPER" fetch --no-tags --depth="$FETCH_DEPTH" origin "$FETCH_REF"
+          fi
+          git checkout -q --force --detach FETCH_HEAD
+          git clean -qfdx
       - env:
           STALE: ${{ needs.resolve.outputs.stale }}
           BASE_DOMAIN: ${{ env.BASE_DOMAIN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,10 +85,14 @@ flowchart LR
 
 ### Pipeline status (the core domain concept)
 `MentorshipRelation.pipelineStatus` mirrors the original spreadsheet's status column.
-Stages (enum `PipelineStatus`): `BASVURU_100` → `ONAY_220` → `GORUSME_250` →
-`TANISTIRMA_270` → `STAJ_BASLAYACAK_300` → `STAJ_DEVAM_450` → `STAJ_BITTI_490` →
-`IS_ARIYOR_500` → `ISE_ALINABILIR_600` → `ISE_ALINDI_660` → `IS_BULDU_700`
-(plus `YARIM_BIRAKTI_460`, `BASKA_YERDE_STAJ_800`). Default `BASVURU_100`.
+Stages (enum `PipelineStatus`, `prisma/schema.prisma` is the source of truth):
+`APPLICATION_100` → `APPROVAL_PENDING_220` → `INTERVIEW_PENDING_250` →
+`INTRODUCTION_PENDING_270` → `INTERNSHIP_STARTING_300` → `INTERNSHIP_IN_PROGRESS_450` →
+`INTERNSHIP_COMPLETED_490` → `JOB_SEEKING_500` → `HIREABLE_600` → `HIRED_660` →
+`EMPLOYED_700` (plus the off-path `INTERNSHIP_DROPPED_460` and
+`INTERNSHIP_FOUND_ELSEWHERE_800`). Default `APPLICATION_100`. The Turkish names are the
+*labels* (`src/lib/pipeline.ts`), not the keys — this list used to give the labels as keys,
+which type-checks nowhere and fails only at runtime.
 
 ## Directory map
 

--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -4120,3 +4120,53 @@ Yeni bir yapılandırma modeli eklerken varsayılan refleks bu olmalı.
 **Tek dal, çok iş → PR'ı gerçeğe uydur.** Oturum tek dalda çalışıyorsa ikinci iş
 açık PR'ın üstüne biniyor. Yeni PR açmaya çalışma; PR'ın başlık ve gövdesini iki işi
 de anlatacak şekilde güncelle ve commit sha'larını yaz — diff zaten ayrı okunuyor.
+
+## 2026-08-24 — etiketler, yedek tatbikatı, topic başına DB, runner 429
+
+**CLAUDE.md'deki aşama listesi yanlıştı** (bu oturumda düzeltildi). Enum anahtarları
+İngilizce (`INTERNSHIP_IN_PROGRESS_450`), Türkçe adlar ise *etiket*. Belgedeki listeye
+güvenip `STAJ_DEVAM_450` yazan testim sessizce yanlış aşamayı kurdu ve asıl iddiayı hiç
+sınamadı. **Şema, dokümandan üstündür**: enum değerini `prisma/schema.prisma`'dan teyit et.
+
+**Sayfanın hangi endpoint'i çağırdığını varsayma.** `/admin/candidates` `/api/users`'ı
+değil `/api/candidates`'i kullanıyor. Filtreyi yanlış route'a koyarsan her şey derlenir,
+test bile geçebilir — ama sayfa filtrelemez.
+
+**Sayfalı listede "diğerleri de görünüyor" diye assert etme.** Kaydedilmiş görünüm
+testim bu yüzden düştü: filtre kalkınca beklediğim aday ilk sayfada değildi. Seed'e
+paylaşılan benzersiz bir isim eki koyup arama kutusuyla daralt; liste artık veritabanında
+başka ne varsa ondan bağımsız.
+
+**`window.prompt` açan bir UI adımından sonra sonucu doğrula.** `page.once('dialog')`
+kurup Save'e tıklamak yetmiyor; kaydedilen görünümün gerçekten belirdiğini assert et,
+yoksa sonraki adımlar sessizce yanlış durumda çalışır. Save düğmesine `data-testid`
+eklemek de rol/isim eşleşmesinin başka bir düğmeye kaymasını engelliyor.
+
+**`pkill -f "next"` kendi `npm run build`'ini de öldürür** (exit 144). Dev sunucusunu
+`setsid nohup ... &` ile başlat ve öldürürken `next dev` gibi dar bir kalıp kullan.
+
+**Yeni route ekledikten sonra hayalet TS hatası görürsen `.next`'i sil.** Bayat
+`.next/types/validator.ts` var olmayan sorunları raporluyor.
+
+**`preview.env`'deki `DATABASE_URL` konteyner için yazılmış.** Host'u
+`host.docker.internal` — sunucuda çalışan bir script'te bu isim hiçbir şeye çözümlenmiyor
+ve her mysql çağrısı saniyeden kısa sürede düşüyor. Host tarafında loopback'e eşle
+(#1185 ilk deploy'u tam olarak buna takıldı).
+
+**Plesk kutusunda MySQL root soketle doğrulanmıyor.** Admin işi için `plesk db` kullan;
+`mysql --protocol=socket -u root` yalnızca Plesk olmayan sunucuda çalışır. GRANT verirken
+de hesabın gerçekten var olduğu host'ları `mysql.user`'dan oku — `'user'@'%'` varsaymak,
+hesap `@'localhost'` ise hiç uygulanmayan bir grant üretir ve veritabanı oluşur ama
+konteyner bağlanamaz. Verdiğin yetkiyi uygulama kullanıcısıyla `USE` ederek doğrula.
+
+**Bir istemcinin çıktısını ayrıştırıp SQL'e koyuyorsan süz.** Çerçeveli tablo basan bir
+istemciye düşülürse "host" değerleri `+------+` ve `|` olur ve doğrudan GRANT'e girer.
+
+**Self-hosted runner'da `uses:` kullanma (#1239).** Her action, arşivini
+codeload.github.com'dan indiriyor; sunucunun IP'sinden bu indirmeler 429 dönüyor ve iş
+"Set up job"da, repo kodu çalışmadan ölüyor. Repoyu düz `git fetch <sha>` ile al; action
+gerektiren adımı ayrı bir GitHub-hosted job'a taşı. Belirti yanıltıcı: runner bozuk gibi
+görünüyor, oysa workflow'a `uses:` eklenmiş oluyor.
+
+**`get_job_logs` iş bitmeden 404 döner.** Koşan bir job'un log'unu çekmeye çalışma;
+`get_check_runs` ile bitmesini bekle.

--- a/infra/README.md
+++ b/infra/README.md
@@ -208,6 +208,32 @@ the private repo's Actions quota exhausted (#636) the builds were moved onto the
 self-hosted runner, so the production host ran `npm ci` + `next build` for every
 merge **and every push to every open PR**.
 
+### No `uses:` in a self-hosted job (#1239)
+
+Every `uses:` makes the runner download that action's archive from
+`codeload.github.com`. From this box's IP those downloads started answering
+**429**, three attempts and a backoff apart, and the job died in *Set up job* —
+before a line of repo code ran. Every topic preview and every deploy failed at
+the same point while the identical `ubuntu-latest` jobs passed, so the throttle
+is on the address, not the workflow.
+
+So the self-hosted jobs use **no actions at all**. They fetch what they need
+with plain git over HTTPS:
+
+```bash
+git init -q .                       # workspace persists between runs
+git remote add origin https://github.com/$GITHUB_REPOSITORY.git
+git fetch --no-tags --depth=1 origin "$SHA"
+git checkout -q --force --detach FETCH_HEAD
+git clean -qfdx
+```
+
+Anything that needs an action — posting the topic-preview comment, sending an
+alert email — is a separate GitHub-hosted job. **Keep it that way**: adding a
+`uses:` to a self-hosted job reintroduces the failure, and it fails before your
+step ever runs, which makes it look like the runner is broken rather than the
+workflow.
+
 ---
 
 ## CI-independent operations (deploying without Actions, #636)

--- a/releases/unreleased/self-hosted-no-actions.json
+++ b/releases/unreleased/self-hosted-no-actions.json
@@ -1,0 +1,4 @@
+{
+  "bump": "patch",
+  "changelog": "- **Deploys stop dying on a 429 (#1239)** — self-hosted jobs no longer use any GitHub Action. Downloading an action archive from codeload answered 429 from the server's IP and failed the job before any repo code ran, taking down every topic preview and every prod/preview deploy; those jobs now fetch the repo with plain git, and the steps that genuinely need an action (the topic-preview comment) moved to a GitHub-hosted job."
+}


### PR DESCRIPTION
Closes #1239.

Every `uses:` makes the runner fetch that action's archive from `codeload.github.com`. From this box's IP those downloads started answering **429** — three attempts and a backoff apart — and the job died in *Set up job*, before a line of repo code ran:

```
##[warning]Failed to download action 'https://codeload.github.com/actions/checkout/tar.gz/3d3c…'.
Error: Response status code does not indicate success: 429 (Too Many Requests).
```

The identical `ubuntu-latest` jobs passed on the same commit, so the throttle is on the **address**, not the workflow. While it lasted, no PR got a preview environment and no merge reached prod or preview.

## The fix

**Self-hosted jobs use no actions at all** — all ten of them (`topic-preview` deploy + teardown, `topic-sweep` collect + sweep, `deploy-prod` gate + deploy, `deploy-preview` gate + deploy, `backup-verify` verify, `demo-reset` which already had none). The repo comes from plain git over HTTPS:

```bash
git init -q .                       # the workspace persists between runs
git remote add origin https://github.com/$GITHUB_REPOSITORY.git
git fetch --no-tags --depth=1 origin "$SHA"
git checkout -q --force --detach FETCH_HEAD
git clean -qfdx
```

Three details that are not incidental:

- **The token never touches argv.** It reaches git through a credential helper that reads the environment, so it is not visible in `ps` on a shared box and is never written into `.git/config` (which `git config http.extraheader` would have done, and which would also have put it in argv).
- **The prod deploy keeps its full history.** `deploy-prod.sh`'s forward-only guard asks `git merge-base --is-ancestor` whether the commit predates the live one, and fails *closed* when it cannot resolve. The `fetch-depth: 0` equivalent here is fetching every branch ref plus the resolved sha.
- **The topic teardown fetches the base branch, not `github.sha`.** On a closed PR that sha is the merge ref, which may already be gone by the time teardown runs.

**The one step that genuinely needs an action** — the topic-preview PR comment — moved to its own GitHub-hosted job, where downloading an action costs nothing.

`infra/README.md` gains the rule and the reason, because the failure mode is misleading: it looks like a broken runner rather than a workflow that added a `uses:`.

## Verification

The generated fetch step was executed for real against this repository, not just eyeballed:

- a clean workspace lands on the requested sha and has `infra/` in it;
- a re-run in a dirty workspace re-lands on the same sha and removes the leftover file (so the persistent workspace can't accumulate state between PRs);
- the full-history variant brings **746 commits** and `git cat-file -e HEAD~5` succeeds — the ancestry query the prod guard depends on can be answered.

`bash -n` on the scripts and a YAML parse on all five workflows; a scripted check asserts every `runs-on: self-hosted` job has an empty `uses:` list, so a regression is detectable.

## Risk, stated plainly

This touches the **production deploy path**. The gate and deploy jobs of `deploy-prod.yml` are in the diff, and their first real exercise is the next merge to `main` — a topic preview cannot cover them. The change is mechanical (same working directory, same files present, same subsequent steps), the ancestry requirement is covered above, and the failure mode if I got it wrong is a red deploy job rather than a bad deploy: the fetch either produces the tree or the step exits non-zero before `deploy-prod.sh` runs. Merging this PR is itself the test — I'll watch that run.

Release fragment: `releases/unreleased/self-hosted-no-actions.json` (`patch`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeSYkGngKpYG4KWsJ7Ph2Z)_