### PR TITLE
Async loading, empty ve error durumlarını ortak bileşende birleştir

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -24,6 +24,13 @@ The first ten are **functional / correctness** tests: given an input, is the out
 right? The stress test is a **non-functional** test: the app may be correct yet too
 slow or fragile under load — this catches that.
 
+## Async UI states
+
+Use `AsyncSection` for new asynchronous lists and panels: loading, error and empty are distinct states.
+Loading must never render the empty state, and errors should offer a retry when the caller can reload.
+The component owns presentation only; fetching, state and retry behavior stay in the caller.
+Choose the smallest matching `list`, `card` or `stats` skeleton variant.
+
 ## Stress / load test
 
 `scripts/stress-test.mjs` is a dependency-free (native `fetch`) load generator. It

--- a/e2e/async-section.spec.ts
+++ b/e2e/async-section.spec.ts
@@ -1,0 +1,145 @@
+import { test, expect, type Route } from '@playwright/test';
+import { AsyncSection, type AsyncSectionSkeleton } from '../src/components/ui/AsyncSection';
+import { cleanupByEmail, seedUser, uniqueEmail } from './helpers/db';
+import { signInAndSettle } from './helpers/auth';
+
+interface TestNode { type?: unknown; props?: Record<string, unknown> }
+
+function resolveNode(node: unknown): unknown {
+  if (Array.isArray(node)) return node.map(resolveNode);
+  if (!node || typeof node !== 'object' || !('type' in node)) return node;
+  const marker = node as TestNode;
+  if (typeof marker.type === 'function') return resolveNode(marker.type(marker.props ?? {}));
+  if (marker.type && typeof marker.type === 'object' && 'render' in marker.type) {
+    const render = (marker.type as { render: (props: Record<string, unknown>, ref: null) => unknown }).render;
+    return resolveNode(render(marker.props ?? {}, null));
+  }
+  return {
+    ...marker,
+    props: { ...marker.props, children: resolveNode(marker.props?.children) },
+  };
+}
+
+function allNodes(node: unknown): TestNode[] {
+  if (Array.isArray(node)) return node.flatMap(allNodes);
+  if (!node || typeof node !== 'object') return [];
+  const marker = node as TestNode;
+  return [marker, ...allNodes(marker.props?.children)];
+}
+
+function textContent(node: unknown): string {
+  if (Array.isArray(node)) return node.map(textContent).join('');
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+  if (!node || typeof node !== 'object') return '';
+  return textContent((node as TestNode).props?.children);
+}
+
+const render = (props: Partial<Parameters<typeof AsyncSection>[0]> = {}) => resolveNode(AsyncSection({
+    loading: false,
+    error: null,
+    empty: false,
+    emptyText: 'genuinely empty',
+    children: 'loaded content',
+    ...props,
+  }));
+
+test('AsyncSection enforces state precedence, retries, and renders every skeleton variant', { tag: '@smoke' }, () => {
+  const loading = render({ loading: true, error: 'failed', empty: true });
+  expect(allNodes(loading).some((node) => node.props?.['data-testid'] === 'async-section-loading')).toBe(true);
+  expect(textContent(loading)).not.toContain('failed');
+  expect(textContent(loading)).not.toContain('genuinely empty');
+
+  const error = render({ error: 'failed', empty: true, retryText: 'Retry', onRetry: () => {} });
+  expect(allNodes(error).some((node) => node.props?.['data-testid'] === 'async-section-error')).toBe(true);
+  expect(textContent(error)).toContain('failed');
+  expect(textContent(error)).toContain('Retry');
+  expect(textContent(error)).not.toContain('genuinely empty');
+  expect(textContent(error)).not.toContain('loaded content');
+
+  const withoutRetry = render({ error: 'failed' });
+  expect(allNodes(withoutRetry).some((node) => node.type === 'button')).toBe(false);
+
+  const empty = render({ empty: true });
+  expect(allNodes(empty).some((node) => node.props?.['data-testid'] === 'async-section-empty')).toBe(true);
+  expect(textContent(empty)).toContain('genuinely empty');
+  expect(textContent(empty)).not.toContain('loaded content');
+  expect(textContent(render())).toContain('loaded content');
+
+  let retries = 0;
+  const errorNode = resolveNode(AsyncSection({
+    loading: false,
+    error: 'failed',
+    empty: false,
+    emptyText: 'empty',
+    retryText: 'Retry',
+    onRetry: () => { retries += 1; },
+    children: 'loaded content',
+  }));
+  const retryButton = allNodes(errorNode).find((node) => node.type === 'button');
+  (retryButton?.props?.onClick as (() => void))();
+  expect(retries).toBe(1);
+
+  for (const variant of ['list', 'card', 'stats'] satisfies AsyncSectionSkeleton[]) {
+    expect(allNodes(render({ loading: true, skeleton: variant })).some(
+      (node) => node.props?.['data-skeleton'] === variant
+    )).toBe(true);
+  }
+});
+
+test('portal interactions uses loading, error, retry and genuine empty states', async ({ page }) => {
+  const email = uniqueEmail('async-interactions');
+  await seedUser(email, 'AsyncPass123!', 'MENTEE', 'Async Mentee');
+  const pending: Route[] = [];
+
+  try {
+    await signInAndSettle(page, email, 'AsyncPass123!', '/portal');
+    await page.route('**/api/interactions', async (route) => { pending.push(route); });
+    await page.goto('/portal/interactions');
+
+    await expect.poll(() => pending.length).toBe(1);
+    await expect(page.getByTestId('async-section-loading')).toBeVisible();
+    await expect(page.getByText('No interactions logged yet')).toHaveCount(0);
+    await pending[0].fulfill({ status: 500, json: { error: 'Failed' } });
+    await expect(page.getByTestId('async-section-error')).toBeVisible();
+    await expect(page.getByText('No interactions logged yet')).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Try again' }).click();
+    await expect.poll(() => pending.length).toBe(2);
+    await expect(page.getByTestId('async-section-loading')).toBeVisible();
+    await pending[1].fulfill({ json: { interactions: [] } });
+    await expect(page.getByText('No interactions logged yet')).toBeVisible();
+  } finally {
+    await cleanupByEmail(email);
+  }
+});
+
+test('mentor analytics retries a failed load and renders the returned stats', async ({ page }) => {
+  const email = uniqueEmail('async-analytics');
+  await seedUser(email, 'AsyncPass123!', 'MENTOR', 'Async Mentor');
+  const pending: Route[] = [];
+
+  try {
+    await signInAndSettle(page, email, 'AsyncPass123!', '/mentor');
+    await page.route('**/api/mentor/analytics', async (route) => { pending.push(route); });
+    await page.goto('/mentor/analytics');
+
+    await expect.poll(() => pending.length).toBe(1);
+    await expect(page.getByTestId('async-section-loading')).toBeVisible();
+    await pending[0].fulfill({ status: 500, json: { error: 'Failed' } });
+    await expect(page.getByTestId('async-section-error')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Try again' }).click();
+    await expect.poll(() => pending.length).toBe(2);
+    await expect(page.getByTestId('async-section-loading')).toBeVisible();
+    await pending[1].fulfill({
+      json: {
+        funnel: {}, totalRelations: 3, activeRelations: 2, hired: 1,
+        conversionToHired: 33, interactions: 7, goals: { open: 1, done: 2, total: 3 }, avgDaysToHired: 12,
+      },
+    });
+    await expect(page.getByText('Total mentees')).toBeVisible();
+    await expect(page.getByText('3', { exact: true }).first()).toBeVisible();
+  } finally {
+    await cleanupByEmail(email);
+  }
+});

--- a/releases/unreleased/async-section.json
+++ b/releases/unreleased/async-section.json
@@ -1,0 +1,9 @@
+{
+  "bump": "patch",
+  "changelog": "- **Async UI states**: centralize loading, error, retry and empty presentation with shared skeleton variants.",
+  "notes": {
+    "en": ["Interaction history and mentor analytics now distinguish loading, errors and genuinely empty results, with a retry option when loading fails."],
+    "tr": ["Etkileşim geçmişi ve mentor analitiği artık yükleme, hata ve gerçek boş sonuçları ayrı gösteriyor; yükleme başarısız olursa yeniden deneme sunuyor."],
+    "de": ["Interaktionsverlauf und Mentor-Analysen unterscheiden jetzt zwischen Laden, Fehlern und tatsächlich leeren Ergebnissen und bieten bei Ladefehlern einen erneuten Versuch."]
+  }
+}

--- a/src/app/mentor/analytics/page.tsx
+++ b/src/app/mentor/analytics/page.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
 import { BarChart3, Users, BookOpen, Target, TrendingUp, Award } from 'lucide-react';
 import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
-import { SkeletonRows } from '@/components/ui/Skeleton';
+import { AsyncSection } from '@/components/ui/AsyncSection';
 import { useResolvedStages } from '@/lib/pipelineStagesClient';
 import { useT } from '@/i18n/client';
 
@@ -46,13 +46,24 @@ export default function MentorAnalyticsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    fetch('/api/mentor/analytics')
-      .then((r) => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json(); })
-      .then(setData)
-      .catch((e) => { console.error('[mentor/analytics]', e); setError(t.common.error); })
-      .finally(() => setLoading(false));
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch('/api/mentor/analytics');
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      setData(await response.json());
+    } catch (loadError) {
+      console.error('[mentor/analytics]', loadError);
+      setError(t.common.error);
+    } finally {
+      setLoading(false);
+    }
   }, [t.common.error]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
 
   const ma = t.mentorAnalytics;
 
