### PR TITLE
fix: rate limit unprotected write endpoints

### DIFF
--- a/e2e/rate-limit.spec.ts
+++ b/e2e/rate-limit.spec.ts
@@ -41,3 +41,21 @@ test('a rotating X-Forwarded-For does not buy a fresh rate-limit bucket', { tag:
   // them is a 429; run alone in the smoke subset the first few still pass.)
   expect(statuses).toContain(429);
 });
+test('support submissions are rate limited and return Retry-After', async ({ request }) => {
+  const statuses: number[] = [];
+  let retryAfter: string | undefined;
+
+  for (let i = 0; i < 6; i++) {
+    const response = await request.post('/api/support', {
+      data: { body: 'rate-limit test' },
+    });
+    statuses.push(response.status());
+
+    if (response.status() === 429) {
+      retryAfter = response.headers()['retry-after'];
+    }
+  }
+
+  expect(statuses).toContain(429);
+  expect(retryAfter).toBeTruthy();
+});

--- a/releases/unreleased/rate-limit-unprotected-writes.json
+++ b/releases/unreleased/rate-limit-unprotected-writes.json
@@ -1,0 +1,9 @@
+{
+  "bump": "patch",
+  "changelog": "- **Security:** Added rate limits to unprotected write endpoints (#1547).",
+  "notes": {
+    "en": ["Public and semi-public write endpoints now have protection against automated request bursts."],
+    "tr": ["Herkese açık ve yarı açık yazma uç noktaları artık otomatik istek yoğunluğuna karşı korunuyor."],
+    "de": ["Öffentliche und halböffentliche Schreib-Endpunkte sind jetzt gegen automatisierte Anfrage-Spitzen geschützt."]
+  }
+}

--- a/src/app/api/conversations/route.ts
+++ b/src/app/api/conversations/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from '@/lib/auth';
 import { z } from 'zod';
 import { createOrGetProjectConversation, findOrCreateDirectConversation, isActiveProjectMember } from '@/lib/conversations';
 import { withTenantScope } from '@/lib/orgContext';
