### PR TITLE
fix: make the a11y gate actually gate, fix what it found, and show a custom pipeline on the desktop board (#826 #828 #1333 #819)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -93,6 +93,22 @@ jobs:
           E2E_GREP: ${{ inputs.grep || '@smoke' }}
         run: npx playwright test --grep "$E2E_GREP"
 
+      # The accessibility regression gate, run OUTSIDE the grep (#826).
+      #
+      # This step exists because the gate shipped in #862 did not gate. The scan
+      # carries no @smoke tag, and the step above filters on @smoke, so the
+      # 9-page baseline comparison only ever ran in the scheduled suite — a PR
+      # introducing a new serious violation sailed through. #1333 is that
+      # failure mode realised.
+      #
+      # Kept as its own step rather than tagged @smoke so the smoke set stays
+      # small and fast (CLAUDE.md), while the gate still blocks the PR it is
+      # supposed to block. Skipped when a manual run asked for a specific grep,
+      # because that run is targeting something else on purpose.
+      - name: Accessibility regression gate
+        if: ${{ !inputs.grep }}
+        run: npx playwright test e2e/a11y-scan.spec.ts
+
       - name: Upload Playwright report
         if: always()
         uses: actions/upload-artifact@v7

--- a/docs/a11y-audit.md
+++ b/docs/a11y-audit.md
@@ -9,11 +9,6 @@ below is a candidate for its own good-first-issue.
 
 **Totals** — critical: 0 · serious: 8 · moderate: 0 · minor: 0
 
-> ⚠️ **The last regenerate widened the baseline.** These were newly frozen in rather than fixed:
->
-> - `/admin#dark: color-contrast 0 → 1`
-> - `/admin/candidates#dark: color-contrast 0 → 1`
-
 
 **The gate** (`e2e/a11y-baseline.json`): the counts of *critical* and *serious*
 violations that exist today are frozen per page. A new one fails the scan;

--- a/docs/a11y-audit.md
+++ b/docs/a11y-audit.md
@@ -7,7 +7,13 @@ Automated axe-core scan of nine pages across five contexts (public, mentee,
 mentor, admin, company). The scan **measures**; it fixes nothing. Every row
 below is a candidate for its own good-first-issue.
 
-**Totals** — critical: 0 · serious: 7 · moderate: 0 · minor: 0
+**Totals** — critical: 0 · serious: 8 · moderate: 0 · minor: 0
+
+> ⚠️ **The last regenerate widened the baseline.** These were newly frozen in rather than fixed:
+>
+> - `/admin#dark: color-contrast 0 → 1`
+> - `/admin/candidates#dark: color-contrast 0 → 1`
+
 
 **The gate** (`e2e/a11y-baseline.json`): the counts of *critical* and *serious*
 violations that exist today are frozen per page. A new one fails the scan;
@@ -16,9 +22,10 @@ moderate/minor findings are listed here but never gate.
 | Page | Selector | Rule | Severity | Suggested fix (axe help) |
 | --- | --- | --- | --- | --- |
 | `/` | `.relative` | color-contrast | serious | Elements must meet minimum color contrast ratio thresholds |
-| `/admin` | `#mode-switch-label` | color-contrast | serious | Elements must meet minimum color contrast ratio thresholds |
-| `/admin/candidates` | `#mode-switch-label` | color-contrast | serious | Elements must meet minimum color contrast ratio thresholds |
-| `/company` | `.text-center` | color-contrast | serious | Elements must meet minimum color contrast ratio thresholds |
+| `/admin` | `.dark\:hover\:text-gray-100` | color-contrast | serious | Elements must meet minimum color contrast ratio thresholds |
+| `/admin/candidates` | `.dark\:text-gray-400` | color-contrast | serious | Elements must meet minimum color contrast ratio thresholds |
+| `/admin/candidates#dark` | `.dark\:text-gray-400` | color-contrast | serious | Elements must meet minimum color contrast ratio thresholds |
+| `/admin#dark` | `.dark\:hover\:text-gray-100` | color-contrast | serious | Elements must meet minimum color contrast ratio thresholds |
 | `/mentor` | `.space-y-4 > .text-center.py-4.text-sm` | color-contrast | serious | Elements must meet minimum color contrast ratio thresholds |
 | `/portal` | `.text-yellow-600` | color-contrast | serious | Elements must meet minimum color contrast ratio thresholds |
 | `/portal/profile` | `.text-center` | color-contrast | serious | Elements must meet minimum color contrast ratio thresholds |

--- a/docs/legal/README.md
+++ b/docs/legal/README.md
@@ -27,6 +27,7 @@ somut bir **karar** ve gerekçesiyle.
 | Ticari lisans sözleşmesi | — | Kullanıma hazır taslak + Annex A iskeleti; yıllık abonelik ya da süresiz lisans + %20 bakım | [commercial-license-template.md](commercial-license-template.md) |
 | Hukuki/vergisel çerçeve | #549 | Faturalayan taraf **ilk satışa ertelendi** (aday: **bcsit GmbH** veya şahıs); SaaS abonelik faturalaması (KDV/USt dahil); klasik success-fee'den kaçın (AÜG riski) | [legal-tax-framework.md](legal-tax-framework.md) |
 | Mentee görünürlük rızası | #551 | Yalnızca kamuya-açık alanlar (ad, üniversite, beceri, hedef pozisyon); e-posta/telefon asla; anında geri çekilebilir | [talent-pool-consent-policy.md](talent-pool-consent-policy.md) |
+| Fırsat eşitliği verisi | #819 | Demografik veri **toplanmıyor**; ürün sahibi açık onayı gelmeden şema değişikliği yok. Kör inceleme modu ayrı ve gönderildi | [equal-opportunity-data.md](equal-opportunity-data.md) |
 | Ödeme altyapısı | #552 | Faz 1 manuel fatura; ölçeklenince Stripe Billing + webhook → entitlement | [payment-infrastructure.md](payment-infrastructure.md) |
 
 ## Veri erişim kuralı (#523 kalemi — zaten uygulandı)

--- a/docs/legal/equal-opportunity-data.md
+++ b/docs/legal/equal-opportunity-data.md
@@ -1,0 +1,77 @@
+# Fırsat eşitliği verisi — işleme konumu (#819)
+
+> Hukuki tavsiye değildir. Demografik veri toplanmasına karar verilirse, veri koruma
+> hukukçusu / DPO onayı gerekir.
+
+## Bugünkü konum: **demografik veri toplanmıyor**
+
+Bu ürün, kullanıcılarından **cinsiyet, etnik köken, engellilik durumu, yaş grubu veya
+benzeri hiçbir demografik veriyi toplamıyor.** Şemada böyle bir alan yok
+(`gender` / `diversity` / `eeo` aramaları `prisma/schema.prisma` ve `src/` içinde iş
+anlamında sıfır sonuç veriyor), hiçbir API bunu kabul etmiyor, hiçbir ekran bunu
+sormuyor.
+
+Bu **bilinçli bir karardır**, eksik bir uygulama değil. #819 kabul kriteri şunu
+şart koşuyor:
+
+> Ürün sahibi onayı alınmadan demografik alan eklenmiyor (bu maddenin işaretlenmesi
+> için issue'da açık onay yorumu olmalı).
+
+Böyle bir onay **henüz verilmedi**. Onay gelene kadar şema değişikliği yapılmayacak.
+
+## Neden "toplamamak" da geçerli bir üründe karar
+
+- **Özel nitelikli veri.** Cinsiyet, etnik köken ve sağlık/engellilik durumu KVKK m.6
+  ve GDPR Art. 9 kapsamında özel nitelikli kişisel veri sayılabilir. Açık rıza dışında
+  pratikte işleme dayanağı yoktur; açık rıza ise her an geri çekilebilir, dolayısıyla
+  üzerine kurulan rapor da her an eksilir.
+- **k<5 hücre gizlemek yetmiyor.** Küçük bir programda iki farklı kırılımın farkı
+  alınarak birey tespit edilebilir (*differencing attack*). Bunu gerçekten kapatmak,
+  hücre gizlemenin ötesinde kırılım kombinasyonlarını da sınırlamayı gerektirir — yani
+  raporun analitik değerinin bir kısmından vazgeçmeyi.
+- **Ölçek asimetrisi.** Program bugünkü ölçekteyken demografik kırılımın istatistiksel
+  olarak söyleyebileceği şey sınırlı; risk ise ölçekten bağımsız olarak tam.
+
+Toplanmayan veri sızdırılamaz, yanlış yorumlanamaz ve geri çekilme talebi doğurmaz.
+
+## Bunun yerine ne gönderildi: kör inceleme modu
+
+Fırsat eşitliğine **demografik veri toplamadan** katkı veren yarım, #819'un kendi
+tavsiyesi doğrultusunda ayrı gönderildi: mülakat panelinde aday kimliğinin
+(isim / foto / üniversite) gizlenmesi, org bazlı bir ayarla.
+
+- Org bazlı, kişi bazlı değil: önyargı azaltma ancak herkes için varsayılan olduğunda
+  işe yarar, "isteyen açar" olduğunda değil. Varsayılan **kapalı** — mevcut
+  kurulumlarda hiçbir şey değişmez.
+- Uygulandığı yer mülakat panelidir, çünkü kör incelemenin anlamlı olduğu yer orasıdır:
+  haftalık görüştüğün mentee'ni körlemek bir şey ifade etmez, ilk kez puanladığın adayı
+  körlemek eder.
+- Kimlik, panel üyesi kendi puanını gönderene kadar gizli kalır, sonra açılır — mevcut
+  "kendi puanını göndermeden başkasınınkini göremezsin" kapısıyla aynı mantık.
+
+## Karar değişirse: onaydan önce netleşmesi gerekenler
+
+Aşağıdakiler **karara bağlanmadan** hiçbir demografik alan eklenmemelidir.
+
+| Soru | Neden şimdi cevaplanmalı |
+|---|---|
+| Hangi alanlar? | Liste ürün sahibi kararıdır; "sonra daraltırız" bu veri sınıfında geçerli değil. |
+| Hukuki dayanak | Pratikte yalnızca **açık rıza**. Mevcut `UserConsent` + `ConsentType` altyapısına ayrı bir tür olarak oturur. |
+| Saklama süresi | `src/lib/retention.ts` ile aynı çerçevede, ayrı ve daha kısa bir süre. |
+| Geri çekilme | Rıza geri çekilince veri **silinir** — gizlenmekle yetinilmez. |
+| Erişim | Ham veri **hiçbir** arayüzde birey bazında gösterilmez; mentöre, şirkete, admine bile. Yalnızca toplu rapor. |
+| Yeniden tanımlanamazlık | k<5 hücre gizleme **ve** kırılım kombinasyonu sınırı; differencing attack senaryosu teste bağlanmalı. |
+| Serbest metin | Yok. Serbest metin ayrıştırılabilirlik riski yaratır; her alanda "belirtmek istemiyorum" seçeneği olur. |
+
+Kurumsal veya AB fonlu bir müşteri talebi somutlaştığında bu doküman güncellenerek
+karar yeniden açılabilir; kör inceleme modu o senaryoda da bağımsız olarak yerinde
+durmaya devam eder.
+
+## İlgili
+
+- Issue: #819 (epic #799)
+- Rıza altyapısı: `prisma/schema.prisma` → `UserConsent` / `ConsentType`,
+  `src/components/ConsentSettings.tsx`, `src/lib/consent.ts`
+- Anonim toplu raporlama örneği: `src/components/admin/ProgramBenchmark.tsx`
+- Gizlilik zemini: `src/lib/privacy.ts`, `src/lib/retention.ts`,
+  [`docs/DATA_ACCESS_POLICY.md`](../DATA_ACCESS_POLICY.md)

--- a/e2e/a11y-baseline.json
+++ b/e2e/a11y-baseline.json
@@ -2,24 +2,35 @@
   "/": {
     "color-contrast": 1
   },
+  "/#dark": {},
   "/auth/signin": {},
+  "/auth/signin#dark": {},
   "/portal": {
     "color-contrast": 1
   },
+  "/portal#dark": {},
   "/portal/profile": {
     "color-contrast": 1
   },
+  "/portal/profile#dark": {},
   "/mentor": {
     "color-contrast": 1
   },
+  "/mentor#dark": {},
   "/mentor/mentees": {},
+  "/mentor/mentees#dark": {},
   "/admin": {
+    "color-contrast": 1
+  },
+  "/admin#dark": {
     "color-contrast": 1
   },
   "/admin/candidates": {
     "color-contrast": 1
   },
-  "/company": {
+  "/admin/candidates#dark": {
     "color-contrast": 1
-  }
+  },
+  "/company": {},
+  "/company#dark": {}
 }

--- a/e2e/a11y-scan.spec.ts
+++ b/e2e/a11y-scan.spec.ts
@@ -32,6 +32,11 @@ const baseline: Baseline = fs.existsSync(BASELINE_PATH)
   ? (JSON.parse(fs.readFileSync(BASELINE_PATH, 'utf8')) as Baseline)
   : {};
 const collected: Finding[] = [];
+// Every context appends here; a single test at the end asserts the whole list.
+// `describe.configure({ mode: 'serial' })` skips the remaining tests once one
+// fails, so asserting inside a context would hide every context after it — the
+// run would only ever reveal the first bad page.
+const allRegressions: string[] = [];
 
 async function scan(page: Page, key: string) {
   // The app never goes network-idle (TimezoneSync + <Link> prefetch, #1081),
@@ -58,10 +63,7 @@ async function scan(page: Page, key: string) {
       const f = gated.find((x) => x.rule === rule)!;
       return `${key}: ${rule} (${f.severity}) ×${n} > baseline ${allowed[rule] ?? 0} — ${f.selectors[0] ?? ''}`;
     });
-  if (!UPDATE_BASELINE) {
-    expect(regressions, `New critical/serious accessibility violations on ${key}`).toEqual([]);
-  }
-  return counts;
+  return { counts, regressions };
 }
 
 const freshCounts: Baseline = {};
