### PR TITLE
fix(infra): let the restore drill create its scratch database, and say which half failed

### DIFF
--- a/.github/workflows/backup-verify.yml
+++ b/.github/workflows/backup-verify.yml
@@ -47,6 +47,8 @@ jobs:
     timeout-minutes: 20
     outputs:
       report: ${{ steps.check.outputs.report }}
+      freshness: ${{ steps.check.outcome }}
+      drill_ran: ${{ steps.drill.outputs.drill_ran }}
     steps:
       # #1239 — NO `uses:` in a self-hosted job. Downloading an action archive
       # from codeload.github.com answers 429 from this box's IP (the GitHub-hosted
@@ -84,6 +86,7 @@ jobs:
 
       - name: Backup freshness & integrity
         id: check
+        continue-on-error: false
         run: |
           set -o pipefail
           chmod +x infra/check-backups.sh
@@ -105,6 +108,7 @@ jobs:
       # restores REAL data into a throwaway database and drops it afterwards;
       # infra/restore-drill.sh refuses any target that isn't clearly scratch.
       - name: Restore drill
+        id: drill
         env:
           # The drill needs the server address and credentials only — it never
           # reads from or writes to the database named here.
@@ -119,6 +123,11 @@ jobs:
           fi
           set -a; . /etc/internship-crm/preview.env; set +a
           chmod +x infra/restore-drill.sh
+          # Mark which half failed. Without this the alert below says "BACKUP
+          # CHECK FAILED" for a drill problem — telling the maintainer their
+          # backups are broken when the report two steps up says they are fine.
+          # A false alarm costs the same trust as a missed one.
+          echo "drill_ran=1" >> "$GITHUB_OUTPUT"
           ./infra/restore-drill.sh --env "$DRILL_ENV" --target internship_restore_test
 
   notify:
@@ -139,9 +148,11 @@ jobs:
           SMTP_PASS: ${{ secrets.SMTP_PASS }}
           SMTP_FROM: ${{ secrets.SMTP_FROM }}
           ALERT_EMAIL_TO: ${{ secrets.ALERT_EMAIL_TO || 'mehmetersahin@gmail.com' }}
-          ALERT_SUBJECT: '🛟 Internship CRM — BACKUP CHECK FAILED'
+          ALERT_SUBJECT: ${{ needs.verify.outputs.drill_ran == '1' && '🛟 Internship CRM — RESTORE DRILL FAILED (backups themselves are fine)' || '🛟 Internship CRM — BACKUP CHECK FAILED' }}
           ALERT_BODY: |
-            The daily backup verification failed. Until this is fixed, assume there is NO usable backup.
+            ${{ needs.verify.outputs.drill_ran == '1'
+              && 'The restore DRILL failed. The freshness check passed, so the backups exist and look well-formed — what is unproven is that they can be restored. Treat this as "recovery untested", not "no backups".'
+              || 'The backup freshness check failed. Until this is fixed, assume there is NO usable backup.' }}
 
             ${{ needs.verify.outputs.report }}
 

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -98,6 +98,13 @@ do not, and the check costs seconds. On failure an email goes to
 `ALERT_EMAIL_TO` from a *GitHub-hosted* job — an alert that needs the failing
 server to be healthy is an alert that may never send.
 
+The alert distinguishes the two halves, because they mean different things: a
+failed **freshness check** means assume there is no usable backup; a failed
+**drill** means the backups exist and look well-formed but recovery is
+unproven. Sending "BACKUP CHECK FAILED" for a drill problem would tell the
+maintainer their backups are broken while the report in the same email says
+they are fine — a false alarm costs the same trust as a missed one.
+
 ```bash
 # By hand, on the server:
 ./infra/check-backups.sh --env prod --env preview
@@ -125,6 +132,12 @@ than described, so the numbers below are measurements and not estimates.
 set -a; . /etc/internship-crm/preview.env; set +a
 ./infra/restore-drill.sh --env preview --target internship_restore_test
 ```
