### PR TITLE
fix(security): stop returning set-password links, and stop hiding failed emails (#987)

### DIFF
--- a/docs/pii-access-lifecycle.md
+++ b/docs/pii-access-lifecycle.md
@@ -104,6 +104,37 @@ ve arama da sunucuya taşındı (arama 300 ms debounce'lu).
 iş. Erişim **loglanmıyor**; PII erişim kaydı
 [#821](https://github.com/21072026/Internship/issues/821) kapsamında.
 
+## Canlı parola linkleri yanıt gövdesine yazılmaz (#987)
+
+**Karar: A** — parola belirleme linki yalnızca e-posta ile gider; API yanıtı
+`{ ok, emailSent }` döner. `POST /api/admin/company-users` ve
+`POST /api/admin/source-users` artık `setPasswordUrl` döndürmüyor.
+
+Gerekçe: bu link canlı, tek kullanımlık bir kimlik bilgisi. HTTP yanıt gövdesine
+koymak onu ters proxy log'larına, tarayıcı devtools'una ve her ekran paylaşımına
+koymak demek — `/api/admin/users/[id]/reset-password` için #875'te kapatılan
+desenin aynısı. İki kural olması uzun vadede kafa karıştırır.
+
+Issue, A'nın gerçek bir operasyonel maliyeti olduğunu varsayıyordu: hesabı admin
+oluşturuyor, e-posta gitmezse hesap erişilemez kalıyor. **Ölçtük, öyle değildi:**
+`src/app/admin/companies/page.tsx` ve `src/app/admin/sources/page.tsx` yanıttaki
+linki hiç okumuyordu — yalnızca başarı mesajı gösterip formu temizliyorlardı.
+Yani link, hiçbir tüketicisi olmadan sızıyordu; kaldırmanın maliyeti sıfır.
+
+Asıl kusur başka yerdeydi ve aynı işte düzeltildi: her iki uç da e-posta hatasını
+yutup yine `ok: true` dönüyordu. Admin "hesap oluşturuldu" görüyordu, posta hiç
+gitmemişken. Artık:
+
+- yanıt `emailSent` taşıyor ve arayüz gönderilemediğini açıkça söylüyor
+  (hesap var, kimse giremiyor, posta düzelince "Parolayı sıfırla");
+- denetim kaydının `detail` alanına da yazılıyor, çünkü bu durumu sonradan
+  açıklamaya çalışan kişi oraya bakacak.
+
+Posta arızasında kurtarma yolu değişmedi: kullanıcı üzerinde parola sıfırlama
+akışını tekrar tetiklemek. Link elle paylaşılacaksa bunun için ayrı ve denetlenen
+bir yol var (#670, e-postasız davet linkleri) — "yanıt gövdesinde döndür" o yol
+değil.
+
 ## Önizleme verisi: anonimleştirme (#1186)
 
 Paylaşılan önizleme ortamı gerçek veriyle çalışıyordu. `scripts/sanitize-db.mjs`

--- a/releases/unreleased/no-password-link-in-response.json
+++ b/releases/unreleased/no-password-link-in-response.json
@@ -1,0 +1,4 @@
+{
+  "bump": "patch",
+  "changelog": "- **Set-password links no longer travel in API responses (#987)** — `POST /api/admin/company-users` and `/api/admin/source-users` emailed the link *and* returned it, putting a live single-use credential into reverse-proxy logs, devtools and screen shares; neither admin screen ever read it. They now return `{ ok, emailSent }`, matching the decision taken for `reset-password` in #875. The same change makes a failed set-password email visible instead of silent: it is reported in the UI and written to the audit trail, where before the admin was told the account was created and nothing else."
+}

--- a/src/app/admin/companies/page.tsx
+++ b/src/app/admin/companies/page.tsx
@@ -46,7 +46,15 @@ export default function CompaniesPage() {
         body: JSON.stringify({ companyId: clCompanyId, email: clEmail, fullName: clName }),
       });
       const data = await res.json();
-      setClMsg(res.ok ? t.companiesPage.loginCreated : data.error || t.common.error);
+      // A created account whose set-password email never sent is unreachable —
+      // say so instead of reporting plain success (#987).
+      setClMsg(
+        res.ok
+          ? data.emailSent === false
+            ? t.companiesPage.loginCreatedNoEmail
+            : t.companiesPage.loginCreated
+          : data.error || t.common.error
+      );
       if (res.ok) {
         setClEmail('');
         setClName('');

--- a/src/app/admin/sources/page.tsx
+++ b/src/app/admin/sources/page.tsx
@@ -51,7 +51,15 @@ export default function AdminSourcesPage() {
         body: JSON.stringify({ sourceId: loginSourceId, email: loginEmail, fullName: loginName || loginEmail }),
       });
       const data = await res.json();
-      setLoginMsg(res.ok ? t.sources.loginCreated : data.error || t.common.error);
+      // A created account whose set-password email never sent is unreachable —
+      // say so instead of reporting plain success (#987).
+      setLoginMsg(
+        res.ok
+          ? data.emailSent === false
+            ? t.sources.loginCreatedNoEmail
+            : t.sources.loginCreated
+          : data.error || t.common.error
+      );
       if (res.ok) { setLoginEmail(''); setLoginName(''); }
     } finally {
       setSaving(false);

--- a/src/app/api/admin/company-users/route.ts
+++ b/src/app/api/admin/company-users/route.ts
@@ -40,11 +40,17 @@ export async function POST(request: Request) {
   });
 
   const token = await createPasswordResetToken(user.id, 'SET_INITIAL');
-  const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+  // The link is emailed and NOT returned (#987, the decision recorded in
+  // docs/pii-access-lifecycle.md). It is a live, single-use credential: putting
+  // it in an HTTP response body puts it in reverse-proxy logs, browser
+  // devtools and every screen share — the same leak #875 closed for
+  // /api/admin/users/[id]/reset-password. Neither admin screen ever read it.
+  let emailSent = true;
   try {
     await sendPasswordResetEmail({ to: user.email, token, fullName: user.fullName, purpose: 'SET_INITIAL', orgId: user.orgId });
   } catch (e) {
     console.error('Company-user set-password email failed:', e);
+    emailSent = false;
   }
 
   await logActivity({
@@ -54,9 +60,14 @@ export async function POST(request: Request) {
     actorEmail: session.user.email ?? null,
     targetType: 'user',
     targetId: user.id,
-    detail: `company ${company.name}`,
+    // Say so in the audit trail when the mail failed: the account exists and
+    // cannot be reached, which is exactly the state somebody will be trying to
+    // explain later.
+    detail: emailSent ? `company ${company.name}` : `company ${company.name} — set-password email failed to send`,
     request,
   });
-  return NextResponse.json({ ok: true, setPasswordUrl: `${appUrl}/auth/reset?token=${token}` });
+  // `emailSent: false` means the account exists but nobody can get into it.
+  // Before #987 this was swallowed and the admin was told "created", full stop.
+  return NextResponse.json({ ok: true, emailSent });
   });
 }

