### PR TITLE
fix: run requisition backfill during deploys (#1359)

### DIFF
--- a/infra/deploy-prod.sh
+++ b/infra/deploy-prod.sh
@@ -527,6 +527,7 @@ run_tool node prisma/seed-goal-templates.mjs || true
 run_tool node prisma/seed-contributor-terms.mjs || true
 run_tool node prisma/backfill-project-members.mjs || true
 run_tool node prisma/backfill-organization.mjs || true
+run_tool node scripts/backfill-requisitions.mjs || true
 # One-shot: baseline the scheduled-job backlog so the first cron tick doesn't
 # email out history. Self-skips once applied (Setting 'cronBaselineAt').
 run_tool node prisma/backfill-cron-baseline.mjs || true

--- a/infra/server/topic-deploy.sh
+++ b/infra/server/topic-deploy.sh
@@ -232,6 +232,7 @@ fi
 _in_image "$IMAGE" npx prisma db push --accept-data-loss
 _in_image "$IMAGE" node prisma/seed-templates.mjs || true
 _in_image "$IMAGE" node prisma/seed-contributor-terms.mjs || true
+_in_image "$IMAGE" node scripts/backfill-requisitions.mjs || true
 
 if [ "${EXISTING_TABLES:-0}" -eq 0 ]; then
   # First deploy of this PR: fill it with the synthetic demo set. Nothing here

--- a/releases/unreleased/requisition-backfill-deploy.json
+++ b/releases/unreleased/requisition-backfill-deploy.json
@@ -1,0 +1,4 @@
+{
+  "bump": "patch",
+  "changelog": "- **Requisition compatibility backfill runs during deploys** (#1359). Production, shared preview and topic deploys now migrate legacy `CompanyNeed` rows through the existing idempotent backfill without making row-level failures block deployment."
+}


### PR DESCRIPTION
## Summary
- Run the existing idempotent `scripts/backfill-requisitions.mjs` during production/shared preview deploys.
- Run the same backfill during topic preview deploys.
- Keep deployment non-blocking with the existing `|| true` pattern while preserving logs and the script's non-zero exit behavior on row-level errors.
- Add a patch release fragment for #1359.

## Validation
- `bash -n infra/deploy-prod.sh`
- `bash -n infra/server/topic-deploy.sh`
- `git diff --check`
- `npm run check:release-fragments`
- `npm run test:release`
- `npx prisma generate`
- `npx tsc --noEmit`
- Local backfill idempotency verified with two runs:
  - first: `backfill-requisitions: migrated=1 skipped=0 errors=0`
  - second: `backfill-requisitions: migrated=0 skipped=1 errors=0`
- Targeted requisition backfill Playwright tests passed.
- Local Prisma schema drift was synchronized and verified with an empty migration diff.
- Auth smoke passed `4/4` with no P2022 schema errors.

## Smoke note
The full smoke suite reached `93 passed, 2 failed`. The `portal-projects` failure passed on isolated rerun. The remaining `unsubscribe-page.spec.ts` smoke failure reproduces unchanged on `origin/main`, so it is not introduced by this branch.

Closes #1359