### PR TITLE
feat(availability): name the time zone, refuse overlapping slots (#1363)

### DIFF
--- a/e2e/availability-scope.spec.ts
+++ b/e2e/availability-scope.spec.ts
@@ -131,3 +131,78 @@ test('an admin cannot delete a slot belonging to another organization', async ({
     }
   }
 });
+
+/**
+ * #1363 — a slot carries no zone of its own and is read in the mentor's
+ * `User.timezone`; overlapping intervals on the same weekday are refused.
+ */
+test('the screen names the time zone the hours are read in', async ({ page }) => {
+  const mentorEmail = uniqueEmail('avail-zone-mentor');
+  const mentor = await seedUser(mentorEmail, PASSWORD, 'MENTOR', 'Avail Zone Mentor');
+
+  try {
+    await signInAndSettle(page, mentorEmail, PASSWORD, '/mentor');
+
+    // A chosen zone is stated plainly, with no prompt.
+    await prisma.user.update({ where: { id: mentor.id }, data: { timezone: 'Europe/Berlin' } });
+    await page.goto('/mentor/availability');
+    const banner = page.getByTestId('availability-zone');
+    await expect(banner).toBeVisible();
+    await expect(banner).toContainText('Europe/Berlin');
+    await expect(banner.getByRole('link')).toHaveCount(0);
+
+    // With none saved, the copy must NOT present the fallback as the mentor's
+    // own, and must offer the way to set one.
+    //
+    // Clearing it after sign-in is deliberate: TimezoneSync (#1030) posts the
+    // browser zone on the first authenticated load, so a freshly seeded mentor
+    // already has one by the time any page renders. It only posts once per
+    // browser session, so the reload below leaves the column null.
+    await prisma.user.update({ where: { id: mentor.id }, data: { timezone: null } });
+    await page.reload();
+    await expect(banner.getByRole('link')).toBeVisible();
+    // The fallback zone is deployment configuration (APP_TIMEZONE), so assert
+    // that the banner agrees with what the endpoint resolved rather than
+    // hard-coding a zone this runner may not use.
+    const { timezone, timezoneSet } = await (await page.request.get('/api/availability')).json();
+    expect(timezoneSet).toBe(false);
+    await expect(banner).toContainText(timezone);
+  } finally {
+    await cleanupByEmail(mentorEmail);
+  }
+});
+
+test('an overlapping slot is refused and no row is created', async ({ page }) => {
+  const mentorEmail = uniqueEmail('avail-overlap-mentor');
+  const mentor = await seedUser(mentorEmail, PASSWORD, 'MENTOR', 'Avail Overlap Mentor');
+
+  try {
+    await signInAndSettle(page, mentorEmail, PASSWORD, '/mentor');
+    const post = (data: Record<string, unknown>) => page.request.post('/api/availability', { data });
+
+    expect((await post({ weekday: 1, startTime: '09:00', endTime: '11:00' })).status()).toBe(201);
+
+    // Straddling, contained, identical — all overlaps.
+    for (const range of [
+      { startTime: '10:00', endTime: '12:00' },
+      { startTime: '09:30', endTime: '10:30' },
+      { startTime: '09:00', endTime: '11:00' },
+      { startTime: '08:00', endTime: '13:00' },
+    ]) {
+      const res = await post({ weekday: 1, ...range });
+      expect(res.status(), `${range.startTime}-${range.endTime} should clash`).toBe(409);
+      expect((await res.json()).code).toBe('overlap');
+    }
+
+    // Back-to-back is not an overlap — the comparison is half-open, which is how
+    // a person reads 09:00–10:00 followed by 10:00–11:00.
+    expect((await post({ weekday: 1, startTime: '11:00', endTime: '12:00' })).status()).toBe(201);
+    // Same clock, different day, is fine.
+    expect((await post({ weekday: 2, startTime: '09:00', endTime: '11:00' })).status()).toBe(201);
+
+    // Exactly the three that were accepted, so no refusal wrote a row anyway.
+    expect(await prisma.availabilitySlot.count({ where: { mentorId: mentor.id } })).toBe(3);
+  } finally {
+    await cleanupByEmail(mentorEmail);
+  }
+});