--- a/src/app/api/admin/source-users/route.ts
+++ b/src/app/api/admin/source-users/route.ts
@@ -39,11 +39,17 @@ export async function POST(request: Request) {
   });
 
   const token = await createPasswordResetToken(user.id, 'SET_INITIAL');
-  const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+  // The link is emailed and NOT returned (#987, the decision recorded in
+  // docs/pii-access-lifecycle.md). It is a live, single-use credential: putting
+  // it in an HTTP response body puts it in reverse-proxy logs, browser
+  // devtools and every screen share — the same leak #875 closed for
+  // /api/admin/users/[id]/reset-password. Neither admin screen ever read it.
+  let emailSent = true;
   try {
     await sendPasswordResetEmail({ to: user.email, token, fullName: user.fullName, purpose: 'SET_INITIAL', orgId: user.orgId });
   } catch (e) {
     console.error('Source-user set-password email failed:', e);
+    emailSent = false;
   }
 
   await logActivity({
@@ -53,9 +59,14 @@ export async function POST(request: Request) {
     actorEmail: session.user.email ?? null,
     targetType: 'user',
     targetId: user.id,
-    detail: `source ${source.name}`,
+    // Say so in the audit trail when the mail failed: the account exists and
+    // cannot be reached, which is exactly the state somebody will be trying to
+    // explain later.
+    detail: emailSent ? `source ${source.name}` : `source ${source.name} — set-password email failed to send`,
     request,
   });
-  return NextResponse.json({ ok: true, setPasswordUrl: `${appUrl}/auth/reset?token=${token}` });
+  // `emailSent: false` means the account exists but nobody can get into it.
+  // Before #987 this was swallowed and the admin was told "created", full stop.
+  return NextResponse.json({ ok: true, emailSent });
   });
 }

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -409,6 +409,7 @@ const en = {
     positions: 'positions',
     openPositions: 'Open positions',
     loginCreated: 'Login created — we emailed a set-password link.',
+    loginCreatedNoEmail: 'Login created, but the set-password email could NOT be sent. The account exists and nobody can sign in to it yet — use “Reset password” on the user once mail is working.',
     loadFailed: 'Failed to load companies',
     createFailed: 'Failed to create company',
     updateFailed: 'Failed to update company',
@@ -1807,6 +1808,7 @@ const en = {
     addLoginHint: 'Give a source a login so they can submit mentees (not read-only).',
     createLogin: 'Create login',
     loginCreated: 'Login created — a set-password email was sent.',
+    loginCreatedNoEmail: 'Login created, but the set-password email could NOT be sent. The account exists and nobody can sign in to it yet — use “Reset password” on the user once mail is working.',
   },
   sourcePortal: {
     title: 'My mentees',
@@ -3486,6 +3488,7 @@ const tr: Dict = {
     positions: 'pozisyon',
     openPositions: 'Açık pozisyonlar',
     loginCreated: 'Giriş oluşturuldu — parola belirleme bağlantısı e-postalandı.',
+    loginCreatedNoEmail: 'Giriş oluşturuldu ama parola belirleme e-postası GÖNDERİLEMEDİ. Hesap var ve şu an kimse giriş yapamıyor — posta düzelince kullanıcıda “Parolayı sıfırla”yı çalıştırın.',
     loadFailed: 'Şirketler yüklenemedi',
     createFailed: 'Şirket oluşturulamadı',
     updateFailed: 'Şirket güncellenemedi',
@@ -4871,6 +4874,7 @@ const tr: Dict = {
     addLoginHint: 'Bir kaynağa giriş ver ki mentee gönderebilsin (salt-okunur değil).',
     createLogin: 'Giriş oluştur',
     loginCreated: 'Giriş oluşturuldu — şifre belirleme e-postası gönderildi.',
+    loginCreatedNoEmail: 'Giriş oluşturuldu ama şifre belirleme e-postası GÖNDERİLEMEDİ. Hesap var ve şu an kimse giriş yapamıyor — posta düzelince kullanıcıda “Parolayı sıfırla”yı çalıştırın.',
   },
   sourcePortal: {
     title: 'Mentee\'lerim',
@@ -6546,6 +6550,7 @@ const de: Dict = {
     positions: 'Positionen',
     openPositions: 'Offene Positionen',
     loginCreated: 'Zugang erstellt — wir haben einen Link zum Setzen des Passworts per E-Mail gesendet.',
+    loginCreatedNoEmail: 'Zugang erstellt, aber die E-Mail zum Setzen des Passworts konnte NICHT gesendet werden. Das Konto existiert und niemand kann sich anmelden — nutze „Passwort zurücksetzen“, sobald der Mailversand wieder geht.',
     loadFailed: 'Unternehmen konnten nicht geladen werden',
     createFailed: 'Unternehmen konnte nicht erstellt werden',
     updateFailed: 'Unternehmen konnte nicht aktualisiert werden',
@@ -7931,6 +7936,7 @@ const de: Dict = {
     addLoginHint: 'Gib einer Quelle einen Login, damit sie Mentees einreichen kann (nicht nur lesend).',
     createLogin: 'Login erstellen',
     loginCreated: 'Login erstellt — eine E-Mail zum Festlegen des Passworts wurde gesendet.',
+    loginCreatedNoEmail: 'Login erstellt, aber die E-Mail zum Festlegen des Passworts konnte NICHT gesendet werden. Das Konto existiert und niemand kann sich anmelden — nutze „Passwort zurücksetzen“, sobald der Mailversand wieder geht.',
   },
   sourcePortal: {
     title: 'Meine Mentees',


### PR DESCRIPTION
Closes #987.

`POST /api/admin/company-users` and `/api/admin/source-users` emailed the set-password link **and** returned it in the response body — a live, single-use credential in reverse-proxy logs, browser devtools and every screen share. Same pattern #875 closed for `/api/admin/users/[id]/reset-password`.

**Decision: A**, the option the issue proposed — the link goes by email only, the response is `{ ok, emailSent }`. Two different rules for the same kind of secret is how the careful one gets forgotten.

## The trade-off the issue described doesn't exist

The issue held A against a real operational cost: the admin creates the account, so if the email fails the account is unreachable, and "never show the link" therefore costs something. I checked the callers before accepting that:

```
src/app/admin/companies/page.tsx:47   setClMsg(res.ok ? t.companiesPage.loginCreated : …)
src/app/admin/sources/page.tsx:56     setLoginMsg(res.ok ? t.sources.loginCreated : …)
```

**Neither screen ever read `setPasswordUrl`.** Both show a success message and clear the form. The credential was leaking with no consumer at all — so removing it costs nothing, and the decision is free rather than a balance of risks.

## The defect that does matter

Looking for that consumer surfaced something worse, fixed in the same change. Both endpoints did this:

```ts
try { await sendPasswordResetEmail(...) } catch (e) { console.error(...) }
…
return NextResponse.json({ ok: true, setPasswordUrl: … });
```

The email failure was swallowed and the admin was told **"Login created"** either way. On a system whose own health endpoint has been reporting `450 4.7.1 Error: too much mail` today, that is not hypothetical: you create an account, get a green message, and nobody can ever sign in to it.

Now:

- the response carries `emailSent`, and both screens say plainly that the account exists and nobody can sign in yet, with what to do about it (EN/TR/DE);
- the audit entry's `detail` records it — that row is where somebody will look when they try to explain the state weeks later.

## Scope

`/api/mentor/mentees/[id]` still returns the link. It has a real consumer (`MenteeActivationPanel`) and its own deliberate design in #1123, and this issue names the two admin endpoints. Flagging it so the omission is visible rather than accidental — if you want that one changed too it should be its own decision, since there the link is used.

`docs/pii-access-lifecycle.md` records the decision, the measurement that made it free, and the recovery path when mail is down (re-trigger reset; the audited way to hand over a link deliberately is #670's email-less invites, not a response body).

## Verification

`npx tsc --noEmit`, `npm run lint` (only the pre-existing `useEffect` dependency warning on `companies/page.tsx:81`, untouched), `npm run check:i18n` → 3070 keys × 3, `npm run build` clean.

Release fragment: `releases/unreleased/no-password-link-in-response.json` (`patch`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeSYkGngKpYG4KWsJ7Ph2Z)_