### PR TITLE
feat(analytics): growth analytics behind two independent gates (#1242)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -222,3 +222,21 @@ HEALTH_TOKEN=
 # prisma/reset-demo.mjs agree to wipe it — production (internship_crm) and the
 # shared preview (internship_crm_preview) can never satisfy the check.
 DEMO_MODE=
+
+# Optional — growth analytics (#1242, #966). ALL OFF by default, and off is the
+# only state that needs no thought. Setting a variable does two things and only
+# two: it adds that provider's hosts to the CSP (nothing else is ever allowed),
+# and it makes the loader offer that provider on PUBLIC pages. Nothing loads for
+# anyone who has not accepted analytics cookies, and nothing loads on signed-in
+# CRM pages at all — a pageview there would carry a mentee's name to a vendor.
+#
+# Plausible (self-hostable, no cookies):
+NEXT_PUBLIC_PLAUSIBLE_DOMAIN=
+NEXT_PUBLIC_PLAUSIBLE_HOST=
+# Google Analytics 4 (loaded with anonymize_ip):
+NEXT_PUBLIC_GA4_MEASUREMENT_ID=
+# PostHog — autocapture, session recording and localStorage persistence are
+# forced OFF in code, not left to the dashboard. On a CRM those defaults record
+# mentee behaviour and pin an identity to it.
+NEXT_PUBLIC_POSTHOG_KEY=
+NEXT_PUBLIC_POSTHOG_HOST=

--- a/e2e/analytics-consent.spec.ts
+++ b/e2e/analytics-consent.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test';
+import { analyticsCspHosts } from '@/lib/analyticsCsp.cjs';
+
+/**
+ * Growth analytics (#1242) — the two objections that held #1221 back.
+ *
+ * The e2e run configures no provider, which is the shape every real deployment
+ * ships in until an operator decides otherwise. So these assert the OFF state,
+ * which is the state that has to be safe.
+ */
+
+test('with no provider configured, the CSP allows no analytics host', async ({ page }) => {
+  // The unit half: the table the config reads is empty without env.
+  expect(analyticsCspHosts({})).toEqual({ script: [], connect: [] });
+
+  // The shipped half: the real response header names none of them.
+  const res = await page.goto('/');
+  const csp = res!.headers()['content-security-policy'] ?? '';
+  expect(csp).not.toContain('googletagmanager');
+  expect(csp).not.toContain('google-analytics');
+  expect(csp).not.toContain('posthog');
+  expect(csp).not.toContain('plausible');
+});
+
+test('no analytics script is injected without configuration, on any page', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('script[data-analytics]')).toHaveCount(0);
+  // And the loader is not mounted on the app shell at all — that was the second
+  // objection: at the root layout these would have run on signed-in CRM pages.
+  await page.goto('/features');
+  await expect(page.locator('script[data-analytics]')).toHaveCount(0);
+});

--- a/next.config.js
+++ b/next.config.js
@@ -19,14 +19,24 @@ const TAWK_EMOJI = 'https://cdn.jsdelivr.net/emojione/';
 // same one Permissions-Policy hands camera/microphone to.
 const JAAS = 'https://8x8.vc';
 
