### PR TITLE
Count messenger outreach in the dormant first-contact rule (#1512)

### DIFF
--- a/docs/dormant-first-contacts.md
+++ b/docs/dormant-first-contacts.md
@@ -19,12 +19,12 @@ Bir ilişki şu koşulların **hepsi** sağlandığında "pasif ilk temas" sayı
 | Koşul | Neden |
 |---|---|
 | Pipeline'ın **ilk aşamasında** (varsayılan `APPLICATION_100`; tenant'ın kendi ilk aşaması, #747) | Süreç hiç başlamamış demektir |
-| **Bir temas kaydı var** (`InteractionLog`) | Mentor üzerine düşeni yapmış |
+| **Bir temas var**: `InteractionLog` **veya** mentee dışında birinin (mentor/admin) attığı bir mesaj — hangisi daha yeniyse | Mentor üzerine düşeni yapmış. Mesaj atmak ile "etkileşim kaydı" formunu doldurmak aynı şey değil; kural yalnızca `InteractionLog`'a bakarsa, dört kez yazılmış bir mentee listede kalır (#1512) |
 | Bu temasın üzerinden en az **`DORMANT_GRACE_DAYS` (14) gün** geçmiş | Dünkü sessizlik bir cevap değildir |
-| Mentee'den **hiç mesaj yok**, **yanıtsız soru yok**, **bekleyen toplantı talebi yok** | Bunların her biri canlı bir konuşma demektir |
+| Mentee'den **son temastan sonra** mesaj yok, **yanıtsız soru yok**, **bekleyen toplantı talebi yok** | Soru "top kimde?" — haziranda konuşup ağustosta yazılan ve o gün bugündür susan kişi yine pasiftir; dün yanıt veren kişi değildir, orada cevap borcu mentordadır |
 | Aşamaya **mentor tarafından konmuş bir termin yok** (`stageDeadline`) | Termin, "bunu takip et" demenin bilinçli hâlidir |
 
-Hiç temas kaydı olmayan bir ilişki **asla** pasif sayılmaz: orada eksik olan şey zaten
+Hiç kimsenin yazmadığı bir ilişki **asla** pasif sayılmaz: orada eksik olan şey zaten
 mentorun göndermediği ilk mesajdır.
 
 ## Ne oluyor
@@ -36,7 +36,10 @@ mentorun göndermediği ilk mesajdır.
 3. **`dormantSince` damgalanır.** Günlük süpürme (`sweepDormantFirstContacts`) bu
    durumun tek yazarıdır; kural eşleşmeyi bıraktığı anda damga **ve sayaçlar** silinir.
 4. **Mentee'ye iki kez "hâlâ ilgileniyor musun?" e-postası gider**
-   (`sendDormantCheckIns`): 14. gün ve ~45. gün. İkincisi *ilk hatırlatmadan* 31 gün sonra
+   (`sendDormantCheckIns`): 14. gün ve ~45. gün. İlki `dormantSince` damgasına bağlıdır —
+   damga zaten 14 günlük sessizlikten sonra vurulduğu için **işaretlenmek = vakti gelmiş
+   olmak**; iş, temasın ne zaman olduğunu yeniden hesaplamaz (hesaplasaydı yine yalnızca
+   `InteractionLog`'a bakma tuzağına düşerdi). İkincisi *ilk hatırlatmadan* 31 gün sonra
    ölçülür — aksi hâlde bu özellik yayına alındığı gün, teması aylar öncesine dayanan
    herkes iki maili peş peşe alırdı. Tur başına en fazla `DORMANT_NUDGE_MAX_PER_RUN` (50)
    e-posta gider; kalanı ertesi gün.

--- a/e2e/dormant-first-contact.spec.ts
+++ b/e2e/dormant-first-contact.spec.ts
@@ -79,3 +79,52 @@ test('a first-stage mentee who was messaged and never replied leaves the attenti
     await cleanupByEmail(freshEmail);
   }
 });
