### PR TITLE
fix: restore public shell on 404 pages

### DIFF
--- a/releases/unreleased/not-found-public-shell.json
+++ b/releases/unreleased/not-found-public-shell.json
@@ -1,0 +1,4 @@
+{
+  "bump": "patch",
+  "changelog": "- **The 404 page keeps the public site shell** (#1409). `not-found.tsx` rendered a bare centred block, so a visitor who mistyped a URL lost the header, the language and theme switches and the footer — every route out of the page except a single \"back home\" button. It now renders inside `PublicShell` with direct links to register, apply as a mentor and the company page, plus a localized title and `noindex, nofollow` robots metadata."
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,23 +1,73 @@
+import type { Metadata } from 'next';
 import Link from 'next/link';
+import { PublicShell } from '@/components/landing/PublicShell';
 import { getServerDictionary } from '@/i18n/server';
 
-// Localized 404. Rendered inside the root layout (which sets <html lang>), so
-// it inherits the active locale like every other page.
+export async function generateMetadata(): Promise<Metadata> {
+  const { t } = await getServerDictionary();
+
+  return {
+    title: t.notFound.title,
+    robots: {
+      index: false,
+      follow: false,
+    },
+  };
+}
+
 export default async function NotFound() {
   const { t } = await getServerDictionary();
+
+  const doors = [
+    { href: '/auth/register', label: t.publicNav.register },
+    { href: '/apply-as-mentor', label: t.publicNav.becomeMentor },
+    { href: '/for-companies', label: t.forCompanies.nav },
+  ];
+
   return (
-    <div className="min-h-screen flex items-center justify-center p-4 bg-gradient-to-br from-blue-50 to-indigo-50 dark:from-gray-900 dark:to-gray-950">
-      <div className="text-center">
-        <p className="text-6xl font-bold text-blue-600">404</p>
-        <h1 className="mt-4 text-2xl font-bold text-gray-900 dark:text-gray-100">{t.notFound.title}</h1>
-        <p className="mt-2 text-gray-500 dark:text-gray-400">{t.notFound.description}</p>
-        <Link
-          href="/"
-          className="mt-6 inline-block rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-blue-700 transition-colors"
-        >
-          {t.notFound.backHome}
-        </Link>
-      </div>
-    </div>
+    <PublicShell>
+      <section className="flex min-h-[60vh] items-center justify-center px-4 py-16">
+        <div className="w-full max-w-3xl text-center">
+          <p className="text-6xl font-bold text-blue-600">404</p>
+
+          <h1 className="mt-4 text-2xl font-bold text-gray-900 dark:text-gray-100">
+            {t.notFound.title}
+          </h1>
+
+          <p className="mt-2 text-gray-500 dark:text-gray-400">
+            {t.notFound.description}
+          </p>
+
+          <Link
+            href="/"
+            className="mt-6 inline-block rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-blue-700"
+          >
+            {t.notFound.backHome}
+          </Link>
+
+          <div className="mt-10 grid gap-4 sm:grid-cols-3">
+            {doors.map((door) => (
+              <Link
+                key={door.href}
+                href={door.href}
+                className="rounded-xl border border-gray-200 bg-white p-5 text-sm font-medium text-gray-800 shadow-sm transition hover:border-blue-300 hover:shadow-md dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+              >
+                {door.label}
+              </Link>
+            ))}
+          </div>
+
+          <div className="mt-6 flex flex-wrap justify-center gap-4 text-sm">
+            <Link href="/features" className="text-blue-600 hover:underline">
+              {t.publicNav.features}
+            </Link>
+
+            <Link href="/projects" className="text-blue-600 hover:underline">
+              {t.projects.title}
+            </Link>
+          </div>
+        </div>
+      </section>
+    </PublicShell>
   );
 }


### PR DESCRIPTION
Closes #1409

## Summary

Restores the public site shell on the 404 page so visitors retain navigation, language/theme controls, and the footer.

## Changes

- Wrapped `not-found.tsx` with `PublicShell`
- Added Register, Become a mentor, and For companies routes
- Added Features and Projects links
- Added localized page title and `noindex, nofollow` robots metadata

## Verification

- [x] `npx tsc --noEmit` passed
- [x] Production build passed
- [x] i18n check passed via `npx --yes tsx scripts/check-i18n.ts`
- [x] Manually verified 404 page, navigation links, footer, HTTP 404 status, and `noindex`
- [ ] E2E smoke test blocked by an existing local database schema mismatch (`Evaluation.publicExcerpt` missing)

## Contributor terms

- [ ] I accept the contributor terms