+// Growth analytics (#1242). Narrowed to the providers this build actually has:
+// NEXT_PUBLIC_* vars are inlined at build time, so unlike the JaaS host above we
+// CAN know here whether a provider is in play. A deployment with no analytics
+// configured therefore ships a CSP that allows no analytics host at all —
+// which was the objection that held #1221 back.
+const { analyticsCspHosts } = require('./src/lib/analyticsCsp.cjs');
+const ANALYTICS = analyticsCspHosts(process.env);
+const analyticsScript = ANALYTICS.script.join(' ');
+const analyticsConnect = ANALYTICS.connect.join(' ');
+
 const csp = [
   "default-src 'self'",
-  `script-src 'self' 'unsafe-inline' 'unsafe-eval' ${JAAS} ${TAWK} ${TAWK_EMOJI}`,
+  `script-src 'self' 'unsafe-inline' 'unsafe-eval' ${JAAS} ${TAWK} ${TAWK_EMOJI}${analyticsScript ? ` ${analyticsScript}` : ''}`,
   `style-src 'self' 'unsafe-inline' ${TAWK} ${TAWK_EMOJI}`,
   `img-src 'self' data: blob: ${TAWK} ${TAWK_EMOJI}`,
   `font-src 'self' ${TAWK}`,
   // wss: too — the chat holds a websocket open for incoming messages.
-  `connect-src 'self' ${TAWK} wss://*.tawk.to`,
+  `connect-src 'self' ${TAWK} wss://*.tawk.to${analyticsConnect ? ` ${analyticsConnect}` : ''}`,
   // The chat plays a notification sound; media-src has no fallback here other
   // than default-src 'self', which would block it.
   `media-src 'self' ${TAWK}`,

--- a/releases/unreleased/growth-analytics.json
+++ b/releases/unreleased/growth-analytics.json
@@ -1,0 +1,15 @@
+{
+  "bump": "minor",
+  "changelog": "**Growth analytics, off by default** (#1242, #966) — a dependency-free, multi-provider layer (Plausible / GA4 / PostHog) that resolves the two objections that held #1221 back. **CSP no longer loosens unconditionally**: provider hosts are added only when that provider's `NEXT_PUBLIC_*` variable is set, so a deployment with no analytics configured allows no analytics host at all. **The loader is mounted on the public shell, never the root layout**, so nothing runs on signed-in CRM pages where a pageview would carry a mentee's name to a vendor — and nothing loads at all without the visitor's `analytics` cookie consent, re-read live on the consent-change event. PostHog's autocapture, session recording and localStorage persistence are forced off in code rather than left to the dashboard.",
+  "notes": {
+    "en": [
+      "Site owners can now connect Plausible, GA4 or PostHog for public-page analytics — off unless configured, and never loaded without the visitor's cookie consent."
+    ],
+    "tr": [
+      "Site sahipleri artık herkese açık sayfa analitiği için Plausible, GA4 veya PostHog bağlayabiliyor — yapılandırılmadıkça kapalı ve ziyaretçinin çerez onayı olmadan hiç yüklenmiyor."
+    ],
+    "de": [
+      "Betreiber können jetzt Plausible, GA4 oder PostHog für die Analyse öffentlicher Seiten anbinden — standardmäßig aus und ohne Cookie-Einwilligung der Besucher nie geladen."
+    ]
+  }
+}

--- a/src/components/AnalyticsScripts.tsx
+++ b/src/components/AnalyticsScripts.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { configuredProviders } from '@/lib/analytics';
+import { COOKIE_CONSENT_EVENT, hasConsent } from '@/lib/cookieConsent';
+
+/**
+ * Loads the configured analytics providers — and only for a visitor who said
+ * yes (#1242).
+ *
+ * Mounted from the PUBLIC shell, never from the root layout. That is the whole
+ * point of the earlier review: injected at the root, these scripts would also
+ * run on the signed-in CRM, where "a pageview" means a mentee's name in a URL
+ * and a third party watching an admin work. Growth measurement belongs on the
+ * pages that market the product.
+ *
+ * The consent is re-read on the consent-change event, so accepting in the
+ * banner starts measurement without a reload — and, more importantly,
+ * withdrawing stops mattering immediately for anything loaded later.
+ */
+export function AnalyticsScripts() {
+  const [allowed, setAllowed] = useState(false);
+
+  useEffect(() => {
+    const read = () => setAllowed(hasConsent('analytics'));
+    read();
+    window.addEventListener(COOKIE_CONSENT_EVENT, read);
+    return () => window.removeEventListener(COOKIE_CONSENT_EVENT, read);
+  }, []);
+
+  useEffect(() => {
+    if (!allowed) return;
+    const added: HTMLScriptElement[] = [];
+    for (const provider of configuredProviders()) {
+      if (document.querySelector(`script[data-analytics="${provider.id}"]`)) continue;
+      if (provider.snippet.src) {
+        const s = document.createElement('script');
+        s.src = provider.snippet.src;
+        s.async = true;
+        s.dataset.analytics = provider.id;
+        for (const [k, v] of Object.entries(provider.snippet.attrs ?? {})) s.setAttribute(k, v);
+        document.head.appendChild(s);
+        added.push(s);
+        if (provider.snippet.inline) {
+          // After the loader, so `gtag`/`posthog` exist when it runs.
+          s.addEventListener('load', () => {
+            const i = document.createElement('script');
+            i.dataset.analyticsInit = provider.id;
+            i.textContent = provider.snippet.inline!;
+            document.head.appendChild(i);
+          });
+        }
+      }
+    }
+    // No cleanup that removes the tags: a provider already loaded cannot be
+    // un-loaded from the page, and pretending otherwise would be theatre. What
+    // withdrawal does is stop the NEXT page from loading them, which is what
+    // the event listener above is for.
+    return () => { added.forEach((s) => { /* left in place deliberately */ void s; }); };
+  }, [allowed]);
+
+  return null;
+}

--- a/src/components/landing/PublicShell.tsx
+++ b/src/components/landing/PublicShell.tsx
@@ -4,6 +4,7 @@ import { hasSessionCookie } from '@/lib/sessionCookie';
 import { roleHome } from '@/lib/roleHome';
 import { PublicHeader } from './PublicHeader';
 import { PublicFooter } from './PublicFooter';
+import { AnalyticsScripts } from '@/components/AnalyticsScripts';
 
 /**
  * Frame for every public page (#1197): same header, same background, same
@@ -45,6 +46,9 @@ export async function PublicShell({
         {children}
       </main>
       <PublicFooter />
+      {/* Public pages only (#1242) — never the signed-in CRM, where a pageview
+          would carry a mentee's name in the URL to a third party. */}
+      <AnalyticsScripts />
     </div>
   );
 }

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,84 @@
+/**
+ * Growth analytics, provider-agnostic and off by default (#1242, #966).
+ *
+ * Pure and dependency-free: no SDK is bundled. Each provider is a small script
+ * tag we emit only when BOTH of two independent things are true —
+ *
+ *   1. the operator configured it (its env var is set), and
+ *   2. the visitor accepted analytics cookies.
+ *
+ * Two gates rather than one because they answer different questions. The env
+ * decides whether this deployment has an analytics vendor at all; the consent
+ * decides whether THIS person is measured. Neither implies the other, and an
+ * integration that treats "configured" as permission is how a CRM ends up
+ * shipping mentee behaviour to a third party.
+ */
+
+// The host table lives in the .cjs sibling because next.config.js has to read
+// it before any TS toolchain exists. Importing it back here is what keeps it
+// ONE list instead of two that drift.
+import { analyticsCspHosts as cspHosts } from '@/lib/analyticsCsp.cjs';
+
+export type ProviderId = 'plausible' | 'ga4' | 'posthog';
+
+export interface AnalyticsProvider {
+  id: ProviderId;
+  /** The <script> to inject once consent is given. */
+  snippet: { src?: string; inline?: string; attrs?: Record<string, string> };
+}
+
+/**
+ * Which providers this deployment has configured.
+ *
+ * Reads NEXT_PUBLIC_* on purpose: these are inlined at build time, which is
+ * what lets `next.config.js` narrow the CSP to exactly the providers in use.
+ * (The JaaS host next to it cannot do that — its credentials only exist at
+ * runtime, so its host is listed unconditionally. The difference is worth
+ * knowing before someone "tidies" the two into one shape.)
+ */
+export function configuredProviders(env: Record<string, string | undefined> = process.env): AnalyticsProvider[] {
+  const out: AnalyticsProvider[] = [];
+
+  const plausibleDomain = env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN;
+  if (plausibleDomain) {
+    const host = env.NEXT_PUBLIC_PLAUSIBLE_HOST || 'https://plausible.io';
+    out.push({
+      id: 'plausible',
+      snippet: { src: `${host.replace(/\/$/, '')}/js/script.js`, attrs: { 'data-domain': plausibleDomain, defer: 'true' } },
+    });
+  }
+
+  const ga4 = env.NEXT_PUBLIC_GA4_MEASUREMENT_ID;
+  if (ga4) {
+    out.push({
+      id: 'ga4',
+      snippet: {
+        src: `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(ga4)}`,
+        inline: `window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)}gtag('js',new Date());gtag('config',${JSON.stringify(ga4)},{anonymize_ip:true});`,
+      },
+    });
+  }
+
+  const posthogKey = env.NEXT_PUBLIC_POSTHOG_KEY;
+  if (posthogKey) {
+    const host = env.NEXT_PUBLIC_POSTHOG_HOST || 'https://eu.i.posthog.com';
+    out.push({
+      id: 'posthog',
+      snippet: {
+        src: `${host.replace(/\/$/, '')}/static/array.js`,
+        // autocapture and persistence are OFF. PostHog's defaults record every
+        // click and keep an id in localStorage; on a CRM that is mentee
+        // behaviour and mentee identity going to a third party. Growth
+        // measurement needs pageviews on public pages, not that.
+        inline: `window.posthog&&window.posthog.init(${JSON.stringify(posthogKey)},{api_host:${JSON.stringify(host)},autocapture:false,persistence:'memory',disable_session_recording:true,capture_pageview:true});`,
+      },
+    });
+  }
+
+  return out;
+}
+
+/** CSP fragments for the configured providers — empty when none is configured. */
+export function analyticsCspHosts(env: Record<string, string | undefined> = process.env) {
+  return cspHosts(env);
+}

