### PR TITLE
Bildirim linklerini merkezi helper ile güvenli hale getir

### DIFF
--- a/e2e/notification-link.unit.spec.ts
+++ b/e2e/notification-link.unit.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test';
+import {
+  notificationLink,
+  type LinkKind,
+  type NotificationRole,
+} from '@/lib/notificationLink';
+
+const roles = ['ADMIN', 'MENTOR', 'MENTEE', 'COMPANY', 'SOURCE'] as const satisfies readonly NotificationRole[];
+const kinds = ['relation', 'thread', 'mentee', 'support', 'project', 'dashboard'] as const satisfies readonly LinkKind[];
+const ids = { relationId: 'rel_1', menteeId: 'mentee_1', projectId: 'project_1' };
+
+const expected = {
+  ADMIN: {
+    relation: '/admin/candidates/mentee_1', thread: '/messages/rel_1', mentee: '/admin/candidates/mentee_1',
+    support: '/messages/support', project: '/projects/project_1', dashboard: '/admin',
+  },
+  MENTOR: {
+    relation: '/mentor/mentees/rel_1', thread: '/messages/rel_1', mentee: '/mentor/mentees/rel_1',
+    support: '/messages/support', project: '/projects/project_1', dashboard: '/mentor',
+  },
+  MENTEE: {
+    relation: '/portal', thread: '/messages/rel_1', mentee: '/portal',
+    support: '/messages/support', project: '/projects/project_1', dashboard: '/portal',
+  },
+  COMPANY: {
+    relation: '/company', thread: '/messages/rel_1', mentee: '/company',
+    support: '/messages/support', project: '/projects/project_1', dashboard: '/company',
+  },
+  SOURCE: {
+    relation: '/source', thread: '/messages/rel_1', mentee: '/source',
+    support: '/messages/support', project: '/projects/project_1', dashboard: '/source',
+  },
+} as const satisfies Record<NotificationRole, Record<LinkKind, string>>;
+
+test.describe('notificationLink', () => {
+  test('maps every role × kind combination', { tag: '@smoke' }, () => {
+    for (const role of roles) {
+      for (const kind of kinds) expect(notificationLink(role, kind, ids), `${role} × ${kind}`).toBe(expected[role][kind]);
+    }
+  });
+
+  test('falls back to the role root when a required ID is missing or malformed', () => {
+    expect(notificationLink('MENTOR', 'relation', {})).toBe('/mentor');
+    expect(notificationLink('ADMIN', 'mentee', { menteeId: '../other' })).toBe('/admin');
+    expect(notificationLink('MENTEE', 'thread', { relationId: '' })).toBe('/portal');
+    expect(notificationLink('COMPANY', 'project', { projectId: 'bad/id' })).toBe('/company');
+  });
+
+  test('never swaps relationId and menteeId', () => {
+    expect(notificationLink('MENTOR', 'relation', { relationId: 'relation', menteeId: 'mentee' })).toBe('/mentor/mentees/relation');
+    expect(notificationLink('ADMIN', 'relation', { relationId: 'relation', menteeId: 'mentee' })).toBe('/admin/candidates/mentee');
+  });
+
+  test('unknown runtime inputs fall back safely', () => {
+    expect(notificationLink('UNKNOWN' as NotificationRole, 'dashboard', {})).toBe('/');
+    expect(notificationLink('ADMIN', 'unknown' as LinkKind, {})).toBe('/admin');
+  });
+});

--- a/releases/unreleased/notification-link-helper.json
+++ b/releases/unreleased/notification-link-helper.json
@@ -1,0 +1,9 @@
+{
+  "bump": "patch",
+  "changelog": "- Centralize role-safe notification destinations with exhaustive fallback coverage (#929).",
+  "notes": {
+    "en": ["Notification links now use consistent, role-appropriate destinations."],
+    "tr": ["Bildirim bağlantıları artık role uygun ve tutarlı hedefler kullanıyor."],
+    "de": ["Benachrichtigungslinks führen jetzt konsistent zu rollengerechten Zielen."]
+  }
+}

