### PR TITLE
feat(ai): rate-limit all five AI endpoints per user and per org (#2028)

### DIFF
--- a/e2e/ai-rate-limit.spec.ts
+++ b/e2e/ai-rate-limit.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// AI endpoint rate limits (#2028):
+// An authenticated caller hitting an AI endpoint past its limit receives a 429
+// with Retry-After header BEFORE any provider or DB read.
+test('AI endpoints throttle requests past the limit with 429', async ({ page }) => {
+  const menteeEmail = uniqueEmail('airatelimit-mentee');
+  const pw = 'AiRateLimitPass123!';
+  await seedUser(menteeEmail, pw, 'MENTEE', 'RateLimit Mentee');
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', menteeEmail);
+    await page.fill('input[type="password"]', pw);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/portal'), { timeout: 20_000 });
+
+    // Call /api/interview-prep up to the limit (6 calls / 10m).
+    // The 7th call must return 429 Too Many Requests.
+    for (let i = 0; i < 6; i++) {
+      const res = await page.request.post('/api/interview-prep', {
+        data: { position: 'Backend Developer' },
+      });
+      // Initial 6 requests pass the rate limiter (and hit downstream logic, returning non-429).
+      expect(res.status()).not.toBe(429);
+    }
+
+    // 7th request must be throttled.
+    const throttled = await page.request.post('/api/interview-prep', {
+      data: { position: 'Backend Developer' },
+    });
+    expect(throttled.status()).toBe(429);
+    const json = await throttled.json();
+    expect(json.error).toBe('Too many requests. Please try again later.');
+    expect(throttled.headers()['retry-after']).toBeDefined();
+  } finally {
+    await cleanupByEmail(menteeEmail);
+  }
+});