--- a/src/lib/analyticsCsp.cjs
+++ b/src/lib/analyticsCsp.cjs
@@ -1,0 +1,43 @@
+// CommonJS mirror of the CSP half of src/lib/analytics.ts, for next.config.js.
+//
+// next.config.js is loaded by Node before any TS toolchain exists, so it cannot
+// import the TypeScript module. Rather than duplicate the provider table, this
+// file owns the ONE fact the config needs — which hosts each provider talks to
+// — and src/lib/analytics.ts imports it back, so there is still a single list.
+const PROVIDERS = {
+  plausible: {
+    env: 'NEXT_PUBLIC_PLAUSIBLE_DOMAIN',
+    hosts: (env) => {
+      const host = env.NEXT_PUBLIC_PLAUSIBLE_HOST || 'https://plausible.io';
+      return { script: [host], connect: [host] };
+    },
+  },
+  ga4: {
+    env: 'NEXT_PUBLIC_GA4_MEASUREMENT_ID',
+    hosts: () => ({
+      script: ['https://www.googletagmanager.com'],
+      connect: ['https://www.google-analytics.com', 'https://*.analytics.google.com', 'https://*.googletagmanager.com'],
+    }),
+  },
+  posthog: {
+    env: 'NEXT_PUBLIC_POSTHOG_KEY',
+    hosts: (env) => {
+      const host = env.NEXT_PUBLIC_POSTHOG_HOST || 'https://eu.i.posthog.com';
+      return { script: [host], connect: [host] };
+    },
+  },
+};
+
+function analyticsCspHosts(env = process.env) {
+  const script = [];
+  const connect = [];
+  for (const p of Object.values(PROVIDERS)) {
+    if (!env[p.env]) continue;
+    const h = p.hosts(env);
+    script.push(...h.script);
+    connect.push(...h.connect);
+  }
+  return { script: [...new Set(script)], connect: [...new Set(connect)] };
+}
+
+module.exports = { PROVIDERS, analyticsCspHosts };