--- a/releases/unreleased/availability-timezone-overlap.json
+++ b/releases/unreleased/availability-timezone-overlap.json
@@ -1,0 +1,9 @@
+{
+  "bump": "minor",
+  "changelog": "**Added** — the availability screen now states which time zone the weekly hours are read in (the mentor's profile zone), prompts for one when none is saved, and groups slots by day. **Fixed** — an interval overlapping one already on that weekday, exact repeats included, is refused with 409 and the message names the interval it collided with; previously the same hours could be added twice.",
+  "notes": {
+    "en": ["Your availability now says which time zone the hours are in, and refuses a slot that overlaps one you already have."],
+    "tr": ["Müsaitlik ekranın artık saatlerin hangi zaman dilimine ait olduğunu yazıyor ve mevcut bir slotla çakışan aralığı kabul etmiyor."],
+    "de": ["Deine Verfügbarkeit nennt jetzt die Zeitzone der Stunden und lehnt einen Slot ab, der sich mit einem bestehenden überschneidet."]
+  }
+}

--- a/src/app/api/availability/route.ts
+++ b/src/app/api/availability/route.ts
@@ -4,9 +4,32 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { withTenantScope } from '@/lib/orgContext';
 import { resolveOrgId } from '@/lib/orgScope';
+import { resolveTimeZone } from '@/lib/timezone';
 import { z } from 'zod';
 
 const TIME = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+// A slot stores a wall-clock time with no zone of its own (#1363). It is read in
+// the MENTOR'S `User.timezone`, and every response says which zone that is, so
+// no reader has to guess — the screen prints it and #1361's date expansion will
+// resolve against it.
+//
+// Decision (recorded on #1363): interpret in `User.timezone` rather than adding
+// a `timezone` column to AvailabilitySlot.
+//   - DST is handled identically either way. Both store a wall clock plus a zone
+//     NAME, so "Monday 09:00" stays 09:00 across a transition, which is what a
+//     person means by a weekly slot. A per-slot fixed offset would be the only
+//     wrong option, and neither design uses one.
+//   - The scenario a per-slot column would buy — hours entered while travelling
+//     — is one this product does not have, and it makes the common case worse:
+//     a mentor who actually relocates wants ALL their hours to move, which one
+//     profile field does in a single edit and a per-row column turns into
+//     editing every row.
+// `set` is false when the mentor never chose one, so the screen can prompt
+// instead of silently applying the fallback zone.
+function zoneOf(timezone: string | null | undefined) {
+  return { timezone: resolveTimeZone(timezone), timezoneSet: !!timezone };
+}
 
 // GET — availability slots. Without a parameter you get your own; ?mentorId=
 // returns a mentor's slots (for booking).
@@ -35,11 +58,14 @@ export async function GET(request: Request) {
   // Own hours: unchanged, and deliberately not tenant-gated — your own row is
   // yours whatever org resolution says.
   if (!requested || requested === session.user.id) {
-    const slots = await prisma.availabilitySlot.findMany({
-      where: { mentorId: session.user.id },
-      orderBy: [{ weekday: 'asc' }, { startTime: 'asc' }],
-    });
-    return NextResponse.json({ slots });
+    const [me, slots] = await Promise.all([
+      prisma.user.findUnique({ where: { id: session.user.id }, select: { timezone: true } }),
+      prisma.availabilitySlot.findMany({
+        where: { mentorId: session.user.id },
+        orderBy: [{ weekday: 'asc' }, { startTime: 'asc' }],
+      }),
+    ]);
+    return NextResponse.json({ slots, ...zoneOf(me?.timezone) });
   }
 
   // Same fail-closed role gate as the mentor directory (#831): COMPANY and
@@ -53,7 +79,7 @@ export async function GET(request: Request) {
     const orgId = resolveOrgId(session);
     const mentor = await prisma.user.findFirst({
       where: { id: requested, role: 'MENTOR', isActive: true, orgId },
-      select: { id: true, publicProfile: true },
+      select: { id: true, publicProfile: true, timezone: true },
     });
     // 404 rather than 403 on purpose: a 403 would confirm that this id exists
     // to a caller in another organization.
@@ -90,7 +116,7 @@ export async function GET(request: Request) {
       where: { mentorId: mentor.id },
       orderBy: [{ weekday: 'asc' }, { startTime: 'asc' }],
     });
-    return NextResponse.json({ slots });
+    return NextResponse.json({ slots, ...zoneOf(mentor.timezone) });
   });
 }
 
