### PR TITLE
fix(alerts): match premium alerts against requisitions too, not just CompanyNeed (#1387)

### DIFF
--- a/e2e/company-need-alerts.spec.ts
+++ b/e2e/company-need-alerts.spec.ts
@@ -15,9 +15,18 @@ test('need-match alerts fire once for premium companies only, on consenting cand
   const adminEmail = uniqueEmail('need-admin');
   const premiumUserEmail = uniqueEmail('need-premium-user');
   const freeUserEmail = uniqueEmail('need-free-user');
+  const reqUserEmail = uniqueEmail('need-req-user');
   const menteeEmail = uniqueEmail('need-mentee');
   const pw = 'NeedAlertPass123';
   const position = `Backend Developer ${stamp}`;
+
+  // Scope the notification count to THIS candidate via the link (`/p/<id>`,
+  // unique per candidate). Counting by (user, type) alone passes only on an
+  // empty database: any other consenting mentee whose targetPosition
+  // substring-matches the seeded position — the demo data set has one — also
+  // alerts this company, and the count silently becomes 2.
+  const alertsAbout = (userId: string, menteeId: string) =>
+    prisma.notification.count({ where: { userId, type: 'need_match.newCandidate', link: `/p/${menteeId}` } });
 
   await seedUser(adminEmail, pw, 'ADMIN', 'Need Admin');
   const hash = await bcrypt.hash(pw, 10);
@@ -35,11 +44,58 @@ test('need-match alerts fire once for premium companies only, on consenting cand
       needs: { create: { position, count: 1, period: '2026' } },
     },
   });
+
+  // #1387: a premium company whose only open role lives in Requisition, with no
+  // CompanyNeed row at all. Before the fix the job never queried Requisition, so
+  // this company matched nobody. Requisition.orgId is non-null while
+  // Company.orgId is nullable, so the org has to exist first.
+  const org = await prisma.organization.upsert({
+    where: { slug: 'default' },
+    update: {},
+    create: { slug: 'default', name: 'Default Organization' },
+    select: { id: true },
+  });
+  const reqCo = await prisma.company.create({
+    data: {
+      name: `Requisition Need Co ${stamp}`,
+      orgId: org.id,
+      entitlements: { create: { feature: 'COMPANY_NEED_MATCH_ALERTS' } },
+      requisitions: {
+        create: { orgId: org.id, title: position, status: 'OPEN', openings: 1, filled: 0, requiredSkills: [] },
+      },
+    },
+  });
+  // Negative cases, both premium and both with no CompanyNeed: an unpublished
+  // role must not alert, and neither must a role that is open on paper but
+  // already fully staffed.
+  const draftCo = await prisma.company.create({
+    data: {
+      name: `Draft Need Co ${stamp}`,
+      orgId: org.id,
+      entitlements: { create: { feature: 'COMPANY_NEED_MATCH_ALERTS' } },
+      requisitions: {
+        create: { orgId: org.id, title: position, status: 'DRAFT', openings: 1, filled: 0, requiredSkills: [] },
+      },
+    },
+  });
+  const filledCo = await prisma.company.create({
+    data: {
+      name: `Filled Need Co ${stamp}`,
+      orgId: org.id,
+      entitlements: { create: { feature: 'COMPANY_NEED_MATCH_ALERTS' } },
+      requisitions: {
+        create: { orgId: org.id, title: position, status: 'OPEN', openings: 2, filled: 2, requiredSkills: [] },
+      },
+    },
+  });
   const premiumUser = await prisma.user.create({
     data: { email: premiumUserEmail, password: hash, role: 'COMPANY', fullName: 'Premium Co User', skills: [], companyId: premiumCo.id },
   });
   await prisma.user.create({
     data: { email: freeUserEmail, password: hash, role: 'COMPANY', fullName: 'Free Co User', skills: [], companyId: freeCo.id },
+  });
+  const reqUser = await prisma.user.create({
+    data: { email: reqUserEmail, password: hash, role: 'COMPANY', fullName: 'Requisition Co User', skills: [], companyId: reqCo.id },
   });
 
   // A consenting mentee (publicProfile + TALENT_POOL_VISIBILITY, #527) whose