+
+// Reaching out is not the same as logging that you reached out. A mentor wrote
+// four times through the in-app messenger and never touched the interaction
+// form, so the relation had no InteractionLog at all — and the rule, which only
+// looked at that table, kept the mentee in the queue with "no recent contact"
+// forever. The outreach date is the later of the last logged interaction and
+// the last message from anybody who is not the mentee.
+test('messenger-only outreach counts, and a reply only counts when it came after it', async () => {
+  const mentorEmail = uniqueEmail('messenger-mentor');
+  const menteeEmail = uniqueEmail('messenger-mentee');
+  try {
+    const mentor = await seedUser(mentorEmail, 'MessengerPass123', 'MENTOR', 'Messenger Mentor');
+    const mentee = await seedUser(menteeEmail, 'MessengerPass123', 'MENTEE', 'Messaged Mentee');
+    const relation = await prisma.mentorshipRelation.create({
+      data: { mentorId: mentor.id, menteeId: mentee.id, status: 'ACTIVE', pipelineStatus: 'APPLICATION_100' },
+    });
+    const at = (days: number) => new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+
+    // Nobody has written at all: the first message is still the mentor's to send.
+    expect((await getAttentionItems(mentor.id)).items.map((i) => i.relationId)).toContain(relation.id);
+
+    // The mentor writes twice through the messenger — no interaction log anywhere.
+    await prisma.message.create({ data: { relationId: relation.id, senderId: mentor.id, body: 'Hoş geldin', createdAt: at(40) } });
+    await prisma.message.create({ data: { relationId: relation.id, senderId: mentor.id, body: 'Ne zaman müsaitsin?', createdAt: at(25) } });
+    expect(await prisma.interactionLog.count({ where: { relationId: relation.id } })).toBe(0);
+    const dormant = await getAttentionItems(mentor.id);
+    expect(dormant.items.map((i) => i.relationId)).not.toContain(relation.id);
+    expect(dormant.dormantCount).toBe(1);
+
+    // A reply from BEFORE the last outreach is not an answer to it: the mentee
+    // talked in month one, was written to in month two and said nothing since.
+    const oldReply = await prisma.message.create({
+      data: { relationId: relation.id, senderId: mentee.id, body: 'Merhaba!', createdAt: at(35) },
+    });
+    expect((await getAttentionItems(mentor.id)).items.map((i) => i.relationId)).not.toContain(relation.id);
+
+    // A reply after it puts the ball back in the mentor's court.
+    await prisma.message.update({ where: { id: oldReply.id }, data: { createdAt: at(3) } });
+    expect((await getAttentionItems(mentor.id)).items.map((i) => i.relationId)).toContain(relation.id);
+
+    // And an outreach inside the grace period is not silence yet.
+    await prisma.message.deleteMany({ where: { relationId: relation.id } });
+    await prisma.message.create({ data: { relationId: relation.id, senderId: mentor.id, body: 'Merhaba', createdAt: at(2) } });
+    expect((await getAttentionItems(mentor.id)).items.map((i) => i.relationId)).toContain(relation.id);
+  } finally {
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(menteeEmail);
+  }
+});

--- a/releases/unreleased/dormant-rule-counts-messenger-outreach.json
+++ b/releases/unreleased/dormant-rule-counts-messenger-outreach.json
@@ -1,0 +1,9 @@
+{
+  "bump": "patch",
+  "changelog": "- **The dormant-first-contact rule now counts messenger outreach** (#1512): it only ever read `InteractionLog`, so a mentee written to four times through the in-app messenger — with no interaction ever logged — had \"no outreach\" by the rule and stayed in the attention queue permanently, which is the exact case the feature was built for. The outreach date is now the later of the last logged interaction and the last message from anybody who is not the mentee. A mentee reply also only counts as a sign of life when it came *after* that outreach: somebody who chatted in June, was written to in August and has said nothing since is dormant again, while somebody who answered yesterday stays on the queue because the mentor owes *them* a reply. The first check-in is anchored on `dormantSince` rather than re-derived from the interaction log, so it cannot fall into the same trap.",
+  "notes": {
+    "en": ["Mentees you contacted through the in-app messenger — rather than by logging an interaction — now correctly drop out of \"Needs attention\" when they never reply."],
+    "tr": ["Etkileşim kaydı girmek yerine uygulama içi mesajla ulaştığın mentee'ler de, hiç yanıt vermediklerinde artık doğru şekilde \"Dikkat gerektiriyor\" listesinden düşüyor."],
+    "de": ["Mentees, die du über den In-App-Messenger statt über einen Interaktionseintrag kontaktiert hast, verschwinden jetzt korrekt aus \"Braucht Aufmerksamkeit\", wenn sie nie antworten."]
+  }
+}