@@ -111,6 +137,29 @@ export async function POST(request: Request) {
   if (parsed.data.endTime <= parsed.data.startTime) {
     return NextResponse.json({ error: 'End time must be after start time' }, { status: 400 });
   }
+  // Reject an interval that overlaps one already on that weekday, exact repeats
+  // included (#1363). Two intervals overlap iff each starts before the other
+  // ends — the half-open comparison, so 09:00–10:00 and 10:00–11:00 are
+  // back-to-back rather than overlapping, which is how a person reads them.
+  // Times are zero-padded "HH:MM", so string order is chronological order and
+  // the DB can do the comparison.
+  const { weekday, startTime, endTime } = parsed.data;
+  const clash = await prisma.availabilitySlot.findFirst({
+    where: {
+      mentorId: session.user.id,
+      weekday,
+      startTime: { lt: endTime },
+      endTime: { gt: startTime },
+    },
+    select: { startTime: true, endTime: true },
+  });
+  if (clash) {
+    return NextResponse.json(
+      { error: 'Overlaps an existing slot', code: 'overlap', clash },
+      { status: 409 }
+    );
+  }
+
   const slot = await prisma.availabilitySlot.create({ data: { mentorId: session.user.id, ...parsed.data } });
   return NextResponse.json({ slot }, { status: 201 });
 }

--- a/src/app/mentor/availability/page.tsx
+++ b/src/app/mentor/availability/page.tsx
@@ -5,7 +5,8 @@ import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { Select } from '@/components/ui/Select';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
-import { Trash2 } from 'lucide-react';
+import Link from 'next/link';
+import { Trash2, Globe } from 'lucide-react';
 import { useT } from '@/i18n/client';
 
 interface Slot { id: string; weekday: number; startTime: string; endTime: string }
@@ -21,10 +22,20 @@ export default function AvailabilityPage() {
   const [error, setError] = useState('');
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const [deleting, setDeleting] = useState(false);
+  // A slot has no zone of its own: it is read in the mentor's profile time zone
+  // (#1363). The endpoint says which, and whether it was actually chosen or
+  // fell back — the two get different copy, because "your hours are Istanbul"
+  // is reassuring when you picked it and misleading when you did not.
+  const [zone, setZone] = useState('');
+  const [zoneSet, setZoneSet] = useState(true);
 
   const load = useCallback(async () => {
     const res = await fetch('/api/availability');
-    if (res.ok) setSlots((await res.json()).slots ?? []);
+    if (!res.ok) return;
+    const d = await res.json();
+    setSlots(d.slots ?? []);
+    setZone(d.timezone ?? '');
+    setZoneSet(d.timezoneSet !== false);
   }, []);
   useEffect(() => { load(); }, [load]);
 
@@ -37,7 +48,16 @@ export default function AvailabilityPage() {
         body: JSON.stringify({ weekday: Number(weekday), startTime, endTime }),
       });
       const d = await res.json();
