### PR TITLE
fix(talent-pool): count and paginate the whole pool, not the first 60 rows (#1392)

### DIFF
--- a/e2e/talent-pool-pagination.spec.ts
+++ b/e2e/talent-pool-pagination.spec.ts
@@ -1,0 +1,120 @@
+import { test, expect } from '@playwright/test';
+import bcrypt from 'bcryptjs';
+import { prisma, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+/**
+ * #1392 — the talent-pool search returned silently incomplete results.
+ *
+ * The endpoint read `take: 60` from the database and only THEN applied the
+ * skill filter in JS, so a skill held by nobody in the 60 most recently updated
+ * mentees simply did not exist as far as the search was concerned. Worse, the
+ * response carried no total, so nothing on screen could hint the answer was
+ * partial: an empty grid and "there is nobody" look identical.
+ *
+ * Seeding is done directly rather than through `seedUser` per row: 65 users via
+ * createMany plus one consent createMany is two statements instead of ~130, and
+ * teardown is by id rather than 65 sequential lookups.
+ */
+
+const PW = 'TalentPage123';
+const OLD_LIMIT = 60;
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('a skill held only outside the old 60-row window is still found', async ({ page }) => {
+  const stamp = `${Date.now()}`;
+  const companyEmail = uniqueEmail('tp-page-co');
+  const rareSkill = `Fortran${stamp}`;
+  const marker = `TPPager${stamp}`;
+
+  const company = await prisma.company.create({
+    data: {
+      name: `Talent Pager Co ${stamp}`,
+      entitlements: { create: { feature: 'TALENT_POOL_SEARCH' } },
+    },
+  });
+  await prisma.user.create({
+    data: {
+      email: companyEmail, password: await bcrypt.hash(PW, 10), role: 'COMPANY',
+      fullName: 'Talent Pager Observer', companyId: company.id, skills: [],
+    },
+  });
+
+  // 65 consenting public mentees. The FIRST one created is the least recently
+  // updated, so it sits outside the old `take: 60` window — it is the one
+  // holding the rare skill.
+  const hash = await bcrypt.hash(PW, 10);
+  const emails = Array.from({ length: OLD_LIMIT + 5 }, (_, i) => `tp-page-${stamp}-${i}@e2e.local`);
+  for (const [i, email] of emails.entries()) {
+    await prisma.user.create({
+      data: {
+        email, password: hash, role: 'MENTEE', fullName: `${marker} ${i}`,
+        publicProfile: true,
+        skills: i === 0 ? [rareSkill] : ['CommonSkill'],
+        consents: { create: { type: 'TALENT_POOL_VISIBILITY', grantedAt: new Date() } },
+      },
+    });
+  }
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', companyEmail);
+    await page.fill('input[type="password"]', PW);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/company'), { timeout: 20_000 });
+
+    // THE regression: on the old code this returns 0 candidates, because the
+    // only holder of the skill was cut off by `take: 60` before the filter ran.
+    const rare = await page.request.get(
+      `/api/company/talent-pool?q=${encodeURIComponent(marker)}&skill=${encodeURIComponent(rareSkill)}`
+    );
+    expect(rare.status()).toBe(200);
+    const rareBody = await rare.json();
+    expect(rareBody.total).toBe(1);
+    expect(rareBody.candidates).toHaveLength(1);
+    expect(rareBody.candidates[0].fullName).toBe(`${marker} 0`);
+
+    // The count is of the whole matching set, not of the page — the number that
+    // used to be missing entirely.
+    const firstPage = await page.request.get(
+      `/api/company/talent-pool?q=${encodeURIComponent(marker)}&pageSize=10&page=1`
+    );
+    const first = await firstPage.json();
+    expect(first.total).toBe(OLD_LIMIT + 5);
+    expect(first.candidates).toHaveLength(10);
+    expect(first.page).toBe(1);
+    expect(first.pageSize).toBe(10);
+
+    // Pages do not overlap.
+    const secondPage = await page.request.get(
+      `/api/company/talent-pool?q=${encodeURIComponent(marker)}&pageSize=10&page=2`
+    );
+    const second = await secondPage.json();
+    expect(second.candidates).toHaveLength(10);
+    const firstIds = new Set(first.candidates.map((c: { id: string }) => c.id));
+    expect(second.candidates.some((c: { id: string }) => firstIds.has(c.id))).toBe(false);
+
+    // A page past the end is empty rather than an error, and still reports the
+    // real total.
+    const beyond = await page.request.get(
+      `/api/company/talent-pool?q=${encodeURIComponent(marker)}&pageSize=10&page=99`
+    );
+    const beyondBody = await beyond.json();
+    expect(beyondBody.candidates).toHaveLength(0);
+    expect(beyondBody.total).toBe(OLD_LIMIT + 5);
+
+    // …and the screen actually says the count, which is the half of the bug a
+    // user could see.
+    await page.goto('/company/talent-pool');
+    await page.getByTestId('talent-pool-search').fill(marker);
+    await expect(page.getByTestId('talent-pool-total')).toContainText(String(OLD_LIMIT + 5), { timeout: 15_000 });
+    await expect(page.getByTestId('talent-pool-next')).toBeVisible();
+  } finally {
+    await prisma.user.deleteMany({ where: { email: { in: emails } } });
+    await cleanupByEmail(companyEmail);
+    await prisma.companyEntitlement.deleteMany({ where: { companyId: company.id } });
+    await prisma.company.delete({ where: { id: company.id } }).catch(() => {});
+  }
+});

--- a/releases/unreleased/talent-pool-filter-before-limit.json
+++ b/releases/unreleased/talent-pool-filter-before-limit.json
@@ -1,0 +1,9 @@
+{
+  "bump": "patch",
+  "changelog": "**Fixed** — talent-pool search read 60 rows from the database and only then applied the skill filter, so a skill held by nobody in the 60 most recently updated candidates returned nothing at all — and the response carried no total, so an incomplete answer looked identical to an empty one. The search now counts and paginates over the whole matching set, the early-access embargo is part of the database filter rather than a post-filter, and the screen shows the result count with a pager.",
+  "notes": {
+    "en": ["Talent-pool search now searches the whole pool, shows how many candidates matched, and pages through them."],
+    "tr": ["Yetenek havuzu araması artık havuzun tamamında arıyor, kaç aday eşleştiğini gösteriyor ve sayfalar arasında geziniyor."],
+    "de": ["Die Talentpool-Suche durchsucht jetzt den gesamten Pool, zeigt die Trefferzahl und blättert durch die Ergebnisse."]
+  }
+}

--- a/src/app/api/company/talent-pool/route.ts
+++ b/src/app/api/company/talent-pool/route.ts
@@ -25,6 +25,8 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const q = (searchParams.get('q') || '').trim().slice(0, 100);
   const skill = (searchParams.get('skill') || '').trim().slice(0, 60).toLowerCase();
+  const page = Math.max(1, parseInt(searchParams.get('page') || '1', 10) || 1);
+  const pageSize = Math.min(60, Math.max(1, parseInt(searchParams.get('pageSize') || '24', 10) || 24));
 
   // Visibility = publicProfile opt-in AND an active TALENT_POOL_VISIBILITY
   // consent (#527, GDPR basis for company-facing exposure). Revoking the
@@ -45,43 +47,63 @@ export async function GET(request: Request) {
     ];
   }
 