@@ -66,26 +122,43 @@ test('need-match alerts fire once for premium companies only, on consenting cand
     await expect
       .poll(async () => prisma.companyNeedAlert.count({ where: { companyId: premiumCo.id, menteeId: mentee.id } }), { timeout: 10_000 })
       .toBe(1);
-    expect(await prisma.notification.count({ where: { userId: premiumUser.id, type: 'need_match.newCandidate' } })).toBe(1);
+    expect(await alertsAbout(premiumUser.id, mentee.id)).toBe(1);
 
     // Free company: no entitlement → no alert.
     expect(await prisma.companyNeedAlert.count({ where: { companyId: freeCo.id } })).toBe(0);
+
+    // #1387: the requisition-only premium company is alerted too. This is the
+    // assertion that fails on the old job, which queried CompanyNeed only.
+    await expect
+      .poll(async () => prisma.companyNeedAlert.count({ where: { companyId: reqCo.id, menteeId: mentee.id } }), { timeout: 10_000 })
+      .toBe(1);
+    expect(await alertsAbout(reqUser.id, mentee.id)).toBe(1);
+
+    // …but only for a role that is actually hiring: DRAFT is unpublished, and
+    // an OPEN requisition with filled === openings has nobody to hire.
+    expect(await prisma.companyNeedAlert.count({ where: { companyId: draftCo.id } })).toBe(0);
+    expect(await prisma.companyNeedAlert.count({ where: { companyId: filledCo.id } })).toBe(0);
 
     // Running again does not re-alert (deduped).
     const run2 = await page.request.get('/api/cron');
     expect(run2.ok()).toBeTruthy();
     expect(await prisma.companyNeedAlert.count({ where: { companyId: premiumCo.id, menteeId: mentee.id } })).toBe(1);
-    expect(await prisma.notification.count({ where: { userId: premiumUser.id, type: 'need_match.newCandidate' } })).toBe(1);
+    expect(await alertsAbout(premiumUser.id, mentee.id)).toBe(1);
+    // The dedupe key is [companyId, menteeId], so it holds across the new
+    // source too — a second source must not mean a second alert.
+    expect(await prisma.companyNeedAlert.count({ where: { companyId: reqCo.id, menteeId: mentee.id } })).toBe(1);
   } finally {
-    await prisma.notification.deleteMany({ where: { userId: premiumUser.id } });
+    const companyIds = [premiumCo.id, freeCo.id, reqCo.id, draftCo.id, filledCo.id];
+    await prisma.notification.deleteMany({ where: { userId: { in: [premiumUser.id, reqUser.id] } } });
     await prisma.companyNeedAlert.deleteMany({ where: { menteeId: mentee.id } });
-    await prisma.companyNeed.deleteMany({ where: { companyId: { in: [premiumCo.id, freeCo.id] } } });
-    await prisma.companyEntitlement.deleteMany({ where: { companyId: premiumCo.id } });
+    await prisma.companyNeed.deleteMany({ where: { companyId: { in: companyIds } } });
+    await prisma.requisition.deleteMany({ where: { companyId: { in: companyIds } } });
+    await prisma.companyEntitlement.deleteMany({ where: { companyId: { in: companyIds } } });
     await cleanupByEmail(menteeEmail);
     await cleanupByEmail(premiumUserEmail);
     await cleanupByEmail(freeUserEmail);
+    await cleanupByEmail(reqUserEmail);
     await cleanupByEmail(adminEmail);
-    await prisma.company.delete({ where: { id: premiumCo.id } }).catch(() => {});
-    await prisma.company.delete({ where: { id: freeCo.id } }).catch(() => {});
+    for (const id of companyIds) await prisma.company.delete({ where: { id } }).catch(() => {});
   }
 });

