### PR TITLE
fix(a11y): lift the journey tracker's upcoming stages over AA (#1415)

### DIFF
--- a/e2e/contrast-1415.spec.ts
+++ b/e2e/contrast-1415.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect, type Page } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { signInAsFreshUser } from './helpers/auth';
+
+/**
+ * #1415 — the JourneyTracker's upcoming stages were under AA in BOTH themes.
+ *
+ * This is the first card a mentee sees, and the "future" rows are most of it:
+ * gray-400 on white is 2.54:1, and in dark the badge came out 2.13:1 because
+ * globals.css remaps `bg-gray-100` to #374151 while the element's own
+ * `dark:bg-gray-800` never applied.
+ *
+ * Why the existing a11y gate never caught it: e2e/a11y-scan.spec.ts signs in a
+ * fresh mentee with NO MentorshipRelation, and JourneyTracker only renders when
+ * there is one. The scanned /portal is the empty state — so these selectors are
+ * absent from the baseline entirely, not merely frozen in it.
+ *
+ * axe measures the COMPOSITED colour, which is the only way to catch an inert
+ * `dark:` variant: the class is present in the markup either way.
+ */
+
+const password = 'Contrast1415Pass!';
+
+async function forceTheme(page: Page, dark: boolean) {
+  await page.emulateMedia({ colorScheme: dark ? 'dark' : 'light' });
+  await page.evaluate((theme) => {
+    document.cookie = `theme=${theme}; path=/; max-age=31536000`;
+    try { localStorage.setItem('theme', theme); } catch { /* ignore */ }
+  }, dark ? 'dark' : 'light');
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await expect(page.locator('html')).toHaveClass(dark ? /\bdark\b/ : /^(?!.*\bdark\b)/);
+}
+
+async function expectNoContrastViolation(page: Page, selector: string) {
+  const results = await new AxeBuilder({ page })
+    .include(selector)
+    .withTags(['wcag2aa', 'wcag22aa'])
+    .analyze();
+  const contrast = results.violations.filter((v) => v.id === 'color-contrast');
+  expect(
+    contrast.map((v) => v.nodes.map((n) => `${n.target.join(' ')} — ${n.failureSummary?.split('\n')[1] ?? ''}`)),
+    `contrast violations under ${selector}`
+  ).toEqual([]);
+}
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('issue #1415 journey tracker stages meet AA contrast in both themes', async ({ page }) => {
+  const menteeEmail = uniqueEmail('contrast-1415-mentee');
+  const mentorEmail = uniqueEmail('contrast-1415-mentor');
+  const mentee = await seedUser(menteeEmail, password, 'MENTEE', 'Contrast 1415 Mentee');
+  const mentor = await seedUser(mentorEmail, password, 'MENTOR', 'Contrast 1415 Mentor');
+  // The tracker only renders with a relation, and the earliest stage leaves
+  // almost every row in the "future" state — the one that was unreadable.
+  const relation = await prisma.mentorshipRelation.create({
+    data: { mentorId: mentor.id, menteeId: mentee.id, status: 'ACTIVE', pipelineStatus: 'APPLICATION_100' },
+  });
+
+  try {
+    await signInAsFreshUser(page, menteeEmail, password, '/portal');
+
+    for (const dark of [false, true]) {
+      await page.goto('/portal');
+      await forceTheme(page, dark);
+
+      const future = page.locator('[data-testid="journey-stage-label"][data-stage-state="future"]');
+      await expect(future.first(), `future stages should render in ${dark ? 'dark' : 'light'}`).toBeVisible();
+
+      // Each state separately, so a failure names which one regressed rather
+      // than "something in the tracker".
+      for (const state of ['future', 'current', 'done'] as const) {
+        const labels = page.locator(`[data-testid="journey-stage-label"][data-stage-state="${state}"]`);
+        if (await labels.count()) {
+          await expectNoContrastViolation(page, `[data-testid="journey-stage-label"][data-stage-state="${state}"]`);
+        }
+        const badges = page.locator(`[data-testid="journey-stage-badge"][data-stage-state="${state}"]`);
+        if (await badges.count()) {
+          await expectNoContrastViolation(page, `[data-testid="journey-stage-badge"][data-stage-state="${state}"]`);
+        }
+      }
+    }
+  } finally {
+    await prisma.mentorshipRelation.deleteMany({ where: { id: relation.id } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+  }
+});

--- a/releases/unreleased/journey-tracker-stage-contrast.json
+++ b/releases/unreleased/journey-tracker-stage-contrast.json
@@ -1,0 +1,9 @@
+{
+  "bump": "patch",
+  "changelog": "**Fixed** — the upcoming stages in the mentee journey tracker were below the WCAG AA contrast threshold in both themes (measured 2.54:1 and 2.31:1 in light, 2.35:1 and 2.13:1 in dark). The dark half was worse than it looked in the source: the badge's `dark:bg-gray-800` never applied, because a flat `html.dark` rule in globals.css outranks the variant. Now 4.83:1–8.33:1 across both themes.",
+  "notes": {
+    "en": ["The upcoming stages on your journey card are readable now, in light and dark alike."],
+    "tr": ["Yolculuk kartındaki gelecek aşamalar artık hem açık hem koyu temada okunabiliyor."],
+    "de": ["Die kommenden Phasen auf deiner Journey-Karte sind jetzt in hellem wie dunklem Design lesbar."]
+  }
+}

--- a/src/components/JourneyTracker.tsx
+++ b/src/components/JourneyTracker.tsx
@@ -94,7 +94,7 @@ export function JourneyTracker({ status }: { status: string }) {
         <>
           <div className="flex items-center justify-between text-sm mb-1">
             <span className="font-semibold text-gray-900 dark:text-gray-100">{label(status)}</span>
-            <span className="text-gray-400 dark:text-gray-500">{pct}%</span>
+            <span className="text-gray-500 dark:!text-gray-400">{pct}%</span>
           </div>
           <div className="h-2 bg-gray-100 dark:bg-gray-800 rounded-full overflow-hidden mb-4">
             <div className="h-full bg-blue-500 transition-all" style={{ width: `${pct}%` }} />
@@ -118,12 +118,33 @@ export function JourneyTracker({ status }: { status: string }) {
               const current = i === idx;
               return (
                 <li key={s} className="flex items-center gap-2 text-sm">
-                  <span className={`flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full text-[10px] ${
-                    done ? 'bg-green-500 text-white' : current ? 'bg-blue-600 text-white' : 'bg-gray-100 dark:bg-gray-800 text-gray-400 dark:text-gray-500'
-                  }`}>
+                  {/* `dark:!` throughout, not a plain `dark:` variant (#1415).
+                      globals.css remaps these base classes with flat
+                      `html.dark .text-gray-500` rules whose specificity (0,2,1)
+                      beats the variant's `.dark .dark\:text-gray-400` (0,2,0),
+                      so the unforced version is silently inert — it looks
+                      applied in the source and changes nothing in the browser.
+                      Measured, not assumed; the e2e asserts the composited
+                      contrast in both themes.
+
+                      The future badge deliberately drops `dark:bg-gray-800`:
+                      globals.css already remaps `bg-gray-100` to #374151 under
+                      html.dark, and that flat rule wins anyway. Keeping the
+                      variant only implied a control that did not exist. */}
+                  <span
+                    data-testid="journey-stage-badge"
+                    data-stage-state={done ? 'done' : current ? 'current' : 'future'}
+                    className={`flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full text-[10px] ${
+                      done ? 'bg-green-500 text-white' : current ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-600 dark:!text-gray-200'
+                    }`}
+                  >
                     {done ? <Check className="h-3 w-3" /> : i + 1}
                   </span>
-                  <span className={current ? 'font-medium text-gray-900 dark:text-gray-100' : done ? 'text-gray-500 dark:text-gray-400' : 'text-gray-400 dark:text-gray-600'}>
+                  <span
+                    data-testid="journey-stage-label"
+                    data-stage-state={done ? 'done' : current ? 'current' : 'future'}
+                    className={current ? 'font-medium text-gray-900 dark:text-gray-100' : done ? 'text-gray-600 dark:!text-gray-300' : 'text-gray-500 dark:!text-gray-400'}
+                  >
                     {label(s)}
                   </span>
                 </li>


### PR DESCRIPTION
Closes #1415 · Part of #1400 · Epic #1395

This is the first card a mentee sees, and the "future" rows are most of it. **All four foreground/background pairs were under the 4.5:1 floor, in both themes.**

Measured in the browser on the composited colours, before and after:

| | before | after |
|---|---|---|
| future label, light | **2.54:1** | 4.83:1 |
| future badge, light | **2.31:1** | 6.87:1 |
| future label, dark | **2.35:1** | 6.99:1 |
| future badge, dark | **2.13:1** | 8.33:1 |

## The dark half was worse than the source suggested

The badge carried `dark:bg-gray-800`. It never applied: `globals.css` remaps `bg-gray-100` to `#374151` with a flat `html.dark` rule whose specificity `(0,2,1)` beats the variant's `.dark .dark\:bg-gray-800` `(0,2,0)`.

So the class implied a control that did not exist. I removed it rather than leave something that reads as deliberate — the flat rule supplies the dark background either way. Every replacement colour uses `dark:!` for the same reason: an unforced `dark:` on a remapped base class is **silently inert**.

## `done` had to move too, and that is not cosmetic

`globals.css` collapses **both** `text-gray-500` and `text-gray-600` to `#9ca3af` under `html.dark`. Lifting only `future` to gray-500 would have made *done* and *future* render identically in dark mode — trading a contrast bug for a meaning bug. `done` goes to gray-600/gray-300.

## Why the a11y gate never caught this

`e2e/a11y-scan.spec.ts` signs in a fresh mentee with **no MentorshipRelation**, and `JourneyTracker` only renders when there is one. The scanned `/portal` is the empty state — so these selectors are **absent from the baseline entirely**, not frozen in it. That gap is #1412's subject; this spec seeds a real relation.

## Verification

- [x] axe `color-contrast` clean under every stage state, in both themes, asserted **per state** so a regression names which one broke
- [x] Before/after contrast measured directly in the browser (table above) rather than inferred from class names — the only way to catch an inert `dark:`, since the class is present in the markup either way
- [x] `npx tsc --noEmit` + `npm run lint` clean, `check:release-fragments` green

**No schema change, no new i18n keys.**

### A note on the "red" for this one

Running the new spec against the old component fails on the missing testids rather than on geometry — a weak proof. That is why the before/after numbers above come from a direct measurement of the old code in the browser, not from the test.

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeSYkGngKpYG4KWsJ7Ph2Z)_