-  const rows = await prisma.user.findMany({
-    where,
-    take: 60,
-    orderBy: { updatedAt: 'desc' },
-    select: {
-      id: true, fullName: true, university: true, department: true,
-      graduationYear: true, city: true, targetPosition: true, skills: true, avatarUrl: true,
-    },
-  });
-
-  // skills is a JSON array — filter in JS when a skill query is given.
-  let candidates = skill
-    ? rows.filter((r) => Array.isArray(r.skills) && (r.skills as string[]).some((s) => String(s).toLowerCase().includes(skill)))
-    : rows;
-
   // Early-access window (#531): a candidate who became hireable (HIREABLE_600)
   // within the last N days is visible ONLY to premium companies holding the
   // EARLY_ACCESS entitlement (admins always see everyone). Non-entitled
   // subscribers see them once the window closes. The window length is an admin
   // setting; '0' disables it. Candidates who never became hireable, or whose
   // window has closed, are unaffected.
+  //
+  // Expressed as part of `where` rather than as a post-filter (#1392) so it
+  // narrows the set the DB counts and paginates. Filtering it afterwards is
+  // what made the old count wrong in the first place.
   const windowDays = parseInt(await getSetting('earlyAccessWindowDays'), 10) || 0;
   const hasEarlyAccess = session.user.role === 'ADMIN' || (await hasFeature(session.user.companyId, 'EARLY_ACCESS'));