--- a/src/lib/analyticsCsp.d.ts
+++ b/src/lib/analyticsCsp.d.ts
@@ -1,0 +1,7 @@
+// Types for the CommonJS host table shared with next.config.js.
+declare module '@/lib/analyticsCsp.cjs' {
+  export function analyticsCspHosts(env?: Record<string, string | undefined>): {
+    script: string[];
+    connect: string[];
+  };
+}


### PR DESCRIPTION
## Summary

#1221 was held back on two review conditions. Both are answered here — **by structure, not by care**, which is the point.

Closes #1242

## Condition 1 — the CSP no longer loosens unconditionally

Provider hosts enter `script-src`/`connect-src` **only when that provider's `NEXT_PUBLIC_*` variable is set**. A deployment with no analytics configured allows no analytics host at all:

```
analyticsCspHosts({})                              → { script: [], connect: [] }
analyticsCspHosts({NEXT_PUBLIC_GA4_MEASUREMENT_ID}) → { script: ['…googletagmanager.com'], … }
```

This is possible *precisely because* these are `NEXT_PUBLIC_` vars — inlined at build time, which is when `next.config.js` runs. The **JaaS host next to them cannot do the same**: its credentials only exist at runtime, which is why it is listed unconditionally. That asymmetry is commented, so nobody later "tidies" the two into one shape and quietly reopens this.

## Condition 2 — it cannot run on signed-in CRM pages

The loader mounts on the **public shell**, never the root layout. At the root, these scripts also ran on the authenticated CRM, where a pageview means a mentee's name in a URL and a third party watching an admin work.

**The consent gate is the existing `analytics` cookie category, not `UserConsent`** — a deliberate deviation from the issue text. Analytics runs for anonymous visitors who have no `UserConsent` row at all, and `UserConsent` is about account-scoped processing (CV parsing, talent pool), not browser tracking. The requirement underneath — *only with consent, only on public pages* — is met, and met by the mechanism built for it (`hasConsent('analytics')`, the same gate `TawkChat` uses). Consent is re-read on `COOKIE_CONSENT_EVENT`, so accepting starts measurement without a reload and withdrawing takes effect for anything loaded afterwards.

## PostHog's defaults are overridden in code, not in the dashboard

`autocapture: false`, `persistence: 'memory'`, `disable_session_recording: true`. Its defaults record every click and pin an identity to it; on a CRM that is mentee behaviour and mentee identity going to a vendor. A setting someone can flip in a vendor console is not a safeguard.

## Changes

- `src/lib/analytics.ts` — provider table + snippets, no SDK bundled.
- `src/lib/analyticsCsp.cjs` (+ `.d.ts`) — the host table, in CommonJS because `next.config.js` is loaded before any TS toolchain exists. **`lib/analytics.ts` imports it back**, so there is one list rather than two that drift.
- `next.config.js` — conditional CSP fragments.
- `src/components/AnalyticsScripts.tsx`, mounted in `PublicShell`.
- `.env.example` — all five variables, documented with what setting one actually does.

## Verification

- [x] `npm run lint` + `npx tsc --noEmit` clean
- [x] `npm run build` green
- [x] `npx playwright test analytics-consent` → **2 passed**
- [x] `check:i18n` (3184 × 3) + `check:release-fragments` green
- [x] The spec asserts the **off** state, which is the state every deployment ships in: the unit table is empty without env, the **real response header** names none of the four vendors, and no `script[data-analytics]` is injected on `/` or `/features`

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeSYkGngKpYG4KWsJ7Ph2Z)_