+
+The app user is usually not allowed to `CREATE DATABASE` — on the Plesk box it
+is not — so the scratch database is created through the same admin route the
+topic deploys use (`plesk db`, then the root socket) and then granted to the app
+user, which is who runs the restore. Without that the drill fails on its first
+statement, having exercised nothing.
 
 Three guards, none optional: the target name must contain `restore` **and**
 must differ from the database in `DATABASE_URL`, and the scratch database is

--- a/infra/restore-drill.sh
+++ b/infra/restore-drill.sh
@@ -62,6 +62,9 @@ db_host="${hostport%%:*}"; db_port="${hostport#*:}"
 [ "$db_port" = "$hostport" ] && db_port=3306
 decode() { printf '%b' "${1//%/\\x}"; }
 db_pass="$(decode "$db_pass")"; db_user="$(decode "$db_user")"
+# The env file's host is the CONTAINER's view; this runs on the host, where
+# `host.docker.internal` resolves to nothing (same trap as #1185).
+case "$db_host" in host.docker.internal|docker.for.mac.localhost) db_host=127.0.0.1 ;; esac
 
 # ── Guards ─────────────────────────────────────────────────────────────────
 case "$TARGET_DB" in
@@ -74,6 +77,19 @@ if [ "$TARGET_DB" = "$live_db" ]; then
 fi
 
 command -v mysql >/dev/null || { echo "ERROR: mysql client not found on PATH" >&2; exit 1; }
+
+# The app user is not necessarily allowed to CREATE DATABASE — on the Plesk box
+# it is not, which would have made this drill fail on its first line without
+# ever exercising a restore. Same two admin routes the topic deploys use
+# (#1185): `plesk db` first, because MySQL root there is not
+# socket-authenticated, then the plain root socket for a non-Plesk host.
+_admin_sql() {
+  if command -v plesk >/dev/null 2>&1; then
+    if printf '%s\n' "$1" | plesk db --batch --skip-column-names 2>/dev/null; then return 0; fi
+    if plesk db -e "$1" 2>/dev/null; then return 0; fi
+  fi
+  mysql --protocol=socket -u root --batch --skip-column-names -e "$1" 2>/dev/null
+}
 
 dump="$(ls -1 "$BACKUP_DIR/${ENV_NAME}-"*.sql.gz 2>/dev/null | sort | tail -1 || true)"
 [ -n "$dump" ] || { echo "ERROR: no ${ENV_NAME} dump in ${BACKUP_DIR}" >&2; exit 1; }