-  if (windowDays > 0 && !hasEarlyAccess && candidates.length > 0) {
+  if (windowDays > 0 && !hasEarlyAccess) {
     const cutoff = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000);
-    const recent = await prisma.statusChange.findMany({
-      where: {
-        toStatus: 'HIREABLE_600',
-        createdAt: { gte: cutoff },
-        relation: { menteeId: { in: candidates.map((c) => c.id) } },
+    where.NOT = {
+      menteeRelations: {
+        some: { statusChanges: { some: { toStatus: 'HIREABLE_600', createdAt: { gte: cutoff } } } },
       },
-      select: { relation: { select: { menteeId: true } } },
-    });
-    const embargoed = new Set(recent.map((s) => s.relation.menteeId));
-    candidates = candidates.filter((c) => !embargoed.has(c.id));
+    };
   }
 
-  return NextResponse.json({ candidates });
+  const select = {
+    id: true, fullName: true, university: true, department: true,
+    graduationYear: true, city: true, targetPosition: true, skills: true, avatarUrl: true,
+  } as const;
+  const orderBy = { updatedAt: 'desc' } as const;
+
+  // Two branches, the same shape as /api/candidates (#1392). The filter used to
+  // run AFTER `take: 60`, so a skill held only by the 61st-most-recently-updated
+  // mentee simply did not exist as far as the search was concerned — and the
+  // response carried no total, so nothing on screen could hint that the answer
+  // was partial. Raising the cap would only move the threshold; the count has to
+  // come from the same set the page is sliced from.
+  let candidates;
+  let total: number;
+  if (!skill) {
+    // Nothing needs JS: the database can count and paginate.
+    total = await prisma.user.count({ where });
+    candidates = await prisma.user.findMany({
+      where,
+      select,
+      orderBy,
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+    });
+  } else {
+    // `skills` is a JSON array and MySQL cannot match inside one, so this branch
+    // has to fetch the visible set and filter in memory — then total and slice
+    // from the FILTERED rows, never from a truncated read.
+    const rows = await prisma.user.findMany({ where, select, orderBy });
+    const filtered = rows.filter(
+      (r) => Array.isArray(r.skills) && (r.skills as string[]).some((s) => String(s).toLowerCase().includes(skill))
+    );
+    total = filtered.length;
+    candidates = filtered.slice((page - 1) * pageSize, page * pageSize);
+  }
+
+  return NextResponse.json({ candidates, total, page, pageSize });
   });
 }