--- a/e2e/ai-rate-limit.spec.ts
+++ b/e2e/ai-rate-limit.spec.ts
@@ -9,12 +9,19 @@ test.afterAll(async () => {
 // Rate limiting is keyed by authenticated user ID (and optionally org ID), so
 // a user exhausting their limit receives a 429 while another user on the same
 // network/IP remains unblocked.
-test('AI endpoints throttle per user ID and not shared IP', { tag: '@smoke' }, async ({ page }) => {
+test('AI endpoints isolate user limits without draining the org budget', { tag: '@smoke' }, async ({ page }) => {
   const menteeAEmail = uniqueEmail('airatelimit-a');
   const menteeBEmail = uniqueEmail('airatelimit-b');
   const pw = 'AiRateLimitPass123!';
-  await seedUser(menteeAEmail, pw, 'MENTEE', 'RateLimit Mentee A');
-  await seedUser(menteeBEmail, pw, 'MENTEE', 'RateLimit Mentee B');
+  const org = await prisma.organization.create({
+    data: { name: `AI Rate Limit Org ${Date.now()}`, slug: uniqueEmail('airatelimit-org').split('@')[0] },
+  });
+  const menteeA = await seedUser(menteeAEmail, pw, 'MENTEE', 'RateLimit Mentee A');
+  const menteeB = await seedUser(menteeBEmail, pw, 'MENTEE', 'RateLimit Mentee B');
+  await prisma.user.updateMany({
+    where: { id: { in: [menteeA.id, menteeB.id] } },
+    data: { orgId: org.id },
+  });
 
   try {
     // 1. Sign in as User A
@@ -42,6 +49,17 @@ test('AI endpoints throttle per user ID and not shared IP', { tag: '@smoke' }, a
     expect(jsonA.error).toBe('Too many requests. Please try again later.');
     expect(throttledA.headers()['retry-after']).toBeDefined();
 
+    // A rejected user must not consume the shared 120-request org budget.
+    // Drive User A to 120 total attempts; only their first six should reach the org limiter.
+    const blockedA = await Promise.all(
+      Array.from({ length: 113 }, () =>
+        page.request.post('/api/interview-prep', {
+          data: { position: 'Backend Developer' },
+        })
+      )
+    );
+    expect(blockedA.every((res) => res.status() === 429)).toBe(true);
+
     // 2. Sign in as User B in a second context (sharing the same network/IP).
     const ctxB = await page.context().browser()!.newContext();
     const pageB = await ctxB.newPage();
@@ -63,5 +81,6 @@ test('AI endpoints throttle per user ID and not shared IP', { tag: '@smoke' }, a
   } finally {
     await cleanupByEmail(menteeAEmail);
     await cleanupByEmail(menteeBEmail);
+    await prisma.organization.delete({ where: { id: org.id } });
   }
 });

--- a/e2e/ai-rate-limit.spec.ts
+++ b/e2e/ai-rate-limit.spec.ts
@@ -9,7 +9,7 @@ test.afterAll(async () => {
 // Rate limiting is keyed by authenticated user ID (and optionally org ID), so
 // a user exhausting their limit receives a 429 while another user on the same
 // network/IP remains unblocked.
-test('AI endpoints throttle per user ID and not shared IP', async ({ page }) => {
+test('AI endpoints throttle per user ID and not shared IP', { tag: '@smoke' }, async ({ page }) => {
   const menteeAEmail = uniqueEmail('airatelimit-a');
   const menteeBEmail = uniqueEmail('airatelimit-b');
   const pw = 'AiRateLimitPass123!';

--- a/e2e/ai-rate-limit.spec.ts
+++ b/e2e/ai-rate-limit.spec.ts
@@ -6,22 +6,25 @@ test.afterAll(async () => {
 });
 
 // AI endpoint rate limits (#2028):
-// An authenticated caller hitting an AI endpoint past its limit receives a 429
-// with Retry-After header BEFORE any provider or DB read.
-test('AI endpoints throttle requests past the limit with 429', async ({ page }) => {
-  const menteeEmail = uniqueEmail('airatelimit-mentee');
+// Rate limiting is keyed by authenticated user ID (and optionally org ID), so
+// a user exhausting their limit receives a 429 while another user on the same
+// network/IP remains unblocked.
+test('AI endpoints throttle per user ID and not shared IP', async ({ page }) => {
+  const menteeAEmail = uniqueEmail('airatelimit-a');
+  const menteeBEmail = uniqueEmail('airatelimit-b');
   const pw = 'AiRateLimitPass123!';
-  await seedUser(menteeEmail, pw, 'MENTEE', 'RateLimit Mentee');
+  await seedUser(menteeAEmail, pw, 'MENTEE', 'RateLimit Mentee A');
+  await seedUser(menteeBEmail, pw, 'MENTEE', 'RateLimit Mentee B');
 
   try {
+    // 1. Sign in as User A
     await page.goto('/auth/signin');
-    await page.fill('input[type="email"], input[name="email"]', menteeEmail);
+    await page.fill('input[type="email"], input[name="email"]', menteeAEmail);
     await page.fill('input[type="password"]', pw);
     await page.click('button[type="submit"]');
     await page.waitForURL((u) => u.pathname.startsWith('/portal'), { timeout: 20_000 });
 
     // Call /api/interview-prep up to the limit (6 calls / 10m).
-    // The 7th call must return 429 Too Many Requests.
     for (let i = 0; i < 6; i++) {
       const res = await page.request.post('/api/interview-prep', {
         data: { position: 'Backend Developer' },
@@ -30,15 +33,35 @@ test('AI endpoints throttle requests past the limit with 429', async ({ page }) 
       expect(res.status()).not.toBe(429);
     }
 
-    // 7th request must be throttled.
-    const throttled = await page.request.post('/api/interview-prep', {
+    // 7th request from User A must be throttled with 429.
+    const throttledA = await page.request.post('/api/interview-prep', {
       data: { position: 'Backend Developer' },
     });
-    expect(throttled.status()).toBe(429);
-    const json = await throttled.json();
-    expect(json.error).toBe('Too many requests. Please try again later.');
-    expect(throttled.headers()['retry-after']).toBeDefined();
+    expect(throttledA.status()).toBe(429);
+    const jsonA = await throttledA.json();
+    expect(jsonA.error).toBe('Too many requests. Please try again later.');
+    expect(throttledA.headers()['retry-after']).toBeDefined();
+
+    // 2. Sign in as User B in a second context (sharing the same network/IP).
+    const ctxB = await page.context().browser()!.newContext();
+    const pageB = await ctxB.newPage();
+    try {
+      await pageB.goto('/auth/signin');
+      await pageB.fill('input[type="email"], input[name="email"]', menteeBEmail);
+      await pageB.fill('input[type="password"]', pw);
+      await pageB.click('button[type="submit"]');
+      await pageB.waitForURL((u) => u.pathname.startsWith('/portal'), { timeout: 20_000 });
+
+      // User B must NOT be throttled even though User A is throttled on the same host/IP.
+      const resB = await pageB.request.post('/api/interview-prep', {
+        data: { position: 'Backend Developer' },
+      });
+      expect(resB.status()).not.toBe(429);
+    } finally {
+      await ctxB.close();
+    }
   } finally {
-    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(menteeAEmail);
+    await cleanupByEmail(menteeBEmail);
   }
 });

--- a/releases/unreleased/ai-endpoint-rate-limits.json
+++ b/releases/unreleased/ai-endpoint-rate-limits.json
@@ -1,0 +1,4 @@
+{
+  "bump": "patch",
+  "changelog": "**AI endpoint rate limits (#2028)** — throttled all five AI endpoints (`/api/cv/feedback`, `/api/interview-prep`, `/api/interactions/summary`, `/api/admin/mentor-suggest`, `/api/cv/[userId]/extract-ai`) per user (`ai:<taskId>:<userId>`) and per org (`ai:org:<orgId>`) before any database read or provider call, with centralized limit budgets in `src/lib/ai/limits.ts`."
+}

--- a/src/app/api/admin/mentor-suggest/route.ts
+++ b/src/app/api/admin/mentor-suggest/route.ts
@@ -32,6 +32,12 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
+  const userLimited = enforceRateLimit(request, 'ai:mentor_match', {
+    ...AI_RATE_LIMITS.mentor_match,
+    subject: session.user.id,
+  });
+  if (userLimited) return userLimited;
+
   if (session.user.orgId) {
     const orgLimited = enforceRateLimit(request, 'ai:org', {
       ...AI_RATE_LIMITS.org_burst,
@@ -39,11 +45,6 @@ export async function POST(request: Request) {
     });
     if (orgLimited) return orgLimited;
   }
-  const userLimited = enforceRateLimit(request, 'ai:mentor_match', {
-    ...AI_RATE_LIMITS.mentor_match,
-    subject: session.user.id,
-  });
-  if (userLimited) return userLimited;
 
   return await withTenantScope(session, async () => {
   const parsed = schema.safeParse(await request.json().catch(() => null));

--- a/src/app/api/admin/mentor-suggest/route.ts
+++ b/src/app/api/admin/mentor-suggest/route.ts
@@ -9,6 +9,8 @@ import { aiRankMentors, type MatchCandidate } from '@/lib/aiMentorMatch';
 import { withTenantScope } from '@/lib/orgContext';
 import { resolveOrgId } from '@/lib/orgScope';
 import { MATCH_RULESET_VERSION } from '@/lib/matchFeedback';
+import { enforceRateLimit } from '@/lib/rateLimit';
+import { AI_RATE_LIMITS } from '@/lib/ai/limits';
 
 const schema = z.object({ menteeId: z.string().min(1) });
 
@@ -29,6 +31,19 @@ export async function POST(request: Request) {
   if (!session || session.user.role !== 'ADMIN') {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
+
+  if (session.user.orgId) {
+    const orgLimited = enforceRateLimit(request, 'ai:org', {
+      ...AI_RATE_LIMITS.org_burst,
+      subject: session.user.orgId,
+    });
+    if (orgLimited) return orgLimited;
+  }
+  const userLimited = enforceRateLimit(request, 'ai:mentor_match', {
+    ...AI_RATE_LIMITS.mentor_match,
+    subject: session.user.id,
+  });
+  if (userLimited) return userLimited;
 
   return await withTenantScope(session, async () => {
   const parsed = schema.safeParse(await request.json().catch(() => null));

--- a/src/app/api/cv/[userId]/extract-ai/route.ts
+++ b/src/app/api/cv/[userId]/extract-ai/route.ts
@@ -6,12 +6,14 @@ import { canAccessCv } from '@/lib/cvAccess';
 import { extractCvText } from '@/lib/cvParse';
 import { aiExtractFromText } from '@/lib/cvExtractAi';
 import { runAiGated } from '@/lib/aiGate';
+import { enforceRateLimit } from '@/lib/rateLimit';
+import { AI_RATE_LIMITS } from '@/lib/ai/limits';
 
 // POST — AI-assisted extraction of profile fields from the stored CV (EPIC B3).
 // Runs through the central AI gate (#537): CV-owner consent → configured
 // provider → monthly quota → call (metered). Only the extracted TEXT is sent
 // to the AI provider, never the file.
-export async function POST(_request: Request, { params }: { params: Promise<{ userId: string }> }) {
+export async function POST(request: Request, { params }: { params: Promise<{ userId: string }> }) {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
@@ -20,6 +22,19 @@ export async function POST(_request: Request, { params }: { params: Promise<{ us
   if (!(await canAccessCv(session.user, target))) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
+
+  if (session.user.orgId) {
+    const orgLimited = enforceRateLimit(request, 'ai:org', {
+      ...AI_RATE_LIMITS.org_burst,
+      subject: session.user.orgId,
+    });
+    if (orgLimited) return orgLimited;
+  }
+  const userLimited = enforceRateLimit(request, 'ai:cv_extract', {
+    ...AI_RATE_LIMITS.cv_extract,
+    subject: session.user.id,
+  });
+  if (userLimited) return userLimited;
 
   const cv = await prisma.cvFile.findUnique({ where: { userId: target } });
   if (!cv) return NextResponse.json({ error: 'No CV uploaded' }, { status: 404 });

--- a/src/app/api/cv/[userId]/extract-ai/route.ts
+++ b/src/app/api/cv/[userId]/extract-ai/route.ts
@@ -23,6 +23,12 @@ export async function POST(request: Request, { params }: { params: Promise<{ use
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
 
+  const userLimited = enforceRateLimit(request, 'ai:cv_extract', {
+    ...AI_RATE_LIMITS.cv_extract,
+    subject: session.user.id,
+  });
+  if (userLimited) return userLimited;
+
   if (session.user.orgId) {
     const orgLimited = enforceRateLimit(request, 'ai:org', {
       ...AI_RATE_LIMITS.org_burst,
@@ -30,11 +36,6 @@ export async function POST(request: Request, { params }: { params: Promise<{ use
     });
     if (orgLimited) return orgLimited;
   }
-  const userLimited = enforceRateLimit(request, 'ai:cv_extract', {
-    ...AI_RATE_LIMITS.cv_extract,
-    subject: session.user.id,
-  });
-  if (userLimited) return userLimited;
 
   const cv = await prisma.cvFile.findUnique({ where: { userId: target } });
   if (!cv) return NextResponse.json({ error: 'No CV uploaded' }, { status: 404 });

--- a/src/app/api/cv/feedback/route.ts
+++ b/src/app/api/cv/feedback/route.ts
@@ -32,6 +32,12 @@ export async function POST(request: Request) {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
+  const userLimited = enforceRateLimit(request, 'ai:cv_feedback', {
+    ...AI_RATE_LIMITS.cv_feedback,
+    subject: session.user.id,
+  });
+  if (userLimited) return userLimited;
+
   if (session.user.orgId) {
     const orgLimited = enforceRateLimit(request, 'ai:org', {
       ...AI_RATE_LIMITS.org_burst,
@@ -39,11 +45,6 @@ export async function POST(request: Request) {
     });
     if (orgLimited) return orgLimited;
   }
-  const userLimited = enforceRateLimit(request, 'ai:cv_feedback', {
-    ...AI_RATE_LIMITS.cv_feedback,
-    subject: session.user.id,
-  });
-  if (userLimited) return userLimited;
 
   const cv = await prisma.cvFile.findUnique({ where: { userId: session.user.id } });
   if (!cv) return NextResponse.json({ error: 'No CV uploaded' }, { status: 404 });

--- a/src/app/api/cv/feedback/route.ts
+++ b/src/app/api/cv/feedback/route.ts
@@ -7,6 +7,8 @@ import { extractCvText } from '@/lib/cvParse';
 import { isAiConfigured } from '@/lib/cvExtractAi';
 import { aiCvFeedback } from '@/lib/aiCvFeedback';
 import { runAiGated } from '@/lib/aiGate';
+import { enforceRateLimit } from '@/lib/rateLimit';
+import { AI_RATE_LIMITS } from '@/lib/ai/limits';
 
 // AI CV improvement feedback (Faz 2, #535) — the mentee's own CV only, and
 // FREE for the mentee: the cost is metered against the org's AI quota via the
@@ -26,9 +28,22 @@ export async function GET() {
 }
 
 // POST — generate feedback for the caller's own uploaded CV.
-export async function POST() {
+export async function POST(request: Request) {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  if (session.user.orgId) {
+    const orgLimited = enforceRateLimit(request, 'ai:org', {
+      ...AI_RATE_LIMITS.org_burst,
+      subject: session.user.orgId,
+    });
+    if (orgLimited) return orgLimited;
+  }
+  const userLimited = enforceRateLimit(request, 'ai:cv_feedback', {
+    ...AI_RATE_LIMITS.cv_feedback,
+    subject: session.user.id,
+  });
+  if (userLimited) return userLimited;
 
   const cv = await prisma.cvFile.findUnique({ where: { userId: session.user.id } });
   if (!cv) return NextResponse.json({ error: 'No CV uploaded' }, { status: 404 });

--- a/src/app/api/interactions/summary/route.ts
+++ b/src/app/api/interactions/summary/route.ts
@@ -22,6 +22,12 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
 
+  const userLimited = enforceRateLimit(request, 'ai:interaction_summary', {
+    ...AI_RATE_LIMITS.interaction_summary,
+    subject: session.user.id,
+  });
+  if (userLimited) return userLimited;
+
   if (session.user.orgId) {
     const orgLimited = enforceRateLimit(request, 'ai:org', {
       ...AI_RATE_LIMITS.org_burst,
@@ -29,11 +35,6 @@ export async function POST(request: Request) {
     });
     if (orgLimited) return orgLimited;
   }
-  const userLimited = enforceRateLimit(request, 'ai:interaction_summary', {
-    ...AI_RATE_LIMITS.interaction_summary,
-    subject: session.user.id,
-  });
-  if (userLimited) return userLimited;
 
   const parsed = schema.safeParse(await request.json().catch(() => null));
   if (!parsed.success) return NextResponse.json({ error: 'Invalid request' }, { status: 400 });

--- a/src/app/api/interactions/summary/route.ts
+++ b/src/app/api/interactions/summary/route.ts
@@ -6,6 +6,8 @@ import { prisma } from '@/lib/prisma';
 import { getThreadIfAllowed } from '@/lib/messaging';
 import { runAiGated } from '@/lib/aiGate';
 import { aiSummarizeInteractions } from '@/lib/aiSummary';
+import { enforceRateLimit } from '@/lib/rateLimit';
+import { AI_RATE_LIMITS } from '@/lib/ai/limits';
 
 const schema = z.object({ relationId: z.string().min(1) });
 
@@ -19,6 +21,19 @@ export async function POST(request: Request) {
   if (session.user.role !== 'MENTOR' && session.user.role !== 'ADMIN') {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
+
+  if (session.user.orgId) {
+    const orgLimited = enforceRateLimit(request, 'ai:org', {
+      ...AI_RATE_LIMITS.org_burst,
+      subject: session.user.orgId,
+    });
+    if (orgLimited) return orgLimited;
+  }
+  const userLimited = enforceRateLimit(request, 'ai:interaction_summary', {
+    ...AI_RATE_LIMITS.interaction_summary,
+    subject: session.user.id,
+  });
+  if (userLimited) return userLimited;
 
   const parsed = schema.safeParse(await request.json().catch(() => null));
   if (!parsed.success) return NextResponse.json({ error: 'Invalid request' }, { status: 400 });

--- a/src/app/api/interview-prep/route.ts
+++ b/src/app/api/interview-prep/route.ts
@@ -35,6 +35,12 @@ export async function POST(request: Request) {
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   if (session.user.role !== 'MENTEE') return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
 
+  const userLimited = enforceRateLimit(request, 'ai:interview_prep', {
+    ...AI_RATE_LIMITS.interview_prep,
+    subject: session.user.id,
+  });
+  if (userLimited) return userLimited;
+
   if (session.user.orgId) {
     const orgLimited = enforceRateLimit(request, 'ai:org', {
       ...AI_RATE_LIMITS.org_burst,
@@ -42,11 +48,6 @@ export async function POST(request: Request) {
     });
     if (orgLimited) return orgLimited;
   }
-  const userLimited = enforceRateLimit(request, 'ai:interview_prep', {
-    ...AI_RATE_LIMITS.interview_prep,
-    subject: session.user.id,
-  });
-  if (userLimited) return userLimited;
 
   return await withTenantScope(session, async () => {
     const parsed = schema.safeParse(await request.json().catch(() => ({})));

--- a/src/app/api/interview-prep/route.ts
+++ b/src/app/api/interview-prep/route.ts
@@ -7,6 +7,8 @@ import { isAiConfigured } from '@/lib/cvExtractAi';
 import { aiInterviewPrep } from '@/lib/aiInterviewPrep';
 import { runAiGated } from '@/lib/aiGate';
 import { withTenantScope } from '@/lib/orgContext';
+import { enforceRateLimit } from '@/lib/rateLimit';
+import { AI_RATE_LIMITS } from '@/lib/ai/limits';
 
 // AI interview-prep assistant (Faz 2, #536) — mentee-facing and FREE for the
 // mentee: cost is metered on the org's AI quota; quota exhaustion surfaces as
@@ -32,6 +34,19 @@ export async function POST(request: Request) {
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   if (session.user.role !== 'MENTEE') return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+  if (session.user.orgId) {
+    const orgLimited = enforceRateLimit(request, 'ai:org', {
+      ...AI_RATE_LIMITS.org_burst,
+      subject: session.user.orgId,
+    });
+    if (orgLimited) return orgLimited;
+  }
+  const userLimited = enforceRateLimit(request, 'ai:interview_prep', {
+    ...AI_RATE_LIMITS.interview_prep,
+    subject: session.user.id,
+  });
+  if (userLimited) return userLimited;
 
   return await withTenantScope(session, async () => {
     const parsed = schema.safeParse(await request.json().catch(() => ({})));

--- a/src/lib/ai/limits.ts
+++ b/src/lib/ai/limits.ts
@@ -1,0 +1,55 @@
+// AI endpoint rate limits (#2028).
+//
+// Every AI route is throttled before any database read or provider call to protect
+// provider budgets and monthly organization quotas from rapid automated loops or
+// accidental spam.
+//
+// NOTE: The underlying rate limiter is in-memory and per-container today (per-container
+// until #1696 lands, which moves the counter behind a shared store). In the current
+// single-container deployment, this provides process-local protection. For multi-container
+// or distributed deployments, rate limiting state should be backed by Redis (#1696).
+//
+// Every limit carries its rationale below, matching the threshold documentation in
+// k6/nightly-load.js.
+
+export interface RateLimitConfig {
+  limit: number;
+  windowMs: number;
+}
+
+export const AI_RATE_LIMITS = {
+  // Generative mentee CV feedback (POST /api/cv/feedback).
+  // 6 calls / 10 minutes: Generates multi-section analysis on full CV text. A mentee
+  // iterating on their CV needs several minutes to edit and re-upload between runs;
+  // 6 per 10m allows legitimate iterative feedback while blocking rapid script loops.
+  cv_feedback: { limit: 6, windowMs: 10 * 60 * 1000 },
+
+  // Generative interview preparation (POST /api/interview-prep).
+  // 6 calls / 10 minutes: Generates tailored interview questions and scenarios.
+  // Reviewing prep questions takes time; 6 per 10m provides generous headroom for
+  // switching target positions or topics without draining provider tokens.
+  interview_prep: { limit: 6, windowMs: 10 * 60 * 1000 },
+
+  // AI-assisted CV profile field extraction (POST /api/cv/[userId]/extract-ai).
+  // 6 calls / 10 minutes: Extracts structured profile fields from uploaded CV text.
+  // Profile extraction only happens on upload or manual refresh; 6 per 10m easily
+  // accommodates re-uploads while preventing bulk scraping.
+  cv_extract: { limit: 6, windowMs: 10 * 60 * 1000 },
+
+  // AI mentor match & ranking (POST /api/admin/mentor-suggest).
+  // 20 calls / 10 minutes: Admin triage tool for candidate-to-mentor matching.
+  // Admins processing queues legitimately click between candidates rapidly; 20 per 10m
+  // accommodates an active triage session without risking runaway background loops.
+  mentor_match: { limit: 20, windowMs: 10 * 60 * 1000 },
+
+  // AI interaction summary (POST /api/interactions/summary).
+  // 10 calls / 10 minutes: Summarizes relation interaction logs for mentors/admins.
+  // Reviewing multiple mentee check-ins in a batch justifies a higher allowance than
+  // mentee generative tools, while 10 per 10m buffers LLM token consumption.
+  interaction_summary: { limit: 10, windowMs: 10 * 60 * 1000 },
+
+  // Coarse per-organization burst limit across all AI routes.
+  // 120 calls / 10 minutes: Prevents a single tenant from starving shared capacity
+  // or exhausting provider burst rates before fine-grained per-tenant quotas land (#1555).
+  org_burst: { limit: 120, windowMs: 10 * 60 * 1000 },
+} as const;

--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -116,7 +116,7 @@ function shouldLogBreach(key: string): boolean {
 }
 
 // Convenience guard for route handlers: returns a 429 NextResponse when the
-// IP has exceeded `limit` requests to `bucket` within `windowMs`, else null.
+// subject (or client IP by default) has exceeded `limit` requests to `bucket` within `windowMs`, else null.
 export function enforceRateLimit(
   request: Request,
   bucket: string,

--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -120,23 +120,24 @@ function shouldLogBreach(key: string): boolean {
 export function enforceRateLimit(
   request: Request,
   bucket: string,
-  opts: { limit: number; windowMs: number }
+  opts: { limit: number; windowMs: number; subject?: string }
 ): NextResponse | null {
-  const ip = clientIp(request);
-  const res = rateLimit(`${bucket}:${ip}`, opts);
+  const identity = opts.subject ?? clientIp(request);
+  const key = `${bucket}:${identity}`;
+  const res = rateLimit(key, opts);
   if (res.ok) return null;
   // Breaches were recorded nowhere, so being under attack looked exactly like
   // being idle (#864). Fire-and-forget keeps this function synchronous — its
-  // six callers stay untouched — and logActivity never throws by design.
+  // callers stay untouched — and logActivity never throws by design.
   //
   // Coalesced to one row per key per minute: a flood is exactly when this fires,
   // and a DB insert per blocked request would turn the rate limiter into an
   // amplifier for the attack it is supposed to absorb.
-  if (shouldLogBreach(`${bucket}:${ip}`)) {
+  if (shouldLogBreach(key)) {
     void logActivity({
       action: 'ratelimit.exceeded',
       level: 'warning',
-      detail: `${bucket} · ${ip}`,
+      detail: `${bucket} · ${identity}`,
     }).catch(() => {});
   }
   return NextResponse.json(


### PR DESCRIPTION
## Summary

    Adds per-user and per-org burst rate limiting to all five AI route handlers before database reads or provider calls, preventing rapid loops or token draining. Extends `enforceRateLimit` with an additive, backward-compatible `subject` override that defaults to
  client IP.

    Closes #2028

    ## Changes

    - `src/lib/rateLimit.ts`: Added optional `subject?: string` in `opts` to `enforceRateLimit` so caller identity can be overridden (e.g. user ID, org ID, API key ID) while defaulting to `clientIp(request)`. All existing callers remain unchanged.
    - `src/lib/ai/limits.ts`: Created shared constants for AI rate limit thresholds and windows with documented rationales, explicitly noting process-local storage until #1696 lands.
    - Applied rate limiting before DB reads / AI gates across all five AI endpoints:
      - `src/app/api/cv/feedback/route.ts` (6 / 10m per user, 120 / 10m per org)
      - `src/app/api/cv/[userId]/extract-ai/route.ts` (6 / 10m per user, 120 / 10m per org)
      - `src/app/api/interview-prep/route.ts` (6 / 10m per user, 120 / 10m per org)
      - `src/app/api/interactions/summary/route.ts` (10 / 10m per user, 120 / 10m per org)
      - `src/app/api/admin/mentor-suggest/route.ts` (20 / 10m per user, 120 / 10m per org)
    - `e2e/ai-rate-limit.spec.ts`: Added e2e test verifying repeated requests receive 429 Too Many Requests with `Retry-After` header.
    - `releases/unreleased/ai-endpoint-rate-limits.json`: Added unreleased release fragment.

    ## Verification

    - [x] `npm run lint` + `npx tsc --noEmit` clean
    - [x] `npm run test:e2e` passing (or CI green)
    - [x] Tested the change manually / added an e2e test

    ## Contributor terms

    - [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
          my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
          passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
          it is my own work, and I make no claim over the application.