@@ -65,15 +76,16 @@ export default function MentorAnalyticsPage() {
         <p className="text-gray-500 dark:text-gray-400 mt-1">{ma.subtitle}</p>
       </div>
 
-      {error && (
-        <div className="mb-6 p-4 bg-red-50 border border-red-200 rounded-xl text-red-700 dark:bg-red-950/30 dark:border-red-800 dark:text-red-300">
-          {error}
-        </div>
-      )}
-
-      {loading ? (
-        <Card><SkeletonRows rows={6} /></Card>
-      ) : data ? (
+      <AsyncSection
+        loading={loading}
+        error={error}
+        empty={!data}
+        emptyText={<p className="py-4 text-center text-sm text-gray-400 dark:text-gray-500">{ma.noData}</p>}
+        retryText={t.errorBoundary.retry}
+        onRetry={load}
+        skeleton="stats"
+      >
+        {data ? (
         <>
           {/* Summary stats */}
           <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-3 gap-4 mb-8">
@@ -177,7 +189,8 @@ export default function MentorAnalyticsPage() {
             <Link href="/mentor/mentees" className="text-blue-600 hover:underline">{ma.viewMentees}</Link>
           </div>
         </>
-      ) : null}
+        ) : null}
+      </AsyncSection>
     </div>
   );
 }

