### PR TITLE
Measure the dormant fortnight from the start of the silence (#1516)

### DIFF
--- a/docs/dormant-first-contacts.md
+++ b/docs/dormant-first-contacts.md
@@ -20,8 +20,8 @@ Bir ilişki şu koşulların **hepsi** sağlandığında "pasif ilk temas" sayı
 |---|---|
 | Pipeline'ın **ilk aşamasında** (varsayılan `APPLICATION_100`; tenant'ın kendi ilk aşaması, #747) | Süreç hiç başlamamış demektir |
 | **Bir temas var**: `InteractionLog` **veya** mentee dışında birinin (mentor/admin) attığı bir mesaj — hangisi daha yeniyse | Mentor üzerine düşeni yapmış. Mesaj atmak ile "etkileşim kaydı" formunu doldurmak aynı şey değil; kural yalnızca `InteractionLog`'a bakarsa, dört kez yazılmış bir mentee listede kalır (#1512) |
-| Bu temasın üzerinden en az **`DORMANT_GRACE_DAYS` (14) gün** geçmiş | Dünkü sessizlik bir cevap değildir |
-| Mentee'den **son temastan sonra** mesaj yok, **yanıtsız soru yok**, **bekleyen toplantı talebi yok** | Soru "top kimde?" — haziranda konuşup ağustosta yazılan ve o gün bugündür susan kişi yine pasiftir; dün yanıt veren kişi değildir, orada cevap borcu mentordadır |
+| **Sessizliğin başlangıcından** (mentee'nin yanıtlamadığı **ilk** temas) en az **`DORMANT_GRACE_DAYS` (14) gün** geçmiş | Dünkü sessizlik bir cevap değildir. Sayaç **son** temastan ölçülürse mentorun ısrarına ait olur: üç haftadır yanıt vermeyen birine atılan bir "Hi?" onu iki hafta daha listeye döndürür ve her kovalama bir iki hafta daha satın alır (#1516) |
+| Mentee'nin **son mesajından sonra en az bir cevapsız temas var**, **yanıtsız soru yok**, **bekleyen toplantı talebi yok** | Soru "top kimde?" — mentee'nin son mesajından beri mentor hiç yazmamışsa cevap borcu **mentordadır**, kişi listede kalır |
 | Aşamaya **mentor tarafından konmuş bir termin yok** (`stageDeadline`) | Termin, "bunu takip et" demenin bilinçli hâlidir |
 
 Hiç kimsenin yazmadığı bir ilişki **asla** pasif sayılmaz: orada eksik olan şey zaten

--- a/e2e/dormant-first-contact.spec.ts
+++ b/e2e/dormant-first-contact.spec.ts
@@ -128,3 +128,34 @@ test('messenger-only outreach counts, and a reply only counts when it came after
     await cleanupByEmail(menteeEmail);
   }
 });
+
+// The fortnight belongs to the mentee's silence, not to the mentor's
+// persistence. Somebody ignored for three weeks who gets one more "Hi?" used to
+// land back on the queue for another fortnight — and every chase bought another
+// one, which is the treadmill this feature exists to end.
+test('a fresh chase does not restart the clock on an unbroken silence', async () => {
+  const mentorEmail = uniqueEmail('chase-mentor');
+  const menteeEmail = uniqueEmail('chase-mentee');
+  try {
+    const mentor = await seedUser(mentorEmail, 'ChasePass123', 'MENTOR', 'Chasing Mentor');
+    const mentee = await seedUser(menteeEmail, 'ChasePass123', 'MENTEE', 'Unresponsive Mentee');
+    const relation = await prisma.mentorshipRelation.create({
+      data: { mentorId: mentor.id, menteeId: mentee.id, status: 'ACTIVE', pipelineStatus: 'APPLICATION_100' },
+    });
+    const at = (days: number) => new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+
+    // Written to 24 days ago, then again yesterday. Nothing back, ever.
+    await prisma.interactionLog.create({ data: { relationId: relation.id, date: at(24), notes: 'No answer', type: 'Feedback' } });
+    await prisma.message.create({ data: { relationId: relation.id, senderId: mentor.id, body: 'Welcome aboard!', createdAt: at(22) } });
+    await prisma.message.create({ data: { relationId: relation.id, senderId: mentor.id, body: 'Hi?', createdAt: at(1) } });
+    expect((await getAttentionItems(mentor.id)).items.map((i) => i.relationId)).not.toContain(relation.id);
+
+    // But a reply resets it for real: the outreach after it is only a day old,
+    // and the two before it were answered.
+    await prisma.message.create({ data: { relationId: relation.id, senderId: mentee.id, body: 'Sorry, I am here', createdAt: at(2) } });
+    expect((await getAttentionItems(mentor.id)).items.map((i) => i.relationId)).toContain(relation.id);
+  } finally {
+    await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(menteeEmail);
+  }
+});