--- a/src/app/company/talent-pool/page.tsx
+++ b/src/app/company/talent-pool/page.tsx
@@ -23,6 +23,8 @@ interface Candidate {
 
 // Premium talent-pool search (Faz 1). Shows a locked upsell when the company
 // lacks the TALENT_POOL_SEARCH entitlement (API returns 403 feature_locked).
+const PAGE_SIZE = 24;
+
 export default function TalentPoolPage() {
   const t = useT();
   const tp = t.talentPool;
@@ -31,7 +33,13 @@ export default function TalentPoolPage() {
   const [candidates, setCandidates] = useState<Candidate[]>([]);
   const [loading, setLoading] = useState(true);
   const [locked, setLocked] = useState(false);
+  // The endpoint used to return an unpaginated, silently truncated list (#1392).
+  // `total` is now the count of the whole matching set, so the page can say how
+  // many results there are rather than implying the screen is all of them.
+  const [page, setPage] = useState(1);
+  const [total, setTotal] = useState(0);
   const hasFilters = Boolean(q.trim() || skill.trim());
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -39,17 +47,25 @@ export default function TalentPoolPage() {
       const params = new URLSearchParams();
       if (q) params.set('q', q);
       if (skill) params.set('skill', skill);
+      params.set('page', String(page));
+      params.set('pageSize', String(PAGE_SIZE));
       const res = await fetch(`/api/company/talent-pool?${params.toString()}`);
       if (res.status === 403) { setLocked(true); return; }
       const d = await res.json();
       setLocked(false);
       setCandidates(d.candidates ?? []);
+      setTotal(typeof d.total === 'number' ? d.total : (d.candidates?.length ?? 0));
     } catch {
       /* ignore */
     } finally {
       setLoading(false);
     }
-  }, [q, skill]);
+  }, [q, skill, page]);
+
+  // Any filter change goes back to page 1. Without this, retyping a filter while
+  // on page 3 asks for page 3 of a smaller result set and renders an empty grid
+  // — which looks exactly like the bug this change fixes.
+  useEffect(() => { setPage(1); }, [q, skill]);
 
   // Debounce searches; initial load on mount.
   useEffect(() => {
@@ -85,6 +101,7 @@ export default function TalentPoolPage() {
             type="text"
             value={q}
             onChange={(e) => setQ(e.target.value)}
+            data-testid="talent-pool-search"
             placeholder={tp.searchPlaceholder}
             className="pl-10 w-full rounded-lg border border-gray-300 dark:border-gray-700 dark:bg-gray-800 px-3.5 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-100 focus:border-blue-400"
           />
@@ -93,6 +110,7 @@ export default function TalentPoolPage() {
           type="text"
           value={skill}
           onChange={(e) => setSkill(e.target.value)}
+          data-testid="talent-pool-skill"
           placeholder={tp.skillPlaceholder}
           className="sm:w-56 rounded-lg border border-gray-300 dark:border-gray-700 dark:bg-gray-800 px-3.5 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-100 focus:border-blue-400"
         />
@@ -114,6 +132,13 @@ export default function TalentPoolPage() {
           />
         </Card>
       ) : (
+        <>
+        <p data-testid="talent-pool-total" className="mb-3 text-sm text-gray-600 dark:text-gray-300">
+          {tp.showing
+            .replace('{from}', String((page - 1) * PAGE_SIZE + 1))
+            .replace('{to}', String(Math.min(page * PAGE_SIZE, total)))
+            .replace('{total}', String(total))}
+        </p>
         <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
           {candidates.map((c) => (
             <Card key={c.id}>
@@ -147,6 +172,32 @@ export default function TalentPoolPage() {
             </Card>
           ))}
         </div>
+        {totalPages > 1 && (
+          <div className="flex items-center justify-center gap-3 mt-6">
+            <button
+              type="button"
+              data-testid="talent-pool-prev"
+              disabled={page <= 1}
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              className="rounded-lg border border-gray-300 dark:border-gray-700 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-200 disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              {t.common.prev}
+            </button>
+            <span className="text-sm text-gray-600 dark:text-gray-300" data-testid="talent-pool-page">
+              {page} / {totalPages}
+            </span>
+            <button
+              type="button"
+              data-testid="talent-pool-next"
+              disabled={page >= totalPages}
+              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+              className="rounded-lg border border-gray-300 dark:border-gray-700 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-200 disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              {t.common.next}
+            </button>
+          </div>
+        )}
+        </>
       )}
     </div>
   );

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -150,6 +150,7 @@ const en = {
     },
   },
   talentPool: {
+    showing: 'Showing {from}–{to} of {total} candidates',
     navLink: 'Talent pool',
     title: 'Talent pool',
     subtitle: 'Search candidates who have opted into a public profile.',
@@ -3390,6 +3391,7 @@ const tr: Dict = {
     },
   },
   talentPool: {
+    showing: '{total} adaydan {from}–{to} gösteriliyor',
     navLink: 'Yetenek havuzu',
     title: 'Yetenek havuzu',
     subtitle: 'Herkese açık profil tercihini açan adayları ara.',
@@ -6608,6 +6610,7 @@ const de: Dict = {
     },
   },
   talentPool: {
+    showing: 'Zeige {from}–{to} von {total} Kandidaten',
     navLink: 'Talentpool',
     title: 'Talentpool',
     subtitle: 'Suche Kandidaten, die ein öffentliches Profil aktiviert haben.',


### PR DESCRIPTION
Closes #1392 · Part of #1364

## A failure with no symptom

The endpoint read `take: 60` from the database and only **then** applied the skill filter in JS. A skill held by nobody among the 60 most recently updated mentees returned zero results — and the response carried no `total`, so an incomplete answer and an empty pool rendered identically. Nothing on screen could hint the search had been cut short.

## Why not just raise the limit

`take: 500` was the tempting fix and it is the wrong one: it moves the threshold, then reports the capped number as the total. That is the same silent lie one layer up — "Showing 1–24 of 500" when there are 600. The issue itself calls the missing count the worst part.

Instead this follows `/api/candidates`, which already solved this exact problem, rather than inventing a third variant:

| branch | how |
|---|---|
| no skill filter | the **database** counts and paginates (`count()` + `skip`/`take`) |
| skill filter | fetch the visible set, filter in JS (MySQL cannot match inside a JSON array), `total` from the **filtered** rows, slice from those |

The count always comes from the same set the page is sliced from. That is the whole invariant.

## The embargo had to move too

The early-access window (#531) ran as a **post-filter**, shrinking the list after the limit. Left there it could only ever make an already-wrong count wronger — and computing `total` before it would recreate the same lie ("Showing 1–24 of 40" with 31 rows). It is now part of `where`, expressed through `menteeRelations.statusChanges`, so it narrows the set the DB counts. The existing embargo spec stays green.

## On screen

The page says how many candidates matched and pages through them, reusing `common.prev` / `common.next` rather than inventing a fourth pagination vocabulary — the repo already has three.

Filter changes reset to page 1. Without that, retyping a filter while on page 3 asks for page 3 of a smaller set and renders an empty grid — which looks *exactly* like the bug being fixed.

New testids (`talent-pool-search`, `talent-pool-skill`, `talent-pool-total`, `talent-pool-prev`/`next`) because `AdminNav` renders its own `input[type="search"]` on every page, so unscoped selectors are unusable here (CLAUDE.md).

## Deliberately out of scope

The skill comparison is still a plain `toLowerCase`. #1392's own item 4 defers the Turkish-casing decision to **#1389**, which is an open `stajyer` good-first-issue — that decision is not mine to pre-empt. The two are separable: this bug is about *ordering*, not casing.

## Verification

Local MySQL, 65 consenting public mentees, **both directions**:

- [x] The rare skill held only by the least-recently-updated mentee — outside the old 60-row window — is found. **Red on the old handler** (`total: undefined`, zero candidates)
- [x] `total` is the whole matching set (65), not the page
- [x] `pageSize=10` pages 1 and 2 return 10 each with **no overlapping ids**
- [x] A page past the end is empty rather than an error, and still reports the real total
- [x] The rendered count line and pager appear (the half of the bug a user can see)
- [x] `e2e/talent-pool.spec.ts` and `e2e/talent-pool-early-access.spec.ts` unchanged and green — the consent-revocation and embargo guards
- [x] `npx tsc --noEmit`, `npm run lint`, `npm run check:i18n` (3221 × 3), `check:release-fragments` all clean

Note: neither the new spec nor the two existing ones carry `@smoke`, so the PR gate does not execute them — they run locally and in the 4×/day full suite. The verification above is my local run.

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeSYkGngKpYG4KWsJ7Ph2Z)_