### PR TITLE
feat(ci): fail the build on a newly hardcoded pipeline stage key (#1886)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,12 @@ jobs:
       - run: npx tsc --noEmit
       - name: i18n parity (EN/TR/DE)
         run: npm run check:i18n
+      # A hardcoded stage key ('HIRED_660', …) type-checks, passes every test on
+      # the default seed, and only misbehaves for a tenant that renamed its
+      # stages — which no test tenant does. That invisibility is why the bug
+      # keeps coming back (#1880); the guard makes a new one a red build.
+      - name: no hardcoded pipeline stage keys (#1886)
+        run: npm run check:stage-keys
       # A malformed release fragment must fail in the PR that adds it, not in
       # next.config.js during the deploy build (#1275).
       - name: release fragments are well-formed (#1275)

--- a/e2e/custom-pipeline-analytics.spec.ts
+++ b/e2e/custom-pipeline-analytics.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedCustomPipelineOrg, cleanupCustomPipelineOrg } from './helpers/db';
+import { signInAndSettle, gotoSettled } from './helpers/auth';
+
+/**
+ * A tenant that renamed its pipeline must still get a hiring funnel (#1886).
+ *
+ * Every other spec runs on the default stage catalogue, which is exactly why a
+ * hardcoded `'HIRED_660'` has been reintroduced so often (#1880): the literal
+ * type-checks, and on the default seed it is even correct. This spec is the
+ * fixture that catches it — six stages keyed `STAGE_A`…`STAGE_F` and nothing
+ * else, so any consumer reasoning about a default key reports zero here.
+ *
+ * The API assertion is the load-bearing one; the two testid assertions only
+ * guard that the screen renders the resolved order rather than a default.
+ * The headline conversion number on /admin/analytics is deliberately NOT
+ * asserted: it still compares against 'HIRED_660'
+ * (src/app/api/admin/analytics/route.ts) and #1882 owns that fix.
+ */
+
+const PASSWORD = 'CustomPipe123!';
+
+let seeded: Awaited<ReturnType<typeof seedCustomPipelineOrg>>;
+
+test.describe.configure({ mode: 'serial' });
+
+test.beforeAll(async () => {
+  seeded = await seedCustomPipelineOrg('custom-pipe', PASSWORD);
+});
+
+test.afterAll(async () => {
+  if (seeded) await cleanupCustomPipelineOrg(seeded.org.id, seeded.emails);
+  await prisma.$disconnect();
+});
+
+test('the hiring funnel reports on a tenant’s renamed pipeline', { tag: '@smoke' }, async ({ page }) => {
+  await signInAndSettle(page, seeded.adminEmail, PASSWORD, '/admin');
+
+  const res = await page.request.get('/api/admin/analytics/funnel');
+  expect(res.ok()).toBeTruthy();
+  const kpi = await res.json();
+  // The order is the tenant's own stage set, in its own order — not the
+  // canonical default catalogue.
+  expect(kpi.order).toEqual(seeded.stageKeys);
+  expect(kpi.journeys).toBeGreaterThan(0);
+  // The seeded relation travelled STAGE_A → STAGE_F, so the last stage has an
+  // entrant. A consumer that looked for a default key would report none.
+  const last = (kpi.conversions as { key: string; entered: number }[]).find((c) => c.key === 'STAGE_F');
+  expect(last?.entered).toBeGreaterThan(0);
+
+  await gotoSettled(page, '/admin/analytics');
+  await expect(page.getByTestId('funnel-kpi-card')).toBeVisible();
+  await expect(page.getByTestId('conversion-STAGE_F')).toBeVisible();
+  await expect(page.getByTestId('conversion-list')).not.toContainText('HIRED_660');
+});

--- a/e2e/helpers/db.ts
+++ b/e2e/helpers/db.ts
@@ -80,3 +80,80 @@ export async function acceptContributorTerms(
     data: { userId, termsKey, version: terms.version, projectId: opts.projectId ?? null },
   });
 }