--- a/releases/unreleased/dormant-clock-belongs-to-the-silence.json
+++ b/releases/unreleased/dormant-clock-belongs-to-the-silence.json
@@ -1,0 +1,9 @@
+{
+  "bump": "patch",
+  "changelog": "- **The dormant fortnight is measured from the start of the silence** (#1516), not from the most recent outreach. Measuring from the last message made the clock belong to the mentor's persistence rather than to the mentee's silence: somebody ignored for three weeks who got one more \"Hi?\" was back on the attention queue for another fortnight, and every chase bought another one — the exact treadmill the feature exists to end. The window now starts at the first outreach the mentee never answered, so a later nudge is more of the same silence rather than a fresh start. A genuine reply still resets it in full, and a relation where the mentor has not written since the mentee's last message stays on the queue, because there the answer is owed by the mentor.",
+  "notes": {
+    "en": ["Chasing someone who never replies no longer puts them back on your \"Needs attention\" list for another two weeks — the clock now runs from their first unanswered message."],
+    "tr": ["Hiç yanıt vermeyen birini tekrar dürtmek onu iki hafta daha \"Dikkat gerektiriyor\" listene geri döndürmüyor; sayaç artık cevapsız kalan ilk mesajdan işliyor."],
+    "de": ["Wer nie antwortet, landet durch eine weitere Nachricht nicht erneut für zwei Wochen in \"Braucht Aufmerksamkeit\" — die Frist läuft jetzt ab der ersten unbeantworteten Nachricht."]
+  }
+}

--- a/src/lib/dormantFirstContact.ts
+++ b/src/lib/dormantFirstContact.ts
@@ -27,15 +27,22 @@ import { onPathKeys } from './pipeline';
 import { resolvePipelineStages } from './pipelineStages';
 
 /**
- * How old the outreach must be before silence counts as dormancy.
+ * How long the silence must have lasted before it counts as dormancy.
  *
- * Without it the rule fires the day after a mentor writes: harmless while this
- * only suppressed reminders, but it now drives a visible "Dormant" badge and an
- * automated check-in, and calling somebody passive the morning after you wrote
- * to them is simply wrong. Fourteen days is the same threshold the attention
- * queue and the staleness reminder already use for "no recent contact", and it
- * also what schedules the first check-in: a relation becomes dormant on exactly
- * the day that mail is due, so being flagged is being due.
+ * Without a window at all the rule fires the day after a mentor writes: harmless
+ * while this only suppressed reminders, but it now drives a visible "Dormant"
+ * badge and an automated check-in, and calling somebody passive the morning
+ * after you wrote to them is simply wrong. Fourteen days is the same threshold
+ * the attention queue and the staleness reminder already use for "no recent
+ * contact", and it is also what schedules the first check-in: a relation becomes
+ * dormant on exactly the day that mail is due, so being flagged is being due.
+ *
+ * Measured from the START of the silence — the first outreach the mentee never
+ * answered — and NOT from the most recent one. Measuring from the last message
+ * makes the clock belong to the mentor's persistence instead of to the mentee's
+ * silence: somebody ignored for three weeks who gets one more "Hi?" is back on
+ * the queue for another fortnight, and every chase buys another one. That
+ * treadmill is the thing this feature exists to end (#1516).
  */
 export const DORMANT_GRACE_DAYS = 14;
 
@@ -45,8 +52,6 @@ export interface DormantCandidate {
   menteeId: string;
   pipelineStatus: string;
   stageDeadline: Date | null;
-  /** Date of the most recent logged interaction, or null when there is none. */
-  lastInteractionAt: Date | null;
 }
 
 // The first stage of a tenant's pipeline. Custom stages (#747) may rename or
@@ -84,56 +89,59 @@ export async function findDormantFirstContacts(relations: DormantCandidate[]): P
   if (candidates.length === 0) return dormant;
 
   const ids = candidates.map((r) => r.id);