--- a/releases/unreleased/requisition-match-alerts.json
+++ b/releases/unreleased/requisition-match-alerts.json
@@ -1,0 +1,9 @@
+{
+  "bump": "patch",
+  "changelog": "**Fixed** — premium open-position match alerts scanned only the legacy `CompanyNeed` table, so a role opened through the Requisition screen never matched anybody: a premium company could have several open requisitions and receive nothing. The job now reads both sources. Only requisitions with status `OPEN` and unfilled openings alert, and the existing per-(company, candidate) dedupe means a role present in both tables still alerts once.",
+  "notes": {
+    "en": ["Premium match alerts now also cover roles opened as requisitions, not only positions added through the company form."],
+    "tr": ["Premium eşleşme uyarıları artık yalnızca şirket formundan eklenen pozisyonları değil, iş talebi olarak açılan rolleri de kapsıyor."],
+    "de": ["Premium-Treffer-Benachrichtigungen decken jetzt auch als Requisition eröffnete Rollen ab, nicht nur über das Firmenformular angelegte Positionen."]
+  }
+}

--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -2002,23 +2002,45 @@ function candidateMatchesNeeds(
   });
 }
 
-// Premium CompanyNeed match alerts (Faz 1, #530). For every company holding the
-// COMPANY_NEED_MATCH_ALERTS entitlement, scan the consenting talent pool (the
-// same publicProfile-only visibility as talent-pool search) for candidates
+// Only an OPEN requisition is hiring: DRAFT is unpublished, and ON_HOLD /
+// FILLED / CANCELLED are all "do not send me candidates" (#1387).
+const ALERTABLE_REQUISITION_STATUS = 'OPEN';
+
+// Premium open-position match alerts (Faz 1, #530). For every company holding
+// the COMPANY_NEED_MATCH_ALERTS entitlement, scan the consenting talent pool
+// (the same publicProfile-only visibility as talent-pool search) for candidates
 // matching an open position, and notify the company's users once per candidate.
 // Repeat notifications are prevented by the CompanyNeedAlert dedupe row (the
 // unique [companyId, menteeId] insert is the marker — createMany/skipDuplicates
 // makes "insert-or-skip" atomic, so a candidate only ever alerts a company once).
