### PR TITLE
test(board): target board columns by testid, not by their label text (#828)

### DIFF
--- a/e2e/board-mobile.spec.ts
+++ b/e2e/board-mobile.spec.ts
@@ -209,12 +209,19 @@ for (const stageCount of [3, 13]) {
       // Every custom stage has a column. This is the assertion the old code
       // failed: iterating PIPELINE_GROUPS, none of these keys matched, so the
       // board rendered three empty group shells and no columns at all.
-      const columns = page.getByTestId('board-columns');
-      for (const [i] of keys.entries()) {
-        await expect(columns.getByText(`bc${stageCount} Aşama ${i + 1}`, { exact: true })).toBeVisible();
+      //
+      // Target the column and its heading by testid, never by their text: the
+      // cards inside a column each carry a "Move to stage" <select> whose
+      // <option>s hold every stage label, so any text locator — even one scoped
+      // to the column — resolves to 2 and trips strict mode.
+      for (const [i, key] of keys.entries()) {
+        await expect(page.getByTestId(`board-column-${key}`)).toBeVisible();
+        await expect(page.getByTestId(`board-column-title-${key}`)).toHaveText(
+          `bc${stageCount} Aşama ${i + 1}`,
+        );
       }
       // …and no built-in stage leaks in alongside them.
-      await expect(columns.getByText('Application', { exact: true })).toHaveCount(0);
+      await expect(page.getByTestId('board-column-APPLICATION_100')).toHaveCount(0);
 
       // The phone list has always been right; assert it still is, so the fix
       // cannot be "make desktop match by breaking mobile".

--- a/src/app/admin/board/page.tsx
+++ b/src/app/admin/board/page.tsx
@@ -195,6 +195,10 @@ export default function AdminBoardPage() {
     return (
       <div
         key={status}
+        // Keyed by stage so a test can name one column. Without it the only
+        // handle is the header text, which also matches every card's "Move to
+        // stage" <option> and trips strict mode (#828).
+        data-testid={`board-column-${status}`}
         onDragOver={(e) => { e.preventDefault(); setDragOver(status); }}
         onDragLeave={() => setDragOver((s) => (s === status ? null : s))}
         onDrop={(e) => {
@@ -208,7 +212,7 @@ export default function AdminBoardPage() {
         }`}
       >
         <div className="flex items-center justify-between mb-3 px-1">
-          <span className="text-xs font-semibold text-gray-700">{label(status)}</span>
+          <span data-testid={`board-column-title-${status}`} className="text-xs font-semibold text-gray-700">{label(status)}</span>
           <span
             title={overLimit ? t.adminBoard.wipWarning : undefined}
             className={`text-xs rounded-full px-2 py-0.5 border ${


### PR DESCRIPTION
Follow-up to #1342. It auto-merged the moment the smoke job went green, and this commit was pushed a few minutes later — so the custom-pipeline board tests landed on `main` in their **failing** form.

They are not tagged `@smoke`, so no PR gate would ever have caught it. The first sign would have been the scheduled full suite going red at 03:00 UTC.

## The failure

Both `admin board shows a {3,13}-stage custom pipeline…` tests fail with a strict-mode violation:

```
Locator: getByTestId('board-column-BC13_STAGE_1').getByText('bc13 Aşama 1', { exact: true })
Error: strict mode violation: … resolved to 2 elements:
    1) <span class="text-xs font-semibold text-gray-700">bc13 Aşama 1</span>
    2) <option value="BC13_STAGE_1">bc13 Aşama 1</option>  aka getByLabel('Move to stage')
```

Every card in a column carries a "Move to stage" `<select>` holding **every** stage label as an `<option>`. Scoping the text locator to the column does not help — the cards live inside the column, which is why the first attempt at this fix failed the same way.

## The fix

Columns and their headings now carry testids (`board-column-<key>` / `board-column-title-<key>`) and the test names those instead of matching on text. Two attributes in `src/app/admin/board/page.tsx`, both commented with the reason.

This is the pitfall CLAUDE.md already warns about under *E2E locator pitfalls* — a page-level text match colliding with a control that repeats the same strings. Worth noting there that the board is another instance.

## Verification

Run against a local MySQL, on top of the merged `main`:

- [x] `admin board shows a 3-stage custom pipeline on desktop and on a phone` — **passes**
- [x] `admin board shows a 13-stage custom pipeline on desktop and on a phone` — **passes**
- [x] Still red when `groups` is temporarily reverted to `PIPELINE_GROUPS.map(...)` — so they remain regression proof for the bug #1342 fixed, not two tests that happen to pass
- [x] `npx tsc --noEmit` clean

The three layout specs from #1342 (768px tablet tier, profile pages at phone width, dark mode at phone width) were verified in the same local run and pass as merged — no change needed to those.

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeSYkGngKpYG4KWsJ7Ph2Z)_