-  const [messages, openQuestions, pendingMeetings] = await Promise.all([
-    // One row per (relation, sender) carrying that sender's latest message, not
-    // the messages themselves: a chatty thread would otherwise pull its whole
-    // history into memory, and the only questions here are "who wrote?" and
-    // "when last?".
-    prisma.message.groupBy({
-      by: ['relationId', 'senderId'],
+  const [messages, interactions, openQuestions, pendingMeetings] = await Promise.all([
+    // The timestamps only, and only for relations parked at first contact —
+    // threads that by definition never got going. Whole rows are not needed and
+    // a message body is the one expensive column here.
+    prisma.message.findMany({
       where: { relationId: { in: ids } },
-      _max: { createdAt: true },
+      select: { relationId: true, senderId: true, createdAt: true },
+    }),
+    // Reaching out is not the same as logging that you reached out, so a logged
+    // interaction and a message from the mentor are the same kind of event to
+    // this rule (#1512).
+    prisma.interactionLog.findMany({
+      where: { relationId: { in: ids } },
+      select: { relationId: true, date: true },
     }),
     prisma.mentorQuestion.findMany({ where: { relationId: { in: ids }, answer: null }, select: { relationId: true } }),
     prisma.meetingRequest.findMany({ where: { relationId: { in: ids }, status: 'PENDING' }, select: { relationId: true } }),
   ]);
 
-  // Reaching out is not the same as logging that you reached out. A mentor who
-  // writes four times through the in-app messenger and never opens the
-  // interaction form has done exactly the thing this rule is about, so the
-  // outreach date is the later of the last logged interaction and the last
-  // message from anybody who is not the mentee (mentor or admin).
-  const lastOutreachMessage = new Map<string, Date>();
-  const lastMenteeMessage = new Map<string, Date>();
   const byMentee = new Map(candidates.map((r) => [r.id, r.menteeId]));
-  for (const row of messages) {
-    if (!row.relationId) continue;
-    const at = row._max.createdAt;
-    if (!at) continue;
-    const target = row.senderId === byMentee.get(row.relationId) ? lastMenteeMessage : lastOutreachMessage;
-    const seen = target.get(row.relationId);
-    if (!seen || at > seen) target.set(row.relationId, at);
+  const outreachTimes = new Map<string, Date[]>();
+  const lastMenteeActivity = new Map<string, Date>();
+  const noteOutreach = (relationId: string, at: Date) => {
+    const list = outreachTimes.get(relationId);
+    if (list) list.push(at);
+    else outreachTimes.set(relationId, [at]);
+  };
+  for (const m of messages) {
+    if (!m.relationId) continue;
+    if (m.senderId === byMentee.get(m.relationId)) {
+      const seen = lastMenteeActivity.get(m.relationId);
+      if (!seen || m.createdAt > seen) lastMenteeActivity.set(m.relationId, m.createdAt);
+    } else {
+      noteOutreach(m.relationId, m.createdAt);
+    }
   }
+  for (const i of interactions) noteOutreach(i.relationId, i.date);
 
   const withOpenQuestion = new Set(openQuestions.map((q) => q.relationId));
   const withPendingMeeting = new Set(pendingMeetings.map((m) => m.relationId));
   const graceCutoff = new Date(Date.now() - DORMANT_GRACE_DAYS * 24 * 60 * 60 * 1000);
 
   for (const r of candidates) {
-    const outreachCandidates = [r.lastInteractionAt, lastOutreachMessage.get(r.id) ?? null].filter(
-      (d): d is Date => d !== null,
-    );
-    if (outreachCandidates.length === 0) continue; // Nobody has written yet.
-    const lastOutreachAt = outreachCandidates.reduce((a, b) => (a > b ? a : b));
-    // Still inside the grace period — the silence is not yet an answer.
-    if (lastOutreachAt > graceCutoff) continue;
-    // A reply AFTER the last outreach, not merely somewhere in the history: the
-    // question is whether the ball is in their court right now. Someone who
-    // chatted in June, was written to in August and said nothing since is
-    // dormant again; someone who answered yesterday is not, and the mentor owes
-    // *them* a reply — which is exactly why they belong on the queue.
-    const repliedAt = lastMenteeMessage.get(r.id);
-    if (repliedAt && repliedAt > lastOutreachAt) continue;
+    const repliedAt = lastMenteeActivity.get(r.id);
+    // Only the outreach the mentee never answered counts. If the mentor has not
+    // written since the mentee's last message, the ball is in the MENTOR's court
+    // and the relation belongs on the queue, not off it.
+    const unanswered = (outreachTimes.get(r.id) ?? []).filter((at) => !repliedAt || at > repliedAt);
+    if (unanswered.length === 0) continue;
+    // The silence began at the FIRST of them — a later "Hi?" is more of the same
+    // silence, not a fresh start.
+    const silenceSince = unanswered.reduce((a, b) => (a < b ? a : b));
+    if (silenceSince > graceCutoff) continue;
     if (withOpenQuestion.has(r.id) || withPendingMeeting.has(r.id)) continue;
     dormant.add(r.id);
   }
@@ -165,7 +173,6 @@ export async function sweepDormantFirstContacts() {
       pipelineStatus: true,
       stageDeadline: true,
       dormantSince: true,
-      interactions: { orderBy: { date: 'desc' }, take: 1, select: { date: true } },
     },
   });
 
@@ -176,7 +183,6 @@ export async function sweepDormantFirstContacts() {
       menteeId: r.menteeId,
       pipelineStatus: r.pipelineStatus,
       stageDeadline: r.stageDeadline,
-      lastInteractionAt: r.interactions[0]?.date ?? null,
     })),
   );
 

