### PR TITLE
fix(notifications): let the Messages preference silence the in-app bell too (#1426)

### DIFF
--- a/e2e/notif-prefs.spec.ts
+++ b/e2e/notif-prefs.spec.ts
@@ -68,3 +68,66 @@ test('the audit categories opt out through the account settings UI', async ({ pa
     await cleanupByEmail(email);
   }
 });
+
+/**
+ * #1426 — the "Messages" category silences e-mail but not the in-app bell.
+ *
+ * `notificationCategoryAllowed` and the `notifyIfAllowed` wrapper both exist and
+ * both document that a category switch covers every channel; the message paths
+ * simply called bare `notify()` four lines above an e-mail branch that did check.
+ * `notifCategoriesHint` promises users in all three locales that these switches
+ * apply to e-mail and in-app alike — this makes that true.
+ */
+test('turning Messages off stops the in-app notification too, not only the email', async ({ page }) => {
+  const mentorEmail = uniqueEmail('np-msg-mentor');
+  const menteeEmail = uniqueEmail('np-msg-mentee');
+  const optedInEmail = uniqueEmail('np-msg-optedin');
+  const pw = 'NotifPrefs123!';
+  const mentor = await seedUser(mentorEmail, pw, 'MENTOR', 'NP Msg Mentor');
+  const mentee = await seedUser(menteeEmail, pw, 'MENTEE', 'NP Msg Mentee');
+  const optedIn = await seedUser(optedInEmail, pw, 'MENTEE', 'NP Msg OptedIn');
+  const optedOutRelation = await prisma.mentorshipRelation.create({
+    data: { mentorId: mentor.id, menteeId: mentee.id, status: 'ACTIVE' },
+  });
+  const controlRelation = await prisma.mentorshipRelation.create({
+    data: { mentorId: mentor.id, menteeId: optedIn.id, status: 'ACTIVE' },
+  });
+  // One mentee opts out; the other is the control, so a test that silenced
+  // everything would not pass either.
+  await prisma.user.update({ where: { id: mentee.id }, data: { notificationPrefs: { messages: false } } });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', mentorEmail);
+    await page.fill('input[type="password"]', pw);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/mentor'), { timeout: 20_000 });
+
+    for (const relationId of [optedOutRelation.id, controlRelation.id]) {
+      const res = await page.request.post('/api/messages', {
+        data: { relationId, body: 'Preference check' },
+      });
+      expect(res.ok(), await res.text()).toBeTruthy();
+    }
+
+    // The opted-out mentee gets no bell row…
+    await expect
+      .poll(async () => prisma.notification.count({ where: { userId: mentee.id, type: { startsWith: 'message.' } } }), { timeout: 10_000 })
+      .toBe(0);
+    // …while the message itself was still delivered to the thread. Opting out of
+    // the notification is not opting out of the conversation.
+    expect(await prisma.message.count({ where: { relationId: optedOutRelation.id } })).toBe(1);
+
+    // The control mentee still gets one, proving the gate is selective.
+    await expect
+      .poll(async () => prisma.notification.count({ where: { userId: optedIn.id, type: { startsWith: 'message.' } } }), { timeout: 10_000 })
+      .toBe(1);
+  } finally {
+    await prisma.notification.deleteMany({ where: { userId: { in: [mentee.id, optedIn.id] } } });
+    await prisma.message.deleteMany({ where: { relationId: { in: [optedOutRelation.id, controlRelation.id] } } });
+    await prisma.mentorshipRelation.deleteMany({ where: { id: { in: [optedOutRelation.id, controlRelation.id] } } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(optedInEmail);
+    await cleanupByEmail(mentorEmail);
+  }
+});

--- a/releases/unreleased/messages-pref-in-app.json
+++ b/releases/unreleased/messages-pref-in-app.json
@@ -1,0 +1,9 @@
+{
+  "bump": "patch",
+  "changelog": "**Fixed** — the **Messages** notification category silenced e-mail but not the in-app bell. Four message paths (direct messages, the mentor bulk composer, emailed replies, and public-profile contact) called `notify()` ungated, in some cases four lines above an e-mail branch that did check the same preference. All four now honour it, failing open on a missing user row.",
+  "notes": {
+    "en": ["Turning off the Messages notification category now also stops the in-app bell, not only the emails."],
+    "tr": ["Mesajlar bildirim kategorisini kapatmak artık yalnızca e-postaları değil, uygulama içi bildirimleri de susturuyor."],
+    "de": ["Das Abschalten der Kategorie „Nachrichten“ stoppt jetzt auch die In-App-Glocke, nicht nur die E-Mails."]
+  }
+}

--- a/src/app/api/mentor/email/route.ts
+++ b/src/app/api/mentor/email/route.ts
@@ -8,7 +8,7 @@ import { notify } from '@/lib/notify';
 import { replyAddress } from '@/lib/replyToken';
 import { conversationForRelation } from '@/lib/conversations';
 import { withTenantScope } from '@/lib/orgContext';
-import { emailAllowed } from '@/lib/notificationPrefs';
+import { emailAllowed, notificationCategoryAllowed } from '@/lib/notificationPrefs';
 import { TEXT_LIMITS } from '@/lib/textLimits';
 import { normalizeEmailVariants, canonicalEmail, resolveEmail } from '@/lib/localizedEmail';
 
@@ -118,7 +118,12 @@ export async function POST(request: Request) {
       });
       const link = conversation ? `/messages/c/${conversation.id}` : `/messages/${rel.id}`;
       const senderName = session.user.name;
-      await notify(rel.menteeId, senderName ? 'message.new' : 'message.newGeneric', senderName ? { from: senderName } : {}, link);
+      // Same category, same gate as the e-mail branch above (#1426). The
+      // mentee record already carries notificationPrefs from the select, so
+      // this costs no extra query.
+      if (notificationCategoryAllowed(rel.mentee, 'messages')) {
+        await notify(rel.menteeId, senderName ? 'message.new' : 'message.newGeneric', senderName ? { from: senderName } : {}, link);
+      }
       sent++;
     }
 

