### PR TITLE
docs(retro): İK gözüyle ürün turundan çıkan dersler

### DIFF
--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -4353,3 +4353,59 @@ ekranıydı. Aynı şekilde board temizliğinde: #869, #705, #714 yalnızca alt 
 kapandığı için kapanmayı bekliyordu; #884'ün PR'ında `Closes #` boş bırakıldığı için
 GitHub bağlamamıştı. **`closed_by_pull_requests` boş olması işin yapılmadığı anlamına
 gelmez** — içerikten doğrula.
+
+## 2026-08-25 — İK gözüyle ürün turu: bulguları issue'ya çevirmek
+
+**"Kapalı" bir issue'nun işi yapıldığı anlamına gelmiyor — tersi de doğru.** Dosyada
+zaten "`closed_by_pull_requests` boş olması işin yapılmadığı anlamına gelmez" notu var;
+bu turda tam **karşıtına** rastladım: #808 (talent pool aramasını derinleştir) `completed`
+olarak kapatılmış, ama kapanan tek alt görevi boş-durum işi #852 idi. Kabul
+kriterlerindeki "yetkinlik filtresi artık JS'te değil" ve "sayfalama + doğru toplam"
+maddeleri hiç yapılmamış, kod satır satır eski hâlinde. Bir hikâye, alt görevleri kapandı
+diye kapanıyorsa gövdesindeki kriterler sessizce kayboluyor. **Yeni bir bulguyu "bu
+zaten kapalı" diye atmadan önce kodu aç.**
+
+**DOM'da olan bir element görünüyor demek değil — grafikleri ölçerek doğrula.**
+`/admin/analytics` "Trendler" kartı hiç çubuk göstermiyor: 12 çubuğun `style.height`
+değeri doğru (`77.7778%`), `getBoundingClientRect().height` ise **0**, çünkü ebeveynin
+yüksekliği 0. Sebep saf CSS: dış kap `h-44` veriyor ama `items-end` olduğu için sütunlar
+stretch edilmiyor, sütun yüksekliği içerikten geliyor, içindeki çubuk alanı `flex-1`
+(`flex-basis: 0`) olduğu için 0 kalıyor → yüzdeler 0'a çözülüyor. Aynı repoda **çalışan**
+karşılığı var (`src/app/mentor/feedback/page.tsx`: dış kap `h-32`, sütun `h-full`). Bunun
+aylarca fark edilmemesinin sebebi, varlık kontrolü yapan bir testin geçmesi. Grafik
+testleri yüksekliği **ölçmeli**.
+
+**`take` + JS'te filtre = sessizce eksik sonuç.** `company/talent-pool` rotası `take: 60`
+uygulayıp *sonra* yetkinliğe göre süzüyor; yani arama havuzun tamamında değil, en son
+güncellenmiş 60 kayıtta çalışıyor ve toplam gösterilmediği için kullanıcı bunu göremiyor.
+Doğrusu aynı repoda yazılı: `api/candidates/route.ts` çek → süz → `total =
+filtered.length` → dilimle. **Aynı problemin iki farklı uygulaması varsa biri yanlıştır** —
+karşılaştır.
+
+**i18n tarih hatasını görmek için tarayıcı dilini uygulama dilinden ayır.** Playwright
+context'ine `locale: 'en-US'`, `timezoneId: 'America/New_York'` verip uygulamaya `locale=tr`
+çerezi eklediğimde `/admin/interview-requests` tamamen Türkçe render edildi ama tarih
+`8/25/2026` çıktı. Tarayıcı dili TR olan bir makinede bu hata **hiç görünmez**. Aynı
+kurulum `toLocaleString()` kaynaklı saat-dilimi hatalarını da açığa çıkarıyor.
+
+**Bir özellik "bozuk" mu, yoksa sadece tohumlanmamış mı — önce satır say.** Requisitions,
+Mülakat talepleri, Teklifler ekranları demo veride bomboş; ilk refleks "bu akış çalışmıyor"
+oldu. `mariadb -e "SELECT COUNT(*) …"` ile bakınca `Requisition`/`InterviewRequest`/`Offer`/
+`InterviewPanel`/`CompanyInterest` **hepsi 0** çıktı: `seed:demo` yalnızca mentorluk yarısını
+üretiyor. Akışları elle (API'ye curl ile iş talebi + kısa liste + mülakat talebi yazarak)
+kurdum, sonra ekranlar doğru çalıştı.
+
+**Kurulum tarifi hâlâ geçerli, tek tuzak Chromium yolu.** `apt` MariaDB + `db push` +
+`db seed` + `seed:demo` sorunsuz. Playwright için `/opt/pw-browsers/chromium` bir
+**symlink** (1194'ün `chrome-linux/chrome`'una), ama `playwright-core`'un varsayılanı
+`chromium-1234/chrome-linux64/chrome` arıyor — `executablePath: '/opt/pw-browsers/chromium'`
+vermek yeterli, dizin kurmaya gerek yok. Ayrıca scratchpad'den `import`: `playwright-core`
+CommonJS, `import pw from '<abs path>/index.js'; const { chromium } = pw;` şeklinde çekilir.
+
+**Issue ağacı kurarken iki pratik kazanç.** (1) `issue_write` **create** çağrısı
+`issue_fields` kabul ediyor, yani org'un `Priority` alanı **oluşturma anında** set edilebilir —
+her issue için ikinci bir `update` çağrısına gerek yok. (2) `sub_issue_write` yanıtı
+ebeveynin **tüm gövdesini** geri veriyor; 20+ bağlamada bu ciddi bağlam yakıyor. Önce
+hepsini oluştur, `child id → parent number` eşlemesini diske yaz, bağlamayı en sona bırak.
+Bir de: yeni issue numaraları **atlamalı** veriliyor (1357 → 1359 → 1364), bu yüzden bir
+issue gövdesinde henüz oluşturulmamış bir numaraya atıf yapma — sonradan düzeltmek gerekti.


### PR DESCRIPTION
## Summary

Ürünü bir İK/işe alım kullanıcısı gibi baştan sona gezdim (yerel MariaDB + `db push` +
`db seed` + `seed:demo` + `npm run build && npm run start`, ardından Playwright ile
admin / şirket / menti rollerinde tıklayarak) ve çıkan bulguları backlog'a issue olarak
açtım: **#1357** epic'i + 6 hikâye (#1359, #1364, #1369, #1372, #1375, #1379) ve 15 görev,
artı mevcut epic #861 altına 3 iş (#1381 / #1422, #1425, #1427).

Bu PR **kod değiştirmiyor** — yalnızca [`docs/agent-experience.md`](docs/agent-experience.md)
dosyasına, CLAUDE.md'deki oturum sonu retrospektif kuralı gereğince, sonraki oturumların
işine yarayacak taktik dersleri ekliyor.

## Changes

- `docs/agent-experience.md`: `## 2026-08-25 — İK gözüyle ürün turu: bulguları issue'ya
  çevirmek` girdisi eklendi. Kaydedilen dersler:
  - **Kapalı bir hikâyenin kabul kriterleri yapılmamış olabilir.** #808 `completed` olarak
    kapatılmış ama kapanan tek alt görevi #852 idi; "filtre artık JS'te değil" ve
    "sayfalama + doğru toplam" maddeleri hiç yapılmamış. Dosyada bunun tersi (`closed_by_pull_requests`
    boş olması işin yapılmadığı anlamına gelmez) zaten notluydu; karşıt yön de artık yazılı.
  - **DOM'da var olan grafik görünür olmayabilir.** Trendler kartındaki 12 çubuğun
    `style.height` değeri doğru, `getBoundingClientRect().height` = 0 (`items-end` +
    `flex-1` ebeveyn yüksekliğini 0'a düşürüyor). Varlık kontrolü yapan test geçiyor; grafik
    testleri yüksekliği **ölçmeli**.
  - **`take` + JS'te filtre sessizce eksik sonuç verir**; aynı problemin doğru uygulaması
    zaten `api/candidates/route.ts`'te.
  - **i18n tarih hatası ancak tarayıcı dili ≠ uygulama dili iken görünür** — Playwright
    context'ine `locale`/`timezoneId` verip uygulamaya `locale=tr` çerezi eklemek gerekiyor.
  - **"Bozuk mu, tohumlanmamış mı"** ayrımını satır sayarak yap: `seed:demo` işe alım
    tarafını hiç üretmiyor.
  - Chromium yolu (`/opt/pw-browsers/chromium` bir symlink, `executablePath` vermek yeterli)
    ve scratchpad'den `playwright-core` (CommonJS) import etme tarifi.
  - Issue ağacı kurarken iki tasarruf: `issue_write` **create** çağrısı `issue_fields`
    kabul ediyor (Priority oluşturma anında set edilebiliyor), ve `sub_issue_write` yanıtı
    ebeveynin tüm gövdesini geri verdiği için bağlama işini en sona bırakmak gerekiyor.

Sürüm fragmenti yok: CLAUDE.md'ye göre saf dokümantasyon değişiklikleri fragment
gerektirmiyor.

## Verification

- [x] `npm run lint` + `npx tsc --noEmit` clean — *değişiklik yalnızca markdown; kod yolu
      etkilenmiyor. Dosya bu turda `npm run build` yeşilken (0.114.0-beta) üretildi.*
- [x] `npm run test:e2e` passing (or CI green) — *markdown değişikliği; e2e kapsamı dışında,
      CI kapısı karar verir.*
- [x] Tested the change manually / added an e2e test — *girdideki her iddia bu oturumda
      ölçümle doğrulandı (ilgili issue'larda ölçüm çıktıları var).*

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LkKsGrL94yyfjw8ND3mLEj


---
_Generated by [Claude Code](https://claude.ai/code/session_01LkKsGrL94yyfjw8ND3mLEj)_