### PR TITLE
fix(email): report what the transport actually did, not "did not throw" (#1431)

### DIFF
--- a/e2e/email-sent-honesty.spec.ts
+++ b/e2e/email-sent-honesty.spec.ts
@@ -1,0 +1,131 @@
+import { test, expect, type APIResponse } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { signInAndSettle } from './helpers/auth';
+
+/**
+ * #1431 — four endpoints reported `emailSent: true` when nothing was delivered.
+ *
+ * `sendEmail` returns NORMALLY when SMTP is unconfigured or demo mode is on; it
+ * records a SKIPPED delivery row and returns. The callers defined success as
+ * "did not throw", so the API said the set-password link was on its way while
+ * the app's own delivery log said SKIPPED. The account existed and nobody could
+ * ever sign in to it — the exact situation the already-written UI string
+ * `loginCreatedNoEmail` was for, which never fired.
+ *
+ * The test environment runs with `SMTP_USER: ''` (playwright.config.ts), which
+ * is precisely the state the bug needs, so no mocking is required.
+ *
+ * The assertion that matters most is not `emailSent === false` on its own but
+ * that it AGREES with the EmailLog row written by the same request: a response
+ * and a delivery log that disagree is the bug, in either direction.
+ */
+
+const PW = 'EmailHonesty123!';
+
+async function latestLogFor(to: string) {
+  return prisma.emailLog.findFirst({ where: { to }, orderBy: { createdAt: 'desc' }, select: { status: true, error: true } });
+}
+
+/** `emailSent` must mirror the delivery row: SENT ⇔ true. */
+async function expectAgreement(res: APIResponse, to: string) {
+  expect(res.ok()).toBeTruthy();
+  const { emailSent } = await res.json();
+  const log = await latestLogFor(to);
+  expect(log, `no EmailLog row was written for ${to}`).not.toBeNull();
+  expect(emailSent, `emailSent=${emailSent} but the delivery log says ${log?.status} (${log?.error ?? ''})`)
+    .toBe(log!.status === 'SENT');
+  return { emailSent, log: log! };
+}
+
+test.describe.configure({ mode: 'serial' });
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('with no SMTP, creating a company login reports that nothing was delivered', async ({ page }) => {
+  const adminEmail = uniqueEmail('honesty-admin');
+  const companyUserEmail = uniqueEmail('honesty-company-user');
+  await seedUser(adminEmail, PW, 'ADMIN', 'Honesty Admin');
+  const company = await prisma.company.create({ data: { name: `Honesty Co ${Date.now()}` } });
+
+  try {
+    await signInAndSettle(page, adminEmail, PW, '/admin');
+
+    const res = await page.request.post('/api/admin/company-users', {
+      data: { companyId: company.id, email: companyUserEmail, fullName: 'Honesty Company User' },
+    });
+    const { emailSent, log } = await expectAgreement(res, companyUserEmail);
+
+    // In this environment delivery is impossible, so the honest answer is false.
+    expect(emailSent).toBe(false);
+    expect(log.status).toBe('SKIPPED');
+    expect(log.error).toContain('SMTP not configured');
+
+    // The account really was created — that is what makes the lie dangerous
+    // rather than merely wrong.
+    expect(await prisma.user.count({ where: { email: companyUserEmail } })).toBe(1);
+  } finally {
+    await prisma.emailLog.deleteMany({ where: { to: companyUserEmail } });
+    await cleanupByEmail(companyUserEmail);
+    await cleanupByEmail(adminEmail);
+    await prisma.company.delete({ where: { id: company.id } }).catch(() => {});
+  }
+});
+
+test('the same holds for a source login and for an admin password reset', async ({ page }) => {
+  const adminEmail = uniqueEmail('honesty-admin2');
+  const sourceUserEmail = uniqueEmail('honesty-source-user');
+  const menteeEmail = uniqueEmail('honesty-mentee');
+  await seedUser(adminEmail, PW, 'ADMIN', 'Honesty Admin 2');
+  const mentee = await seedUser(menteeEmail, PW, 'MENTEE', 'Honesty Mentee');
+  const source = await prisma.source.create({ data: { name: `Honesty Source ${Date.now()}` } });
+
+  try {
+    await signInAndSettle(page, adminEmail, PW, '/admin');
+
+    const sourceRes = await page.request.post('/api/admin/source-users', {
+      data: { sourceId: source.id, email: sourceUserEmail, fullName: 'Honesty Source User' },
+    });
+    expect((await expectAgreement(sourceRes, sourceUserEmail)).emailSent).toBe(false);
+
+    const resetRes = await page.request.post(`/api/admin/users/${mentee.id}/reset-password`);
+    expect((await expectAgreement(resetRes, menteeEmail)).emailSent).toBe(false);
+
+    // #987 must stay closed: the reset endpoint still does not hand back a
+    // live credential, however loudly it now reports the delivery failure.
+    const resetBody = await resetRes.json();
+    expect(resetBody.setPasswordUrl).toBeUndefined();
+    expect(JSON.stringify(resetBody)).not.toContain('/auth/reset?token=');
+  } finally {
+    await prisma.emailLog.deleteMany({ where: { to: { in: [sourceUserEmail, menteeEmail] } } });
+    await cleanupByEmail(sourceUserEmail);
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(adminEmail);
+    await prisma.source.delete({ where: { id: source.id } }).catch(() => {});
+  }
+});
+
+test('an invitation stops claiming it was sent when it was only skipped', async ({ page }) => {
+  // The invite routes already guessed via `!!process.env.SMTP_USER`, which is
+  // right about a missing SMTP_USER and wrong about demo mode. They now read the
+  // same value as everyone else.
+  const adminEmail = uniqueEmail('honesty-admin3');
+  const inviteeEmail = uniqueEmail('honesty-invitee');
+  await seedUser(adminEmail, PW, 'ADMIN', 'Honesty Admin 3');
+
+  try {
+    await signInAndSettle(page, adminEmail, PW, '/admin');
+    const res = await page.request.post('/api/invite', { data: { email: inviteeEmail, role: 'MENTEE' } });
+    expect(res.ok()).toBeTruthy();
+    const body = await res.json();
+    expect(body.emailSent).toBe(false);
+    // …and the link is still returned, because sharing it manually is the whole
+    // fallback this honesty enables.
+    expect(body.registerUrl ?? body.inviteUrl ?? '').toContain('token=');
+  } finally {
+    await prisma.emailLog.deleteMany({ where: { to: inviteeEmail } });
+    await prisma.invitationToken.deleteMany({ where: { email: inviteeEmail } });
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/releases/unreleased/email-sent-honesty.json
+++ b/releases/unreleased/email-sent-honesty.json
@@ -1,0 +1,9 @@
+{
+  "bump": "patch",
+  "changelog": "**Fixed** — four endpoints reported `emailSent: true` when nothing had been delivered. `sendEmail` returns normally (recording a SKIPPED row) when SMTP is unconfigured or demo mode is on, and the callers read that silence as success — so creating a company or source login, resetting a password, or activating a mentee claimed the set-password link was on its way while the delivery log said SKIPPED, leaving an account nobody could sign in to. `sendEmail` and its wrappers now return `'SENT' | 'SKIPPED' | 'FAILED'`, all six routes derive `emailSent` from that, and the invite routes' `!!process.env.SMTP_USER` guess is gone — it was right about a missing SMTP_USER and wrong about demo mode.",
+  "notes": {
+    "en": ["When a set-password or invitation email cannot be delivered, the screen now says so instead of reporting it as sent."],
+    "tr": ["Parola belirleme ya da davet e-postası gönderilemediğinde ekran artık \"gönderildi\" demiyor, durumu olduğu gibi söylüyor."],
+    "de": ["Wenn eine Passwort- oder Einladungs-E-Mail nicht zugestellt werden kann, sagt der Bildschirm das jetzt, statt sie als gesendet zu melden."]
+  }
+}

--- a/src/app/api/admin/company-users/route.ts
+++ b/src/app/api/admin/company-users/route.ts
@@ -45,9 +45,13 @@ export async function POST(request: Request) {
   // it in an HTTP response body puts it in reverse-proxy logs, browser
   // devtools and every screen share — the same leak #875 closed for
   // /api/admin/users/[id]/reset-password. Neither admin screen ever read it.
+  // Derived from what the transport actually reported, not from "did not
+  // throw" (#1431): sendEmail returns normally on the demo-mode and
+  // no-SMTP paths, and reading that silence as success is what told an admin
+  // an account was reachable when nobody could sign in to it.
   let emailSent = true;
   try {
-    await sendPasswordResetEmail({ to: user.email, token, fullName: user.fullName, purpose: 'SET_INITIAL', orgId: user.orgId });
+    emailSent = (await sendPasswordResetEmail({ to: user.email, token, fullName: user.fullName, purpose: 'SET_INITIAL', orgId: user.orgId })) === 'SENT';
   } catch (e) {
     console.error('Company-user set-password email failed:', e);
     emailSent = false;

--- a/src/app/api/admin/source-users/route.ts
+++ b/src/app/api/admin/source-users/route.ts
@@ -44,9 +44,13 @@ export async function POST(request: Request) {
   // it in an HTTP response body puts it in reverse-proxy logs, browser
   // devtools and every screen share — the same leak #875 closed for
   // /api/admin/users/[id]/reset-password. Neither admin screen ever read it.
+  // Derived from what the transport actually reported, not from "did not
+  // throw" (#1431): sendEmail returns normally on the demo-mode and
+  // no-SMTP paths, and reading that silence as success is what told an admin
+  // an account was reachable when nobody could sign in to it.
   let emailSent = true;
   try {
-    await sendPasswordResetEmail({ to: user.email, token, fullName: user.fullName, purpose: 'SET_INITIAL', orgId: user.orgId });
+    emailSent = (await sendPasswordResetEmail({ to: user.email, token, fullName: user.fullName, purpose: 'SET_INITIAL', orgId: user.orgId })) === 'SENT';
   } catch (e) {
     console.error('Source-user set-password email failed:', e);
     emailSent = false;

--- a/src/app/api/admin/users/[id]/reset-password/route.ts
+++ b/src/app/api/admin/users/[id]/reset-password/route.ts
@@ -42,9 +42,13 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
   }
 
   const token = await createPasswordResetToken(user.id, 'RESET');
+  // Derived from what the transport actually reported, not from "did not
+  // throw" (#1431): sendEmail returns normally on the demo-mode and
+  // no-SMTP paths, and reading that silence as success is what told an admin
+  // an account was reachable when nobody could sign in to it.
   let emailSent = true;
   try {
-    await sendPasswordResetEmail({ to: user.email, token, fullName: user.fullName, orgId: user.orgId });
+    emailSent = (await sendPasswordResetEmail({ to: user.email, token, fullName: user.fullName, orgId: user.orgId })) === 'SENT';
   } catch (e) {
     console.error('Admin reset email failed:', e);
     emailSent = false;

--- a/src/app/api/invite/[id]/route.ts
+++ b/src/app/api/invite/[id]/route.ts
@@ -37,8 +37,8 @@ export async function POST(_request: Request, { params }: { params: Promise<{ id
   let emailSent = false;
   if (invite.email) {
     try {
-      await sendInvitationEmail({ to: invite.email, token: invite.token, role: invite.role, orgId: resolveOrgId(session) });
-      emailSent = !!process.env.SMTP_USER;
+      // Same single source of truth as POST /api/invite (#1431).
+      emailSent = (await sendInvitationEmail({ to: invite.email, token: invite.token, role: invite.role, orgId: resolveOrgId(session) })) === 'SENT';
     } catch (e) {
       console.error('Resend invitation email failed (token still valid):', e);
     }

--- a/src/app/api/invite/route.ts
+++ b/src/app/api/invite/route.ts
@@ -193,8 +193,12 @@ export async function POST(request: Request) {
       let emailSent = false;
       if (email) {
         try {
-          await sendInvitationEmail({ to: email, token, role, orgId: resolveOrgId(session) });
-          emailSent = !!process.env.SMTP_USER;
+          // Was `!!process.env.SMTP_USER` — a guess that happened to be right
+          // about a missing SMTP_USER and wrong about demo mode, where nothing
+          // is delivered either. The transport now reports what it did, so
+          // there is one source of truth and a future skip reason (a
+          // suppression list, say) is covered without touching this line.
+          emailSent = (await sendInvitationEmail({ to: email, token, role, orgId: resolveOrgId(session) })) === 'SENT';
         } catch (mailErr) {
           console.error('Invitation email failed (token still valid):', mailErr);
         }

--- a/src/app/api/mentor/mentees/[id]/route.ts
+++ b/src/app/api/mentor/mentees/[id]/route.ts
@@ -97,13 +97,13 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
       const setPasswordUrl = `${appUrl}/auth/reset?token=${token}`;
       let emailSent = true;
       try {
-        await sendPasswordResetEmail({
+        emailSent = (await sendPasswordResetEmail({
           to: email,
           token,
           fullName: mentee.fullName,
           purpose: 'SET_INITIAL',
           orgId: mentee.orgId,
-        });
+        })) === 'SENT';
       } catch (e) {
         console.error('Mentee activation email failed:', e);
         emailSent = false;

--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -258,6 +258,18 @@ export async function runEmailHealthCheck(): Promise<EmailHealth> {
   return health;
 }
 
+// What actually happened to a message, mirroring the EmailLog row this call
+// writes (#1431). Returned rather than only recorded, because "did not throw"
+// is not the same as "was delivered": the two SKIPPED paths below return
+// normally, and four routes were reading that silence as success — reporting
+// `emailSent: true` for an account nobody could ever sign in to.
+//
+// The throw behaviour is deliberately unchanged: a real transport failure still
+// throws (and is recorded FAILED first), so every existing try/catch keeps
+// working exactly as before. 'FAILED' is in the union for callers that catch and
+// want to name the outcome; sendEmail itself never returns it.
+export type EmailDeliveryResult = 'SENT' | 'SKIPPED' | 'FAILED';
+
 export async function sendEmail({
   to,
   subject,
@@ -302,13 +314,13 @@ export async function sendEmail({
   if (IS_DEMO_MODE) {
     logger.info('Email not sent: demo mode', { to, subject, category });
     await recordEmail(to, subject, category, 'SKIPPED', transport, 'Demo mode — delivery disabled');
-    return;
+    return 'SKIPPED';
   }
 
   if (!process.env.SMTP_USER) {
     logger.error('Email not sent: SMTP is not configured', { to, subject, category });
     await recordEmail(to, subject, category, 'SKIPPED', transport, 'SMTP not configured (SMTP_USER unset)');
-    return;
+    return 'SKIPPED';
   }
 
   try {
@@ -332,6 +344,7 @@ export async function sendEmail({
   }
 
   await recordEmail(to, subject, category, 'SENT', transport);
+  return 'SENT';
 }
 
 // Connectivity-only check (auth + reachability), no message sent — used by the
@@ -387,7 +400,7 @@ export async function sendInvitationEmail({
   const registerUrl = `${appUrl}/auth/register?token=${token}`;
   const brand = await emailBrand(orgId);
 
-  await sendEmail({
+  return await sendEmail({
     to,
     fromName: brand.name,
     category: 'invitation',
@@ -443,7 +456,7 @@ export async function sendPasswordResetEmail({
     : 'We received a request to reset your password. Click the button below to choose a new one.';
   const cta = isInitial ? 'Set password' : 'Reset password';
 
-  await sendEmail({
+  return await sendEmail({
     to,
     fromName: brand.name,
     category: 'password-reset',


### PR DESCRIPTION
Closes #1431 · Part of #1430 · Epic #1429

## The lie

`sendEmail` returns **normally** when SMTP is unconfigured or demo mode is on — it records a `SKIPPED` delivery row and returns. Four routes defined success as *"did not throw"*, so:

```
POST /api/admin/company-users  → 200 {"ok":true,"emailSent":true}
GET  /api/admin/email-log      → { "status":"SKIPPED",
                                   "error":"SMTP not configured (SMTP_USER unset)" }
```

The application's own delivery log and its API answer disagreed, in the direction that hurts: the account existed and **nobody could ever sign in to it**. That is exactly what the already-written UI string `loginCreatedNoEmail` is for — *"Login created, but the set-password email could NOT be sent…"* — and it never fired.

## The fix

`sendEmail` and its two wrappers now return `'SENT' | 'SKIPPED' | 'FAILED'` — the same value already written to `EmailLog`, just also handed back. Six routes derive `emailSent` from it.

**Throw behaviour is deliberately unchanged.** A real transport failure still records `FAILED` and rethrows, so every existing `try/catch` keeps working exactly as before. `'FAILED'` is in the union for callers that catch and want to name the outcome; `sendEmail` itself never returns it.

### The invite routes' guess goes too

`emailSent = !!process.env.SMTP_USER` was right about a missing `SMTP_USER` and **wrong about demo mode**, where nothing is delivered either. Being a second, parallel notion of "was it sent", it would drift again the next time a skip reason is added. The decision now lives in one place, so a future suppression list is covered without touching a caller.

## What the tests actually assert

The load-bearing assertion is **not** `emailSent === false` on its own — it is that `emailSent` **agrees with the `EmailLog` row written by the same request**:

```ts
expect(emailSent, `emailSent=${emailSent} but the delivery log says ${log.status}`)
  .toBe(log.status === 'SENT');
```

A response and a delivery log that disagree is the bug, in either direction. Pinning `false` alone would pass just as happily on a build that never sends anything at all.

The test environment already runs with `SMTP_USER: ''` (`playwright.config.ts:83`), which is precisely the state the bug needs — no mocking involved.

## Verification

Local MySQL, **both directions**:

- [x] Company login: `emailSent: false`, log `SKIPPED — SMTP not configured`, and the user row really exists (that is what makes the lie dangerous rather than merely wrong)
- [x] Source login and admin password reset: same agreement
- [x] Invitation: `emailSent: false`, and the `registerUrl` is still returned — sharing it by hand is the fallback this honesty enables
- [x] **Red on the old code**: `Expected: false, Received: true` — the exact lie the issue measured
- [x] **#987 stays closed**: the reset response carries no `setPasswordUrl` and no `/auth/reset?token=` anywhere in the body — asserted, not assumed
- [x] `admin-reset-password`, `email-health`, `email-channels`, `email-hardening` all green (7/7)
- [x] `npm run build`, `npx tsc --noEmit`, `npm run lint`, `check:release-fragments` clean

**No schema change.** No new i18n keys — the UI strings and their EN/TR/DE translations were already written and simply never reached.

### One correction to my own process

While checking for regressions I ran the four related specs as a batch, saw `email-hardening:19` fail, then re-ran that one test alone on a clean tree and concluded I had broken it. That comparison was invalid — one test in isolation versus four in a batch. Re-running the same batch with the change gives 7/7 green; the failure was cross-spec ordering, not this diff.

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeSYkGngKpYG4KWsJ7Ph2Z)_