-      if (!res.ok) throw new Error(d.error || 'Failed');
+      if (!res.ok) {
+        // 409 carries the interval it collided with, so the message can name it
+        // rather than saying "that didn't work" (#1363).
+        if (d.code === 'overlap' && d.clash) {
+          throw new Error(
+            t.availability.overlap.replace('{from}', d.clash.startTime).replace('{to}', d.clash.endTime)
+          );
+        }
+        throw new Error(d.error || 'Failed');
+      }
       await load();
     } catch (e2) {
       setError(e2 instanceof Error ? e2.message : 'Failed');
@@ -47,6 +67,12 @@ export default function AvailabilityPage() {
   };
 
   const remove = (id: string) => setDeleteId(id);
+
+  // [weekdayIndex, slots][] in weekday order, preserving the API's time order
+  // inside each day.
+  const byDay = Array.from(
+    slots.reduce((m, s) => m.set(s.weekday, [...(m.get(s.weekday) ?? []), s]), new Map<number, Slot[]>())
+  ).sort((a, b) => a[0] - b[0]);
 
   const confirmRemove = async () => {
     if (!deleteId || deleting) return;
@@ -67,6 +93,30 @@ export default function AvailabilityPage() {
         <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.availability.title}</h1>
         <p className="text-gray-500 mt-1">{t.availability.subtitle}</p>
       </div>
+
+      {zone && (
+        <div
+          data-testid="availability-zone"
+          className={`mb-6 flex items-start gap-2 rounded-lg border px-3 py-2.5 text-sm ${
+            zoneSet
+              ? 'border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300'
+              : 'border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/10 text-amber-800 dark:text-amber-300'
+          }`}
+        >
+          <Globe className="h-4 w-4 shrink-0 mt-0.5" aria-hidden />
+          <p>
+            {(zoneSet ? t.availability.inZone : t.availability.zoneUnset).replace('{zone}', zone)}
+            {!zoneSet && (
+              <>
+                {' '}
+                <Link href="/mentor/profile" className="underline font-medium">
+                  {t.availability.zoneSetCta}
+                </Link>
+              </>
+            )}
+          </p>
+        </div>
+      )}
 
       <Card className="mb-6 max-w-xl">
         <CardHeader><CardTitle>{t.availability.addSlot}</CardTitle></CardHeader>
@@ -93,11 +143,23 @@ export default function AvailabilityPage() {
         {slots.length === 0 ? (
           <p className="text-center py-8 text-gray-400">{t.availability.none}</p>
         ) : (
-          <div className="divide-y divide-gray-50">
-            {slots.map((s) => (
-              <div key={s.id} className="flex items-center justify-between py-2.5 text-sm">
-                <span><span className="font-medium text-gray-900">{days[s.weekday]}</span> · {s.startTime}–{s.endTime}</span>
-                <button onClick={() => remove(s.id)} aria-label={t.availability.remove} className="p-2 text-gray-400 hover:text-red-600"><Trash2 className="h-4 w-4" /></button>
+          /* Grouped by day rather than one flat list (#1363): the day name used
+             to repeat on every row, which at a glance read as noise instead of
+             structure. The API already returns weekday-then-time order. */
+          <div className="divide-y divide-gray-100 dark:divide-gray-800">
+            {byDay.map(([weekdayIndex, daySlots]) => (
+              <div key={weekdayIndex} className="py-3 first:pt-0 last:pb-0">
+                <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-1.5">
+                  {days[weekdayIndex]}
+                </p>
+                <div className="space-y-1">
+                  {daySlots.map((s) => (
+                    <div key={s.id} className="flex items-center justify-between text-sm">
+                      <span className="text-gray-900 dark:text-gray-100">{s.startTime}–{s.endTime}</span>
+                      <button onClick={() => remove(s.id)} aria-label={t.availability.remove} className="p-2 text-gray-400 hover:text-red-600"><Trash2 className="h-4 w-4" /></button>
+                    </div>
+                  ))}
+                </div>
               </div>
             ))}
           </div>

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -2011,6 +2011,10 @@ const en = {
     remove: 'Remove',
     none: 'No availability set',
     days: ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'],
+    inZone: 'Times are shown in {zone} — your profile time zone.',
+    zoneUnset: 'You have not set a time zone yet, so these hours are read as {zone}. Set yours so mentees see the right time.',
+    zoneSetCta: 'Set your time zone',
+    overlap: 'That overlaps a slot you already have on this day ({from}–{to}).',
   },
   integrations: {
     title: 'Integrations & API',
@@ -5205,6 +5209,10 @@ const tr: Dict = {
     remove: 'Kaldır',
     none: 'Müsaitlik tanımlı değil',
     days: ['Pazar','Pazartesi','Salı','Çarşamba','Perşembe','Cuma','Cumartesi'],
+    inZone: 'Saatler {zone} dilimine göre gösteriliyor — profilindeki saat dilimi.',
+    zoneUnset: 'Henüz bir saat dilimi seçmedin, bu yüzden bu saatler {zone} kabul ediliyor. Mentee’lerin doğru saati görmesi için kendi dilimini ayarla.',
+    zoneSetCta: 'Saat dilimini ayarla',
+    overlap: 'Bu aralık, o gün zaten olan bir slotla çakışıyor ({from}–{to}).',
   },
   integrations: {
     title: 'Entegrasyonlar & API',
@@ -8395,6 +8403,10 @@ const de: Dict = {
     remove: 'Entfernen',
     none: 'Keine Verfügbarkeit festgelegt',
     days: ['Sonntag','Montag','Dienstag','Mittwoch','Donnerstag','Freitag','Samstag'],
+    inZone: 'Zeiten werden in {zone} angezeigt — deine Profil-Zeitzone.',
+    zoneUnset: 'Du hast noch keine Zeitzone gesetzt, daher gelten diese Zeiten als {zone}. Setze deine eigene, damit Mentees die richtige Zeit sehen.',
+    zoneSetCta: 'Zeitzone festlegen',
+    overlap: 'Das überschneidet sich mit einem Slot, den du an diesem Tag schon hast ({from}–{to}).',
   },
   integrations: {
     title: 'Integrationen & API',


### PR DESCRIPTION
Closes #1363 · Part of #1350 · Epic #1348

Second of three slices for #1350. #1358 (tenant scoping) landed in #1393; #1361 (a mentee actually requesting a slot) follows and builds directly on the zone contract added here.

## Whose 09:00?

A slot stored a wall clock and nothing else, so "Monday 09:00–10:00" never said whose 09:00 it was — and the screen did not say either. The rest of the product is already zone-aware (meetings render in the participant's zone via `lib/timezone.ts`); availability was the one surface cut off from it.

### The decision the issue asked for

**Read slots in the mentor's `User.timezone`. No `timezone` column on `AvailabilitySlot`.**

- **DST comes out identical either way.** Both designs store a wall clock plus a zone *name*, so "Monday 09:00" stays 09:00 across a transition — which is what a person means by a weekly slot. A stored fixed offset would be the only wrong option, and neither design uses one.
- **The travelling case a per-slot column would buy does not exist here**, and it makes the common case worse: a mentor who actually relocates wants *all* their hours to move. One profile field does that in a single edit; a per-row column turns it into editing every row.

Recorded as a comment on the handler so the next person does not have to re-derive it.

### Saved zone vs. fallback zone

Every response now carries the resolved zone **and whether it was actually saved**, because those need different copy — presenting a fallback as "your profile time zone" would be a confident lie:

| State | Copy |
|---|---|
| saved | "Times are shown in {zone} — your profile time zone." |
| none saved | amber: "…these hours are read as {zone}. Set yours so mentees see the right time." + a link to the profile |

The unset branch is **rare in practice and I nearly wrote a test that lied about it**: `TimezoneSync` (#1030) posts the browser zone on the first authenticated load, so a freshly seeded mentor already has one by the time any page renders. My first version of the test asserted `Europe/Istanbul` on a fresh mentor and failed with "UTC" — the sync had already run, and the fallback is deployment config (`APP_TIMEZONE`) rather than a constant. The branch is still correct behaviour for a browser with `Intl` or `sessionStorage` blocked, so it stays; the test now clears the column *after* sign-in (the sync posts once per browser session) and asserts the banner agrees with what the endpoint resolved instead of hard-coding a zone.

## Overlapping slots

The same hours could be added twice, and nothing stopped a straddling interval either — the only check was `endTime <= startTime`.

Now refused with **409**, and the response carries the interval it collided with so the message can name it ("That overlaps a slot you already have on this day (09:00–11:00)") rather than saying "that didn't work".

The comparison is **half-open** — `startTime < other.endTime && endTime > other.startTime` — so 09:00–10:00 followed by 10:00–11:00 is back-to-back, not a clash. That is how a person reads two adjacent slots.

## Also

Slots are grouped by day on screen. The day name used to repeat on every row, which at a glance read as noise rather than structure.

## Verification

Local MySQL, five specs green (three from #1393 plus two new):

- [x] `the screen names the time zone the hours are read in` — a saved zone stated with no prompt; cleared, the prompt appears and the banner matches the endpoint's resolved zone with `timezoneSet: false`
- [x] `an overlapping slot is refused and no row is created` — straddling, contained and identical intervals all 409 with `code: "overlap"`; back-to-back and same-clock-different-day both 201; final row count is exactly the three accepted, proving no refusal wrote anyway
- [x] `npx tsc --noEmit` + `npm run lint` clean
- [x] `npm run check:i18n` — 3191 keys × 3 locales
- [x] `npm run check:release-fragments` green

**No schema change**, so no `prisma db push` on any shared database.

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeSYkGngKpYG4KWsJ7Ph2Z)_