### PR TITLE
Aday geçmişi silme hatalarını kullanıcıya göster

### DIFF
--- a/e2e/admin-history-edit.spec.ts
+++ b/e2e/admin-history-edit.spec.ts
@@ -38,12 +38,33 @@ test('admin can add and delete stage-history entries', async ({ page }) => {
     expect(afterAdd[0].changedById).toBe(admin.id);
     expect(afterAdd[0].toStatus).toBe('HIRED_660');
 
+    await expect(page.getByRole('button', { name: 'Delete entry' })).toBeVisible();
+    let detailReloads = 0;
+    page.on('request', (request) => {
+      if (request.method() === 'GET' && new URL(request.url()).pathname === `/api/users/${mentee.id}`) {
+        detailReloads += 1;
+      }
+    });
+    await page.route(`**/api/status-changes/${afterAdd[0].id}`, async (route) => {
+      await route.fulfill({ status: 500, json: { error: 'Failed' } });
+    }, { times: 1 });
+
+    await page.getByRole('button', { name: 'Delete entry' }).click();
+    await expect(page.getByRole('status')).toContainText('Something went wrong');
+    expect(detailReloads).toBe(0);
+    expect(await prisma.statusChange.findMany({ where: { relationId: rel.id } })).toHaveLength(1);
+
     // Delete it again.
     const removed = page.waitForResponse(
       (r) => r.url().includes('/api/status-changes/') && r.request().method() === 'DELETE'
     );
+    const reloaded = page.waitForResponse(
+      (r) => new URL(r.url()).pathname === `/api/users/${mentee.id}` && r.request().method() === 'GET'
+    );
     await page.getByRole('button', { name: 'Delete entry' }).click();
     await removed;
+    await reloaded;
+    expect(detailReloads).toBe(1);
 
     const afterDelete = await prisma.statusChange.findMany({ where: { relationId: rel.id } });
     expect(afterDelete).toHaveLength(0);

--- a/releases/unreleased/candidate-history-delete-error.json
+++ b/releases/unreleased/candidate-history-delete-error.json
@@ -1,0 +1,9 @@
+{
+  "bump": "patch",
+  "changelog": "- **Candidate history deletion**: surface failed stage-history deletes and avoid reloading stale candidate data.",
+  "notes": {
+    "en": ["Candidate stage-history deletion errors are now shown instead of silently refreshing unchanged data."],
+    "tr": ["Aday aşama geçmişi silinemediğinde değişmemiş veriler sessizce yenilenmek yerine artık hata gösteriliyor."],
+    "de": ["Fehler beim Löschen des Kandidaten-Phasenverlaufs werden jetzt angezeigt, statt unveränderte Daten still neu zu laden."]
+  }
+}

--- a/src/app/admin/candidates/[id]/page.tsx
+++ b/src/app/admin/candidates/[id]/page.tsx
@@ -238,10 +238,18 @@ export default function AdminMenteeDetailPage() {
 
   const deleteHistory = useCallback(
     async (changeId: string) => {
-      await fetch(`/api/status-changes/${changeId}`, { method: 'DELETE' });
-      await load();
+      try {
+        const res = await fetch(`/api/status-changes/${changeId}`, { method: 'DELETE' });
+        if (!res.ok) {
+          toast(t.common.error, 'error');
+          return;
+        }
+        await load();
+      } catch {
+        toast(t.common.error, 'error');
+      }
     },
-    [load]
+    [load, toast, t.common.error]
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Özet

Bu PR, aday detay sayfasındaki geçmiş kaydı silme işleminde API hatalarının sessizce göz ardı edilmesini düzeltir.

Önceden `deleteHistory()` DELETE isteğinin sonucunu kontrol etmeden listeyi yeniden yüklüyordu. Bu nedenle 403, 404, 500 veya network hatalarında kullanıcı silme işleminin başarısız olduğunu fark etmiyordu.

## Yapılan değişiklik

DELETE isteği artık `try/catch` içinde çalışıyor ve response sonucu kontrol ediliyor.

Başarısız HTTP veya network isteğinde:

* localized error toast gösteriliyor
* liste yeniden yüklenmiyor
* mevcut kayıt ekranda korunuyor

Başarılı DELETE işleminde mevcut davranış korunuyor:

* `await load()` çalışıyor
* liste güncelleniyor

Mevcut `t.common.error` metni kullanıldığı için yeni i18n anahtarı eklenmedi.

## Testler

* Candidate history + admin status production testleri: **2 passed**
* İlgili pipeline `@smoke`: **1 passed**
* `npm run check:i18n`: **passed**
* `npm run check:release-fragments`: **passed**
* `npm run build`: **passed**
* `git diff --check`: **passed**

## Release

Yeni release fragment:

`releases/unreleased/candidate-history-delete-error.json`

`bump: patch`

Manuel package version, CHANGELOG veya releaseNotes değişikliği yapılmadı.
