### PR TITLE
docs: session retrospective for the meeting auto-log work (#1489)

### DIFF
--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -5200,3 +5200,47 @@ ebeveyne eşzamanlı ekleme yarış riski taşıdığı için turları *farklı*
 **Bu repoda semantik `search_issues` her sorguya 0 döndürdü.** Mükerrer kontrolünü
 `list_issues` + `state: OPEN` ile yaptım (18 açık kayıt, hepsi tek sayfa). Semantik arama
 boş dönüyorsa "mükerrer yok" diye okumak yanlış — listeye bak.
+
+## 2026-08-28 — Yapılan toplantıyı etkileşim kaydına otomatik yazmak (#1489)
+
+**"Otomatik ekle" isteğinde asıl iş, *ne zaman* olduğunu tanımlamak.** Kod tarafı kısa;
+zor olan "toplantı gerçekleşti"nin tanımı. Burada iki sinyal var ve ikisi de tek başına
+yetmiyor: `Meeting.endedAt` (birinin "toplantı bitti" tıklaması — güvenilir ama çoğu zaman
+kimse tıklamıyor) ve saatin geçmesi (herkeste var ama toplantının yapıldığını kanıtlamıyor).
+İkisini birden yazmak gerekti: tıklama anında + tıklanmayanlar için 2 saat toleranslı
+süpürme. `rsvp: DECLINED` olanları dışarıda bırakmak da aynı ailedan bir karar —
+yapılmamış bir toplantıyı mentee'nin kendi geçmişine "yapıldı" diye yazmak, eksik
+kayıttan daha kötü.
+
+**Süpürmeye geriye bakış penceresi koymayı unutma.** Penceresiz ilk tick, kurulumdaki
+*tüm* geçmiş toplantılar için yer tutucu kayıt üretir — aylarca öncesi bir anda mentee
+yolculuklarına düşer. 30 günlük `gte` filtresi bunu kapatıyor; süpürme geçmişi yeniden
+kurmak için değil, tıklama yolunun kaçırdığını yakalamak için var.
+
+**Unique FK = idempotency anahtarı.** `InteractionLog.meetingId @unique` sayesinde
+"tıklama mı, cron mu önce yazdı" sorusu ortadan kalkıyor: ikinci yazan P2002 alıp sessizce
+`false` dönüyor. Ayrı bir `autoLogged` boolean'ı tutmak fazlalık gibi görünüyor ama
+`onDelete: SetNull` yüzünden şart — toplantı satırı silindiğinde kayıt elde yazılmış gibi
+görünmemeli.
+
+**Yeni bir kayıt türü eklerken *okuyan* yerleri de tara.** `type: 'Meeting'` etkileşimleri
+`/api/calendar-events` içinde "logged" olayı olarak zaten takvime düşüyormuş; otomatik kayıt
+eklenince aynı toplantı takvimde iki kez görünecekti (planlanan + kayıt). `grep -rn
+"type: 'Meeting'" src` bunu bir dakikada gösteriyor — şema alanını eklemeden önce yapılacak
+iş. Aynı tarama `checkMentorInteractionReminders`'ın da davranışını değiştirdiğini gösterdi
+(bu sefer istenen yönde: toplantı yapılmışsa "etkileşim yok" uyarısı gitmiyor).
+
+**Cron içinde webhook varsa batch'i küçük tut.** `dispatchWebhook` başına 5 sn timeout var;
+200'lük bir süpürme partisi, asılı kalan tek bir endpoint'te 15 dakikalık tick'i aşabilirdi.
+50 (+ kardeş satırlar için 25) sınırı bunu kapatıyor, kalan iş bir sonraki tick'e kalıyor.
+
+**Kutuda tekrar eden iki kurulum adımı:** `npm install` (bağımlılıklar preinstall değil) ve
+Chromium sürüm uyuşmazlığı — bu turda beklenen 1234, kurulu olan 1194'tü. Symlink tarifi
+(`chromium_headless_shell-1234/chrome-headless-shell-linux64/chrome-headless-shell` →
+1194'ün `chrome-linux/headless_shell`'i) yine çalıştı; ayrıca `chromium-1234/chrome-linux`
+için de aynısını kurmak gerekti. `prisma validate/format` ise `.env` yoksa
+`DATABASE_URL bulunamadı` diye patlıyor — komutun başına sahte bir URL vermek yetiyor.
+
+**`admin@example.com` ile giren specler seed'siz DB'de kırmızı yanar.** Yerelde
+`calendar-logged-meetings` bu yüzden düştü, değişiklikten değil — `prisma db seed`
+öncesi bir başarısızlığı regresyon sanmadan önce specin hangi hesapla girdiğine bak.


### PR DESCRIPTION
## Summary

#1490 sonrası oturum retrospektifi — `docs/agent-experience.md`'ye dated bir giriş
(standing instruction). Sadece dokümantasyon; kod, şema veya davranış değişmiyor,
bu yüzden release fragment yok.

Refs #1489

## Changes

- `docs/agent-experience.md`: "yapılan toplantıyı otomatik kaydetme" turundan çıkan
  tekrar kullanılabilir dersler — iki sinyalli "gerçekleşti" tanımı, süpürmeye geriye
  bakış penceresi koymanın gerekçesi, unique FK'nin idempotency anahtarı olarak
  kullanımı, yeni kayıt türü eklerken *okuyan* yerleri taramak (takvimdeki çift kayıt
  buradan çıktı), cron içindeki webhook yüzünden batch sınırı, ve kutudaki tekrar eden
  kurulum adımları (npm install, Chromium symlink, `prisma validate` için sahte
  `DATABASE_URL`, seed'siz DB'de `admin@example.com` specleri).

## Verification

- [x] `npm run lint` + `npx tsc --noEmit` clean (dokümantasyon değişikliği; kod dokunulmadı)
- [x] `npm run test:e2e` passing (or CI green) — #1490'da smoke dahil tüm CI yeşildi
- [x] Tested the change manually / added an e2e test — N/A (docs)

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Tmc7vr4iNKSFUCHqngMSm


---
_Generated by [Claude Code](https://claude.ai/code/session_015Tmc7vr4iNKSFUCHqngMSm)_