### PR TITLE
fix: keep portal tabs consistent across pages

### DIFF
--- a/releases/unreleased/portal-tabs-consistency.json
+++ b/releases/unreleased/portal-tabs-consistency.json
@@ -1,0 +1,9 @@
+{
+  "bump": "patch",
+  "changelog": "- **Mentee portal:** Kept the portal tab bar in one consistent place on every portal page (#1424).",
+  "notes": {
+    "en": ["Portal navigation tabs now stay visible and in the same position on every portal page."],
+    "tr": ["Portal gezinme sekmeleri artık tüm portal sayfalarında görünür ve aynı konumda kalır."],
+    "de": ["Die Portal-Navigation bleibt jetzt auf allen Portalseiten sichtbar und an derselben Stelle."]
+  }
+}

--- a/src/app/portal/calendar/page.tsx
+++ b/src/app/portal/calendar/page.tsx
@@ -2,7 +2,6 @@ import { getServerSession } from 'next-auth';
 import { redirect } from 'next/navigation';
 import { getServerDictionary } from '@/i18n/server';
 import { authOptions } from '@/lib/auth';
-import { PortalTabs } from '@/components/PortalTabs';
 import { CalendarView } from '@/components/CalendarView';
 import { IcsFeedCard } from '@/components/IcsFeedCard';
 
@@ -23,7 +22,6 @@ export default async function PortalCalendarPage() {
         <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.portal.calendarTitle}</h1>
         <p className="text-gray-500 mt-1">{t.portal.calendarSubtitle}</p>
       </div>
-      <PortalTabs />
       <CalendarView />
       <IcsFeedCard />
     </div>

--- a/src/app/portal/goals/page.tsx
+++ b/src/app/portal/goals/page.tsx
@@ -3,7 +3,6 @@ import { redirect } from 'next/navigation';
 import { getServerDictionary } from '@/i18n/server';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
-import { PortalTabs } from '@/components/PortalTabs';
 import { GoalsPanel } from '@/components/GoalsPanel';
 import { EvaluationPanel } from '@/components/EvaluationPanel';
 import { WeeklyReportsPanel } from '@/components/WeeklyReportsPanel';
@@ -35,7 +34,6 @@ export default async function PortalGoalsPage() {
 
   return (
     <div>
-      <PortalTabs />
       <div className="mb-6">
         <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.portal.tabs.goals}</h1>
         <p className="text-gray-500 mt-1">{t.portal.goalsSubtitle}</p>

--- a/src/app/portal/journey/page.tsx
+++ b/src/app/portal/journey/page.tsx
@@ -4,7 +4,6 @@ import Link from 'next/link';
 import { getServerDictionary } from '@/i18n/server';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
-import { PortalTabs } from '@/components/PortalTabs';
 import { JourneyTracker } from '@/components/JourneyTracker';
 import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { StatusBadge } from '@/components/ui/Badge';
@@ -46,7 +45,6 @@ export default async function PortalJourneyPage() {
 
   return (
     <div>
-      <PortalTabs />
       <div className="mb-6">
         <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.portal.tabs.journey}</h1>
         <p className="text-gray-500 mt-1">{t.portal.journeySubtitle}</p>

--- a/src/app/portal/layout.tsx
+++ b/src/app/portal/layout.tsx
@@ -17,6 +17,7 @@ import { resolveCustomCriteria } from '@/lib/evaluationTemplates';
 import { ModeSwitcher } from '@/components/ModeSwitcher';
 import { availableModes, canUsePortal } from '@/lib/dualRole';
 import { is2faRequiredFor } from '@/lib/twoFactorPolicy';
+import { PortalTabs } from '@/components/PortalTabs';
 
 export default async function PortalLayout({ children }: { children: React.ReactNode }) {
   const session = await getServerSession(authOptions);
@@ -92,7 +93,10 @@ export default async function PortalLayout({ children }: { children: React.React
       }
     >
       <PipelineStagesProvider stages={customStages}>
-        <EvaluationCriteriaProvider criteria={customCriteria}>{children}</EvaluationCriteriaProvider>
+        <EvaluationCriteriaProvider criteria={customCriteria}>
+  <PortalTabs />
+  {children}
+</EvaluationCriteriaProvider>
       </PipelineStagesProvider>
     </ResponsiveShell>
   );

--- a/src/app/portal/page.tsx
+++ b/src/app/portal/page.tsx
@@ -8,7 +8,6 @@ import { OfferCard } from '@/components/OfferCard';
 import { JourneyTracker } from '@/components/JourneyTracker';
 import { AnnouncementsCard } from '@/components/AnnouncementsCard';
 import { ReferralLinkCard } from '@/components/ReferralLinkCard';
-import { PortalTabs } from '@/components/PortalTabs';
 import { getServerDictionary } from '@/i18n/server';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
@@ -89,7 +88,6 @@ export default async function PortalDashboard() {
         <p className="text-gray-500 mt-1">{t.portal.dashSubtitle}</p>
       </div>
 
-      <PortalTabs />
 
       {/* Half an hour before a meeting, and for as long as it runs (#51 follow-up). */}
       <UpcomingMeetingBanner />

--- a/src/app/portal/requests/page.tsx
+++ b/src/app/portal/requests/page.tsx
@@ -3,7 +3,6 @@ import { redirect } from 'next/navigation';
 import { getServerDictionary } from '@/i18n/server';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
-import { PortalTabs } from '@/components/PortalTabs';
 import { QuestionsPanel } from '@/components/QuestionsPanel';
 import { MeetingRequestsPanel } from '@/components/MeetingRequestsPanel';
 import { Card } from '@/components/ui/Card';
@@ -37,7 +36,6 @@ export default async function PortalRequestsPage() {
 
   return (
     <div>
-      <PortalTabs />
       <div className="mb-6">
         <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t.portal.tabs.requests}</h1>
         {/* "Ask your mentor a question or request a meeting" would contradict the


### PR DESCRIPTION
Closes #1424

## Summary

Centralizes the portal navigation tabs in the portal layout so every portal page shows them in one consistent position.

## Changes

- Moved `PortalTabs` into the shared portal layout.
- Removed duplicate per-page tab renders.
- Added a patch release note.

## Verification

- [x] `git diff --check`
- [x] `npx tsc --noEmit`
- [x] `npm run check:release-fragments`
- [x] `npm run build`

## Contributor terms

- [x] I accept the contributor terms.