--- a/src/app/api/messages/route.ts
+++ b/src/app/api/messages/route.ts
@@ -18,7 +18,7 @@ import { replyAddress } from '@/lib/replyToken';
 import { reactionLinksHtml, markReadUrl } from '@/lib/emailActionToken';
 import { sendEmail } from '@/services/emailService';
 import { logger } from '@/lib/logger';
-import { emailAllowed } from '@/lib/notificationPrefs';
+import { emailAllowed, notificationCategoryAllowed } from '@/lib/notificationPrefs';
 import { ALLOWED_DOC_MIME, MAX_DOC_BYTES } from '@/lib/documentAccess';
 import { contentMatchesType, CONTENT_MISMATCH_ERROR } from '@/lib/fileType';
 import { withTenantScope } from '@/lib/orgContext';
@@ -305,14 +305,24 @@ export async function POST(request: Request) {
     // the sentence is rendered in the recipient's locale at display time.
     const senderName = session.user.name;
     for (const recipient of recipients) {
-      await notify(recipient, senderName ? 'message.new' : 'message.newGeneric', senderName ? { from: senderName } : {}, link);
-
-      // Mirror the message to the recipient's inbox (unless they opted out). The
-      // Reply-To routes email replies back into this thread via /api/inbound-email.
+      // Read the recipient's preferences BEFORE either channel (#1426). The
+      // "Messages" switch on /account is documented — in all three locales — as
+      // applying to e-mail and in-app alike, but the in-app insert below used to
+      // run ungated while the e-mail branch four lines down obeyed it. Someone
+      // who turned the category off still got the bell filling up.
       const rcpt = await prisma.user.findUnique({
         where: { id: recipient },
         select: { email: true, emailNotifications: true, notificationPrefs: true },
       });
+      // Fail OPEN on a missing row: `!rcpt || allowed`, never `rcpt && allowed`.
+      // A notification that vanishes because a lookup came back empty is worse
+      // than one that arrives despite an opt-out, and the default is ON anyway.
+      if (!rcpt || notificationCategoryAllowed(rcpt, 'messages')) {
+        await notify(recipient, senderName ? 'message.new' : 'message.newGeneric', senderName ? { from: senderName } : {}, link);
+      }
+
+      // Mirror the message to the recipient's inbox (unless they opted out). The
+      // Reply-To routes email replies back into this thread via /api/inbound-email.
       if (rcpt?.email && emailAllowed(rcpt, 'messages')) {
         const sender = session.user.name ?? 'Your mentor';
         const safe = body.replace(/[<>&]/g, (c) => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;' }[c] as string));

--- a/src/app/api/public-contact/[userId]/route.ts
+++ b/src/app/api/public-contact/[userId]/route.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { prisma } from '@/lib/prisma';
 import { enforceRateLimit } from '@/lib/rateLimit';
 import { TEXT_LIMITS } from '@/lib/textLimits';
-import { emailAllowed } from '@/lib/notificationPrefs';
+import { emailAllowed, notificationCategoryAllowed } from '@/lib/notificationPrefs';
 import { notify } from '@/lib/notify';
 import { sendPublicContactEmail } from '@/services/emailService';
 
@@ -51,7 +51,11 @@ export async function POST(request: Request, { params }: { params: Promise<{ use
   if (!owner) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 
   const preview = message.length > 300 ? `${message.slice(0, 300)}…` : message;
-  await notify(owner.id, 'public_contact.message', { name, email, preview });
+  // Gated on the same category as the e-mail below (#1426) — the owner already
+  // carries notificationPrefs from the select above.
+  if (notificationCategoryAllowed(owner, 'messages')) {
+    await notify(owner.id, 'public_contact.message', { name, email, preview });
+  }
 
   // Email the owner too (#668) — an outside enquiry is the most time-sensitive
   // thing a public profile receives and used to be in-app only. Opt-out

--- a/src/lib/inboundEmail.ts
+++ b/src/lib/inboundEmail.ts
@@ -1,4 +1,5 @@
 import { prisma } from '@/lib/prisma';
+import { notificationCategoryAllowed } from '@/lib/notificationPrefs';
 import { conversationForRelation } from '@/lib/conversations';
 import { verifyReplyToken, extractReplyToken } from '@/lib/replyToken';
 import { notify } from '@/lib/notify';
@@ -47,7 +48,12 @@ export async function routeInboundEmail(input: InboundEmail): Promise<InboundRes
 
   const rel = await prisma.mentorshipRelation.findUnique({
     where: { id: relationId },
-    include: { mentor: { select: { id: true, email: true } }, mentee: { select: { id: true, email: true } } },
+    include: {
+      // notificationPrefs so the in-app reply notification can honour the
+      // recipient's "Messages" category (#1426).
+      mentor: { select: { id: true, email: true, notificationPrefs: true } },
+      mentee: { select: { id: true, email: true, notificationPrefs: true } },
+    },
   });
   if (!rel) return { ok: false, status: 404, reason: 'Thread not found' };
 
@@ -111,9 +117,14 @@ export async function routeInboundEmail(input: InboundEmail): Promise<InboundRes
     logger.error('Failed to mark thread read after inbound reply', { relationId, senderId, error: String(e) });
   }
 
-  const recipient = senderId === rel.mentor.id ? rel.mentee.id : rel.mentor.id;
+  const recipientUser = senderId === rel.mentor.id ? rel.mentee : rel.mentor;
   const link = conversation ? `/messages/c/${conversation.id}` : `/messages/${relationId}`;
-  await notify(recipient, 'message.newByEmail', {}, link);
+  // An emailed reply is still a message, so it belongs to the same category
+  // (#1426). Someone who switched Messages off has said they do not want the
+  // bell for this conversation, whichever door the reply came through.
+  if (notificationCategoryAllowed(recipientUser, 'messages')) {
+    await notify(recipientUser.id, 'message.newByEmail', {}, link);
+  }
 
   return { ok: true, relationId, duplicate: false };
 }


### PR DESCRIPTION
Closes #1426 · Part of #1405

## A promise the code did not keep

The category switches on `/account` are documented as covering every channel — in `notificationPrefs.ts`, in `notifyIfAllowed`'s own comment, and in the `notifCategoriesHint` string users read in **all three locales**. For the Messages category that was simply false.

In `src/app/api/messages/route.ts` the ungated `notify()` sat **four lines above** an email branch that *did* check the same preference:

```ts
await notify(recipient, 'message.new', …);          // ← ungated

const rcpt = await prisma.user.findUnique({ … notificationPrefs: true });
if (rcpt?.email && emailAllowed(rcpt, 'messages')) { …                // ← gated
```

Someone who switched Messages off stopped getting the emails and kept watching the bell fill up.

The helper this needed already existed — `notificationCategoryAllowed`, and the `notifyIfAllowed` wrapper built on it for #886. These call sites never reached for it.

## Four sites, one gate

| Path | How |
|---|---|
| `/api/messages` | the recipient lookup **moves above** the notify — which is also why this costs no extra query |
| `/api/mentor/email` | `rel.mentee` already carried `notificationPrefs` |
| `lib/inboundEmail` | an emailed reply is still a message; both selects now include `notificationPrefs` |
| `/api/public-contact/[userId]` | a **fourth** instance the issue does not name |

**Fail open on a missing row** — `!rcpt || allowed`, never `rcpt && allowed`. A notification that vanishes because a lookup came back empty is worse than one that arrives despite an opt-out, and the default is ON anyway.

### Left alone deliberately

`questions`, admin password reset, impersonation, the support routes, and mentorship assignment. Those carry no category and no email counterpart — several are security notices nobody should be able to switch off.

## What the test proves

Two mentees, one opted out and one **control who did not** — so a change that silenced everything would fail it too. It also asserts the message itself still reached the thread: **opting out of the notification is not opting out of the conversation.**

- [x] Opted-out mentee: 0 bell rows — **red on the old code** (`Expected: 0, Received: 1`)
- [x] Control mentee: exactly 1, so the gate is selective
- [x] `Message` row still created for the opted-out thread
- [x] `e2e/messaging.spec.ts` + `e2e/inbound-email.spec.ts` green (4/4) — they assert the in-app row is created, and still get it
- [x] `npx tsc --noEmit` + `npm run lint` clean, `check:release-fragments` green

**No schema change** (`User.notificationPrefs` already exists) and **no new i18n keys** — this makes an existing promise true rather than adding a new one.

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeSYkGngKpYG4KWsJ7Ph2Z)_