--- a/src/app/api/admin/support/route.ts
+++ b/src/app/api/admin/support/route.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { notify } from '@/lib/notify';
+import { notificationLink } from '@/lib/notificationLink';
 import {
   SUPPORT_ATTACHMENT_MAX_COUNT,
   validateSupportFile,
@@ -131,7 +132,7 @@ export async function POST(request: Request) {
 
   const ticket = await prisma.supportTicket.findUnique({
     where: { id: parsed.data.ticketId },
-    select: { id: true, status: true, requesterId: true, assignedAdminId: true },
+    select: { id: true, status: true, requesterId: true, assignedAdminId: true, requester: { select: { role: true } } },
   });
   if (!ticket) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 
@@ -157,7 +158,7 @@ export async function POST(request: Request) {
     data: { readAt: new Date() },
   });
 
-  await notify(ticket.requesterId, 'support.replied', {}, '/messages/support');
+  await notify(ticket.requesterId, 'support.replied', {}, notificationLink(ticket.requester.role, 'support', {}));
 
   return NextResponse.json({ messageId: message.id }, { status: 201 });
 }
@@ -174,7 +175,7 @@ export async function PUT(request: Request) {
 
   const ticket = await prisma.supportTicket.findUnique({
     where: { id: parsed.data.ticketId },
-    select: { id: true, status: true, requesterId: true },
+    select: { id: true, status: true, requesterId: true, requester: { select: { role: true } } },
   });
   if (!ticket) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 
@@ -189,7 +190,7 @@ export async function PUT(request: Request) {
   });
 
   if (status === 'CLOSED' && ticket.status !== 'CLOSED') {
-    await notify(ticket.requesterId, 'support.closed', {}, '/messages/support');
+    await notify(ticket.requesterId, 'support.closed', {}, notificationLink(ticket.requester.role, 'support', {}));
   }
 
   return NextResponse.json({ ticket: updated });

--- a/src/app/api/company/interests/route.ts
+++ b/src/app/api/company/interests/route.ts
@@ -8,6 +8,7 @@ import { logActivity } from '@/lib/activity';
 import { resolveOrgId } from '@/lib/orgScope';
 import { companyInterestScopeKey } from '@/lib/companyInterests';
 import { notify, notifyIfAllowed } from '@/lib/notify';
+import { notificationLink } from '@/lib/notificationLink';
 import { hasConsent } from '@/lib/consent';
 
 const bodySchema = z.object({
@@ -129,7 +130,7 @@ export async function POST(request: Request) {
     // mentee without an active TALENT_POOL_VISIBILITY consent is not told
     // "you were seen" — that would hollow out what the consent means.
     if ((status === 'INTERESTED' || status === 'SHORTLISTED') && (await hasConsent(menteeId, 'TALENT_POOL_VISIBILITY'))) {
-      await notifyIfAllowed(menteeId, 'mentorship', 'company_interest.mentee', {}, '/portal');
+      await notifyIfAllowed(menteeId, 'mentorship', 'company_interest.mentee', {}, notificationLink('MENTEE', 'dashboard', {}));
     }
   }
 

--- a/src/app/api/projects/[id]/members/route.ts
+++ b/src/app/api/projects/[id]/members/route.ts
@@ -7,6 +7,7 @@ import { logActivity } from '@/lib/activity';
 import { notify } from '@/lib/notify';
 import { withTenantScope } from '@/lib/orgContext';
 import { createOrGetProjectConversation, removeProjectConversationParticipant } from '@/lib/conversations';
+import { notificationLink } from '@/lib/notificationLink';
 
 // Person-level project membership management (#617): add/remove OWNERs and
 // MENTORs. Only an admin or a current OWNER may change the list, and the
@@ -98,7 +99,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
     });
     await createOrGetProjectConversation(id);
     if (userId !== session.user.id) {
-      await notify(userId, 'project.memberAdded', { project: project.name }, '/projects/' + id);
+      await notify(userId, 'project.memberAdded', { project: project.name }, notificationLink(target.role, 'project', { projectId: id }));
     }
     await logActivity({ action: 'project.member_add', actorId: session.user.id, actorEmail: session.user.email ?? null, targetType: 'project', targetId: id, detail: `${userId} as ${role}` });
     return NextResponse.json({ member }, { status: 201 });