@@ -91,7 +107,9 @@ run_sql() { MYSQL_PWD="$db_pass" mysql -h "$db_host" -P "$db_port" -u "$db_user"
 cleanup() {
   if [ "$KEEP" -eq 0 ]; then
     log "Dropping scratch database ${TARGET_DB} (a restored dump is a second copy of real personal data)"
-    run_sql -e "DROP DATABASE IF EXISTS \`${TARGET_DB}\`;" || true
+    run_sql -e "DROP DATABASE IF EXISTS \`${TARGET_DB}\`;" 2>/dev/null \
+      || _admin_sql "DROP DATABASE IF EXISTS \`${TARGET_DB}\`;" \
+      || echo "WARN: could not drop ${TARGET_DB} — it holds a copy of real data, remove it by hand" >&2
   else
     echo "NOTE: ${TARGET_DB} kept (--keep). Drop it yourself — it holds real personal data."
   fi
@@ -102,7 +120,20 @@ log "Dump: ${dump##*/} (taken ${rpo_min} minutes ago)"
 log "Restoring into scratch database ${TARGET_DB} on ${db_host}:${db_port}"
 
 start=$(date -u +%s)
-run_sql -e "DROP DATABASE IF EXISTS \`${TARGET_DB}\`; CREATE DATABASE \`${TARGET_DB}\` CHARACTER SET utf8mb4;"
+CREATE_SQL="DROP DATABASE IF EXISTS \`${TARGET_DB}\`; CREATE DATABASE \`${TARGET_DB}\` CHARACTER SET utf8mb4;"
+if ! run_sql -e "$CREATE_SQL" 2>/dev/null; then
+  log "App user cannot create databases; creating the scratch database as an admin"
+  _admin_sql "$CREATE_SQL" || {
+    echo "ERROR: could not create the scratch database ${TARGET_DB} as either '${db_user}' or an admin." >&2
+    exit 1
+  }
+  # …and let the app user load into it, since that is who runs the restore.
+  for h in $(_admin_sql "SELECT host FROM mysql.user WHERE user='${db_user}';" \
+             | grep -E '^[A-Za-z0-9_.%:-]+$' || true); do
+    _admin_sql "GRANT ALL PRIVILEGES ON \`${TARGET_DB}\`.* TO '${db_user}'@'${h}';" >/dev/null || true
+  done
+  _admin_sql "FLUSH PRIVILEGES;" >/dev/null || true
+fi
 gzip -dc "$dump" | MYSQL_PWD="$db_pass" mysql -h "$db_host" -P "$db_port" -u "$db_user" "$TARGET_DB"
 rto_s=$(( $(date -u +%s) - start ))
 

--- a/releases/unreleased/restore-drill-privileges.json
+++ b/releases/unreleased/restore-drill-privileges.json
@@ -1,0 +1,4 @@
+{
+  "bump": "patch",
+  "changelog": "- **The restore drill can actually run (#1183 follow-up)** — it creates its scratch database through the same admin route the topic deploys use, because the app user cannot `CREATE DATABASE` on the server and the drill would otherwise fail before exercising a restore. The backup alert now names which half failed: a stale backup and an unproven restore are different problems, and sending \"BACKUP CHECK FAILED\" for a drill error reports broken backups that are in fact fine."
+}


### PR DESCRIPTION
Follow-up to #1183 (merged in #1314). Two defects in what I shipped an hour ago, both found by **running** the verification against the real server rather than assuming it worked.

## The freshness half does work

I dispatched `backup-verify.yml` on `main`. On the box:

```
OK  prod:    prod-20260824T184343Z.sql.gz — 0h old, 11463941B, 5 day(s) retained
OK  preview: preview-20260824T184238Z.sql.gz — 0h old,  7061987B, 5 day(s) retained
All checked environments have a fresh, non-empty, well-formed backup.
```

An 11.5 MB prod dump, five days of history, gzip and size checks passing, and the drill correctly skipping (not the 1st, not requested). That acceptance criterion is now evidenced rather than asserted.

## Defect 1 — the drill could never have run

It created its scratch database as the **app user**. On the Plesk box that user cannot `CREATE DATABASE` — the same wall the topic deploys hit in #1185 earlier today, where the log said *"App user cannot create databases"*. The drill would have failed on its first statement, having exercised no restore at all, and the only way anyone would have found out is the monthly run going red.

Now it uses the same admin route (`plesk db`, then the root socket), grants the new database to the app user — who is the one running the actual restore — and falls back to the admin for the cleanup `DROP` too. That last part matters: a scratch database that survives the drill is a second copy of real personal data left sitting on disk. The env file's `host.docker.internal` is mapped to loopback for the same reason it is in `topic-deploy.sh`.

## Defect 2 — the alarm would have lied

The alert said **"BACKUP CHECK FAILED"** whichever step failed. So a drill permissions error would have emailed the maintainer that their backups are broken — while the report embedded in that same email said both environments are fine.

The two now read differently:

- failed **freshness check** → *assume there is no usable backup*;
- failed **drill** → *the backups exist and look well-formed; what is unproven is that they can be restored.*

A false alarm costs the same trust as a missed one, and this one would have arrived pre-discredited by its own attachment.

## Verification

Drill re-run end to end locally after the change, with a container-style `DATABASE_URL` to exercise the host mapping: 77 tables and 25 users restored, row counts printed, scratch database dropped (`SELECT COUNT(*) … = 0`). `bash -n` on the script, YAML parse on the workflow.

The admin fallback itself is not exercised locally — the local MySQL user *can* create databases, which is exactly why the defect was invisible here in the first place. It is the same code path already proven on the box by #1185's deploy.

**Still open from #1183:** the preview drill row in the runbook's drill log. Once this merges, *Run workflow → Also run the restore drill* should produce real RPO/RTO numbers on the box; I'll run it and fill the row in.

Release fragment: `releases/unreleased/restore-drill-privileges.json` (`patch`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeSYkGngKpYG4KWsJ7Ph2Z)_