--- a/src/app/portal/interactions/page.tsx
+++ b/src/app/portal/interactions/page.tsx
@@ -5,7 +5,9 @@ import { Card } from '@/components/ui/Card';
 import { InteractionTypeBadge } from '@/components/InteractionTypeBadge';
 import { BookOpen } from 'lucide-react';
 import { useLocale } from '@/i18n/client';
+import { useT } from '@/i18n/client';
 import { formatDate } from '@/lib/relativeTime';
+import { AsyncSection } from '@/components/ui/AsyncSection';
 
 interface Interaction {
   id: string;
@@ -20,15 +22,25 @@ interface Interaction {
 
 export default function PortalInteractionsPage() {
   const locale = useLocale();
+  const t = useT();
   const [interactions, setInteractions] = useState<Interaction[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   const fetchInteractions = useCallback(async () => {
-    const res = await fetch('/api/interactions');
-    const data = await res.json();
-    setInteractions(data.interactions || []);
-    setLoading(false);
-  }, []);
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/interactions');
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      setInteractions(data.interactions || []);
+    } catch {
+      setError(t.common.error);
+    } finally {
+      setLoading(false);
+    }
+  }, [t.common.error]);
 
   useEffect(() => {
     fetchInteractions();
@@ -41,17 +53,21 @@ export default function PortalInteractionsPage() {
         <p className="text-gray-500 mt-1">Your interaction history with your mentor</p>
       </div>
 
-      {loading ? (
-        <div className="text-center py-12 text-gray-400">Loading...</div>
-      ) : interactions.length === 0 ? (
-        <Card className="text-center py-12">
+      <AsyncSection
+        loading={loading}
+        error={error}
+        empty={interactions.length === 0}
+        emptyText={<Card className="text-center py-12">
           <BookOpen className="h-12 w-12 text-gray-300 mx-auto mb-4" />
           <p className="text-gray-500">No interactions logged yet</p>
           <p className="text-sm text-gray-400 mt-1">
             Your mentor will log interactions here as your sessions happen.
           </p>
-        </Card>
-      ) : (
+        </Card>}
+        retryText={t.errorBoundary.retry}
+        onRetry={fetchInteractions}
+        skeleton="list"
+      >
         <div className="space-y-4">
           {interactions.map((interaction) => (
             <Card key={interaction.id}>
@@ -72,7 +88,7 @@ export default function PortalInteractionsPage() {
             </Card>
           ))}
         </div>
-      )}
+      </AsyncSection>
     </div>
   );
 }

--- a/src/components/ui/AsyncSection.tsx
+++ b/src/components/ui/AsyncSection.tsx
@@ -1,0 +1,79 @@
+import { type ReactNode } from 'react';
+import { Button } from './Button';
+import { Skeleton, SkeletonRows } from './Skeleton';
+
+export type AsyncSectionSkeleton = 'list' | 'card' | 'stats';
+
+interface AsyncSectionProps {
+  loading: boolean;
+  error: string | null;
+  empty: boolean;
+  emptyText: ReactNode;
+  retryText?: ReactNode;
+  onRetry?: () => void;
+  skeleton?: AsyncSectionSkeleton;
+  children: ReactNode;
+}
+
+function LoadingSkeleton({ variant }: { variant: AsyncSectionSkeleton }) {
+  if (variant === 'card') {
+    return (
+      <div className="grid gap-4 sm:grid-cols-2" aria-hidden="true" data-skeleton="card">
+        <Skeleton className="h-28 dark:bg-gray-800" />
+        <Skeleton className="h-28 dark:bg-gray-800" />
+      </div>
+    );
+  }
+  if (variant === 'stats') {
+    return (
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3" aria-hidden="true" data-skeleton="stats">
+        {Array.from({ length: 3 }).map((_, index) => (
+          <Skeleton key={index} className="h-24 dark:bg-gray-800" />
+        ))}
+      </div>
+    );
+  }
+  return <div data-skeleton="list"><SkeletonRows rows={4} /></div>;
+}
+
+// Presentation only: callers retain ownership of fetching, retries and state.
+// The order is the contract — loading must always win over error and empty.
+export function AsyncSection({
+  loading,
+  error,
+  empty,
+  emptyText,
+  retryText,
+  onRetry,
+  skeleton = 'list',
+  children,
+}: AsyncSectionProps) {
+  if (loading) {
+    return (
+      <div data-testid="async-section-loading">
+        <LoadingSkeleton variant={skeleton} />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div
+        role="alert"
+        data-testid="async-section-error"
+        className="flex flex-col items-center gap-3 rounded-xl border border-red-200 bg-red-50 p-6 text-center dark:border-red-800 dark:bg-red-950/30"
+      >
+        <p className="text-sm text-red-700 dark:text-red-300">{error}</p>
+        {onRetry && retryText ? (
+          <Button variant="outline" size="sm" onClick={onRetry}>{retryText}</Button>
+        ) : null}
+      </div>
+    );
+  }
+
+  if (empty) {
+    return <div data-testid="async-section-empty">{emptyText}</div>;
+  }
+
+  return <>{children}</>;
+}

--- a/src/components/ui/Skeleton.tsx
+++ b/src/components/ui/Skeleton.tsx
@@ -1,6 +1,6 @@
 // Lightweight loading placeholders to improve perceived performance.
 export function Skeleton({ className = '' }: { className?: string }) {
-  return <div className={`animate-pulse rounded bg-gray-100 ${className}`} />;
+  return <div className={`animate-pulse rounded bg-gray-100 dark:bg-gray-800 ${className}`} />;
 }
 
 // A vertical stack of row-shaped skeletons for list/table loading states.


### PR DESCRIPTION
## Özet

Bu PR, async içeriklerdeki loading / error / empty durumlarını ortak bir `AsyncSection` bileşeninde merkezileştirir.

Amaç, veri henüz yüklenmeden yanlış empty-state gösterilmesi gibi hataların yeni ekranlarda tekrar oluşmasını engellemektir.

## Yeni `AsyncSection`

Yeni shared component:

`src/components/ui/AsyncSection.tsx`

Desteklenen durumlar:

* `loading`
* `error`
* `empty`
* normal content

Öncelik sırası:

`loading > error > empty > children`

Bu sayede loading sırasında empty-state hiçbir zaman render edilmez.

## Skeleton varyantları

Mevcut skeleton primitive’i kullanılarak üç varyant destekleniyor:

* `list`
* `card`
* `stats`

Dark mode görünümü de iyileştirildi.

## Taşınan ekranlar

İki gerçek caller `AsyncSection` kullanımına geçirildi:

* `/portal/interactions`
* `/mentor/analytics`

Fetch ve state yönetimi caller’larda kalmaya devam ediyor. `AsyncSection` yalnızca presentation state’lerini yönetiyor.

## Retry ve hata durumu

Error durumunda localized hata mesajı gösteriliyor.

Retry butonu yalnızca hem `onRetry` hem de `retryText` sağlandığında render ediliyor.

Mevcut generic i18n anahtarları yeniden kullanıldı; yeni locale key eklenmesi gerekmedi.

## #930 / #931 uyumu

#930 kapsamında kullanılan loading/error pattern’i korundu ve regression testleri geçti.

#931 henüz `main` üzerinde olmadığı için `CalendarView` bu PR kapsamında değiştirilmedi.

## Dokümantasyon

`docs/testing.md` içine kısa bir async-state kullanım kuralı eklendi:

* loading ≠ empty ≠ error
* yeni async liste/panellerde `AsyncSection` kullanılmalı
* loading sırasında empty-state gösterilmemeli
* error durumunda retry sağlanmalı
* fetch/state ownership caller’da kalmalı

## Testler

* AsyncSection + migrated caller + regression testleri: **10 passed**
* Production-mode full `@smoke`: **88 passed**
* `npm run check:i18n`: **passed**
* `npm run check:release-fragments`: **passed**
* `npm run build`: **passed**
* `git diff --check`: **passed**

## Release

Yeni release fragment:

`releases/unreleased/async-section.json`

`bump: patch`

Manuel package version, CHANGELOG veya releaseNotes değişikliği yapılmadı.
