### PR TITLE
Bildirim linklerini alıcı rolleriyle uyumlu hale getir

### DIFF
--- a/e2e/admin-as-mentor.spec.ts
+++ b/e2e/admin-as-mentor.spec.ts
@@ -5,7 +5,7 @@ test.afterAll(async () => {
   await prisma.$disconnect();
 });
 
-test('an admin can be assigned as a mentee\'s mentor', async ({ page }) => {
+test('an admin can be assigned as a mentee\'s mentor', { tag: '@smoke' }, async ({ page }) => {
   const adminEmail = uniqueEmail('aam-admin');
   const admin = await seedUser(adminEmail, 'AdminPass123', 'ADMIN', 'AAM Admin');
   const mentee = await seedUser(uniqueEmail('aam-mentee'), 'x', 'MENTEE', 'AAM Mentee');
@@ -27,6 +27,10 @@ test('an admin can be assigned as a mentee\'s mentor', async ({ page }) => {
     await page.goto('/admin/mentorship');
     const data = await (await page.request.get('/api/users')).json();
     expect(data.users.some((u: { id: string; role: string }) => u.id === admin.id && u.role === 'ADMIN')).toBeTruthy();
+
+    await page.goto(`/mentor/mentees/${relId}`);
+    await expect(page).toHaveURL(`/mentor/mentees/${relId}`);
+    await expect(page.getByText('AAM Mentee').first()).toBeVisible();
   } finally {
     if (relId) await prisma.mentorshipRelation.deleteMany({ where: { id: relId } });
     await cleanupByEmail(mentee.email);

--- a/e2e/notification-coverage.spec.ts
+++ b/e2e/notification-coverage.spec.ts
@@ -112,6 +112,7 @@ test('mentee actions notify the mentor — two-way (#925)', async ({ page }) => 
   expect(done.ok()).toBeTruthy();
   await expect.poll(() => mentorCount('goal.completed')).toBe(1);
   expect(await menteeCount('goal.completed')).toBe(0);
+  expect((await prisma.notification.findFirstOrThrow({ where: { userId: mentorId, type: 'goal.completed' } })).link).toBe(`/mentor/mentees/${relationId}`);
 
   // Re-saving the already-done goal must not notify again.
   const again = await page.request.patch(`/api/goals/${seededGoal.id}`, { data: { status: 'DONE', title: 'Finish portfolio v2' } });
@@ -122,6 +123,7 @@ test('mentee actions notify the mentor — two-way (#925)', async ({ page }) => 
   const evalRes = await page.request.post('/api/evaluations', { data: { relationId, scores: { guidance: 5 } } });
   expect(evalRes.status()).toBe(201);
   await expect.poll(() => mentorCount('evaluation.added')).toBe(1);
+  expect((await prisma.notification.findFirstOrThrow({ where: { userId: mentorId, type: 'evaluation.added' } })).link).toBe(`/mentor/mentees/${relationId}`);
 });
 
 test('every stage-write path emits the same notification + keeps pipelineStatus in sync (#926)', async ({ page }) => {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -62,6 +62,10 @@ export default defineConfig({
         // the spoofing assertions in rate-limit-spoof.spec.ts meaningful (#858).
         env: {
           TRUSTED_PROXY_COUNT: '0',
+          // E2E must never deliver real mail from a developer's loaded .env;
+          // synchronous route mail would otherwise wait on that external SMTP.
+          SMTP_USER: '',
+          SMTP_BULK_USER: '',
           // Exercises the gated shape of /api/health (#897). Unset, the endpoint
           // keeps its legacy fully-public response and health.spec.ts's
           // assertions about what an anonymous caller may see would be vacuous.

--- a/releases/unreleased/notification-link-role-compatibility.json
+++ b/releases/unreleased/notification-link-role-compatibility.json
@@ -1,0 +1,9 @@
+{
+  "bump": "patch",
+  "changelog": "- **Role-compatible notification links**: notification targets now use the recipient’s mentorship side and the correct relation or conversation identifier across evaluations, goals, requests, questions, invitations, meetings, and document reminders.",
+  "notes": {
+    "en": ["Notifications now open the correct page for your role and relationship context, including mentor, mentee, dual-role, meeting, and document-reminder flows."],
+    "tr": ["Bildirimler artık mentör, mentee, çift rollü kullanıcı, toplantı ve belge hatırlatma akışlarında rolünüze ve ilişki bağlamınıza uygun doğru sayfayı açar."],
+    "de": ["Benachrichtigungen öffnen jetzt die richtige Seite für Ihre Rolle und den jeweiligen Beziehungskontext, einschließlich Mentor-, Mentee-, Doppelrollen-, Meeting- und Dokumenterinnerungsabläufen."]
+  }
+}

--- a/src/app/api/evaluations/route.ts
+++ b/src/app/api/evaluations/route.ts
@@ -103,7 +103,7 @@ export async function POST(request: Request) {
   // page that shows it behind a session.
   const recipientId = session.user.id === rel.menteeId ? rel.mentorId : rel.menteeId;
   if (recipientId !== session.user.id) {
-    const link = recipientId === rel.menteeId ? '/portal' : `/mentor/mentees/${rel.menteeId}`;
+    const link = recipientId === rel.menteeId ? '/portal' : `/mentor/mentees/${rel.id}`;
     await notifyIfAllowed(recipientId, 'goalsEvaluations', 'evaluation.added', {}, link);
   }
   return NextResponse.json({ evaluation }, { status: 201 });

--- a/src/app/api/goals/[id]/route.ts
+++ b/src/app/api/goals/[id]/route.ts
@@ -51,7 +51,7 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
     const rel = goal.relation;
     const recipientId = session.user.id === rel.menteeId ? rel.mentorId : rel.menteeId;
     if (recipientId !== session.user.id) {
-      const link = recipientId === rel.menteeId ? '/portal/goals' : `/mentor/mentees/${rel.menteeId}`;
+      const link = recipientId === rel.menteeId ? '/portal/goals' : `/mentor/mentees/${rel.id}`;
       await notifyIfAllowed(recipientId, 'goalsEvaluations', 'goal.completed', { title: updated.title }, link);
     }
   }

--- a/src/app/api/goals/route.ts
+++ b/src/app/api/goals/route.ts
@@ -64,7 +64,7 @@ export async function POST(request: Request) {
   // development the goal tracks) is told. Link fits the recipient's role.
   const recipientId = session.user.id === rel.mentorId ? rel.menteeId : session.user.id === rel.menteeId ? rel.mentorId : rel.menteeId;
   if (recipientId !== session.user.id) {
-    const link = recipientId === rel.menteeId ? '/portal/goals' : `/mentor/mentees/${rel.menteeId}`;
+    const link = recipientId === rel.menteeId ? '/portal/goals' : `/mentor/mentees/${rel.id}`;
     await notifyIfAllowed(recipientId, 'goalsEvaluations', 'goal.assigned', { title: goal.title }, link);
   }
   return NextResponse.json({ goal }, { status: 201 });

--- a/src/app/api/meeting-requests/[id]/route.ts
+++ b/src/app/api/meeting-requests/[id]/route.ts
@@ -47,11 +47,16 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
 
   const parsed = schema.safeParse(await request.json());
   if (!parsed.success) return NextResponse.json({ error: 'Validation failed' }, { status: 400 });
+  const requesterLink = req.requestedById === rel.mentorId
+    ? `/mentor/mentees/${rel.id}`
+    : req.requestedById === rel.menteeId
+      ? '/portal'
+      : `/messages/${rel.id}`;
 
   if (parsed.data.action === 'decline') {
     await prisma.meetingRequest.update({ where: { id }, data: { status: 'DECLINED' } });
-    await notify(req.requestedById, 'meeting_request.declined', {}, '/portal');
-    await emailDecision(req.requestedById, { topic: req.topic, accepted: false, link: '/portal' });
+    await notify(req.requestedById, 'meeting_request.declined', {}, requesterLink);
+    await emailDecision(req.requestedById, { topic: req.topic, accepted: false, link: requesterLink });
     return NextResponse.json({ ok: true, status: 'DECLINED' });
   }
 

--- a/src/app/api/meeting-requests/route.ts
+++ b/src/app/api/meeting-requests/route.ts
@@ -60,7 +60,7 @@ export async function POST(request: Request) {
   // Notify the other party (the mentor) of the request.
   const recipient = otherParticipant(rel, session.user.id);
   if (recipient && recipient !== session.user.id) {
-    const link = `/mentor/mentees/${rel.id}`;
+    const link = recipient === rel.mentorId ? `/mentor/mentees/${rel.id}` : '/portal';
     const requesterName = session.user.name;
     await notify(
       recipient,

--- a/src/app/api/questions/[id]/route.ts
+++ b/src/app/api/questions/[id]/route.ts
@@ -25,6 +25,11 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
     where: { id },
     data: { answer: parsed.data.answer, answeredAt: new Date() },
   });
-  await notify(q.askedById, 'question.answered', {}, '/portal');
+  const link = q.askedById === q.relation.mentorId
+    ? `/mentor/mentees/${q.relation.id}`
+    : q.askedById === q.relation.menteeId
+      ? '/portal'
+      : `/messages/${q.relation.id}`;
+  await notify(q.askedById, 'question.answered', {}, link);
   return NextResponse.json({ question: updated });
 }

--- a/src/app/api/questions/route.ts
+++ b/src/app/api/questions/route.ts
@@ -35,7 +35,8 @@ export async function POST(request: Request) {
   const recipient = otherParticipant(rel, session.user.id);
   if (recipient && recipient !== session.user.id) {
     const askerName = session.user.name;
-    await notify(recipient, askerName ? 'question.asked' : 'question.askedGeneric', askerName ? { from: askerName } : {}, `/mentor/mentees/${rel.id}`);
+    const link = recipient === rel.mentorId ? `/mentor/mentees/${rel.id}` : '/portal';
+    await notify(recipient, askerName ? 'question.asked' : 'question.askedGeneric', askerName ? { from: askerName } : {}, link);
   }
   return NextResponse.json({ question: q }, { status: 201 });
 }

--- a/src/app/api/register/route.ts
+++ b/src/app/api/register/route.ts
@@ -202,7 +202,7 @@ export async function POST(request: Request) {
             counterpartId,
             'mentorship.connected',
             { name: user.fullName },
-            role === 'MENTEE' ? '/mentor/mentees' : '/admin/mentorship'
+            role === 'MENTEE' ? '/mentor/mentees' : '/portal'
           );
         }
         if (autoLink.projectId) {

--- a/src/app/api/rsvp/route.ts
+++ b/src/app/api/rsvp/route.ts
@@ -28,18 +28,28 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
   }
   const { token, response } = parsed.data;
-  const meeting = await prisma.meeting.findUnique({ where: { rsvpToken: token } });
+  const meeting = await prisma.meeting.findUnique({
+    where: { rsvpToken: token },
+    include: { relation: { select: { mentorId: true, menteeId: true } } },
+  });
   if (!meeting) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 
   await prisma.meeting.update({
     where: { id: meeting.id },
     data: { rsvp: response === 'yes' ? 'ACCEPTED' : 'DECLINED' },
   });
+  const creatorLink = meeting.projectId
+    ? `/projects/${meeting.projectId}`
+    : meeting.conversationId
+      ? `/messages/c/${meeting.conversationId}`
+      : meeting.relation?.menteeId === meeting.createdById
+        ? '/portal'
+        : '/mentor/meetings';
   await notify(
     meeting.createdById,
     response === 'yes' ? 'rsvp.accepted' : 'rsvp.declined',
     { title: meeting.title },
-    '/mentor/meetings'
+    creatorLink
   );
   return NextResponse.json({ ok: true, rsvp: response === 'yes' ? 'ACCEPTED' : 'DECLINED' });
 }

--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -1529,7 +1529,7 @@ export async function sendMeetingReminders() {
     );
 
     for (const user of participants) {
-      const link = user.role === 'MENTEE' ? '/portal' : '/mentor/meetings';
+      const link = user.id === m.relation.mentorId ? '/mentor/meetings' : '/portal/calendar';
       // Per participant: the two sides of a relation can sit in different zones,
       // and each must read the time on their own clock (#1030).
       const when = formatInTimeZone(m.scheduledAt!, user.timezone);
@@ -2070,7 +2070,7 @@ export async function sendWeeklyMissingDocumentReminders(now = new Date()) {
           id: true, fullName: true, email: true, orgId: true, preferredLanguage: true, emailNotifications: true, notificationPrefs: true,
           menteeRelations: {
             where: { status: 'ACTIVE', mentor: { isActive: true } },
-            select: { mentor: { select: { id: true, fullName: true, email: true, orgId: true, preferredLanguage: true, emailNotifications: true, notificationPrefs: true } } },
+            select: { id: true, mentor: { select: { id: true, fullName: true, email: true, orgId: true, preferredLanguage: true, emailNotifications: true, notificationPrefs: true } } },
           },
         },
       });
@@ -2079,7 +2079,10 @@ export async function sendWeeklyMissingDocumentReminders(now = new Date()) {
       for (const row of result.rows) {
         const mentee = byId.get(row.user.id);
         if (!mentee) continue;
-        const recipients = [mentee, ...mentee.menteeRelations.map((relation) => relation.mentor)]
+        const recipients = [
+          { ...mentee, relationId: null },
+          ...mentee.menteeRelations.map((relation) => ({ ...relation.mentor, relationId: relation.id })),
+        ]
           .filter((recipient, index, all) => all.findIndex((candidate) => candidate.id === recipient.id) === index);
         for (const requirement of row.missing) {
           for (const recipient of recipients) {
@@ -2093,7 +2096,7 @@ export async function sendWeeklyMissingDocumentReminders(now = new Date()) {
             const t = getDictionary(locale).documentRequirements;
             const label = requirement.labels[locale] || requirement.labels.en || requirement.key;
             const isMentee = recipient.id === mentee.id;
-            const link = isMentee ? '/portal/profile#documents' : `/mentor/mentees/${mentee.id}`;
+            const link = isMentee ? '/portal/profile#documents' : `/mentor/mentees/${recipient.relationId}`;
             await notify(
               recipient.id,
               isMentee ? 'missing_document.self' : 'missing_document.mentor',


### PR DESCRIPTION
## Özet

Bu PR, uygulamadaki tüm `notify()` / `notifyIfAllowed()` çağrılarını alıcının rolü, relation context’i ve hedef route erişimi açısından baştan sona denetler ve tespit edilen uyumsuz linkleri düzeltir.

Toplam **67 notification recipient/call noktası** kontrol edildi.

* 66 çağrı uyumlu
* 0 kontrol edilmemiş çağrı
* #927 kapsamındaki deadline bildirimi bu PR’da değiştirilmedi ve ayrı task olarak bırakıldı

## Yapılan düzeltmeler

* Evaluation mentor bildirimlerinde `menteeId` yerine doğru `relationId` kullanılıyor.
* Goal assigned/completed mentor linkleri `relationId` kullanıyor.
* Meeting-request bildirimleri recipient’ın gerçek relation tarafına göre `/portal` veya `/mentor/mentees/<relationId>` hedefini kullanıyor.
* Question ask/answer bildirimleri relation tarafına göre doğru hedefe yönleniyor.
* Yeni mentor mevcut bir mentee ile bağlandığında mentee artık erişemediği `/admin/mentorship` linkini almıyor.
* RSVP notification hedefi meeting context’ine göre belirleniyor.
* Meeting reminder linkleri stored role yerine relation tarafına göre üretiliyor.
* Missing-document mentor bildirimlerinde mentee user ID yerine ilgili `relationId` kullanılıyor.
* ADMIN-as-mentor senaryosunda `/mentor/mentees/<relationId>` erişimi doğrulandı.
* Playwright E2E ortamı geliştiricinin gerçek SMTP ayarlarını miras almayacak şekilde izole edildi.

## Admin-as-mentor

ADMIN kullanıcılarının mentor olarak çalıştığı senaryo ayrıca incelendi.

`canUseMentorShell()` davranışı korunuyor ve ADMIN-as-mentor kullanıcısı:

`/mentor/mentees/<relationId>`

hedefini redirect olmadan açabiliyor.

## #927

Deadline notification örneği bu PR kapsamında değiştirilmedi ve ayrı task olarak bırakıldı.

## Audit özeti

| Sonuç                                                               |     Sayı |
| ------------------------------------------ | -------: |
| Toplam notification recipient/call noktası |       67 |
| Uyumlu                                                         |       66 |
| Yeni uyumsuzluk                                          |        0 |
| Ayrı task olarak bırakılan                             | 1 (#927) |
| Kontrol edilmemiş                                         |        0 |

Tam audit kapsamında her notification çağrısında:

* recipient’ın gerçek rolü / relation tarafı
* hedef route’un erişim kuralları
* ADMIN-as-mentor / dual-role senaryoları
* `relationId`, `menteeId` ve user ID tiplerinin doğruluğu

kontrol edildi.

## Testler

* ADMIN-as-mentor targeted E2E: **1 passed**
* Notification coverage E2E: **4 passed**
* CI ile aynı `@smoke` seçimi: **82 passed**
* `npm run check:release-fragments`: **passed**
* `npm run build`: **passed**
* `git diff --check`: **passed**

## Release

Yeni release-fragment sistemi kullanıldı:

`releases/unreleased/notification-link-role-compatibility.json`

Manuel package.json, CHANGELOG.md veya src/lib/releaseNotes.ts version bump yapılmadı.



## Tam bildirim linki denetimi

Toplam **67 notification recipient/call noktası** incelendi.

- ✅ 66 uyumlu
- ⚠️ 1 ayrı task olarak bırakıldı: #927
- ❌ 0 kontrol edilmemiş çağrı

Aşağıdaki tablolar, bildirimleri kullanım alanına göre gruplar.

### 1. Admin ve destek bildirimleri

| Kaynak | Alıcı | Link | Durum |
| --- | --- | --- | --- |
| `admin/impersonate` | MENTOR / MENTEE / COMPANY / SOURCE | Link yok | ✅ Uyumlu |
| `admin/support` | Ticket requester | `/messages/support` | ✅ Uyumlu |
| `admin/testimonials` | Evaluation author | `/testimonials/approve` | ✅ Uyumlu |
| `admin/users/reset-password` | Herhangi bir kullanıcı | Link yok | ✅ Uyumlu |
| `company-inquiry` | ADMIN | `/admin/company-inquiries` | ✅ Uyumlu |
| `support` | ADMIN | `/admin/support` | ✅ Uyumlu |
| `testimonials/approve` | ADMIN | `/admin/testimonials` | ✅ Uyumlu |

### 2. Mentor / mentee ilişki bildirimleri

| Kaynak | Alıcı | Link | Durum |
| --- | --- | --- | --- |
| `evaluations` | Mentee | `/portal` | ✅ Uyumlu |
| `evaluations` | Mentor | `/mentor/mentees/<relationId>` | ✅ Düzeltildi |
| `goals/[id]` | Mentee | `/portal/goals` | ✅ Uyumlu |
| `goals/[id]` | Mentor | `/mentor/mentees/<relationId>` | ✅ Düzeltildi |
| `goals` | Mentee | `/portal/goals` | ✅ Uyumlu |
| `goals` | Mentor | `/mentor/mentees/<relationId>` | ✅ Düzeltildi |
| `interactions` | Mentee | `/portal/journey` | ✅ Uyumlu |
| `mentorship` | Yeni mentee | `/portal` | ✅ Uyumlu |
| `mentorship` | Yeni mentor | `/mentor` | ✅ Uyumlu |

### 3. Meeting request bildirimleri

| Senaryo | Alıcı | Link | Durum |
| --- | --- | --- | --- |
| Requester mentee ise | Mentee | `/portal` | ✅ Uyumlu |
| Requester mentor/admin ise | Mentor side | `/mentor/mentees/<relationId>` | ✅ Düzeltildi |
| Yeni request → mentor | Mentor side | `/mentor/mentees/<relationId>` | ✅ Uyumlu |
| Yeni request → mentee | Mentee side | `/portal` | ✅ Düzeltildi |
| Request sonucu | Relation participant | `/messages/<relationId>` | ✅ Uyumlu |

### 4. Question bildirimleri

| Senaryo | Alıcı | Link | Durum |
| --- | --- | --- | --- |
| Mentee soru sorarsa | Mentor | `/mentor/mentees/<relationId>` | ✅ Uyumlu |
| Mentor/admin soru sorarsa | Mentee | `/portal` | ✅ Düzeltildi |
| Cevap → mentee asker | Mentee | `/portal` | ✅ Uyumlu |
| Cevap → mentor/admin asker | Mentor side | `/mentor/mentees/<relationId>` | ✅ Düzeltildi |

### 5. Meeting ve RSVP bildirimleri

| Kaynak | Alıcı | Link | Durum |
| --- | --- | --- | --- |
| Scheduled meeting | Mentee | `/portal` | ✅ Uyumlu |
| RSVP → normal mentor/admin creator | Mentor/Admin | `/mentor/meetings` | ✅ Uyumlu |
| RSVP → instant meeting creator | Meeting context’e göre | Project / conversation / portal / mentor target | ✅ Düzeltildi |
| Meeting reminder | Mentor side | Mentor meeting context | ✅ Düzeltildi |
| Meeting reminder | Mentee side | Portal meeting context | ✅ Düzeltildi |
| Instant meeting invite | Participant | Harici meeting linki | ✅ Uyumlu |

### 6. Registration ve invitation bildirimleri

| Senaryo | Alıcı | Link | Durum |
| --- | --- | --- | --- |
| Yeni mentee mevcut mentorla bağlanır | Mentor/Admin | `/mentor/mentees` | ✅ Uyumlu |
| Yeni mentor mevcut mentee ile bağlanır | Mentee | `/portal` | ✅ Düzeltildi |
| Yeni user bildirimi | ADMIN | `/admin/users` | ✅ Uyumlu |
| Duplicate bildirimi | ADMIN | `/admin/duplicates` | ✅ Uyumlu |
| Mentor application approved | Yeni MENTOR | `/mentor` | ✅ Uyumlu |

### 7. Project ve task bildirimleri

| Kaynak | Alıcı | Link | Durum |
| --- | --- | --- | --- |
| Project join request | Owner/Admin | `/projects/<id>` | ✅ Uyumlu |
| Join request sonucu | Request sahibi | `/projects/<id>` | ✅ Uyumlu |
| Project member eklendi | Member | `/projects/<id>` | ✅ Uyumlu |
| Project task | Assignee | `/todos` | ✅ Uyumlu |
| Project task template / task | Assignee | `/todos` | ✅ Uyumlu |
| Project series | Project team | `/projects/<id>` | ✅ Uyumlu |

### 8. Message ve communication bildirimleri

| Kaynak | Alıcı | Link | Durum |
| --- | --- | --- | --- |
| Messages | Relation / conversation participant | `/messages/...` | ✅ Uyumlu |
| Mentor email | Mentee | Conversation veya relation thread | ✅ Uyumlu |
| Inbound email | Karşı participant | Conversation veya relation thread | ✅ Uyumlu |
| Public contact | Profile owner | Link yok | ✅ Uyumlu |

### 9. EmailService özel kontrolleri

| Bildirim | Alıcı | Link | Durum |
| --- | --- | --- | --- |
| Stale mentee | Mentor / ADMIN-as-mentor | `/mentor/mentees/<relationId>` | ✅ Uyumlu |
| Deadline | Normal mentor | `/admin/candidates/<menteeId>` | ⚠️ #927 — ayrı task |
| Weekly report | Mentee | `/portal` | ✅ Uyumlu |
| Meeting reminder | Relation tarafına göre | Mentor veya portal context | ✅ Düzeltildi |
| Retention reminder | Mentee | `/consent/renew?...` | ✅ Uyumlu |
| Retention admin alert | ADMIN | `/admin/retention` | ✅ Uyumlu |
| Candidate match | COMPANY | `/p/<candidateId>` | ✅ Uyumlu |
| Missing document → mentee | Mentee | `/portal/profile#documents` | ✅ Uyumlu |
| Missing document → mentor | Mentor / ADMIN-as-mentor | `/mentor/mentees/<relationId>` | ✅ Düzeltildi |

### 10. Diğer doğrulanan bildirimler

| Kaynak | Alıcı | Link | Durum |
| --- | --- | --- | --- |
| Interview panel | ADMIN / MENTOR | `/interviews/<id>` | ✅ Uyumlu |
| Interview request | Mentee | `/portal` | ✅ Uyumlu |
| Mentorship request | ADMIN | `/admin/mentorship` | ✅ Uyumlu |
| Todos | Authenticated user | `/todos` | ✅ Uyumlu |
| Role change | Yeni role göre user | `/mentor` veya `/portal` | ✅ Uyumlu |
| Weekly report result | Mentee | `/portal` | ✅ Uyumlu |
| Offer notification | Mentee | `/portal` | ✅ Uyumlu |
| Offer result | ADMIN | `/admin/candidates` | ✅ Uyumlu |
| Outcome comms | Mentee / Mentor | `/portal` veya mentor email composer | ✅ Uyumlu |
| Stage change | Mentee | `/portal` | ✅ Uyumlu |

## Admin-as-mentor sonucu

ADMIN kullanıcıları mentor olarak çalışırken `canUseMentorShell()` üzerinden `/mentor/*` yollarını açabiliyor.

`/mentor/mentees/<relationId>` hedefi ADMIN-as-mentor için doğru relation context ile çalışıyor.

## Sonuç

Audit sonrasında:

- **67 / 67** notification noktası kontrol edildi
- **66** nokta uyumlu
- **0** yeni uyumsuzluk kaldı
- **1** bilinen konu ayrı task olarak bırakıldı: **#927**