### PR TITLE
feat(infra): keep the public demo on the image preview just shipped (#1249)

### DIFF
--- a/.github/workflows/demo-reset.yml
+++ b/.github/workflows/demo-reset.yml
@@ -15,6 +15,10 @@ name: Reset the public demo
 #   - the demo container `internship-crm-demo` is running
 #   - /etc/internship-crm/demo.env has DATABASE_URL pointing at
 #     internship_crm_demo, plus DEMO_MODE=true
+#
+# The steps themselves live in infra/server/demo-refresh.sh, which the preview
+# deploy also calls (#1249) — one implementation for "make the demo current",
+# whether that means new data or a new image.
 
 on:
   schedule:
@@ -34,43 +38,26 @@ jobs:
     name: Wipe + re-seed the demo database
     runs-on: self-hosted
     steps:
-      - name: Reset
+      - name: Fetch the repo (no action download)
         env:
-          ENV_FILE: /etc/internship-crm/demo.env
-          CONTAINER: internship-crm-demo
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FETCH_REF: ${{ github.sha }}
         run: |
           set -euo pipefail
+          [ -d .git ] || git init -q .
+          git remote get-url origin >/dev/null 2>&1 \
+            || git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          HELPER='!f() { echo "username=x-access-token"; echo "password=$GH_TOKEN"; }; f'
+          git -c credential.helper="$HELPER" fetch --no-tags --depth=1 origin "$FETCH_REF"
+          git checkout -q --force --detach FETCH_HEAD
+          git clean -qfdx
 
-          [ -f "$ENV_FILE" ] || { echo "ERROR: $ENV_FILE is missing — see docs/DEMO.md" >&2; exit 1; }
-          docker inspect "$CONTAINER" >/dev/null 2>&1 || {
-            echo "ERROR: container '$CONTAINER' does not exist — the demo is not deployed" >&2; exit 1; }
-
-          # Run inside the demo container so the tools use exactly the image,
-          # Prisma client and DATABASE_URL the demo itself runs with. Nothing is
-          # passed in from the workflow — the env file on the box is the source
-          # of truth, and secrets never enter the Actions log.
-          run() { docker exec "$CONTAINER" "$@"; }
-
-          echo "==> Wiping (refuses anything not named *_demo)"
-          run node prisma/reset-demo.mjs
-
-          echo "==> Re-applying the schema"
-          run npx prisma db push --accept-data-loss --skip-generate
-
-          echo "==> Seeding the first admin"
-          run node prisma/seed.mjs
-
-          echo "==> Seeding the synthetic demo dataset"
-          run node prisma/seed-demo.mjs
-
-          echo "==> Health check"
-          # The reset does not restart the container, but a wiped-then-reseeded
-          # DB is exactly when a stale Prisma client or a failed seed shows up.
-          for i in $(seq 1 10); do
-            if curl -fsS --max-time 5 http://127.0.0.1:3203/api/health >/dev/null; then
-              echo "demo is healthy"; exit 0
-            fi
-            sleep 3
-          done
-          echo "ERROR: the demo did not answer /api/health after the reset" >&2
-          exit 1
+      - name: Reset
+        run: |
+          set -euo pipefail
+          chmod +x infra/server/demo-refresh.sh
+          # Same script the preview deploy calls with --image (#1249). One
+          # implementation, so the twice-daily reset and the redeploy cannot
+          # drift into doing different things to the same environment.
+          ./infra/server/demo-refresh.sh --data-only

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -257,6 +257,49 @@ jobs:
           ENV_FILE="$ENV_FILE" \
           ./infra/deploy-prod.sh --no-pull --pull-image
 
+  # ── 3b. The public demo rides the same image (#1249) ────────────────────────
+  # The demo container was provisioned once, on 2026-08-19, and nothing ever
+  # updated its IMAGE again — `demo-reset.yml` refreshes the data twice a day,
+  # so the demo LOOKED maintained while the software inside it aged. Measured on
+  # 2026-08-24: demo 0.78.0-beta against 0.105.0-beta on prod and preview, 27
+  # minor versions behind, with the landing page pointing visitors straight at
+  # it. A live demo that is months old is worse than none, because it is
+  # believed.
+  #
+  # Separate job, not a step inside `deploy`: the demo is optional and must
+  # never be able to fail the preview deploy. `continue-on-error` keeps the
+  # deploy's verdict about preview, and the script exits 0 when the demo is not
+  # provisioned on this host at all.
+  demo:
+    name: Refresh the public demo
+    needs: [gate, build, deploy]
+    if: needs.gate.outputs.deploy == 'true'
+    continue-on-error: true
+    runs-on: self-hosted
+    steps:
+      - name: Fetch the repo (no action download)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FETCH_REF: ${{ needs.gate.outputs.sha }}
+        run: |
+          set -euo pipefail
+          [ -d .git ] || git init -q .
+          git remote get-url origin >/dev/null 2>&1 \
+            || git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          HELPER='!f() { echo "username=x-access-token"; echo "password=$GH_TOKEN"; }; f'
+          git -c credential.helper="$HELPER" fetch --no-tags --depth=1 origin "$FETCH_REF"
+          git checkout -q --force --detach FETCH_HEAD
+          git clean -qfdx
+
+      - name: Put the demo on the image preview just deployed
+        env:
+          IMAGE: ${{ needs.build.outputs.image }}
+        run: |
+          set -euo pipefail
+          chmod +x infra/server/demo-refresh.sh
+          ./infra/server/demo-refresh.sh --image "$IMAGE"
+
   # ── 4. Alert ────────────────────────────────────────────────────────────────
   # A failed deploy leaves the container swapped out (docker stop precedes
   # docker run), so silence here is the worst case: the env can be down, or

--- a/docs/DEMO.md
+++ b/docs/DEMO.md
@@ -92,8 +92,42 @@ mysql -e "GRANT ALL ON internship_crm_demo.* TO 'crm-demo'@'%' IDENTIFIED BY '<p
 gh workflow run demo-reset.yml
 ```
 
-Once `/etc/internship-crm/demo.env` and the container exist, the scheduled
-workflow keeps the data fresh; nothing else is manual.
+Once `/etc/internship-crm/demo.env` and the container exist, nothing else is
+manual: the scheduled workflow keeps the **data** fresh, and every preview
+deploy puts the demo on the **image** it just shipped (#1249).
+
+## How it stays current
+
+Both halves run the same script, `infra/server/demo-refresh.sh`, so the two
+paths cannot drift into doing different things to the same environment:
+
+| | Trigger | What it does |
+|---|---|---|
+| `--data-only` | `demo-reset.yml`, 02:00 and 14:00 UTC | wipe → schema → seed |
+| `--image <ref>` | `deploy-preview.yml`, after every preview deploy | recreate the container on that image, **then** wipe → schema → seed |
+
+The image path re-seeds too, deliberately: a new image can move the schema, so
+the data has to be rebuilt against it rather than left in place. It is a no-op
+when the demo already runs that image.
+
+Two properties worth keeping if this is ever rewritten:
+
+- **Not provisioned is not a failure.** If `demo.env` or the container is
+  missing the script exits 0 saying so. The demo is optional; a preview deploy
+  must not go red because an optional environment was never set up here. The
+  job is `continue-on-error` for the same reason — the deploy's verdict is
+  about *preview*.
+- **Nothing is passed in from CI.** The container is started with
+  `--env-file /etc/internship-crm/demo.env`, so the demo's own configuration
+  never enters an Actions log, and the tools run *inside* the container with
+  exactly the image, Prisma client and `DATABASE_URL` the demo itself uses.
+
+Why this exists: the container was provisioned on 2026-08-19 and nothing
+updated its image again, while `demo-reset.yml` refreshed the data twice a day
+— so the demo *looked* maintained as the software inside it aged. Measured on
+2026-08-24 before the fix: **0.78.0-beta on the demo against 0.105.0-beta on
+prod and preview**, 27 minor versions apart, with the landing page sending
+visitors straight to it.
 
 ## Not included yet
 
@@ -103,8 +137,7 @@ workflow keeps the data fresh; nothing else is manual.
   to the demo from the hero (`hero-demo-cta`), the bottom CTA block and the
   public footer, plus a `features.ts` catalogue entry. All of them read
   `DEMO_URL` from `src/lib/demoMode.ts` and are hidden on the demo instance
-  itself. ⚠️ Note: nothing redeploys the demo container on merges yet — it runs
-  the `preview-<sha>` image from provisioning day until redeployed by hand.
+  itself.
 - **OpenGraph social cards and product analytics.** These arrived in the same
   original PR (#1221) but are separate concerns with their own trade-offs (a
   permanently widened CSP, and third-party trackers on authenticated CRM pages

--- a/infra/server/demo-refresh.sh
+++ b/infra/server/demo-refresh.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# Refresh the public demo (#1249, epic #966).
+#
+# WHY THIS EXISTS
+#   The demo container was provisioned once, on 2026-08-19, and nothing ever
+#   updated its IMAGE again. `demo-reset.yml` refreshes the data twice a day, so
+#   the demo looked maintained while the software inside it aged — a "live demo"
+#   that is months behind the product is worse than no demo, because it is
+#   believed. This script is what a preview deploy calls to keep the demo on the
+#   same build as preview.
+#
+# WHAT IT DOES
+#   --image <ref>   recreate the container on that image, then wipe + re-seed
+#                   (an image change can move the schema, so the data has to be
+#                   rebuilt against it, not just left there)
+#   --data-only     leave the container alone and only wipe + re-seed. This is
+#                   the twice-daily reset.
+#
+#   Both end with the same health check, because both can leave the demo broken
+#   in the same way: a stale Prisma client or a failed seed.
+#
+# NOT PROVISIONED IS NOT A FAILURE
+#   The demo is optional (docs/DEMO.md). If the env file or the container is
+#   missing, this exits 0 with a message: a preview deploy must not go red
+#   because an optional environment was never set up on this box.
+set -euo pipefail
+
+ENV_FILE="${ENV_FILE:-/etc/internship-crm/demo.env}"
+CONTAINER="${CONTAINER:-internship-crm-demo}"
+PORT="${PORT:-3203}"
+IMAGE=""
+DATA_ONLY=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --image) IMAGE="${2:?--image needs a value}"; shift 2 ;;
+    --data-only) DATA_ONLY=1; shift ;;
+    *) echo "Unknown flag: $1" >&2; exit 2 ;;
+  esac
+done
+[ "$DATA_ONLY" = 1 ] || [ -n "$IMAGE" ] || { echo "ERROR: pass --image <ref> or --data-only" >&2; exit 2; }
+
+log() { printf '\n\033[1;34m==>\033[0m %s\n' "$*"; }
+
+if [ ! -f "$ENV_FILE" ]; then
+  log "No ${ENV_FILE} — the demo is not provisioned on this host (docs/DEMO.md). Nothing to do."
+  exit 0
+fi
+command -v docker >/dev/null || { echo "ERROR: docker not found on PATH" >&2; exit 1; }
+
+if ! docker inspect "$CONTAINER" >/dev/null 2>&1 && [ "$DATA_ONLY" = 1 ]; then
+  log "No ${CONTAINER} container — the demo is not deployed. Nothing to reset."
+  exit 0
+fi
+
+# ── Container: only recreate when the image actually changed ─────────────────
+if [ "$DATA_ONLY" = 0 ]; then
+  CURRENT="$(docker inspect --format '{{.Config.Image}}' "$CONTAINER" 2>/dev/null || true)"
+  if [ "$CURRENT" = "$IMAGE" ]; then
+    log "Demo already runs ${IMAGE} — leaving the container alone"
+  else
+    log "Demo: ${CURRENT:-<none>} → ${IMAGE}"
+    docker image inspect "$IMAGE" >/dev/null 2>&1 || docker pull "$IMAGE" >/dev/null
+    docker stop "$CONTAINER" >/dev/null 2>&1 || true
+    docker rm   "$CONTAINER" >/dev/null 2>&1 || true
+    # The env file is the single source of truth for the demo's configuration —
+    # nothing is passed in from CI, so no secret of the demo's ever reaches an
+    # Actions log. DATABASE_URL there points at host.docker.internal, hence
+    # bridge networking with a published port.
+    docker run -d \
+      --name "$CONTAINER" \
+      --env-file "$ENV_FILE" \
+      --add-host=host.docker.internal:host-gateway \
+      -p "${PORT}:3000" \
+      --restart=unless-stopped \
+      "$IMAGE" >/dev/null
+    RECREATED=1
+  fi
+fi
+
+# ── Data: wipe + re-seed ─────────────────────────────────────────────────────
+# Run INSIDE the container so the tools use exactly the image, Prisma client and
+# DATABASE_URL the demo itself runs with. prisma/reset-demo.mjs refuses any
+# database whose name does not end in `_demo` (infra/test/reset-demo-guard.test.sh).
+run() { docker exec "$CONTAINER" "$@"; }
+
+# A freshly started container needs a moment before `docker exec` is useful.
+for i in $(seq 1 20); do
+  docker exec "$CONTAINER" true >/dev/null 2>&1 && break
+  sleep 1
+done
+
+log "Wiping (refuses anything not named *_demo)"
+run node prisma/reset-demo.mjs
+log "Re-applying the schema"
+run npx prisma db push --accept-data-loss --skip-generate
+log "Seeding the first admin"
+run node prisma/seed.mjs
+log "Seeding the synthetic demo dataset"
+run node prisma/seed-demo.mjs
+
+log "Health check http://127.0.0.1:${PORT}/api/health"
+for i in $(seq 1 15); do
+  if curl -fsS --max-time 5 "http://127.0.0.1:${PORT}/api/health" >/dev/null; then
+    log "Demo is healthy${RECREATED:+ on ${IMAGE}}"
+    exit 0
+  fi
+  sleep 3
+done
+echo "ERROR: the demo did not answer /api/health after the refresh. Recent logs:" >&2
+docker logs --tail 40 "$CONTAINER" >&2 || true
+exit 1

--- a/releases/unreleased/demo-follows-preview.json
+++ b/releases/unreleased/demo-follows-preview.json
@@ -1,0 +1,9 @@
+{
+  "bump": "patch",
+  "changelog": "- **The public demo stops aging (#1249)** — every preview deploy now puts the demo container on the image it just shipped and re-seeds it, instead of leaving it on the image from provisioning day. Measured before the fix: the demo served 0.78.0-beta while prod and preview served 0.105.0-beta. The twice-daily data reset and the redeploy share one script (`infra/server/demo-refresh.sh`), and a host without the demo provisioned is a no-op rather than a failed deploy.",
+  "notes": {
+    "en": ["The public demo now updates with every release instead of standing still — what you see there is what shipped."],
+    "tr": ["Herkese açık demo artık her sürümle birlikte güncelleniyor; orada gördüğünüz şey yayınlanan sürüm."],
+    "de": ["Die öffentliche Demo wird jetzt mit jedem Release aktualisiert — was dort zu sehen ist, ist der ausgelieferte Stand."]
+  }
+}


### PR DESCRIPTION
Closes #1249.

The demo container was provisioned on 2026-08-19 and nothing ever updated its **image** again. `demo-reset.yml` refreshes the **data** twice a day, so the demo *looked* maintained while the software inside it aged. I measured it before writing anything:

| | Version |
|---|---|
| `crm-demo.ersah.in` | **0.78.0-beta** (918689d) |
| `crm.ersah.in` | 0.105.0-beta (dbef492) |
| `crm-preview.ersah.in` | 0.105.0-beta (dbef492) |

27 minor versions behind — everything shipped since 19 August is invisible there — while the landing page hero, the bottom CTA and the footer all send visitors straight to it. A live demo that is months old is worse than no demo, because it is believed.

## What ships

**`infra/server/demo-refresh.sh`** — one script, two modes:

| Mode | Caller | Does |
|---|---|---|
| `--data-only` | `demo-reset.yml`, 02:00 / 14:00 UTC | wipe → schema → seed |
| `--image <ref>` | `deploy-preview.yml`, after each preview deploy | recreate the container on that image, **then** wipe → schema → seed |

The image path re-seeds deliberately: a new image can move the schema, so the data has to be rebuilt against it rather than left in place. It is a no-op when the demo already runs that image, so a redeploy of the same build doesn't churn the environment.

**`deploy-preview.yml`** gains a `demo` job. Separate job and `continue-on-error` on purpose — the demo is optional, and its state must never decide the verdict of a preview deploy.

**`demo-reset.yml`** now calls the same script instead of carrying its own copy of the reset steps, so the twice-daily reset and the redeploy cannot drift into doing different things to the same environment.

## Two properties kept deliberately

- **Not provisioned is not a failure.** No `demo.env` or no container → exit 0 with a line saying so. A preview deploy must not go red because an optional environment was never set up on that host.
- **Nothing is passed in from CI.** The container starts from `--env-file /etc/internship-crm/demo.env` and the tools run *inside* it, so the demo's own configuration never enters an Actions log and the seeds use exactly the image, Prisma client and `DATABASE_URL` the demo itself runs with. `prisma/reset-demo.mjs` still refuses any database not named `*_demo`.

## Verification

No docker daemon here, so the paths were exercised against a stub whose `docker inspect` fails for a missing container — enough to prove the control flow, which is where the risk is:

| Case | Result |
|---|---|
| no env file, `--data-only` | exit 0, "not provisioned … nothing to do" |
| env file, container missing | exit 0, "not deployed … nothing to reset" |
| no flags | exit 2 |
| `--image` matching the running one | "leaving the container alone", zero `docker run` |
| `--image` differing | `stop` → `rm` → `run -d --env-file … -p 3203:3000 --restart=unless-stopped` → re-seed → health check |

`bash -n` on the script, YAML parse on both workflows. The real proof is the next merge to `main`: the demo job runs on the server and `crm-demo.ersah.in/api/health` should report the same sha as preview. I'll check it and report the before/after.

Release fragment: `releases/unreleased/demo-follows-preview.json` (`patch`, with user-facing notes — the demo is public).

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeSYkGngKpYG4KWsJ7Ph2Z)_