### PR TITLE
chore: ignore .claude/worktrees/ background-agent scratch checkouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,7 @@ e2e/.state/
 # the document through next.config.js -> nextConfig.env, so nothing imports this
 # file and `npx tsc --noEmit` on a fresh clone never looks for it.
 /src/generated/openapi.json
+
+# Isolated worktrees created by Claude Code's background Agent tool for
+# in-progress work — internal tooling state, not a project artifact.
+/.claude/worktrees/


### PR DESCRIPTION
## Summary

This session's CI-watchdog run spawned a background Claude Code agent (via the Agent tool's isolated-worktree mode) to reproduce and fix a batch of recurring `e2e-full.yml` failures. That mode checks out an isolated git worktree under `.claude/worktrees/` so the agent can commit/push freely without touching this branch. The repo's stop hook flagged that directory as untracked, since it wasn't in `.gitignore`.

## Changes

- Add `/.claude/worktrees/` to `.gitignore` — it's internal tooling scratch state (a full nested checkout), not a project artifact, and shouldn't ever be committed.

## Verification

- [x] Single-line, additive `.gitignore` change — no code paths affected.
- [x] Confirmed `.claude/worktrees/` was untracked scratch state (the background agent's own isolated checkout), not a real repo artifact, before ignoring it.
- [ ] `npm run lint` / `npx tsc --noEmit` / e2e — not applicable, no source files changed.

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ls2E49Z1f7EP4QHoUuypVG)_