### PR TITLE
docs(agent-experience): Goal vs ProjectTask split, and the stale apt index

### DIFF
--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -5244,3 +5244,30 @@ için de aynısını kurmak gerekti. `prisma validate/format` ise `.env` yoksa
 **`admin@example.com` ile giren specler seed'siz DB'de kırmızı yanar.** Yerelde
 `calendar-logged-meetings` bu yüzden düştü, değişiklikten değil — `prisma db seed`
 öncesi bir başarısızlığı regresyon sanmadan önce specin hangi hesapla girdiğine bak.
+
+## 2026-08-28 — "Açık hedef yok" dediği hâlde açık iş olması (#1491)
+
+**Bu repoda bir mentee'ye verilen iş iki ayrı modelde yaşıyor: `Goal` ve `ProjectTask`.**
+`Goal`, ilişkinin (`MentorshipRelation`) hedefi; yapılacaklar listesi (#1113) ise
+`ProjectTask` — ve **ortak havuzdan verilen her madde `ProjectTask`**, `Goal` değil.
+`mentorAttention.ts` "açık iş var mı?" sorusunu yalnızca `Goal`'a sorduğu için,
+listesinde 4 açık maddesi olan mentee ekranda kalıcı olarak "Açık hedef yok" damgası
+alıyordu. Bir sinyal/rapor/e-posta "hiç işi yok" diyorsa, **iki modeli de** saymalı;
+`grep -rn "status: 'OPEN'"` bu tür yerleri hızla buluyor (`activityReport.ts` de aynı
+soyutlamada).
+
+**Başkasının listesini okurken görünürlük filtresini kopyala, yeniden icat etme.**
+`GET /api/todos` başka birinin listesinde yalnızca *bir projeden ya da başkası tarafından*
+eklenmiş maddeleri gösteriyor; kişinin kendine yazdığı satır özel. Mentor'a gösterilen
+damgayı hesaplarken aynı filtreyi uygulamak gerekiyor — yoksa damga sayfada görünenle
+çelişiyor (mentor "hiçbir şey yok" görüyor ama damga kayboluyor).
+
+**Testin hatayı gerçekten ürettiğini kanıtla.** Düzeltmeyi tek `sed` ile geri alıp spec'i
+yeniden koşturdum: `Expected: 0, Received: 1`. Bu 40 saniye, "yeşil ama boşa dönen" bir
+iddiayı elemenin en ucuz yolu.
+
+**Kutudaki apt indeksi bayat: `mariadb-server` kurulumu önce 404 veriyor.**
+Güvenlik playbook'undaki tarif doğru, ama tek başına `apt-get install -y mariadb-server`
+`iproute2` ve `libmysqlclient21` için "404 Not Found" ile düşüyor. Önce
+`apt-get update` — sonra kurulum sorunsuz. (Ardından `.env` + `export DATABASE_URL` ve
+headless-shell symlink'i: ikisi de bu dosyada yukarıda yazılı, hâlâ geçerli.)


### PR DESCRIPTION
End-of-session retrospective for #1491 / #1493 (standing instruction in `CLAUDE.md`). Pure docs — no release fragment.

Four reusable lessons:

- **Work assigned to a mentee lives in two models.** `Goal` hangs off the relation; the to-do list (#1113) is `ProjectTask`, and *everything handed out from the shared pool is a `ProjectTask`*. That is exactly what #1491 was: the attention queue asked only `Goal`, so a mentee with four open to-dos was flagged "Açık hedef yok" forever. Any "has nothing open" signal has to count both — `grep -rn "status: 'OPEN'"` finds the places (`activityReport.ts` sits at the same abstraction).
- **Reuse the visibility filter, don't reinvent it.** `GET /api/todos` shows only project-sourced or other-authored items on somebody else's list; a self-written line is private. A badge computed for the mentor has to apply the same filter or it contradicts what the page shows them.
- **Prove the spec reproduces the bug.** Reverting the fix with one `sed` and re-running gave `Expected: 0, Received: 1` — 40 seconds to rule out a green-but-vacuous assertion.
- **The container's apt index is stale.** The security playbook's recipe is right, but `apt-get install -y mariadb-server` 404s on `iproute2` / `libmysqlclient21` until `apt-get update` runs first.

The `DATABASE_URL` export and the headless-shell symlink both bit again this session — already documented further up the file, and the entry points back at them rather than repeating them.

---
_Generated by [Claude Code](https://claude.ai/code/session_011WLZ25VBPhfQYpeGjshofY)_