+import { enforceRateLimit } from '@/lib/rateLimit';
 
 const schema = z.union([
   z.object({ userId: z.string().min(1), projectId: z.never().optional() }),
@@ -15,6 +16,9 @@ const schema = z.union([
 // conversation. 403 when the two aren't allowed to message each other, which
 // today means they share no project and have no mentorship (see canMessage).
 export async function POST(request: Request) {
+    // 20 per 15 minutes permits normal conversation setup while limiting automated creation attempts.
+  const limited = enforceRateLimit(request, 'conversation-create', { limit: 20, windowMs: 15 * 60 * 1000 });
+  if (limited) return limited;
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 

--- a/src/app/api/inbound-email/route.ts
+++ b/src/app/api/inbound-email/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { timingSafeEqual } from 'crypto';
 import { z } from 'zod';
 import { routeInboundEmail } from '@/lib/inboundEmail';
+import { enforceRateLimit } from '@/lib/rateLimit';
 
 const schema = z.object({
   to: z.string().min(1),
@@ -31,6 +32,9 @@ function secretOk(request: Request): boolean {
 // directly.) Routes it to a thread only when the HMAC reply token verifies AND
 // the sender is a participant of that thread.
 export async function POST(request: Request) {
+    // The mail provider can deliver a burst from one IP, so allow 120 messages per minute.
+  const limited = enforceRateLimit(request, 'inbound-email', { limit: 120, windowMs: 60 * 1000 });
+  if (limited) return limited;
   if (!secretOk(request)) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
   const parsed = schema.safeParse(await request.json().catch(() => ({})));

--- a/src/app/api/messages/route.ts
+++ b/src/app/api/messages/route.ts
@@ -34,9 +34,6 @@ const ATTACHMENT_SELECT = { id: true, filename: true, contentType: true, size: t
 
 // GET ?relationId= — messages in a thread (participants/admin only).
 export async function GET(request: Request) {
-    // 60 per minute allows a normal back-and-forth conversation while stopping automated bursts.
-  const limited = enforceRateLimit(request, 'messages', { limit: 60, windowMs: 60 * 1000 });
-  if (limited) return limited;
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
@@ -216,6 +213,10 @@ const schema = z
 // party. Accepts either JSON (text-only, the original shape) or multipart
 // form-data (text + an optional file attachment).
 export async function POST(request: Request) {
+  // 60 per minute allows a normal back-and-forth conversation while stopping automated bursts.
+  const limited = enforceRateLimit(request, 'messages', { limit: 60, windowMs: 60 * 1000 });
+  if (limited) return limited;
+
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 

--- a/src/app/api/messages/route.ts
+++ b/src/app/api/messages/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { enforceRateLimit } from '@/lib/rateLimit';
 import { z } from 'zod';
 import { getThreadIfAllowed, otherParticipant } from '@/lib/messaging';
 import {
@@ -33,6 +34,9 @@ const ATTACHMENT_SELECT = { id: true, filename: true, contentType: true, size: t
 
 // GET ?relationId= — messages in a thread (participants/admin only).
 export async function GET(request: Request) {
+    // 60 per minute allows a normal back-and-forth conversation while stopping automated bursts.
+  const limited = enforceRateLimit(request, 'messages', { limit: 60, windowMs: 60 * 1000 });
+  if (limited) return limited;
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 

--- a/src/app/api/push/subscribe/route.ts
+++ b/src/app/api/push/subscribe/route.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { pushConfigured } from '@/lib/webPush';
+import { enforceRateLimit } from '@/lib/rateLimit';
 
 // A push endpoint is a URL issued by the browser's push service. Only https, and
 // bounded by the column width — an endpoint is never user-authored text, so
@@ -23,6 +24,9 @@ const unsubscribeSchema = z.object({ endpoint: z.string().min(1).max(500) });
 // updates its row rather than adding a second one that would deliver the same
 // notification twice.
 export async function POST(request: Request) {
+    // 10 per 15 minutes covers normal browser re-subscriptions without permitting automated churn.
+  const limited = enforceRateLimit(request, 'push-subscribe', { limit: 10, windowMs: 15 * 60 * 1000 });
+  if (limited) return limited;
   const session = await getServerSession(authOptions);
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   if (!pushConfigured()) return NextResponse.json({ error: 'Push not configured' }, { status: 503 });

--- a/src/app/api/support/route.ts
+++ b/src/app/api/support/route.ts
@@ -10,6 +10,7 @@ import {
   readSupportMessageRequest,
 } from '@/lib/supportMessageRequest';
 import { withTenantScope } from '@/lib/orgContext';
+import { enforceRateLimit } from '@/lib/rateLimit';
 
 // User side of the support channel (#593): every role has a pinned "Support"
 // conversation. The first message opens a SupportTicket; further messages join
@@ -64,6 +65,9 @@ export async function GET() {
 
 // POST — send a message to support.
 export async function POST(request: Request) {
+    // Support submissions may store attachments, so 5 per 15 minutes limits storage abuse.
+  const limited = enforceRateLimit(request, 'support', { limit: 5, windowMs: 15 * 60 * 1000 });
+  if (limited) return limited;
   const session = await getServerSession(authOptions);
 
   if (!session) {


### PR DESCRIPTION
Closes #1547

## Summary

Adds rate limiting to the five public or semi-public write endpoints that previously had no throttle.

## Changes

- Added distinct, documented rate-limit buckets for messages, conversation creation, support, push subscriptions, and inbound email.
- Kept messaging generous for normal conversations and inbound email suitable for provider bursts.
- Added an E2E case confirming the support endpoint returns `429` with `Retry-After`.
- Added the required patch release fragment.

## Verification

- [x] `git diff --check`
- [x] `npx tsc --noEmit`
- [x] `npm run check:release-fragments`
- [ ] `npx playwright test e2e/rate-limit.spec.ts` could not start locally because the local database schema is missing `Evaluation.publicExcerpt` (`P2022`) before tests begin. No database changes were made.
- [ ] `npm run build` will be validated by CI.

## Contributor terms

- [x] I accept the contributor terms.