### PR TITLE
docs(testing): record the measured production baseline behind the k6 budgets (#1449)

### DIFF
--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -69,6 +69,29 @@ tarafı için ayrı bir kapı koymak: `k6 archive <betik> -O /dev/null` tek iste
 bundle + init-context değerlendirmesi yapıyor, var olmayan bir metriği adlandıran eşiği bile
 yakalıyor.
 
+**"Ortam bozuk" demeden önce zaman çizelgesine bak — ortam silinmiş olabilir.** Topic
+ortamına (`crm-pr1458.ersah.in`) k6 koşturdum, her istek
+`x509: certificate is valid for s.ersah.in` ile patladı. İlk teşhisim "yeni subdomain'in
+sertifikası henüz kesilmemiş" oldu ve bunu PR'a yorum olarak yazdım — **yanlıştı**. Gerçek
+sıralama: 14:26'da curl ile altı uç noktayı da 200 aldım, 14:26:40'ta PR auto-merge ile
+birleşti, 14:27:29'da `topic-teardown.sh` Plesk subdomain'ini sildi, 14:27:32'de k6 koşum
+başladı. Yani sertifika sorunu değil, **ortam artık yoktu**; sunucu varsayılan sertifikasını
+dönüyordu. Ders: bir PR ortamına karşı ölçüm yapıyorsan önce PR'ın hâlâ açık olduğunu doğrula,
+ve beklenmedik bir altyapı hatasında iş akışı loglarının zaman damgalarını kendi
+komutlarınınkiyle yan yana koy. Prod (`crm.ersah.in`) k6 ile sorunsuz — kalıcı doğrulamayı
+orada yap.
+
+**Auto-merge açtıysan branch'in ayağının altından kayabilir.** Baseline ölçümünü commit'leyip
+push ettiğimde PR çoktan birleşmişti (dokuz dakika önce); commit branch'te kaldı, main'e
+girmedi. Birleşmiş bir PR yeni iş taşıyamaz — branch'i güncel main'den yeniden kurup ayrı bir
+PR açmak gerekiyor. Auto-merge açıkken "bir şey daha ekleyeyim" refleksi bu tuzağa götürüyor.
+
+**Eşikleri "muhakemeyle koydum" diye bırakma; PR'ın kendi önizleme ortamı canlıya çıkınca
+gerçek bir taban ölç.** 1 VU'luk 40 saniyelik bir koşu (prod'a ihmal edilebilir yük) altı uç
+noktanın da 200 döndüğünü, Cloudflare'in k6 user-agent'ına challenge basmadığını ve p95'lerin
+156–777ms bandında olduğunu gösterdi — yani koyduğum bütçelerin tabanın 2–6 katı olduğunu.
+Bu tablo dokümana girdi; "sayılar nereden geliyor" sorusunun cevabı artık dosyada duruyor.
+
 **Kendi işini düşman gözüyle inceleten paralel ajanlar burada gerçekten karşılığını verdi:**
 dört bağımsız merceğin (k6 betiği / e-posta / workflow / güvenlik+doküman) bulduğu 20 kusurun
 neredeyse tamamı somut ve doğruydu, ve yarısı ancak k6'i kurup koşturarak bulunabilirdi.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -162,6 +162,24 @@ deliberately match the ones production has been held to since `stress.yml` shipp
 Per-endpoint budgets are tighter than the aggregate *because they are allowed to be*: holding
 `/auth/signin` to the landing page's 2500ms would make it untestable.
 
+#### Measured baseline (2026-08-26, production, 1 VU)
+
+The budgets above were set by reasoning about what each endpoint does, then sanity-checked
+against an unloaded production baseline. They are **not** derived from a loaded run, so treat
+the first few nightly results as calibration rather than as a verdict:
+
+| `ep` | baseline p95 | budget | headroom |
+|------|--------------|--------|----------|
+| `health` | 156ms | 800ms | 81% |
+| `stories_api` | 164ms | 1200ms | 86% |
+| `signin` | 539ms | 1500ms | 64% |
+| `features` | 677ms | 1500ms | 55% |
+| `landing` | 777ms | 2000ms | 61% |
+
+Roughly 2–6× baseline. That is deliberate: latency at 20 VU is higher than at 1 VU, and a
+budget with no room for the load the test itself applies would fire every night. If the real
+nightly numbers land far from these, move the budgets — and say so in the comment next to them.
+
 ### Safety rules (these are hard constraints)
 
 A k6 script in this repo points at a **live, shared environment**, so:


### PR DESCRIPTION
## Summary

#1458'in devamı — o PR bu değişiklik inmeden birleşti, o yüzden ayrı PR.

`k6/nightly-load.js`'deki uç nokta bütçeleri **muhakemeyle** konulmuştu, ölçümle değil. Prod'a karşı 1 VU'luk 40 saniyelik bir koşu (ihmal edilebilir yük) yüksüz tabanı verdi ve bütçelerin o tabanın kabaca **2–6 katı** olduğunu gösterdi — 20 VU'da gecikme yükseleceği için istenen pay tam da bu. Sayıları `docs/testing.md`'ye yazdım ki "bu bütçeler nereden geliyor" sorusunun cevabı dosyada dursun; bir sonraki kişi tahmin etmek yerine ölçüme bakarak oynatabilsin.

| `ep` | taban p95 | bütçe | pay |
|------|-----------|-------|-----|
| `health` | 156ms | 800ms | %81 |
| `stories_api` | 164ms | 1200ms | %86 |
| `signin` | 539ms | 1500ms | %64 |
| `features` | 677ms | 1500ms | %55 |
| `landing` | 777ms | 2000ms | %61 |

Bu arada #1458'de açık bıraktığım iki soru da kapandı: altı uç nokta da k6'in user-agent'ına **200** dönüyor (Cloudflare challenge yok), ve `crm.ersah.in`'e k6'den TLS temiz.

## Changes

- `docs/testing.md` — eşik tablosunun altına "Measured baseline (2026-08-26, production, 1 VU)" alt bölümü.
- `docs/agent-experience.md` — bu turun iki dersi, biri **kendi hatamın düzeltmesi**: #1458'e "yeni topic ortamının sertifikası yok" diye yorum yazmıştım, yanlıştı. Gerçek sıralama — 14:26 curl ile altı uç nokta da 200, **14:26:40 PR auto-merge ile birleşti**, 14:27:29 `topic-teardown.sh` subdomain'i sildi, 14:27:32 k6 koşum başladı. Sertifika sorunu değil, ortam artık yoktu. #1458'e de düzeltme yorumu bıraktım.

## Verification

- [x] `npm run lint` + `npx tsc --noEmit` clean — değişen tek şey iki markdown dosyası
- [x] CI green bekleniyor
- [x] Tablodaki sayılar uydurma değil: `BASE_URL=https://crm.ersah.in K6_PEAK_VUS=1 K6_SMOKE=1 k6 run k6/nightly-load.js` çıktısından alındı (14 istek, %0 hata)

Sadece dokümantasyon olduğu için sürüm parçası yok (`releases/README.md`: "pure docs … need no fragment").

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.


---
_Generated by [Claude Code](https://claude.ai/code/session_017u1CYx3Fwtpq5uDWsGYEkE)_