+//
+// Positions come from BOTH tables (#1387). The job used to read CompanyNeed
+// only, so a role opened through the Requisition screen — the newer of the two,
+// and the one the product is migrating to — never matched anybody: a premium
+// company could have five open requisitions and receive nothing at all.
+// CompanyNeed is NOT dead and is not being dropped here: the admin company form
+// still writes those rows (src/app/api/companies/[id]/route.ts), and the
+// CompanyNeed→Requisition backfill is manual and runs in no deploy step. So this
+// adds a source rather than replacing one; the [companyId, menteeId] dedupe key
+// means a company with the same role in both tables still alerts once.
 export async function checkCompanyNeedMatches() {
   const companies = await prisma.company.findMany({
     where: {
       entitlements: { some: { feature: 'COMPANY_NEED_MATCH_ALERTS' } },
-      needs: { some: {} },
+      OR: [{ needs: { some: {} } }, { requisitions: { some: { status: ALERTABLE_REQUISITION_STATUS } } }],
     },
     select: {
       id: true,
       name: true,
       needs: { select: { position: true } },
+      requisitions: {
+        where: { status: ALERTABLE_REQUISITION_STATUS },
+        // `openings`/`filled` so a role that is open-but-fully-staffed can be
+        // dropped: the API accepts status OPEN with filled === openings, and
+        // Prisma cannot compare two columns in a `where`, so it is filtered
+        // below in JS.
+        select: { title: true, openings: true, filled: true },
+      },
       users: {
         where: { role: 'COMPANY', isActive: true },
         select: { id: true, email: true, fullName: true, emailNotifications: true, notificationPrefs: true },
@@ -2045,11 +2067,25 @@ export async function checkCompanyNeedMatches() {
   let alerts = 0;
 
   for (const company of companies) {
-    const positions = company.needs.map((n) => n.position.toLowerCase().trim()).filter(Boolean);
+    // Requisition.title is the analogue of CompanyNeed.position, and the only
+    // field taken from it. `requiredSkills` is deliberately NOT folded in:
+    // candidateMatchesNeeds matches substrings in BOTH directions, so a short
+    // skill like "Go" or "R" would match almost every targetPosition and turn a
+    // premium alert into noise. Widening the match is a separate decision from
+    // fixing the missing source.
+    const positions = [
+      ...company.needs.map((n) => n.position),
+      ...company.requisitions.filter((r) => r.filled < r.openings).map((r) => r.title),
+    ]
+      .map((p) => (p ?? '').toLowerCase().trim())
+      .filter(Boolean);
+    // Still reachable after the OR filter above: a company can match on having
+    // open requisitions and then have every one of them fully staffed.
     if (positions.length === 0) continue;
+    const terms = [...new Set(positions)];
 
     for (const cand of pool) {
-      if (!candidateMatchesNeeds(positions, cand)) continue;
+      if (!candidateMatchesNeeds(terms, cand)) continue;
 
       // Atomic dedupe: the insert succeeds only the first time; count 0 means
       // this company was already alerted about this candidate — skip silently.


### PR DESCRIPTION
Closes #1387 · Part of #1359 / Epic #1357

## Not "matched badly" — excluded before matching started

`checkCompanyNeedMatches()` selected companies on `needs: { some: {} }` and built its term list from `company.needs` alone. `Requisition` — the newer of the two tables, and the one the product is migrating to — was never queried at all. So a premium company whose roles were all opened through the requisition screen failed the *company filter* before matching even began, and received nothing.

**`CompanyNeed` is not dropped.** The admin company form still writes those rows (`src/app/api/companies/[id]/route.ts`), and the `CompanyNeed → Requisition` backfill is manual and wired into no deploy step — so requisitions have no `CompanyNeed` shadow. This adds a source rather than swapping one out. The existing `[companyId, menteeId]` dedupe key means a company holding the same role in both tables still alerts exactly once, which the spec now asserts.

**No schema change.**

## Two judgement calls, both narrowing

**Only `Requisition.title` feeds the terms.** `requiredSkills` is deliberately left out. `candidateMatchesNeeds` substring-matches in *both* directions:

```ts
if (target.includes(pos) || pos.includes(target)) return true;
```

so a short skill like `"Go"` or `"R"` would match nearly every `targetPosition` and turn a premium alert into noise. `title` is the like-for-like analogue of `CompanyNeed.position`; widening the match is a separate decision from fixing the missing source, and I did not want to smuggle it in here.

**Only `status: 'OPEN'` with `filled < openings` alerts.** `DRAFT` is unpublished; `ON_HOLD` / `FILLED` / `CANCELLED` are not hiring. The API also accepts `OPEN` with `filled === openings`, which has nobody left to hire — Prisma cannot compare two columns in a `where`, so that test runs in JS after the query. Both are covered by negative assertions.

## ⚠️ Worth a decision before this deploys

On the first cron run after merge, premium companies that already have open requisitions will match the existing pool for the first time. `CompanyNeedAlert` only suppresses *repeats*, so each such company gets one notification + one email per never-alerted matching candidate — a one-time burst proportional to how long they have been invisible.

I have not tried to suppress it: silently backfilling dedupe rows would mean deliberately withholding matches these customers should already have had. But if you would rather it landed quietly, say so and I will add a one-off backfill script before this goes to prod.

## A blind spot in the spec itself

While extending `e2e/company-need-alerts.spec.ts` I hit a failure that was **not** my change:

```
Expected: 1
Received: 2
```

Two assertions counted notifications by `(userId, type)` — which passes only against an **empty** database. Any other consenting mentee whose `targetPosition` substring-matches the seeded position also alerts the same company. The local demo data set has exactly such a mentee (`targetPosition: "Backend Developer"` vs. the spec's `"Backend Developer <stamp>"`), so the count was legitimately 2.

They now scope by the notification's `link` (`/p/<menteeId>`), which is unique per candidate — so the spec measures what it always meant to, on any database rather than only a clean one.

## Verification

Local MySQL, **both directions**:

- [x] Requisition-only premium company gets exactly 1 alert + 1 notification — **red on the old job** (verified by reverting `emailService.ts` and re-running: fails at the `reqCo` assertion)
- [x] `DRAFT`-only company: 0 alerts
- [x] `OPEN` but `filled === openings` company: 0 alerts
- [x] Existing CompanyNeed-only premium company: still exactly 1 — the legacy path is untouched
- [x] Free company (no entitlement): still 0
- [x] Second cron run does not re-alert, across both sources
- [x] `npx tsc --noEmit` + `npm run lint` clean
- [x] `npm run check:release-fragments` green

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeSYkGngKpYG4KWsJ7Ph2Z)_