--- a/src/lib/dormantFirstContact.ts
+++ b/src/lib/dormantFirstContact.ts
@@ -34,8 +34,8 @@ import { resolvePipelineStages } from './pipelineStages';
  * automated check-in, and calling somebody passive the morning after you wrote
  * to them is simply wrong. Fourteen days is the same threshold the attention
  * queue and the staleness reminder already use for "no recent contact", and it
- * is deliberately the same as DORMANT_FIRST_NUDGE_DAYS: a relation becomes
- * dormant on exactly the day its first check-in is due.
+ * also what schedules the first check-in: a relation becomes dormant on exactly
+ * the day that mail is due, so being flagged is being due.
  */
 export const DORMANT_GRACE_DAYS = 14;
 
@@ -74,37 +74,66 @@ export async function findDormantFirstContacts(relations: DormantCandidate[]): P
   if (relations.length === 0) return dormant;
 
   const firstStageKey = createFirstStageResolver();
-  const graceCutoff = new Date(Date.now() - DORMANT_GRACE_DAYS * 24 * 60 * 60 * 1000);
   const candidates: DormantCandidate[] = [];
   for (const r of relations) {
-    // No outreach yet, or a deadline the mentor set on purpose: never dormant.
-    if (!r.lastInteractionAt || r.stageDeadline) continue;
-    // Still inside the grace period — the silence is not yet an answer.
-    if (r.lastInteractionAt > graceCutoff) continue;
+    // A deadline the mentor set on purpose is a deliberate "chase this one".
+    if (r.stageDeadline) continue;
     if (r.pipelineStatus !== (await firstStageKey(r.orgId))) continue;
     candidates.push(r);
   }
   if (candidates.length === 0) return dormant;
 
   const ids = candidates.map((r) => r.id);