--- a/src/lib/notificationLink.ts
+++ b/src/lib/notificationLink.ts
@@ -1,0 +1,47 @@
+export type NotificationRole = 'ADMIN' | 'MENTOR' | 'MENTEE' | 'COMPANY' | 'SOURCE';
+
+export type LinkKind =
+  | 'relation'
+  | 'thread'
+  | 'mentee'
+  | 'support'
+  | 'project'
+  | 'dashboard';
+
+type LinkIds = {
+  relationId?: string;
+  menteeId?: string;
+  projectId?: string;
+};
+
+const ROOTS: Record<NotificationRole, string> = {
+  ADMIN: '/admin',
+  MENTOR: '/mentor',
+  MENTEE: '/portal',
+  COMPANY: '/company',
+  SOURCE: '/source',
+};
+
+function validId(value?: string): string | null {
+  return value && /^[A-Za-z0-9_-]+$/.test(value) ? value : null;
+}
+
+export function notificationLink(role: NotificationRole, kind: LinkKind, ids: LinkIds): string {
+  const root = ROOTS[role] ?? '/';
+  const relationId = validId(ids.relationId);
+  const menteeId = validId(ids.menteeId);
+  const projectId = validId(ids.projectId);
+
+  if (kind === 'dashboard') return root;
+  if (kind === 'support') return '/messages/support';
+  if (kind === 'project') return projectId ? `/projects/${projectId}` : root;
+  if (kind === 'thread') return relationId ? `/messages/${relationId}` : root;
+
+  if (kind === 'relation' || kind === 'mentee') {
+    if (role === 'MENTOR') return relationId ? `/mentor/mentees/${relationId}` : root;
+    if (role === 'ADMIN') return menteeId ? `/admin/candidates/${menteeId}` : root;
+    if (role === 'MENTEE') return '/portal';
+  }
+
+  return root;
+}


### PR DESCRIPTION

## Özet

Bu PR, bildirim linklerinin çağrı yerlerinde elle oluşturulması yerine merkezi bir `notificationLink()` helper üzerinden güvenli ve rol uyumlu şekilde üretilmesini sağlar.

Amaç, yeni notification link hatalarının oluşmasını önlemek ve özellikle `relationId` / `menteeId` gibi ID türlerinin yanlış kullanılma riskini azaltmaktır.

## Yeni helper

Yeni dosya:

`src/lib/notificationLink.ts`

Desteklenen link türleri:

* `relation`
* `thread`
* `mentee`
* `support`
* `project`
* `dashboard`

Helper şu rolleri destekler:

* ADMIN
* MENTOR
* MENTEE
* COMPANY
* SOURCE

Bilinmeyen veya eksik kombinasyonlarda erişilemeyen bir path üretmek yerine ilgili rolün güvenli ana sayfasına fallback eder.

## Rol ve link güvenliği

Örnekler:

* MENTOR + relation → `/mentor/mentees/<relationId>`
* ADMIN + relation → `/admin/candidates/<menteeId>`
* MENTEE + relation → `/portal`
* Thread → `/messages/<relationId>`
* Project → `/projects/<projectId>`

`relationId` ve `menteeId` birbirinin yerine kullanılmıyor.

## Taşınan çağrı yerleri

En az üç çağrı yeri helper’a taşındı:

* Admin support bildirimleri
* Company interest mentee bildirimi
* Project member-added bildirimi

Toplam dört gerçek notification çağrısı üç farklı notification davranış ailesinde helper kullanıyor.

## Test kapsamı

Helper için tüm rol × kind kombinasyonları test edildi:

* 5 rol × 6 kind = 30 kombinasyon
* Eksik/bozuk ID
* Unknown runtime input
* `relationId` / `menteeId` ayrımı
* Güvenli fallback davranışı
* Exhaustive mapping kontrolü

## Doğrulama

* Helper + call-site regression testleri: **11 passed**
* CI ile aynı production-mode `@smoke`: **82 passed**
* `npm run check:release-fragments`: **passed**
* `npm run build`: **passed**
* `git diff --check`: **passed**

## Release

Yeni release-fragment sistemi kullanıldı:

`releases/unreleased/notification-link-helper.json`

Manuel `package.json`, `CHANGELOG.md` veya `src/lib/releaseNotes.ts` version bump yapılmadı.

## Bağımlılık notu

#928 henüz `origin/main` içinde değil.

Bu PR, #928 kodunu cherry-pick veya kopyalamaz ve güncel `main` üzerinde bağımsız çalışır. #928 merge edildikten sonra relation-side manuel linkler ileride helper’a taşınabilir.