+
+/**
+ * A tenant whose pipeline is NOT the default catalogue (#1886).
+ *
+ * Every other spec runs against `resolvePipelineStages()`'s fallback, so a
+ * consumer that hardcodes `'HIRED_660'` passes the whole suite and only
+ * misbehaves for a customer who renamed their stages. This seeds exactly that
+ * customer: six `PipelineStage` rows keyed `STAGE_A`…`STAGE_F`, an admin, and a
+ * relation that has actually travelled from the first stage to the last one, so
+ * the funnel has a journey to report on.
+ */
+export async function seedCustomPipelineOrg(prefix: string, password: string) {
+  const org = await prisma.organization.create({
+    data: { slug: `${prefix}-${Date.now()}-${crypto.randomBytes(3).toString('hex')}`, name: `${prefix} Org` },
+  });
+  const keys = ['STAGE_A', 'STAGE_B', 'STAGE_C', 'STAGE_D', 'STAGE_E', 'STAGE_F'];
+  await prisma.pipelineStage.createMany({
+    data: keys.map((key, i) => ({
+      orgId: org.id,
+      key,
+      label: `Custom ${key.slice(-1)}`,
+      order: i,
+      // Only the last stage ends the journey; nothing here is off-path, so the
+      // whole set is the on-path order the funnel reports.
+      isTerminal: i === keys.length - 1,
+      isOffPath: false,
+    })),
+  });
+
+  const adminEmail = uniqueEmail(`${prefix}-admin`);
+  const mentorEmail = uniqueEmail(`${prefix}-mentor`);
+  const menteeEmail = uniqueEmail(`${prefix}-mentee`);
+  const admin = await seedUser(adminEmail, password, 'ADMIN', `${prefix} Admin`);
+  const mentor = await seedUser(mentorEmail, password, 'MENTOR', `${prefix} Mentor`);
+  const mentee = await seedUser(menteeEmail, password, 'MENTEE', `${prefix} Mentee`);
+  await prisma.user.updateMany({
+    where: { id: { in: [admin.id, mentor.id, mentee.id] } },
+    data: { orgId: org.id },
+  });
+
+  const relation = await prisma.mentorshipRelation.create({
+    data: {
+      orgId: org.id,
+      mentorId: mentor.id,
+      menteeId: mentee.id,
+      pipelineStatus: 'STAGE_F',
+      startDate: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
+    },
+  });
+  await prisma.statusChange.create({
+    data: {
+      relationId: relation.id,
+      fromStatus: 'STAGE_A',
+      toStatus: 'STAGE_F',
+      changedById: admin.id,
+    },
+  });
+
+  return {
+    org,
+    relationId: relation.id,
+    adminEmail,
+    emails: [adminEmail, mentorEmail, menteeEmail],
+    stageKeys: keys,
+  };
+}
+
+/** Teardown for {@link seedCustomPipelineOrg}. */
+export async function cleanupCustomPipelineOrg(orgId: string, emails: string[]) {
+  // Explicit, in dependency order: PipelineStage cascades from Organization,
+  // but a partial failure should still leave nothing behind.
+  await prisma.statusChange.deleteMany({ where: { relation: { orgId } } });
+  await prisma.mentorshipRelation.deleteMany({ where: { orgId } });
+  await prisma.pipelineStage.deleteMany({ where: { orgId } });
+  for (const email of emails) await cleanupByEmail(email);
+  await prisma.organization.delete({ where: { id: orgId } }).catch(() => {});
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "check:demo-blocklist": "node scripts/check-demo-blocklist.mjs",
     "check:i18n": "node --experimental-strip-types scripts/check-i18n.ts",
     "check:release-fragments": "node scripts/check-release-fragments.mjs",
+    "check:stage-keys": "node scripts/check-stage-keys.mjs",
     "test:release": "node --test scripts/test/release-derive.test.mjs",
     "check:auth-reads": "node scripts/check-auth-reads.mjs",
     "check:query-scalars": "node scripts/check-query-scalars.mjs",

--- a/releases/unreleased/check-stage-keys.json
+++ b/releases/unreleased/check-stage-keys.json
@@ -1,0 +1,4 @@
+{
+  "bump": "patch",
+  "changelog": "- **Stage-key guard** (#1886). `npm run check:stage-keys` fails CI when a canonical pipeline stage key (`HIRED_660`, `APPLICATION_100`, …) is hardcoded in a new place, with `src/lib/pipeline.ts` and `src/lib/offers.ts` allowed and today's offenders recorded in `scripts/stage-keys-baseline.json` as a shrinking ratchet. A `@smoke` e2e fixture seeds a tenant whose stages are `STAGE_A`…`STAGE_F` and asserts the hiring funnel reports on those."
+}

--- a/scripts/check-stage-keys.mjs
+++ b/scripts/check-stage-keys.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+// Guard: a canonical pipeline stage key must not be hardcoded in src/ (#1886).
+//
+// WHY THIS EXISTS
+//   Since #747 the pipeline stages are per-tenant rows (`PipelineStage`), and
+//   `resolvePipelineStages()` falls back to the canonical defaults for an org
+//   that has none. That fallback is why a hardcoded `'HIRED_660'` is invisible:
+//   it type-checks (the column is a String), it passes every test on the default
+//   seed, and it only misbehaves for a customer who renamed their stages — which
+//   no test tenant does. The bug has been reintroduced repeatedly (#1880 and its
+//   tasks #1882/#1884/#1634), so it gets a mechanical guard rather than another
+//   round of review vigilance.
+//
+// WHAT IT ALLOWS
+//   Two files legitimately name the defaults, listed in ALLOWED below.
+//   Everything else must go through `resolvePipelineStages()` / `onPathKeys()`.
+//
+//   The offenders already on `main` are recorded in
+//   scripts/stage-keys-baseline.json as a SHRINKING RATCHET: a baselined file
+//   may keep (or lower) its recorded count, but a file that is NOT listed — a
+//   newly reintroduced literal, the case this guard exists for — fails the
+//   build. The baseline file is deleted once it reaches `{}`.
+//
+// Comment lines are stripped before matching: this file, funnelKpi.ts and the
+// funnel route all *document* the keys in prose, and a guard that fires on its
+// own documentation gets disabled instead of obeyed.
+//
+// Run: node scripts/check-stage-keys.mjs            (npm run check:stage-keys)
+//      node scripts/check-stage-keys.mjs --update    rewrite the baseline
+
+import { readFileSync, writeFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const args = process.argv.slice(2);
+const UPDATE = args.includes('--update');
+// Overridable so the guard itself can be exercised against a fixture.
+const positional = args.filter((a) => !a.startsWith('--'));
+const ROOTS = positional.length > 0 ? positional : ['src'];
+
+const BASELINE_FILE = 'scripts/stage-keys-baseline.json';
+
+// The canonical default keys. Not the whole catalogue — these are the ones a
+// consumer reaches for when it wants "hired", "applied" or "dropped out", which
+// is exactly the reasoning that silently breaks on a renamed pipeline.
+const KEYS =
+  /\b(HIRED_660|EMPLOYED_700|APPLICATION_100|INTERNSHIP_DROPPED_460|INTERNSHIP_FOUND_ELSEWHERE_800)\b/g;
+
+// Files that are allowed to name a default key, and why.
+const ALLOWED = {
+  // The canonical default stage catalogue itself — these keys ARE the defaults,
+  // and every tenant-aware consumer resolves through it.
+  'src/lib/pipeline.ts': 'the canonical default stage catalogue',
+  // DEFAULT_HIRED_STAGE_KEY: the documented fallback for a tenant whose own
+  // stage set declares no terminal stage.
+  'src/lib/offers.ts': 'DEFAULT_HIRED_STAGE_KEY, the documented fallback',
+};
+
+// A file that has never been triaged gets the parent story as its owner; the
+// task issues keep the files the triage already attributed to them.
+const DEFAULT_OWNER = '#1880';
+
+function sourceFiles(paths) {
+  const out = [];
+  const walk = (p) => {
+    const st = statSync(p);
+    if (st.isDirectory()) {
+      for (const entry of readdirSync(p)) walk(join(p, entry));
+    } else if (/\.tsx?$/.test(p)) {
+      out.push(p);
+    }
+  };
+  for (const p of paths) walk(p);
+  return out;
+}
+
+// Line-start only: enough to skip prose, and cheaper to reason about than
+// telling a trailing `// ...` apart from a string that contains `//`.
+const isCommentLine = (line) => /^(\/\/|\*|\/\*)/.test(line.trim());
+
+// path -> [{ line, key }]
+const hits = new Map();
+for (const file of sourceFiles(ROOTS)) {
+  const rel = file.split('\\').join('/');
+  if (ALLOWED[rel]) continue;
+  readFileSync(file, 'utf8')
+    .split('\n')
+    .forEach((line, i) => {
+      if (isCommentLine(line)) return;
+      KEYS.lastIndex = 0;
+      let m;
+      while ((m = KEYS.exec(line))) {
+        if (!hits.has(rel)) hits.set(rel, []);
+        hits.get(rel).push({ line: i + 1, key: m[1] });
+      }
+    });
+}
+
+const { _comment, ...recorded } = JSON.parse(readFileSync(BASELINE_FILE, 'utf8'));
+const byPath = [...hits].sort((a, b) => a[0].localeCompare(b[0]));
+
+if (UPDATE) {
+  const next = { _comment };
+  for (const [file, found] of byPath) {
+    next[file] = { hits: found.length, issue: recorded[file]?.issue ?? DEFAULT_OWNER };
+  }
+  writeFileSync(BASELINE_FILE, `${JSON.stringify(next, null, 2)}\n`);
+  console.log(`stage keys — baseline rewritten: ${byPath.length} file(s) recorded.`);
+  process.exit(0);
+}
+
+const failures = [];
+const stale = [];
+
+for (const [file, found] of byPath) {
+  const allowance = recorded[file];
+  if (!allowance) {
+    // The case this guard exists for: a literal in a file nobody signed off on.
+    for (const h of found) failures.push(`${file}:${h.line}  ${h.key}`);
+  } else if (found.length > allowance.hits) {
+    failures.push(
+      `${file}  ${found.length} hardcoded key(s), baseline allows ${allowance.hits} ` +
+        `(${allowance.issue}) — hits at line(s) ${found.map((h) => h.line).join(', ')}`
+    );
+  } else if (found.length < allowance.hits) {
+    stale.push(`${file}  ${allowance.hits} → ${found.length}`);
+  }
+}
+
+// A baselined file that is now clean (or was renamed away) is stale too. Never
+// a failure: a cleanup PR must be nudged, not blocked.
+for (const [file, allowance] of Object.entries(recorded)) {
+  if (!hits.has(file)) stale.push(`${file}  ${allowance.hits} → 0`);
+}
+
+if (failures.length > 0) {
+  console.error('stage keys FAILED — a canonical pipeline stage key is hardcoded:\n');
+  for (const failure of failures) console.error(`  • ${failure}`);
+  console.error(
+    '\nStages are per-tenant since #747, so resolve them instead of naming a key:\n' +
+      '  server:  const stages = await resolvePipelineStages(orgId); onPathKeys(stages)\n' +
+      '  client:  useResolvedStages() / useStageLabel()\n' +
+      `Allowed to name a default: ${Object.keys(ALLOWED).join(', ')}.\n` +
+      `Offenders awaiting cleanup live in ${BASELINE_FILE} — that list may only shrink.`
+  );
+  process.exit(1);
+}
+
+const remaining = byPath.reduce((n, [, found]) => n + found.length, 0);
+console.log(
+  `stage keys OK — no new hardcoded key; ${remaining} known hit(s) in ` +
+    `${byPath.length} baselined file(s) still to clean up.`
+);
+if (stale.length > 0) {
+  console.log('\nBaseline is now generous (good — run `node scripts/check-stage-keys.mjs --update`):');
+  for (const s of stale) console.log(`  • ${s}`);
+}

--- a/scripts/stage-keys-baseline.json
+++ b/scripts/stage-keys-baseline.json
@@ -1,0 +1,59 @@
+{
+  "_comment": "Hardcoded pipeline stage keys still on main, per file, with the issue that owns the cleanup (#1886). This list may only ever SHRINK: scripts/check-stage-keys.mjs fails on any file that is not listed here, and on a listed file whose count went up. When a cleanup PR lowers a count, run `node scripts/check-stage-keys.mjs --update`. The remaining acceptance criterion of #1886 — the guard passing with nothing but the two-file allowlist — is met by the PR that empties this file and deletes it.",
+  "src/app/admin/candidates/[id]/page.tsx": {
+    "hits": 2,
+    "issue": "#1884"
+  },
+  "src/app/admin/cohorts/page.tsx": {
+    "hits": 2,
+    "issue": "#1884"
+  },
+  "src/app/api/admin/analytics/benchmark/route.ts": {
+    "hits": 4,
+    "issue": "#1882"
+  },
+  "src/app/api/admin/analytics/cohorts/route.ts": {
+    "hits": 6,
+    "issue": "#1882"
+  },
+  "src/app/api/admin/analytics/route.ts": {
+    "hits": 4,
+    "issue": "#1882"
+  },
+  "src/app/api/admin/analytics/sources/route.ts": {
+    "hits": 2,
+    "issue": "#1882"
+  },
+  "src/app/api/admin/sources/route.ts": {
+    "hits": 2,
+    "issue": "#1884"
+  },
+  "src/app/api/calendar-events/route.ts": {
+    "hits": 3,
+    "issue": "#1884"
+  },
+  "src/app/api/mentor/analytics/route.ts": {
+    "hits": 4,
+    "issue": "#1882"
+  },
+  "src/components/JourneyTracker.tsx": {
+    "hits": 2,
+    "issue": "#1884"
+  },
+  "src/lib/dormantFirstContact.ts": {
+    "hits": 1,
+    "issue": "#1880"
+  },
+  "src/lib/menteeOnboarding.ts": {
+    "hits": 1,
+    "issue": "#1634"
+  },
+  "src/lib/outcomeComms.ts": {
+    "hits": 2,
+    "issue": "#1880"
+  },
+  "src/services/emailService.ts": {
+    "hits": 5,
+    "issue": "#1884"
+  }
+}


### PR DESCRIPTION
## Summary

Stages have been per-tenant rows since #747, and `resolvePipelineStages()` falls back to the canonical catalogue for an org that has none. That fallback is why a hardcoded `'HIRED_660'` is invisible: it type-checks (the column is a `String`), it passes the whole suite on the default seed, and it only misbehaves for a customer who renamed their stages. The literal keeps coming back (#1880 and its tasks), so it gets a mechanical guard instead of another round of review vigilance.

Closes #1886

## Changes

- **`scripts/check-stage-keys.mjs`** — walks `src/` for the five canonical keys (`HIRED_660`, `EMPLOYED_700`, `APPLICATION_100`, `INTERNSHIP_DROPPED_460`, `INTERNSHIP_FOUND_ELSEWHERE_800`), skipping comment lines (the funnel route and `funnelKpi.ts` document these keys in prose, and a guard that fires on its own documentation gets disabled rather than obeyed). `src/lib/pipeline.ts` and `src/lib/offers.ts` are allowed to name a default, each with the reason inline. `--update` rewrites the baseline.
- **`scripts/stage-keys-baseline.json`** — the 40 hits already on `main`, per file, attributed to the issue that owns each cleanup (#1882, #1884, #1634, #1880). Semantics: an **unlisted** file fails the build (the case the guard exists for), a listed file whose count went **up** fails, and a **lower** count only prints a `run --update` nudge — a cleanup PR is nudged, never blocked.
- **`package.json` + `.github/workflows/ci.yml`** — `npm run check:stage-keys`, wired in next to the other guard steps with the reasoning in a comment.
- **`e2e/custom-pipeline-analytics.spec.ts` (`@smoke`) + `seedCustomPipelineOrg()`** — seeds a tenant whose stages are `STAGE_A`…`STAGE_F` with a relation that travelled `STAGE_A → STAGE_F`, then asserts `GET /api/admin/analytics/funnel` returns exactly that order with a real journey, and that the screen renders `conversion-STAGE_F` and no `HIRED_660`. This fixture is what the suite never had.

**Deliberate deviation from the issue text:** its two-file allowlist cannot pass on `main` today — #1882, #1884 and #1634 still own ~20 real hits — so the guard ships as a shrinking baseline ratchet. Acceptance criterion 2 ("passes with a two-file allowlist") is met by the PR that empties `stage-keys-baseline.json` and deletes it once those three land. The spec also deliberately does **not** assert the headline conversion number on `/admin/analytics`: it still compares against `'HIRED_660'` and #1882 owns that fix.

## Verification

- [x] `npm run lint` + `npx tsc --noEmit` clean (lint prints only the two pre-existing warnings on `admin/mentorship/page.tsx` and `MessageThreadView.tsx`)
- [ ] `npm run test:e2e` passing (or CI green) — no MySQL and no browser in this container, so the new `@smoke` spec is first run by the PR's Playwright job
- [x] Tested the change manually / added an e2e test — `npm run check:stage-keys` is green on a clean tree, and adding `const X = 'HIRED_660';` to `src/lib/version.ts` makes it exit 1 naming `src/lib/version.ts:12`; `npm run check:release-fragments` prints this change as `0.128.3-beta`

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qTSgQDDVBYo6gXf8xpsnR

---
_Generated by [Claude Code](https://claude.ai/code/session_017qTSgQDDVBYo6gXf8xpsnR)_