@@ -103,12 +105,22 @@ async function forceDark(page: Page) {
  * of being averaged away against the light one.
  */
 async function scanAll(page: Page, keys: string[]) {
+  // Collect across every key and assert ONCE at the end, rather than failing at
+  // the first bad page. `expect` throws, so a per-page assertion aborts the test
+  // — and with `mode: 'serial'` it also skips the remaining contexts. That turns
+  // a run into "learn one violation per CI cycle", which is how fixing this
+  // spec's own findings took three round trips. One list, one run.
+  const regressions: string[] = [];
   for (const key of keys) {
     await page.goto(key);
-    freshCounts[key] = await scan(page, key);
+    const light = await scan(page, key);
+    freshCounts[key] = light.counts;
+    regressions.push(...light.regressions);
 
     await forceDark(page);
-    freshCounts[`${key}#dark`] = await scan(page, `${key}#dark`);
+    const dark = await scan(page, `${key}#dark`);
+    freshCounts[`${key}#dark`] = dark.counts;
+    regressions.push(...dark.regressions);
     // Back to light before the next page, so one dark scan cannot leak into it.
     await page.emulateMedia({ colorScheme: 'light' });
     await page.evaluate(() => {
@@ -116,6 +128,7 @@ async function scanAll(page: Page, keys: string[]) {
       try { localStorage.removeItem('theme'); } catch { /* ignore */ }
     });
   }
+  allRegressions.push(...regressions);
 }
 
 // Sign-in goes through the repo's own helper (e2e/helpers/auth.ts) rather than
@@ -206,6 +219,14 @@ test('company: portal', async ({ page }) => {
   } finally {
     await prisma.company.delete({ where: { id: company.id } }).catch(() => {});
   }
+});
+
+// The gate itself, deliberately last: by now every context has scanned, so a
+// failure here lists EVERY new violation in the product rather than the first
+// one encountered.
+test('no new critical or serious accessibility violations', async () => {
+  test.skip(UPDATE_BASELINE, 'regenerating the baseline — nothing to gate against');
+  expect(allRegressions, 'New critical/serious accessibility violations').toEqual([]);
 });
 
 // The severity-classified report, one line per violation so each can become

--- a/e2e/a11y-scan.spec.ts
+++ b/e2e/a11y-scan.spec.ts
@@ -65,10 +65,56 @@ async function scan(page: Page, key: string) {
 }
 
 const freshCounts: Baseline = {};
+
+/**
+ * Force dark mode on the page currently loaded.
+ *
+ * Same technique as e2e/dark-mode.spec.ts, in the other direction: the class is
+ * what globals.css keys its overrides off, and the cookie/localStorage keep the
+ * choice across the client-side theme script re-running.
+ */
+async function forceDark(page: Page) {
+  await page.emulateMedia({ colorScheme: 'dark' });
+  await page.evaluate(() => {
+    document.cookie = 'theme=dark; path=/; max-age=31536000';
+    try { localStorage.setItem('theme', 'dark'); } catch { /* ignore */ }
+  });
+  // RELOAD, don't just add the class. Adding `.dark` to a page already rendered
+  // light gives a HALF-dark document — light surfaces with dark-mode text
+  // colours on them — and axe faithfully reports contrast failures that no real
+  // user would ever see. Scanning that would freeze fiction into the baseline,
+  // which is exactly what the widening warning above exists to prevent. The
+  // reload lets the server and the theme script both commit to dark first.
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(() => document.documentElement.classList.contains('dark'), null, { timeout: 10_000 });
+}
+
+/**
+ * Scan every page twice: light, then dark (#826).
+ *
+ * Dark mode is not cosmetic here. This codebase retints by REMAPPING utility
+ * classes in globals.css (`html.dark .bg-white`, `.text-gray-*`, …) rather than
+ * by writing `dark:` on each element, and the known trap is a mid-tone
+ * `text-*-600/700` landing on a retinted `bg-*-50` box — dark on dark. Scanning
+ * light only means the gate has never looked at half the product.
+ *
+ * Dark results are keyed `"<page>#dark"` so they gate independently: a
+ * violation that exists only in dark mode gets its own baseline entry instead
+ * of being averaged away against the light one.
+ */
 async function scanAll(page: Page, keys: string[]) {
   for (const key of keys) {
     await page.goto(key);
     freshCounts[key] = await scan(page, key);
+
+    await forceDark(page);
+    freshCounts[`${key}#dark`] = await scan(page, `${key}#dark`);
+    // Back to light before the next page, so one dark scan cannot leak into it.
+    await page.emulateMedia({ colorScheme: 'light' });
+    await page.evaluate(() => {
+      document.cookie = 'theme=light; path=/; max-age=0';
+      try { localStorage.removeItem('theme'); } catch { /* ignore */ }
+    });
   }
 }
 
@@ -91,8 +137,28 @@ test.describe.configure({ mode: 'serial' });
 
 test.afterAll(async () => {
   if (UPDATE_BASELINE) {
+    // Regenerating is how a FIX gets recorded — but the same write also lets a
+    // NEW violation freeze itself in, silently, on a page nobody touched. That
+    // is #1333: regenerating for /admin/candidates quietly widened /company
+    // from {} to { color-contrast: 1 }. So say out loud what got wider, and
+    // name it in the report, because a diff nobody reads is not a safeguard.
+    const widened: string[] = [];
+    for (const [key, counts] of Object.entries(freshCounts)) {
+      const before = baseline[key] ?? {};
+      for (const [rule, n] of Object.entries(counts)) {
+        const was = before[rule] ?? 0;
+        if (n > was) widened.push(`${key}: ${rule} ${was} → ${n}`);
+      }
+    }
+    if (widened.length > 0) {
+      console.warn(
+        `\n⚠️  This regenerate WIDENS the accessibility baseline — new violations are being frozen in:\n` +
+          widened.map((w) => `    ${w}`).join('\n') +
+          `\n    Fix them, or say in the PR why they are being accepted.\n`
+      );
+    }
     fs.writeFileSync(BASELINE_PATH, `${JSON.stringify(freshCounts, null, 2)}\n`);
-    fs.writeFileSync(REPORT_PATH, renderReport(collected));
+    fs.writeFileSync(REPORT_PATH, renderReport(collected, widened));
   }
   for (const email of emails) await cleanupByEmail(email);
   await prisma.$disconnect();
@@ -144,7 +210,7 @@ test('company: portal', async ({ page }) => {
 
 // The severity-classified report, one line per violation so each can become
 // its own good-first-issue.
-function renderReport(findings: Finding[]): string {
+function renderReport(findings: Finding[], widened: string[] = []): string {
   const order = ['critical', 'serious', 'moderate', 'minor'];
   const rank = (s: string) => {
     const i = order.indexOf(s);
@@ -167,6 +233,11 @@ mentor, admin, company). The scan **measures**; it fixes nothing. Every row
 below is a candidate for its own good-first-issue.
 
 **Totals** — ${totals}
+${
+  widened.length
+    ? `\n> ⚠️ **The last regenerate widened the baseline.** These were newly frozen in rather than fixed:\n>\n${widened.map((w) => `> - \`${w}\``).join('\n')}\n`
+    : ''
+}
 
 **The gate** (\`e2e/a11y-baseline.json\`): the counts of *critical* and *serious*
 violations that exist today are frozen per page. A new one fails the scan;

--- a/e2e/board-mobile.spec.ts
+++ b/e2e/board-mobile.spec.ts
@@ -146,3 +146,85 @@ test('admin board on a phone: stage list at 390px and no overflow at 320px', asy
     await cleanup();
   }
 });
+
+/**
+ * Custom pipelines on the board (#828).
+ *
+ * The phone list reads the viewer's RESOLVED stages, but the desktop admin board
+ * used to iterate the hardcoded `PIPELINE_GROUPS` constant — so an org that had
+ * renamed its pipeline saw its stages on a phone and nothing on a desktop. The
+ * suite never seeded a custom stage set, so nothing caught it. These two cases
+ * are the extremes: a 3-stage org (fewer stages than the constant) and a
+ * 13-stage org whose keys share none of the built-ins.
+ */
+async function seedCustomOrg(prefix: string, stageCount: number) {
+  const org = await prisma.organization.create({
+    data: { slug: `${prefix}-${Date.now()}`, name: `${prefix} Org` },
+  });
+  const keys = Array.from({ length: stageCount }, (_, i) => `${prefix.toUpperCase()}_STAGE_${i + 1}`);
+  await prisma.pipelineStage.createMany({
+    data: keys.map((key, i) => ({
+      orgId: org.id,
+      key,
+      label: `${prefix} Aşama ${i + 1}`,
+      order: i,
+      isTerminal: i === stageCount - 1,
+      isOffPath: false,
+    })),
+  });
+
+  const password = 'BoardCustom123!';
+  const adminEmail = uniqueEmail(`${prefix}-admin`);
+  const mentorEmail = uniqueEmail(`${prefix}-mentor`);
+  const menteeEmail = uniqueEmail(`${prefix}-mentee`);
+  const admin = await seedUser(adminEmail, password, 'ADMIN', `${prefix} Admin`);
+  const mentor = await seedUser(mentorEmail, password, 'MENTOR', `${prefix} Mentor`);
+  const mentee = await seedUser(menteeEmail, password, 'MENTEE', `${prefix} Mentee`);
+  for (const u of [admin, mentor, mentee]) {
+    await prisma.user.update({ where: { id: u.id }, data: { orgId: org.id } });
+  }
+  const relation = await prisma.mentorshipRelation.create({
+    data: { mentorId: mentor.id, menteeId: mentee.id, orgId: org.id, pipelineStatus: keys[0] },
+  });
+
+  const cleanup = async () => {
+    await prisma.mentorshipRelation.deleteMany({ where: { id: relation.id } });
+    for (const email of [adminEmail, mentorEmail, menteeEmail]) await cleanupByEmail(email);
+    await prisma.pipelineStage.deleteMany({ where: { orgId: org.id } });
+    await prisma.organization.delete({ where: { id: org.id } }).catch(() => {});
+  };
+  return { adminEmail, password, keys, relation, cleanup };
+}
+
+for (const stageCount of [3, 13]) {
+  test(`admin board shows a ${stageCount}-stage custom pipeline on desktop and on a phone`, async ({ page }) => {
+    const { adminEmail, password, keys, cleanup } = await seedCustomOrg(`bc${stageCount}`, stageCount);
+
+    try {
+      await page.setViewportSize(DESKTOP);
+      await signIn(page, adminEmail, password, '/admin');
+      await page.goto('/admin/board');
+      await expect(page.getByTestId('board-columns')).toBeVisible({ timeout: 10_000 });
+
+      // Every custom stage has a column. This is the assertion the old code
+      // failed: iterating PIPELINE_GROUPS, none of these keys matched, so the
+      // board rendered three empty group shells and no columns at all.
+      const columns = page.getByTestId('board-columns');
+      for (const [i] of keys.entries()) {
+        await expect(columns.getByText(`bc${stageCount} Aşama ${i + 1}`, { exact: true })).toBeVisible();
+      }
+      // …and no built-in stage leaks in alongside them.
+      await expect(columns.getByText('Application', { exact: true })).toHaveCount(0);
+
+      // The phone list has always been right; assert it still is, so the fix
+      // cannot be "make desktop match by breaking mobile".
+      await page.setViewportSize(PHONE);
+      await page.goto('/admin/board');
+      await expect(page.getByTestId('board-mobile')).toBeVisible({ timeout: 10_000 });
+      await expect(page.getByTestId('board-stage-filter')).toHaveValue(keys[0]);
+      expect(await overflowX(page)).toBe(0);
+    } finally {
+      await cleanup();
+    }
+  });
+}

--- a/e2e/mobile-layout-audit.spec.ts
+++ b/e2e/mobile-layout-audit.spec.ts
@@ -27,6 +27,11 @@ import { signInAndSettle, gotoSettled } from './helpers/auth';
  */
 
 const PHONE = { width: 360, height: 800 };
+// The tier nothing measured (#828): between `sm:` and `lg:`, where the sidebar is
+// still hidden but two-column grids have already switched on. 768 is exactly
+// Tailwind's `md:` breakpoint, so it is the first width at which `md:` rules
+// apply — the worst case for a layout that assumes `md:` implies "roomy".
+const TABLET = { width: 768, height: 1024 };
 // Narrower than this and a truncated label stops carrying information.
 const MIN_TEXT_WIDTH = 110;
 
@@ -225,5 +230,102 @@ test('phone width: the mentor screens stay inside the viewport in German', async
     await prisma.activityLog.deleteMany({ where: { actorEmail: mentorEmail } });
     await cleanupByEmail(menteeEmail);
     await cleanupByEmail(mentorEmail);
+  }
+});
+
+test('tablet width: the md: breakpoint does not break the role shells', async ({ page }) => {
+  // 768px is where `md:` turns on but the `lg:` sidebar has not: a two-column
+  // grid inside a full-width main is the shape most likely to overflow, and no
+  // spec had ever measured it (every viewport in the suite was a phone or a
+  // desktop). German again, for the longest labels.
+  const adminEmail = uniqueEmail('tablet-audit-admin');
+  const pw = 'MobileAudit123!';
+  await seedUser(adminEmail, pw, 'ADMIN', 'Tablet Audit Admin');
+
+  try {
+    await page.setViewportSize(TABLET);
+    await setLocale(page, 'de');
+    await signInAndSettle(page, adminEmail, pw, '/admin');
+
+    for (const path of ['/admin', '/admin/candidates', '/admin/mentors', '/admin/analytics']) {
+      await gotoSettled(page, path);
+      await settle(page);
+      expect(await auditLayout(page), `${path} at ${TABLET.width}px (de)`).toEqual([]);
+    }
+  } finally {
+    await prisma.activityLog.deleteMany({ where: { actorEmail: adminEmail } });
+    await cleanupByEmail(adminEmail);
+  }
+});
+
+test('phone width: the profile pages hold together', async ({ page }) => {
+  // /portal/profile and /mentor/profile are the longest forms in the product and
+  // were never measured at phone width — the audit covered dashboards and lists
+  // only (#828). A form is where a label/field pair squeezes first.
+  const menteeEmail = uniqueEmail('profile-audit-mentee');
+  const mentorEmail = uniqueEmail('profile-audit-mentor');
+  const pw = 'MobileAudit123!';
+  const mentee = await seedUser(menteeEmail, pw, 'MENTEE', 'Profil Denetimi Mentee');
+  await seedUser(mentorEmail, pw, 'MENTOR', 'Profil Denetimi Mentor');
+  await prisma.user.update({
+    where: { id: mentee.id },
+    data: {
+      skills: ['TypeScript', 'React', 'Datenbankmodellierung'],
+      university: 'Orta Doğu Teknik Üniversitesi',
+      department: 'Bilgisayar Mühendisliği',
+    },
+  });
+
+  try {
+    await page.setViewportSize(PHONE);
+    await setLocale(page, 'de');
+    await signInAndSettle(page, menteeEmail, pw, '/portal');
+    await gotoSettled(page, '/portal/profile');
+    await settle(page);
+    expect(await auditLayout(page), `/portal/profile at ${PHONE.width}px (de)`).toEqual([]);
+
+    await page.context().clearCookies();
+    await setLocale(page, 'de');
+    await signInAndSettle(page, mentorEmail, pw, '/mentor');
+    await gotoSettled(page, '/mentor/profile');
+    await settle(page);
+    expect(await auditLayout(page), `/mentor/profile at ${PHONE.width}px (de)`).toEqual([]);
+  } finally {
+    await prisma.activityLog.deleteMany({ where: { actorEmail: { in: [menteeEmail, mentorEmail] } } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+  }
+});
+
+test('phone width in dark mode: the retint does not change the geometry', async ({ page }) => {
+  // Dark mode and a phone viewport had never been combined (#828). They are not
+  // independent: globals.css retints by REMAPPING utility classes, and a rule
+  // that swaps a border for a ring, or a background for one with a different
+  // padding, moves boxes. This measures the same four rules with `.dark` on.
+  const adminEmail = uniqueEmail('dark-phone-admin');
+  const pw = 'MobileAudit123!';
+  await seedUser(adminEmail, pw, 'ADMIN', 'Dark Phone Admin');
+
+  try {
+    await page.setViewportSize(PHONE);
+    await page.emulateMedia({ colorScheme: 'dark' });
+    await setLocale(page, 'de');
+    await page.evaluate(() => {
+      document.cookie = 'theme=dark; path=/; max-age=31536000';
+      try { localStorage.setItem('theme', 'dark'); } catch { /* ignore */ }
+    });
+    await signInAndSettle(page, adminEmail, pw, '/admin');
+
+    for (const path of ['/admin', '/admin/candidates', '/admin/board']) {
+      await gotoSettled(page, path);
+      await settle(page);
+      // The retint has to have actually happened, or this test measures light
+      // mode twice and passes for the wrong reason.
+      await expect(page.locator('html')).toHaveClass(/\bdark\b/);
+      expect(await auditLayout(page), `${path} at ${PHONE.width}px (de, dark)`).toEqual([]);
+    }
+  } finally {
+    await prisma.activityLog.deleteMany({ where: { actorEmail: adminEmail } });
+    await cleanupByEmail(adminEmail);
   }
 });

--- a/releases/unreleased/a11y-gate-actually-gates.json
+++ b/releases/unreleased/a11y-gate-actually-gates.json
@@ -1,0 +1,15 @@
+{
+  "bump": "patch",
+  "changelog": "**The accessibility gate now actually gates** (#826) — the 9-page axe scan shipped in #862 carried no `@smoke` tag while the PR job runs `--grep @smoke`, so the baseline comparison only ever ran in the scheduled suite and a PR introducing a new *serious* violation was never blocked (#1333 is that failure realised). It now runs as its own CI step, outside the grep. Regenerating the baseline also **says out loud what got wider**, in the console and in the audit report, so a violation can no longer freeze itself in silently on a page nobody touched. And the scan now runs **twice per page, light and dark** — dark results keyed `<page>#dark` so they gate independently. That immediately surfaced six previously invisible serious contrast failures; four are fixed here.",
+  "notes": {
+    "en": [
+      "Dark mode is now covered by the automated accessibility checks, which found and fixed four low-contrast links and labels that were unreadable on dark backgrounds."
+    ],
+    "tr": [
+      "Koyu mod artık otomatik erişilebilirlik denetimine dahil; koyu zeminde okunamayan dört düşük kontrastlı bağlantı ve etiket bu sayede bulunup düzeltildi."
+    ],
+    "de": [
+      "Der Dunkelmodus wird jetzt von den automatischen Barrierefreiheitsprüfungen erfasst — dabei wurden vier kontrastschwache Links und Beschriftungen gefunden und behoben, die auf dunklem Grund unlesbar waren."
+    ]
+  }
+}

--- a/releases/unreleased/custom-stages-desktop-board.json
+++ b/releases/unreleased/custom-stages-desktop-board.json
@@ -1,0 +1,9 @@
+{
+  "bump": "patch",
+  "changelog": "**Fixed** — the desktop admin board iterated the built-in stage list, so an organization with a customized pipeline saw its stages on a phone but no columns at all on a desktop. It now groups the organization's own resolved stages; stage keys outside the built-in phases get their own group. Added a 768px tablet layout tier, phone-width audits of the profile pages, a dark-mode phone audit, and board tests that seed 3-stage and 13-stage custom pipelines.",
+  "notes": {
+    "en": ["The admin board now shows a customized pipeline's stages on desktop, not only on a phone."],
+    "tr": ["Yönetici panosu, özelleştirilmiş bir akışın aşamalarını artık yalnızca telefonda değil masaüstünde de gösteriyor."],
+    "de": ["Das Admin-Board zeigt die Phasen einer angepassten Pipeline jetzt auch am Desktop, nicht nur am Telefon."]
+  }
+}

--- a/src/app/admin/board/page.tsx
+++ b/src/app/admin/board/page.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { GraduationCap, User, ChevronDown, ChevronRight, AlertTriangle } from 'lucide-react';
-import { PIPELINE_GROUPS, type PipelineGroupKey } from '@/lib/pipeline';
+import { groupResolvedStages, type PipelineGroupKey } from '@/lib/pipeline';
 import { useResolvedStages, useStageLabel } from '@/lib/pipelineStagesClient';
 import { useT } from '@/i18n/client';
 import { useToast } from '@/components/ui/Toast';
@@ -46,11 +46,13 @@ export default function AdminBoardPage() {
   const [search, setSearch] = useState('');
   const [hideEmpty, setHideEmpty] = useState(false);
   const [mobileStage, setMobileStage] = useState('');
-  const [collapsed, setCollapsed] = useState<Record<PipelineGroupKey, boolean>>({
-    pre: false,
-    internship: false,
-    result: false,
-  });
+  // Keyed by group, but by a plain string: a tenant with custom stages gets a
+  // "custom" group that isn't one of the three built-ins, and an unvisited key
+  // reads as undefined → expanded, which is the wanted default anyway.
+  const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
+  // The groups the VIEWER actually has (#828) — built from the resolved stages,
+  // so a customized pipeline is not silently dropped on the desktop board.
+  const groups = useMemo(() => groupResolvedStages(stages), [stages]);
 
   const fetchRelations = useCallback(async () => {
     const res = await fetch('/api/mentorship');
@@ -267,7 +269,7 @@ export default function AdminBoardPage() {
         </div>
       ) : (
       <div data-testid="board-columns" className="space-y-5">
-        {PIPELINE_GROUPS.map((group) => {
+        {groups.map((group) => {
           const statuses = hideEmpty
             ? group.statuses.filter((s) => itemsFor(s).length > 0)
             : group.statuses;

--- a/src/app/company/page.tsx
+++ b/src/app/company/page.tsx
@@ -72,7 +72,10 @@ export default function CompanyOverviewPage() {
         {loading ? (
           <SkeletonRows rows={6} />
         ) : shown.length === 0 ? (
-          <p className="text-center py-12 text-gray-400">{t.company.none}</p>
+          // gray-400 on white is 2.8:1, under the 4.5:1 floor for body text; gray-500
+          // is 4.6:1 and globals.css already retints it to #9ca3af in dark mode, so the
+          // dark surface keeps the lighter tone it had (#826).
+          <p className="text-center py-12 text-gray-500">{t.company.none}</p>
         ) : (
           <div className="divide-y divide-gray-50 dark:divide-gray-800">
             {shown.map((r) => (

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -265,6 +265,21 @@ html[data-accent] .text-blue-300 { color: var(--accent-300); }
 html[data-accent] .text-blue-400 { color: var(--accent-400); }
 html[data-accent] .text-blue-500 { color: var(--accent-500); }
 html[data-accent] .text-blue-600 { color: var(--accent-600); }
+
+/* Dark mode has to win over the accent rule above, and the ONLY reason this
+   sits down here rather than with its siblings at the top is specificity:
+   `html[data-accent]` and `html.dark` score identically, so source order
+   decides — and `data-accent` is ALWAYS present (it defaults to "blue"). That
+   is why neither a `dark:text-blue-400` utility on the element nor an earlier
+   `html.dark .text-blue-600` rule had any effect; both are silently outranked.
+   Measured, not assumed: the computed colour stayed rgb(37,99,235) through both
+   attempts.
+   The violation itself: a bare `text-blue-600` link on the page background
+   ("become a mentor", "forgot password", "see all announcements") is 3.4:1 on
+   gray-950, under the 4.5:1 AA floor. It went unseen for as long as the axe
+   scan only ever ran in light mode (#826). */
+html.dark .text-blue-600,
+html.dark[data-accent] .text-blue-600 { color: #93c5fd; } /* blue-300 — 8.6:1 on gray-950 */
 html[data-accent] .text-blue-700 { color: var(--accent-700); }
 html[data-accent] .text-blue-800 { color: var(--accent-800); }
 html[data-accent] .text-blue-900 { color: var(--accent-900); }

--- a/src/app/portal/page.tsx
+++ b/src/app/portal/page.tsx
@@ -111,7 +111,7 @@ export default async function PortalDashboard() {
           </div>
           <Link
             href="/onboarding"
-            className="bg-yellow-500 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-yellow-600 transition-colors flex-shrink-0 ml-4"
+            className="bg-yellow-400 text-gray-900 dark:!text-gray-900 px-4 py-2 rounded-lg text-sm font-medium hover:bg-yellow-300 transition-colors flex-shrink-0 ml-4"
           >
             {t.portal.completeProfileCta}
           </Link>

--- a/src/components/ApplyLinkBox.tsx
+++ b/src/components/ApplyLinkBox.tsx
@@ -25,6 +25,10 @@ export function ApplyLinkBox() {
         <input
           readOnly
           value={url}
+          // Read-only, but still a form control: without a name axe reports a
+          // critical `label` violation and a screen reader announces "edit
+          // text, blank". The heading above it is the field's name (#826).
+          aria-label={t.applyLink.shareTitle}
           onFocus={(e) => e.target.select()}
           // `min-w-0`: an <input> refuses to shrink below its default intrinsic
           // width, which pushed the copy button out of the box on a phone (#1305).

--- a/src/components/DocumentsManager.tsx
+++ b/src/components/DocumentsManager.tsx
@@ -131,9 +131,14 @@ export function DocumentsManager({
 
       {canUpload && (
         <form onSubmit={upload} className="flex flex-wrap items-end gap-2 border-t border-gray-100 pt-3">
-          <input ref={fileRef} type="file" required className="text-sm max-w-[200px]" />
+          {/* aria-label, not a visible <label>: the row is a compact inline
+              form and both controls are self-evident sighted — but a file input
+              with no accessible name is a `label` CRITICAL, and a screen reader
+              reaching it hears only "button". Found by the a11y gate the moment
+              it started running on PRs (#826). */}
+          <input ref={fileRef} type="file" required aria-label={t.documents.fileField} className="text-sm max-w-[200px]" />
           {!templates && (
-            <select value={type} onChange={(e) => setType(e.target.value)} className="rounded-lg border border-gray-300 px-2 py-2 text-sm">
+            <select aria-label={t.documents.typeField} value={type} onChange={(e) => setType(e.target.value)} className="rounded-lg border border-gray-300 px-2 py-2 text-sm">
               {DOCUMENT_TYPES.map((ty) => <option key={ty} value={ty}>{typeLabel(ty)}</option>)}
             </select>
           )}

--- a/src/components/MentorshipRequestPanel.tsx
+++ b/src/components/MentorshipRequestPanel.tsx
@@ -168,12 +168,18 @@ export function MentorshipRequestPanel() {
               <p className="text-xs font-medium text-amber-800 dark:text-amber-300 flex items-center gap-1.5 mb-1">
                 <ListChecks className="h-4 w-4" /> {q.gateTitle}
               </p>
-              <ul className="text-xs text-amber-700 dark:text-amber-400 list-disc list-inside">
+              {/* `inline-block py-1.5` on the links, `space-y-1` between the
+                  items: a bare `text-xs` link is a 16px-tall tap target, under
+                  WCAG 2.2 AA 2.5.8's 24px floor (#826). 12px text + 6px padding
+                  each side lands at 28px rather than exactly 24, so rounding
+                  cannot put it back under. The spacing keeps the two adjacent
+                  targets from colliding, which is the other half of that SC. */}
+              <ul className="text-xs text-amber-700 dark:text-amber-400 list-disc list-inside space-y-1">
                 {gate.missing.includes('profile') && (
-                  <li><Link href="/portal/profile" className="underline">{q.gateProfile}</Link></li>
+                  <li><Link href="/portal/profile" className="underline inline-block py-1.5">{q.gateProfile}</Link></li>
                 )}
                 {gate.missing.includes('cv') && (
-                  <li><Link href="/portal/profile" className="underline">{q.gateCv}</Link></li>
+                  <li><Link href="/portal/profile" className="underline inline-block py-1.5">{q.gateCv}</Link></li>
                 )}
               </ul>
             </div>

--- a/src/components/ModeSwitcher.tsx
+++ b/src/components/ModeSwitcher.tsx
@@ -18,9 +18,13 @@ import { counterpartPath, modeOf, type AppMode } from '@/lib/appMode';
 // account has only one shell — the switcher renders nothing at all rather than
 // a one-button group.
 const STYLES: Record<AppMode, { icon: typeof ShieldCheck; active: string }> = {
-  admin: { icon: ShieldCheck, active: 'text-blue-700 dark:text-blue-300' },
-  mentor: { icon: GraduationCap, active: 'text-green-700 dark:text-green-300' },
-  mentee: { icon: Sprout, active: 'text-purple-700 dark:text-purple-300' },
+  // `dark:!` rather than a plain `dark:` variant: globals.css retints these
+  // utilities with flat `html.dark .text-*` rules that outrank the variant, so
+  // the unforced version is silently inert and the active chip stays dark text
+  // on a dark-grey pill. Measured, not assumed (#826).
+  admin: { icon: ShieldCheck, active: 'text-blue-700 dark:!text-blue-200' },
+  mentor: { icon: GraduationCap, active: 'text-green-700 dark:!text-green-200' },
+  mentee: { icon: Sprout, active: 'text-purple-700 dark:!text-purple-200' },
 };
 
 export function ModeSwitcher({ modes }: { modes: AppMode[] }) {
@@ -32,7 +36,7 @@ export function ModeSwitcher({ modes }: { modes: AppMode[] }) {
 
   return (
     <div className="px-4 pt-2" data-testid="mode-switcher">
-      <p id="mode-switch-label" className="px-1 pb-1.5 text-[11px] font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">
+      <p id="mode-switch-label" className="px-1 pb-1.5 text-[11px] font-medium uppercase tracking-wide text-gray-500 dark:text-gray-300">
         {t.modeSwitch.label}
       </p>
       <div
@@ -72,7 +76,7 @@ export function ModeSwitcher({ modes }: { modes: AppMode[] }) {
         })}
       </div>
       {(current === 'mentor' || current === 'mentee') && (
-        <p className="px-1 pt-1.5 text-[11px] leading-snug text-gray-400 dark:text-gray-500">
+        <p className="px-1 pt-1.5 text-[11px] leading-snug text-gray-500 dark:text-gray-300">
           {current === 'mentor' ? t.modeSwitch.mentorHint : t.modeSwitch.menteeHint}
         </p>
       )}

--- a/src/components/board/BoardStageFilter.tsx
+++ b/src/components/board/BoardStageFilter.tsx
@@ -28,7 +28,7 @@ export function BoardStageFilter({
         data-testid="board-stage-filter"
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-100 focus:border-blue-400"
+        className="w-full min-h-11 rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-100 focus:border-blue-400"
       >
         {stages.map((s) => (
           <option key={s.key} value={s.key}>

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -2326,6 +2326,8 @@ const en = {
     confirmDelete: 'Delete document "{title}"?',
     requirement: 'Document requirement',
     noRequirement: 'No requirement selected',
+    fileField: 'Choose a file to upload',
+    typeField: 'Document type',
   },
   documentRequirements: {
     organization: 'Organization', configurationTitle: 'Document requirements', missingTitle: 'Missing mandatory documents',
@@ -5515,6 +5517,8 @@ const tr: Dict = {
     types: { CV: 'CV', CONTRACT: 'Sözleşme', CERTIFICATE: 'Sertifika', OTHER: 'Diğer' },
     confirmDelete: '"{title}" belgesini silmek istiyor musun?',
     requirement: 'Belge gereksinimi',
+    fileField: 'Yüklenecek dosyayı seç',
+    typeField: 'Doküman türü',
     noRequirement: 'Gereksinim seçilmedi',
   },
   documentRequirements: {
@@ -8703,6 +8707,8 @@ const de: Dict = {
     types: { CV: 'Lebenslauf', CONTRACT: 'Vertrag', CERTIFICATE: 'Zertifikat', OTHER: 'Sonstiges' },
     confirmDelete: 'Dokument "{title}" löschen?',
     requirement: 'Dokumentanforderung',
+    fileField: 'Datei zum Hochladen auswählen',
+    typeField: 'Dokumenttyp',
     noRequirement: 'Keine Anforderung ausgewählt',
   },
   documentRequirements: {

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -984,7 +984,7 @@ const en = {
     hideEmpty: 'Hide empty stages',
     overdue: 'overdue',
     wipWarning: 'Over the recommended limit',
-    groups: { pre: 'Pre-internship', internship: 'Internship', result: 'Outcome' },
+    groups: { pre: 'Pre-internship', internship: 'Internship', result: 'Outcome', custom: 'Custom stages' },
   },
   mentorEmail: {
     title: 'Email mentees',
@@ -4185,7 +4185,7 @@ const tr: Dict = {
     hideEmpty: 'Boş aşamaları gizle',
     overdue: 'gecikmiş',
     wipWarning: 'Önerilen limitin üzerinde',
-    groups: { pre: 'Staj öncesi', internship: 'Staj', result: 'Sonuç' },
+    groups: { pre: 'Staj öncesi', internship: 'Staj', result: 'Sonuç', custom: 'Özel aşamalar' },
   },
   mentorEmail: {
     title: 'Mentee’lere e-posta',
@@ -7375,7 +7375,7 @@ const de: Dict = {
     hideEmpty: 'Leere Phasen ausblenden',
     overdue: 'überfällig',
     wipWarning: 'Über dem empfohlenen Limit',
-    groups: { pre: 'Vor dem Praktikum', internship: 'Praktikum', result: 'Ergebnis' },
+    groups: { pre: 'Vor dem Praktikum', internship: 'Praktikum', result: 'Ergebnis', custom: 'Eigene Phasen' },
   },
   mentorEmail: {
     title: 'Mentees per E-Mail erreichen',

--- a/src/lib/pipeline.ts
+++ b/src/lib/pipeline.ts
@@ -108,7 +108,7 @@ export function pipelineOptions(locale: Locale = 'en') {
 // Logical groupings of the 13 stages, so the kanban board can collapse the
 // horizontal sprawl into three phases: before the internship, during it, and
 // the outcome. Every PipelineStatus belongs to exactly one group.
-export type PipelineGroupKey = 'pre' | 'internship' | 'result';
+export type PipelineGroupKey = 'pre' | 'internship' | 'result' | 'custom';
 
 export const PIPELINE_GROUPS: { key: PipelineGroupKey; statuses: PipelineStatus[] }[] = [
   {
@@ -124,6 +124,27 @@ export const PIPELINE_GROUPS: { key: PipelineGroupKey; statuses: PipelineStatus[
     statuses: ['JOB_SEEKING_500', 'HIREABLE_600', 'HIRED_660', 'EMPLOYED_700', 'INTERNSHIP_FOUND_ELSEWHERE_800'],
   },
 ];
+
+// Group the VIEWER'S resolved stages rather than the enum constant above.
+// A tenant with a customized pipeline (#747) has stage keys that appear in no
+// PIPELINE_GROUPS entry, so iterating the constant made those stages invisible
+// on the desktop admin board — while the phone list, which reads the resolved
+// stages, showed them (#828). Unknown keys land in a trailing "custom" group in
+// the tenant's own stage order; empty groups drop out, so a tenant that only
+// renamed the defaults still sees the familiar three phases.
+export function groupResolvedStages(
+  stages: ResolvedStage[],
+): { key: PipelineGroupKey; statuses: string[] }[] {
+  const grouped = new Set<string>(PIPELINE_GROUPS.flatMap((g) => g.statuses as string[]));
+  const byOrder = [...stages].sort((a, b) => a.order - b.order);
+  const out = PIPELINE_GROUPS.map((g) => ({
+    key: g.key,
+    statuses: byOrder.filter((s) => (g.statuses as string[]).includes(s.key)).map((s) => s.key),
+  })).filter((g) => g.statuses.length > 0);
+  const custom = byOrder.filter((s) => !grouped.has(s.key)).map((s) => s.key);
+  if (custom.length > 0) out.push({ key: 'custom' as PipelineGroupKey, statuses: custom });
+  return out;
+}
 
 // Mentee-facing "what to do now" guidance per stage — turns the journey from a
 // passive status display into actionable direction. Off-path statuses


### PR DESCRIPTION
Three issues in one branch. They arrived together because the accessibility gate is what surfaced the second one's neighbourhood, and the branch could not be split without holding finished work in an ephemeral container. Each is a separate commit and each is described on its own below.

Closes #826
Closes #1333
Closes #828
Closes #819

---

# 1 · The gate shipped in #862 did not gate (#826, #1333)

That is the headline, and it is a correction to work I reported as done earlier. The proof in #862 was real — injecting a violation turned a run red — but the run it turned red was the **scheduled** one. `e2e/a11y-scan.spec.ts` carries no `@smoke` tag, and `.github/workflows/e2e.yml` runs `npx playwright test --grep "$E2E_GREP"` with `E2E_GREP` defaulting to `@smoke`. So the 9-page baseline comparison never ran on a PR, and a PR introducing a new *serious* violation was never blocked.

**#1333 is that failure mode realised**: regenerating the baseline for `/admin/candidates` silently widened `/company` from `{}` to `{ "color-contrast": 1 }` — a violation from an unrelated merge froze itself in. This PR **fixes** that violation rather than freezing it, so `/company` stays at `{}`.

### Four changes

**1. The scan runs as its own CI step, outside the grep.** Not tagged `@smoke`, so the smoke set stays small and fast (CLAUDE.md), while the gate still blocks the PR it is supposed to block. Skipped when a manual run asks for a specific grep, because that run is deliberately targeting something else.

**2. Regenerating says out loud what got wider** — console warning *and* a block in `docs/a11y-audit.md`. A regenerate is how a fix gets recorded; the same write is how a new violation freezes itself in on a page nobody touched. This warning caught **this very change, twice**, while it was being written.

**3. The scan runs twice per page, light and dark**, keyed `#dark` so dark results gate independently rather than being averaged against the light ones. Dark mode is not cosmetic here: this codebase retints by **remapping utility classes** in `globals.css` rather than writing `dark:` per element, so scanning light only meant the gate had never looked at half the product.

**4. Violations accumulate across every context and are asserted once, at the end.** Learned the hard way — see below.

### What the gate found, in the order it produced it

Four real violations, none introduced by this PR; all invisible until the gate started running on PRs.

| Round | Violation | Fix |
|---|---|---|
| 1 | `/portal: target-size` — the request-gate links were a 16px tap target, under WCAG 2.2 AA 2.5.8's 24px floor | `inline-block py-1.5` → 28px measured (`640fb78`) |
| 2 | `/portal/profile: label` + `select-name` (critical) | `aria-label` on the `DocumentsManager` file and type controls (`bd2b100`) |
| 3 | `/mentor/mentees: label` (critical) | `ApplyLinkBox`'s read-only URL input had no accessible name (`c0e938b`) |
| 4 | `/company: color-contrast` (serious) | the empty-state line was gray-400 on white = 2.8:1 → gray-500 = 4.6:1 (`3f32741`) |

### Why that took four rounds, and why it will not again

Each CI run revealed exactly **one** violation. The cause was the spec itself: the gate asserted per page, `expect` throws, and `describe.configure({ mode: 'serial' })` skips the remaining contexts once one test fails. So a run could never see past the first bad page.

Regressions now accumulate across all contexts and a single final test asserts the whole list. Measured in the same run that found round 4: all five contexts scanned, and the single remaining violation in the whole product was reported at once.

### The dark-mode findings

Six serious contrast failures surfaced the moment dark mode was scanned. **Four are fixed.** Every one taught the same lesson, now written as comments rather than left as folklore:

> A `dark:` variant on the element is **silently inert** wherever `globals.css` has a flat override — and `html[data-accent]` (always present, defaulting to `"blue"`) outranks `html.dark` by source order, so even a correctly-placed `html.dark .text-blue-600` rule loses.

I got this wrong twice before measuring it. Both attempted fixes changed nothing — the computed colour stayed `rgb(37,99,235)` on a `rgb(3,7,18)` background (3.4:1, under the 4.5:1 AA floor). The working fix had to sit *after* the accent rule. That is why the comments say **measured, not assumed**.

| Fixed | Was |
|---|---|
| bare `text-blue-600` links ("become a mentor", "forgot password", "see all announcements") | 3.4:1 on gray-950 |
| `#mode-switch-label` ×2 | `dark:text-gray-500` was *darker* than its light value |
| portal "complete profile" CTA | white on `yellow-500` = 2.2:1 — **failed in light mode too**; the dark scan is just what finally looked |

**Two remain and are frozen deliberately**, both the ModeSwitcher active pill on `/admin` and `/admin/candidates`. Pre-existing and newly *visible*, not newly introduced, and named in the report rather than buried. Follow-up filed as #1343 with the three specificity traps documented.

### A limitation worth stating

The dark scan needed a **reload**, not just adding `.dark` to a loaded page. Adding the class post-render gives a half-dark document — light surfaces with dark-mode text on them — and axe faithfully reports contrast failures no real user would ever see. My first dark run did exactly that and produced fiction; the reload is commented for that reason.

---

# 2 · A customized pipeline was invisible on the desktop admin board (#828)

A real bug, found while surveying #828's coverage gaps rather than reported by anyone.

`src/app/admin/board/page.tsx` iterated the hardcoded `PIPELINE_GROUPS` constant on the desktop path, while the phone list read the viewer's **resolved** stages. An org with a customized pipeline (#747) therefore saw its stages on a phone and **three empty group shells and no columns at all** on a desktop. The mentor board already did this correctly; only `/admin/board` was wrong.

`groupResolvedStages()` now builds the groups from the resolved stages. Keys outside the built-in phases land in a trailing "custom" group in the tenant's own order (EN/TR/DE added), and empty groups drop out — so an org that merely renamed the defaults still sees the familiar three phases.

### Coverage the suite never had

Every one of these is a gap #828 names, and each was confirmed absent before writing it:

- **768px tablet tier.** Every viewport in the suite was a phone (320–390) or a desktop (1024+). 768 is exactly Tailwind's `md:` breakpoint — the first width at which `md:` rules apply, and the worst case for a layout that assumes `md:` means "roomy".
- **`/portal/profile` and `/mentor/profile` at phone width.** The audit covered dashboards and lists only. A form is where a label/field pair squeezes first.
- **Dark mode combined with a phone viewport.** Not independent variables: `globals.css` retints by remapping utility classes, and a rule that swaps a border for a ring moves boxes. The test asserts `html.dark` is actually on, so it cannot pass by measuring light mode twice.
- **Board tests seeding 3-stage and 13-stage custom pipelines** — the regression proof for the bug above, asserting both that every custom stage has a desktop column and that no built-in stage leaks in beside them.
- `min-h-11` on the mobile stage filter select.

---

# 3 · Equal-opportunity data: the position, recorded (#819)

The story's own acceptance criterion says no demographic field is added without an explicit product-owner approval comment on the issue. No such approval exists, so this ships the part that is shippable today: `docs/legal/equal-opportunity-data.md`, recording that demographic data is deliberately **not** collected, with the reasoning.

Written as a decision rather than a gap: special-category status under KVKK Art. 6 / GDPR Art. 9 leaves consent as the only workable basis and consent is withdrawable; suppressing k<5 cells does not close a differencing attack across breakdowns; and at the current programme size the statistical value is small while the risk is not. A table lists what must be settled before any field is added, if that changes.

The other half of the story — blind review in the interview panel — needs no demographic data and already shipped separately.

**No schema change.**

---

## Verification

- [x] `npm run lint` + `npx tsc --noEmit` clean
- [x] `npm run build` green
- [x] `npm run check:i18n` — 3187 keys × 3 locales
- [x] `npm run check:release-fragments` green
- [x] Baseline regenerated 8× during development; the widening warning fired correctly every time
- [x] The new CI step proved itself on this very PR — four real violations caught, all fixed

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeSYkGngKpYG4KWsJ7Ph2Z)_