### PR TITLE
fix(analytics): give the trend bars a height that resolves (#1425)

### DIFF
--- a/e2e/analytics-trends.spec.ts
+++ b/e2e/analytics-trends.spec.ts
@@ -28,3 +28,90 @@ test('analytics returns a 6-month trend series', async ({ page }) => {
     await cleanupByEmail(email);
   }
 });
+
+/**
+ * #1425 — every bar in the Trends chart rendered at 0px.
+ *
+ * The data was right; a percentage height sat inside a column with no height of
+ * its own, so it computed to `auto` — 0px for an empty div. The month labels
+ * kept rendering because text has intrinsic height, which is exactly why this
+ * read as a data problem rather than a layout one.
+ *
+ * The assertion is the layout invariant itself: a bar's rendered pixels must
+ * equal its own inline percentage of the row it sits in. That is precisely what
+ * was broken (the percentage never became pixels), and unlike comparing against
+ * a separately-fetched API response it cannot drift — the page requests its own
+ * date range, so a bare /api/admin/analytics call returns a different number of
+ * months and the indices do not line up. I tried that first and it produced a
+ * confident, wrong failure.
+ */
+test('every trend bar turns its percentage into real pixels', async ({ page }) => {
+  const email = uniqueEmail('at-render-admin');
+  const mentorEmail = uniqueEmail('at-render-mentor');
+  const menteeEmail = uniqueEmail('at-render-mentee');
+  const pw = 'AdminPass123';
+  await seedUser(email, pw, 'ADMIN', 'AT Render Admin');
+  const mentor = await seedUser(mentorEmail, pw, 'MENTOR', 'AT Render Mentor');
+  const mentee = await seedUser(menteeEmail, pw, 'MENTEE', 'AT Render Mentee');
+  // A relation started this month plus an interaction, so at least one bar is
+  // non-zero however empty the database is.
+  const relation = await prisma.mentorshipRelation.create({
+    data: { mentorId: mentor.id, menteeId: mentee.id, status: 'ACTIVE', startDate: new Date() },
+  });
+  await prisma.interactionLog.create({
+    data: { relationId: relation.id, type: 'Meeting', notes: 'Trend render check', date: new Date() },
+  });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', email);
+    await page.fill('input[type="password"]', pw);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    await page.goto('/admin/analytics');
+    const chart = page.getByTestId('analytics-trend-chart');
+    await expect(chart).toBeVisible({ timeout: 15_000 });
+
+    const bars = await chart.evaluate((track) =>
+      Array.from(track.children).flatMap((column) => {
+        const row = column.firstElementChild as HTMLElement;
+        const rowHeight = row.getBoundingClientRect().height;
+        return Array.from(row.children).map((b) => {
+          const el = b as HTMLElement;
+          return {
+            id: el.dataset.testid ?? '?',
+            pct: parseFloat(el.style.height) || 0,
+            px: el.getBoundingClientRect().height,
+            rowHeight,
+          };
+        });
+      })
+    );
+
+    expect(bars.length, 'the chart rendered no bars at all').toBeGreaterThan(0);
+    // The row itself must have a real height — if it collapses, every bar below
+    // is trivially 0 and the percentage assertion would pass vacuously.
+    expect(bars[0].rowHeight).toBeGreaterThan(50);
+
+    for (const bar of bars) {
+      const expected = (bar.pct / 100) * bar.rowHeight;
+      expect(
+        Math.abs(bar.px - expected),
+        `${bar.id}: style height ${bar.pct}% of a ${bar.rowHeight}px row should be ~${expected.toFixed(1)}px, rendered ${bar.px}px`
+      ).toBeLessThan(2);
+    }
+
+    // …and the data must actually reach the chart: with a fresh relation and
+    // interaction seeded, at least one bar is non-zero and the tallest fills
+    // most of the row. Without this a chart of twelve 0% bars would pass.
+    const tallest = Math.max(...bars.map((b) => b.px));
+    expect(tallest, 'no bar had any height — the chart is empty').toBeGreaterThan(bars[0].rowHeight * 0.5);
+  } finally {
+    await prisma.interactionLog.deleteMany({ where: { relationId: relation.id } });
+    await prisma.mentorshipRelation.deleteMany({ where: { id: relation.id } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(email);
+  }
+});

--- a/releases/unreleased/analytics-trends-bar-height.json
+++ b/releases/unreleased/analytics-trends-bar-height.json
@@ -1,0 +1,4 @@
+{
+  "bump": "patch",
+  "changelog": "**Fixed** — every bar in the admin analytics Trends chart rendered at 0px. The bars size themselves with percentage heights, but no ancestor had a definite height, so the percentages resolved to `auto`. The month labels kept rendering (text has intrinsic height), which made an empty chart look like missing data rather than a broken layout."
+}

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -105,6 +105,12 @@ interface FunnelKpi {
   journeys: number;
 }
 
+// Height of the bar area inside the `h-44` (176px) trends track: the track
+// minus the month label line and its gap. Pinned rather than flex-derived
+// because the bars size themselves with percentage heights, and a percentage
+// only resolves against a definite height (#1425).
+const BAR_AREA_PX = 150;
+
 export default function AdminAnalyticsPage() {
   const t = useT();
   const label = useStageLabel();
@@ -533,18 +539,35 @@ export default function AdminAnalyticsPage() {
         return (
           <Card className="mt-6">
             <CardHeader><CardTitle>{t.analytics.trends}</CardTitle></CardHeader>
-            <div className="flex items-end gap-3 h-44 px-2">
+            {/* A percentage height needs an ancestor with a DEFINITE height,
+                or it computes to `auto` — 0px for an empty div. The column had
+                no height of its own, so all twelve bars collapsed while the
+                month labels (text, so intrinsic height) kept rendering. That is
+                why this read as a data problem rather than a layout one (#1425).
+
+                `h-full` on the column is necessary but not sufficient: a height
+                that comes from `flex-1` is a used value, not a definite one, so
+                percentages inside it still resolve to auto. I measured that —
+                the first attempt kept `flex-1` on the bar row and the bars were
+                still 0px. Hence the explicit row height below; `BAR_AREA_PX` is
+                the `h-44` track (176px) minus the label line and its gap.
+                (The working chart in src/app/mentor/feedback/page.tsx gets away
+                with percentages because its bars are direct children of the
+                definite-height column, with no flex-sized row in between.) */}
+            <div className="flex items-end gap-3 h-44 px-2" data-testid="analytics-trend-chart">
               {data.trends.months.map((m, i) => (
-                <div key={m} className="flex-1 flex flex-col items-center gap-1 min-w-0">
-                  <div className="flex items-end gap-1 flex-1 w-full justify-center">
+                <div key={m} className="flex h-full flex-1 flex-col items-center justify-end gap-1 min-w-0">
+                  <div className="flex w-full items-end justify-center gap-1" style={{ height: BAR_AREA_PX }}>
                     <div
                       className="w-3 sm:w-4 bg-blue-500 rounded-t"
                       style={{ height: `${(data.trends!.newRelations[i] / max) * 100}%` }}
+                      data-testid={`trend-bar-new-${i}`}
                       title={`${t.analytics.trendNewRelations}: ${data.trends!.newRelations[i]}`}
                     />
                     <div
                       className="w-3 sm:w-4 bg-emerald-400 rounded-t"
                       style={{ height: `${(data.trends!.interactions[i] / max) * 100}%` }}
+                      data-testid={`trend-bar-interactions-${i}`}
                       title={`${t.analytics.trendInteractions}: ${data.trends!.interactions[i]}`}
                     />
                   </div>


### PR DESCRIPTION
Closes #1425 · Epic #1429

## Why an empty chart looked like missing data

All twelve bars rendered at 0px. The data was right — the bars size themselves with **percentage heights**, and a percentage needs an ancestor with a *definite* height or it computes to `auto`, which is 0px for an empty div.

The month labels kept rendering, because text has intrinsic height. That is the whole reason this reads as a data problem in a screenshot.

## Two wrong attempts, both measured

**1. `h-full` on the column.** Necessary, not sufficient. The bars sit inside an intermediate row whose height came from `flex-1`, and a flex-derived height is a *used* value, not a definite one. Still 0px.

**2. Pinning the row height.** The test was still red — so I stopped guessing and probed the live DOM:

```json
"row": { "h": 150, "computed": "150px" },
"bar": { "h": 0, "styleH": "0%" }
```

The row *had* resolved. `styleH: "0%"` meant that particular bar's **value was genuinely zero** — the layout was already fixed and my test was wrong.

### What the test was doing wrong

It compared the rendered bars against a separately-fetched `/api/admin/analytics`. But the page requests **its own date range** via `rangeQuery(range)`, so the bare call returned 6 months while the chart drew 7 — and every index was off by one. It produced a confident, wrong failure that sent me looking for a second layout bug that did not exist.

The test now asserts the **layout invariant itself**: every bar's rendered pixels equal its own inline percentage of its row. That is exactly what was broken, and it cannot drift with the date range.

Measured after the fix: **22% → 33px, 89% → 133px, 100% → 150px.**

## The fix

`BAR_AREA_PX` — the `h-44` track minus the label line and its gap — on the bar row, so the percentages resolve against something real.

The working chart in `mentor/feedback/page.tsx` gets away with plain percentages only because its bars are **direct children** of the definite-height column, with no flex-sized row in between. That is now a comment, so the next person does not "simplify" this back into the bug.

## Verification

- [x] `every trend bar turns its percentage into real pixels` — passes, with a non-vacuous guard that the row has real height and at least one bar is tall (a chart of twelve 0% bars would otherwise pass)
- [x] Zero-valued bars still render at 0px — the fix must not invent height
- [x] The existing `analytics returns a 6-month trend series` spec unchanged and green
- [x] `npx tsc --noEmit` + `npm run lint` clean, `check:release-fragments` green

## Unrelated failure I ran into, and did not cause

`e2e/mobile-layout-audit.spec.ts`'s German sweep fails on `/mentor` at 360px — the mentee onboarding wizard overflows its box by 33px. I confirmed it is **pre-existing** by running the *same grep on a clean tree* (not one test in isolation versus a batch — that mistake cost me a wrong conclusion earlier today). Filed as #1465 and left for an intern: it is a small, teachable `min-w-0`-shaped fix in a `stajyer` area.

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeSYkGngKpYG4KWsJ7Ph2Z)_