### PR TITLE
fix: label evaluation type selector for screen readers

### DIFF
--- a/releases/unreleased/evaluation-select-label.json
+++ b/releases/unreleased/evaluation-select-label.json
@@ -1,0 +1,9 @@
+{
+  "bump": "patch",
+  "changelog": "- **Accessibility:** Added an accessible label to the evaluation type selector (#1413).",
+  "notes": {
+    "en": ["The evaluation type selector is now announced correctly by screen readers."],
+    "tr": ["Değerlendirme türü seçim alanı artık ekran okuyucular tarafından doğru okunur."],
+    "de": ["Das Auswahlfeld für den Bewertungstyp wird jetzt von Screenreadern korrekt angekündigt."]
+  }
+}

--- a/src/components/EvaluationPanel.tsx
+++ b/src/components/EvaluationPanel.tsx
@@ -132,7 +132,7 @@ export function EvaluationPanel({
               </label>
             ))}
           </div>
-          <div className="flex items-center gap-2">
+          <label className="flex items-center gap-2">
             <span className="text-sm text-gray-700">{t.evaluation.type}:</span>
             <select
               value={type}
@@ -142,7 +142,7 @@ export function EvaluationPanel({
               <option value="INTERIM">{t.evaluation.interim}</option>
               <option value="FINAL">{t.evaluation.final}</option>
             </select>
-          </div>
+          </label>
           <Textarea
             value={comment}
             onChange={(e) => setComment(e.target.value)}


### PR DESCRIPTION
Closes #1413

## Summary

Adds a semantic label to the evaluation type selector so screen readers announce it correctly.

## Changes

- Replaced the visual wrapper with a semantic `label` around the evaluation type selector.
- Added a patch release note in English, Turkish, and German.

## Verification

- [x] `git diff --check`
- [x] `npx tsc --noEmit`
- [x] `npx --yes tsx scripts/check-i18n.ts`
- [x] `npm run build`
- [x] Confirmed no existing `select-name` baseline entry required removal.

## Contributor terms

- [x] I accept the contributor terms.