### PR TITLE
fix(availability): gate reading another mentor's hours by tenant (#1358)

### DIFF
--- a/e2e/availability-scope.spec.ts
+++ b/e2e/availability-scope.spec.ts
@@ -1,0 +1,133 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { signInAndSettle } from './helpers/auth';
+
+/**
+ * `/api/availability?mentorId=` used to hand ANY signed-in account ANY mentor's
+ * weekly hours, across organizations (#1350).
+ *
+ * `AvailabilitySlot` carries no `orgId` and is not one of orgContext's
+ * TENANT_MODELS, so the central isolation middleware never saw the query — the
+ * row is only reachable as a tenant row through `mentorId → User`, and nothing
+ * made that hop. These tests are that hop, asserted from the outside.
+ *
+ * Everything goes through `page.request`, which carries the signed-in session
+ * cookie, because the leak is in the endpoint rather than in any screen: no UI
+ * has ever passed `?mentorId=`, which is exactly why nothing caught this.
+ */
+
+const PASSWORD = 'AvailScope123!';
+
+async function seedOrgWithMentor(prefix: string) {
+  const org = await prisma.organization.create({
+    data: { slug: `${prefix}-${Date.now()}-${Math.round(performance.now())}`, name: `${prefix} Org` },
+  });
+  const mentorEmail = uniqueEmail(`${prefix}-mentor`);
+  const mentor = await seedUser(mentorEmail, PASSWORD, 'MENTOR', `${prefix} Mentor`);
+  await prisma.user.update({ where: { id: mentor.id }, data: { orgId: org.id } });
+  await prisma.availabilitySlot.create({
+    data: { mentorId: mentor.id, weekday: 2, startTime: '10:00', endTime: '11:00' },
+  });
+  return { org, mentor, mentorEmail };
+}
+
+test.describe.configure({ mode: 'serial' });
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('a mentee in another organization cannot read a mentor’s hours', async ({ page }) => {
+  const a = await seedOrgWithMentor('scope-a');
+  const b = await seedOrgWithMentor('scope-b');
+  const intruderEmail = uniqueEmail('scope-b-mentee');
+  const intruder = await seedUser(intruderEmail, PASSWORD, 'MENTEE', 'Scope B Mentee');
+  await prisma.user.update({ where: { id: intruder.id }, data: { orgId: b.org.id } });
+
+  try {
+    await signInAndSettle(page, intruderEmail, PASSWORD, '/portal');
+
+    // The cross-tenant read: org B's mentee asking for org A's mentor.
+    const res = await page.request.get(`/api/availability?mentorId=${a.mentor.id}`);
+    // 404 rather than 403 on purpose — a 403 would confirm the id exists.
+    expect(res.status()).toBe(404);
+
+    // Its own org's mentor is refused too, because no relation and no directory
+    // consent: being in the same tenant is necessary, not sufficient.
+    const sameOrg = await page.request.get(`/api/availability?mentorId=${b.mentor.id}`);
+    expect(sameOrg.status()).toBe(404);
+
+    // And its own (empty) hours still come back, so the gate did not break the
+    // ordinary path.
+    const own = await page.request.get('/api/availability');
+    expect(own.status()).toBe(200);
+    expect((await own.json()).slots).toEqual([]);
+  } finally {
+    await cleanupByEmail(intruderEmail);
+    for (const seeded of [a, b]) {
+      await cleanupByEmail(seeded.mentorEmail);
+      await prisma.organization.delete({ where: { id: seeded.org.id } }).catch(() => {});
+    }
+  }
+});
+
+test('the mentee actually paired with the mentor does get the hours', async ({ page }) => {
+  const a = await seedOrgWithMentor('scope-paired');
+  const menteeEmail = uniqueEmail('scope-paired-mentee');
+  const mentee = await seedUser(menteeEmail, PASSWORD, 'MENTEE', 'Scope Paired Mentee');
+  await prisma.user.update({ where: { id: mentee.id }, data: { orgId: a.org.id } });
+  const relation = await prisma.mentorshipRelation.create({
+    data: { mentorId: a.mentor.id, menteeId: mentee.id, orgId: a.org.id, status: 'ACTIVE' },
+  });
+
+  try {
+    await signInAndSettle(page, menteeEmail, PASSWORD, '/portal');
+    const res = await page.request.get(`/api/availability?mentorId=${a.mentor.id}`);
+    expect(res.status()).toBe(200);
+    const { slots } = await res.json();
+    expect(slots).toHaveLength(1);
+    expect(slots[0]).toMatchObject({ weekday: 2, startTime: '10:00', endTime: '11:00' });
+
+    // Ending the relation ends the access — the gate reads live state, it does
+    // not remember that these two were once paired.
+    await prisma.mentorshipRelation.update({ where: { id: relation.id }, data: { status: 'COMPLETED' } });
+    const after = await page.request.get(`/api/availability?mentorId=${a.mentor.id}`);
+    expect(after.status()).toBe(404);
+  } finally {
+    await prisma.mentorshipRelation.deleteMany({ where: { id: relation.id } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(a.mentorEmail);
+    await prisma.organization.delete({ where: { id: a.org.id } }).catch(() => {});
+  }
+});
+
+test('an admin cannot delete a slot belonging to another organization', async ({ page }) => {
+  const a = await seedOrgWithMentor('scope-del-a');
+  const b = await seedOrgWithMentor('scope-del-b');
+  const adminEmail = uniqueEmail('scope-del-admin');
+  const admin = await seedUser(adminEmail, PASSWORD, 'ADMIN', 'Scope Del Admin');
+  await prisma.user.update({ where: { id: admin.id }, data: { orgId: b.org.id } });
+  const victim = await prisma.availabilitySlot.findFirstOrThrow({ where: { mentorId: a.mentor.id } });
+
+  try {
+    await signInAndSettle(page, adminEmail, PASSWORD, '/admin');
+
+    const res = await page.request.delete(`/api/availability?id=${victim.id}`);
+    expect(res.status()).toBe(403);
+    // Refused, and the row is still there — a 403 that deleted anyway would be
+    // the worse bug.
+    expect(await prisma.availabilitySlot.count({ where: { id: victim.id } })).toBe(1);
+
+    // The same admin may still delete inside its own organization.
+    const own = await prisma.availabilitySlot.findFirstOrThrow({ where: { mentorId: b.mentor.id } });
+    const ok = await page.request.delete(`/api/availability?id=${own.id}`);
+    expect(ok.status()).toBe(200);
+    expect(await prisma.availabilitySlot.count({ where: { id: own.id } })).toBe(0);
+  } finally {
+    await cleanupByEmail(adminEmail);
+    for (const seeded of [a, b]) {
+      await cleanupByEmail(seeded.mentorEmail);
+      await prisma.organization.delete({ where: { id: seeded.org.id } }).catch(() => {});
+    }
+  }
+});

--- a/releases/unreleased/availability-tenant-scope.json
+++ b/releases/unreleased/availability-tenant-scope.json
@@ -1,0 +1,4 @@
+{
+  "bump": "patch",
+  "changelog": "**Fixed** — `GET /api/availability?mentorId=` returned any mentor's weekly hours to any signed-in account, across organizations: `AvailabilitySlot` carries no `orgId` and is not a tenant-anchored model, so the central isolation middleware never saw the query. Reading another mentor's hours now requires being an admin in the same organization, a mentee with an active relation to that mentor, or the mentor having opted into the directory. The admin delete escape hatch is scoped to the admin's own organization for the same reason."
+}

--- a/src/app/api/availability/route.ts
+++ b/src/app/api/availability/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { withTenantScope } from '@/lib/orgContext';
+import { resolveOrgId } from '@/lib/orgScope';
 import { z } from 'zod';
 
 const TIME = /^([01]\d|2[0-3]):[0-5]\d$/;
@@ -13,12 +15,83 @@ const TIME = /^([01]\d|2[0-3]):[0-5]\d$/;
 // reach the mentor shell through the view switch to work their own mentees), so
 // a GET that only defaulted for MENTORs left the page permanently empty — every
 // added slot vanished and the Add button looked dead.
+//
+// ?mentorId= used to return ANY mentor's hours to ANY signed-in account, across
+// organizations (#1350). AvailabilitySlot carries no orgId and is not one of
+// orgContext's TENANT_MODELS, so the central isolation middleware never saw
+// this query — the row is reached through `mentorId → User`, and nothing made
+// that hop. The gate below is that hop, made explicit.
+//
+// Who may read another mentor's hours is deliberately the same set that may see
+// the mentor at all, so availability can never expose someone the directory
+// would not: an ADMIN in the org, a mentee with an ACTIVE relation to them, or a
+// mentor who opted into the directory (publicProfile + an active
+// MENTOR_DIRECTORY_VISIBILITY consent — the double opt-in from #937/#938).
 export async function GET(request: Request) {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  const mentorId = new URL(request.url).searchParams.get('mentorId') || session.user.id;
-  const slots = await prisma.availabilitySlot.findMany({ where: { mentorId }, orderBy: [{ weekday: 'asc' }, { startTime: 'asc' }] });
-  return NextResponse.json({ slots });
+
+  const requested = new URL(request.url).searchParams.get('mentorId');
+  // Own hours: unchanged, and deliberately not tenant-gated — your own row is
+  // yours whatever org resolution says.
+  if (!requested || requested === session.user.id) {
+    const slots = await prisma.availabilitySlot.findMany({
+      where: { mentorId: session.user.id },
+      orderBy: [{ weekday: 'asc' }, { startTime: 'asc' }],
+    });
+    return NextResponse.json({ slots });
+  }
+
+  // Same fail-closed role gate as the mentor directory (#831): COMPANY and
+  // SOURCE have their own separately-consented surfaces and no business reading
+  // a mentor's calendar.
+  if (!['MENTEE', 'MENTOR', 'ADMIN'].includes(session.user.role)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  return await withTenantScope(session, async () => {
+    const orgId = resolveOrgId(session);
+    const mentor = await prisma.user.findFirst({
+      where: { id: requested, role: 'MENTOR', isActive: true, orgId },
+      select: { id: true, publicProfile: true },
+    });
+    // 404 rather than 403 on purpose: a 403 would confirm that this id exists
+    // to a caller in another organization.
+    if (!mentor) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    let visible = session.user.role === 'ADMIN';
+    // A mentee may read the hours of the mentor they are actually paired with.
+    // Deliberately MENTEE-only: there is no co-mentoring feature, so a mentor
+    // has no errand in a peer's calendar — and a relation filter without
+    // `menteeId` would match "this mentor has some mentee", which is true for
+    // nearly everyone and would be a gate that gates nothing.
+    if (!visible && session.user.role === 'MENTEE') {
+      const related = await prisma.mentorshipRelation.findFirst({
+        where: { status: 'ACTIVE', mentorId: mentor.id, menteeId: session.user.id },
+        select: { id: true },
+      });
+      visible = !!related;
+    }
+    if (!visible && mentor.publicProfile) {
+      const consent = await prisma.userConsent.findFirst({
+        where: {
+          userId: mentor.id,
+          type: 'MENTOR_DIRECTORY_VISIBILITY',
+          grantedAt: { not: null },
+          revokedAt: null,
+        },
+        select: { id: true },
+      });
+      visible = !!consent;
+    }
+    if (!visible) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    const slots = await prisma.availabilitySlot.findMany({
+      where: { mentorId: mentor.id },
+      orderBy: [{ weekday: 'asc' }, { startTime: 'asc' }],
+    });
+    return NextResponse.json({ slots });
+  });
 }
 
 const schema = z.object({
@@ -43,14 +116,28 @@ export async function POST(request: Request) {
 }
 
 // DELETE ?id= — remove one of the current mentor's slots.
+//
+// The admin escape hatch is scoped to the admin's OWN organization (#1350): the
+// previous `role !== 'ADMIN'` test was global, so an admin who knew a cuid could
+// delete a slot belonging to a mentor in a different tenant. Same missing
+// `mentorId → User` hop as the GET above.
 export async function DELETE(request: Request) {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   const id = new URL(request.url).searchParams.get('id') || '';
   const slot = await prisma.availabilitySlot.findUnique({ where: { id } });
   if (!slot) return NextResponse.json({ error: 'Not found' }, { status: 404 });
-  if (slot.mentorId !== session.user.id && session.user.role !== 'ADMIN') {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  if (slot.mentorId !== session.user.id) {
+    if (session.user.role !== 'ADMIN') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+    const sameOrg = await withTenantScope(session, () =>
+      prisma.user.findFirst({
+        where: { id: slot.mentorId, orgId: resolveOrgId(session) },
+        select: { id: true },
+      })
+    );
+    if (!sameOrg) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
   await prisma.availabilitySlot.delete({ where: { id } });
   return NextResponse.json({ ok: true });


### PR DESCRIPTION
Closes #1358 · Part of #1350 · Epic #1348

The security slice of story #1350. The feature half (#1361 — a mentee actually requesting one of these slots) and the validation half (#1363 — timezone, overlapping slots) follow in their own PRs, because a leak fix should not wait on a feature.

## The leak

`GET /api/availability?mentorId=` returned **any mentor's weekly hours to any signed-in account, in any organization**.

The reason it survived is worth writing down, because it is a shape that will recur:

> `AvailabilitySlot` carries no `orgId` and is not one of `orgContext`'s `TENANT_MODELS`. The central isolation middleware auto-scopes queries on tenant-anchored models, and child records are meant to be reached "through scoped parents" — but this row is only reachable as a tenant row through `mentorId → User`, and **nothing made that hop**. The middleware never saw the query at all.

So the model was neither anchored nor reached through an anchor. It fell between the two mechanisms rather than past either one.

**No caller has ever passed `?mentorId=`.** `grep` finds the parameter used by no screen — `/mentor/availability`, `MentorOnboardingForm` and the onboarding checklist all read their own. That is why nothing caught it, and also why closing it breaks nothing.

## The gate

Who may read another mentor's hours is now exactly the set that may see the mentor at all, so availability can never expose someone the directory would not:

| Caller | Allowed |
|---|---|
| Anyone, their own hours | yes — unchanged, not tenant-gated (your row is yours) |
| ADMIN, same organization | yes |
| MENTEE with an **ACTIVE** relation to that mentor | yes |
| Anyone, mentor opted into the directory | yes — `publicProfile` + active `MENTOR_DIRECTORY_VISIBILITY` consent (#937/#938) |
| COMPANY / SOURCE | **403**, the same fail-closed role gate as the directory (#831) |
| Everything else | **404** |

Two decisions worth calling out:

**404, not 403, on refusal.** A 403 tells a caller in another tenant that the id exists. The refusal has to be indistinguishable from "no such mentor".

**The relation branch is MENTEE-only.** My first draft filtered `{ status: 'ACTIVE', mentorId }` with the `menteeId` added only for mentees — which for a mentor caller means "this mentor has *some* active mentee". That is true for nearly everyone: a gate that gates nothing. There is no co-mentoring feature, so a mentor has no errand in a peer's calendar; they get the directory rule like anyone else.

## `DELETE` had the same missing hop

Its admin escape hatch tested `session.user.role !== 'ADMIN'` **globally**, so an admin who knew a slot's cuid could delete a slot belonging to a mentor in a different tenant. Now scoped to the admin's own organization.

## Verification

Run against a local MySQL — and **both directions**, so these are leak proof rather than three tests that happen to pass:

- [x] `a mentee in another organization cannot read a mentor's hours` — 404 cross-tenant; also 404 for a same-org mentor with no relation and no consent (same tenant is necessary, not sufficient); own hours still 200
- [x] `the mentee actually paired with the mentor does get the hours` — 200 with the slot, and **404 again once the relation is set to COMPLETED**: the gate reads live state, it does not remember that these two were once paired
- [x] `an admin cannot delete a slot belonging to another organization` — 403 **and the row is still present** (a 403 that deleted anyway would be the worse bug); the same admin can still delete inside its own org
- [x] All three **fail on the old handler** (verified by reverting the route and re-running)
- [x] `npx tsc --noEmit` and `npm run lint` clean
- [x] `npm run check:release-fragments` green

## Note on the story text

#1349 and #1350 point at their sub-tasks by placeholder — `#TASK_A1`, `#TASK_B1` — which were never substituted for the real numbers (#1354/#1355/#1356 and #1358/#1361/#1363). Worth fixing in the story bodies so the tree is navigable; the detail in the bodies was enough to work from, so it did not block anything.

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeSYkGngKpYG4KWsJ7Ph2Z)_