--- a/src/lib/mentorAttention.ts
+++ b/src/lib/mentorAttention.ts
@@ -84,7 +84,6 @@ export async function getAttentionItems(mentorId: string): Promise<AttentionQueu
       menteeId: r.mentee.id,
       pipelineStatus: r.pipelineStatus,
       stageDeadline: r.stageDeadline,
-      lastInteractionAt: r.interactions[0]?.date ?? null,
     })),
   );
 


### PR DESCRIPTION
## Summary

A mentee at `100 · İlk temas` written to on 06.08 and 08.08, who has never replied, was still in "Dikkat gerektiriyor" on 30.08 — 24 days of unbroken silence. The only thing that had changed was one more message from the mentor ("Hi?") the day before.

The grace period was measured from the **most recent** outreach, which makes the clock belong to the mentor's persistence rather than to the mentee's silence. Every chase put the person back on the queue for another fortnight — and chasing is exactly what a mentor does with somebody who keeps appearing on their "needs attention" list. Ending that treadmill is the whole point of #1499.

The window now starts at the **first outreach the mentee never answered**:

- `unanswered` = outreach events (logged interactions **and** messages from anybody who is not the mentee) later than the mentee's last message.
- Empty → **never dormant**: the mentor has not written since the mentee's last message, so the answer is owed by the *mentor*, which is precisely why the relation belongs on the queue.
- Otherwise the fortnight runs from `min(unanswered)` — a later "Hi?" is more of the same silence, not a fresh start.

A genuine reply still resets everything, because every outreach before it is answered by definition. The separate "did they reply after the last outreach?" test is gone; it is implied by the above.

Closes #1516

## Changes

- `src/lib/dormantFirstContact.ts` — the rule above, and the `DORMANT_GRACE_DAYS` note rewritten to say what the window is measured *from* and why that is not the last message. `DormantCandidate` loses `lastInteractionAt`: one timestamp from the caller can no longer answer the question, so the rule reads the history itself.
- The lookup now selects message and interaction **timestamps** (three columns, no bodies) instead of a `groupBy` of maxima, scoped as before to first-stage relations only — threads that by definition never got going.
- `src/lib/mentorAttention.ts` — passes one field fewer.
- `e2e/dormant-first-contact.spec.ts` — regression test reproducing the reported shape exactly: outreach at day 24, a chase at day 1, no reply ever → dormant; then a mentee reply between them → back on the queue.
- `docs/dormant-first-contacts.md` — rule table corrected; release fragment (patch).

## Verification

- [x] `npm run lint` + `npx tsc --noEmit` clean (only the three pre-existing warnings)
- [x] `npm run check:release-fragments` clean
- [x] `e2e/dormant-first-contact.spec.ts` + `e2e/dormant-check-in.spec.ts` — 6 tests, all passing against a local MariaDB; the new test fails on the previous rule
- [ ] Full `npm run test:e2e` — CI

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.


---
_Generated by [Claude Code](https://claude.ai/code/session_013A2VVT5n29hBJ7F2XMaynv)_