-  const [menteeMessages, openQuestions, pendingMeetings] = await Promise.all([
-    // Grouped rather than listed: one row per (relation, sender) is all we need,
-    // and a chatty thread would otherwise pull its whole history into memory.
-    prisma.message.groupBy({ by: ['relationId', 'senderId'], where: { relationId: { in: ids } } }),
+  const [messages, openQuestions, pendingMeetings] = await Promise.all([
+    // One row per (relation, sender) carrying that sender's latest message, not
+    // the messages themselves: a chatty thread would otherwise pull its whole
+    // history into memory, and the only questions here are "who wrote?" and
+    // "when last?".
+    prisma.message.groupBy({
+      by: ['relationId', 'senderId'],
+      where: { relationId: { in: ids } },
+      _max: { createdAt: true },
+    }),
     prisma.mentorQuestion.findMany({ where: { relationId: { in: ids }, answer: null }, select: { relationId: true } }),
     prisma.meetingRequest.findMany({ where: { relationId: { in: ids }, status: 'PENDING' }, select: { relationId: true } }),
   ]);
 
-  const repliedByMentee = new Set(
-    menteeMessages
-      .filter((m) => m.relationId !== null)
-      .map((m) => `${m.relationId}:${m.senderId}`)
-  );
+  // Reaching out is not the same as logging that you reached out. A mentor who
+  // writes four times through the in-app messenger and never opens the
+  // interaction form has done exactly the thing this rule is about, so the
+  // outreach date is the later of the last logged interaction and the last
+  // message from anybody who is not the mentee (mentor or admin).
+  const lastOutreachMessage = new Map<string, Date>();
+  const lastMenteeMessage = new Map<string, Date>();
+  const byMentee = new Map(candidates.map((r) => [r.id, r.menteeId]));
+  for (const row of messages) {
+    if (!row.relationId) continue;
+    const at = row._max.createdAt;
+    if (!at) continue;
+    const target = row.senderId === byMentee.get(row.relationId) ? lastMenteeMessage : lastOutreachMessage;
+    const seen = target.get(row.relationId);
+    if (!seen || at > seen) target.set(row.relationId, at);
+  }
+
   const withOpenQuestion = new Set(openQuestions.map((q) => q.relationId));
   const withPendingMeeting = new Set(pendingMeetings.map((m) => m.relationId));
+  const graceCutoff = new Date(Date.now() - DORMANT_GRACE_DAYS * 24 * 60 * 60 * 1000);
 
   for (const r of candidates) {
-    if (repliedByMentee.has(`${r.id}:${r.menteeId}`)) continue;
+    const outreachCandidates = [r.lastInteractionAt, lastOutreachMessage.get(r.id) ?? null].filter(
+      (d): d is Date => d !== null,
+    );
+    if (outreachCandidates.length === 0) continue; // Nobody has written yet.
+    const lastOutreachAt = outreachCandidates.reduce((a, b) => (a > b ? a : b));
+    // Still inside the grace period — the silence is not yet an answer.
+    if (lastOutreachAt > graceCutoff) continue;
+    // A reply AFTER the last outreach, not merely somewhere in the history: the
+    // question is whether the ball is in their court right now. Someone who
+    // chatted in June, was written to in August and said nothing since is
+    // dormant again; someone who answered yesterday is not, and the mentor owes
+    // *them* a reply — which is exactly why they belong on the queue.
+    const repliedAt = lastMenteeMessage.get(r.id);
+    if (repliedAt && repliedAt > lastOutreachAt) continue;
     if (withOpenQuestion.has(r.id) || withPendingMeeting.has(r.id)) continue;
     dormant.add(r.id);
   }

--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -1922,18 +1922,25 @@ export async function sendWeeklyReportReminders(now = new Date()) {
  * is what gets a sending domain marked as spam, and the cost of that is borne
  * by every meeting invitation and password reset the product sends.
  *
- * The cadence is day 14 and day 45, measured from the mentor's own outreach for
- * the first and from the previous nudge for the second. Measuring the second
- * one from the FIRST NUDGE rather than from the outreach is what keeps the
- * backlog sane: on the day this ships, everybody whose outreach was months ago
- * is due for nudge one, and an outreach-anchored second nudge would follow it
- * the very next morning.
+ * The cadence is day 14 and day 45. The first is anchored on `dormantSince`,
+ * which the sweep only stamps once the outreach is already DORMANT_GRACE_DAYS
+ * (14) old — so being flagged IS being due, and the job never has to re-derive
+ * when the mentor last reached out. (It must not: an outreach is often an
+ * in-app message rather than a logged interaction, and reading only the
+ * interaction log is exactly the bug that left a mentee who had been written to
+ * four times sitting in the queue.) The second is measured from the FIRST
+ * NUDGE rather than from the outreach, which is what keeps the backlog sane: on
+ * the day this ships, everybody whose outreach was months ago is due for nudge
+ * one, and an outreach-anchored second nudge would follow it the very next
+ * morning.
  *
  * No in-app notification: the entire premise is a person who does not sign in.
  * The mail is the only channel that can reach them, and a bell item nobody will
  * ever look at is not a second attempt.
  */
-export const DORMANT_FIRST_NUDGE_DAYS = 14;
+// No DORMANT_FIRST_NUDGE_DAYS here: the first nudge's timing is DORMANT_GRACE_DAYS
+// in lib/dormantFirstContact.ts, spent before the flag is even stamped. Two
+// constants for one delay is how they drift apart.
 export const DORMANT_SECOND_NUDGE_GAP_DAYS = 31;
 export const DORMANT_MAX_NUDGES = 2;
 // A ceiling on one tick, not on the feature: the first run after this ships
@@ -1955,9 +1962,9 @@ export async function sendDormantCheckIns(now = new Date()) {
     select: {
       id: true,
       orgId: true,
+      dormantSince: true,
       dormantNudgeCount: true,
       dormantNudgeSentAt: true,
-      interactions: { orderBy: { date: 'desc' }, take: 1, select: { date: true } },
       mentee: {
         select: { id: true, fullName: true, email: true, preferredLanguage: true, emailNotifications: true, notificationPrefs: true },
       },
@@ -1973,12 +1980,16 @@ export async function sendDormantCheckIns(now = new Date()) {
     if (sent >= DORMANT_NUDGE_MAX_PER_RUN) break;
     checked += 1;
     const count = relation.dormantNudgeCount;
-    const since = count === 0
-      ? relation.interactions[0]?.date ?? null
-      : relation.dormantNudgeSentAt;
-    if (!since) continue;
-    const days = Math.floor((now.getTime() - since.getTime()) / DAY_MS);
-    if (days < (count === 0 ? DORMANT_FIRST_NUDGE_DAYS : DORMANT_SECOND_NUDGE_GAP_DAYS)) continue;
+    if (count > 0) {
+      // Every nudge after the first is spaced from the one before it.
+      if (!relation.dormantNudgeSentAt) continue;
+      const days = Math.floor((now.getTime() - relation.dormantNudgeSentAt.getTime()) / DAY_MS);
+      if (days < DORMANT_SECOND_NUDGE_GAP_DAYS) continue;
+    } else if (!relation.dormantSince || relation.dormantSince > now) {
+      // Flagged is due (see the note above); a stamp in the future can only
+      // come from a caller passing a `now` in the past, and is not due.
+      continue;
+    }
 
     // Preferences are read BEFORE the claim on purpose: claiming first would
     // spend an opted-out person's two-nudge budget on mail that was never sent,


### PR DESCRIPTION
## Summary

A mentee sitting at `100 · İlk temas` who had been written to **four times** through the in-app messenger, and never replied, was still in "Dikkat gerektiriyor" with *Yakın zamanda temas yok* + *Açık hedef veya yapılacak yok* — the exact case #1499 was built to remove.

**Reaching out and logging that you reached out are two different acts.** `findDormantFirstContacts` derived the outreach date from `InteractionLog` alone, so a mentor who uses the messenger and never opens the interaction form leaves the relation with no rows there, and the rule read that as *"nobody has written yet — the first message is still the mentor's to send"*. The `Message` table was already queried, but only to spot a mentee reply.

**A second defect in the same function:** a reply counted as a sign of life whenever it happened, so somebody who chatted in June, was written to in August and has said nothing since was treated as a live thread.

## Changes

- `src/lib/dormantFirstContact.ts`
  - The outreach date is now the later of the last `InteractionLog` and the last `Message` from anybody who is **not** the mentee (mentor or admin). The `groupBy` that already ran carries `_max: { createdAt }`, so this costs no extra query.
  - A mentee reply counts only when it came **after** that outreach. The question is whose court the ball is in: a reply from yesterday keeps the relation on the queue precisely because the mentor now owes an answer.
  - The grace-period check moved after the outreach date is resolved (it can no longer pre-filter on the interaction log alone).
- `src/services/emailService.ts` — `sendDormantCheckIns` anchors the first check-in on `dormantSince` instead of re-deriving the outreach date, so it cannot fall into the same trap: the sweep only stamps that field once the silence is already `DORMANT_GRACE_DAYS` old, which makes *being flagged* the same as *being due*. The now-duplicated `DORMANT_FIRST_NUDGE_DAYS` constant is gone — two constants for one delay is how they drift apart.
- `e2e/dormant-first-contact.spec.ts` — regression test reproducing the reported shape (messenger-only outreach, asserting `interactionLog.count === 0`), plus reply-before-outreach, reply-after-outreach, and outreach-inside-the-grace-period.
- `docs/dormant-first-contacts.md` — rule table and cadence corrected; release fragment (patch).

Closes #1512

## Verification

- [x] `npm run lint` + `npx tsc --noEmit` clean (only the three pre-existing warnings)
- [x] `npm run check:release-fragments` clean
- [x] `e2e/dormant-first-contact.spec.ts` + `e2e/dormant-check-in.spec.ts` — 5 tests, all passing against a local MariaDB; the new test fails on the previous rule
- [ ] Full `npm run test:e2e` — CI

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.


---
_Generated by [Claude Code](https://claude.ai/code/session_013A2VVT5n29hBJ7F2XMaynv)_