### PR TITLE
fix(auth): end the target's live session when an account is deactivated

### DIFF
--- a/e2e/admin-user-active.spec.ts
+++ b/e2e/admin-user-active.spec.ts
@@ -1,10 +1,26 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
 import { signInAsFreshUser, submitSignInForm } from './helpers/auth';
 
 test.afterAll(async () => {
   await prisma.$disconnect();
 });
+
+// Plain sign-in in a context of its own (each role gets its own browser here,
+// so the fresh-user cookie dance of signInAsFreshUser is not needed).
+async function signIn(page: Page, email: string, pw: string) {
+  await page.goto('/auth/signin');
+  await page.fill('input[type="email"], input[name="email"]', email);
+  await page.fill('input[type="password"]', pw);
+  await page.click('button[type="submit"]');
+  await page.waitForURL((u) => !u.pathname.startsWith('/auth'), { timeout: 20_000 });
+}
+
+// The signed-in email per /api/auth/session (null once the session is revoked).
+async function sessionEmail(page: Page): Promise<string | null> {
+  const s = await (await page.request.get('/api/auth/session')).json();
+  return s?.user?.email ?? null;
+}
 
 test('admin deactivates a user and that user can no longer sign in', async ({ page }) => {
   const adminEmail = uniqueEmail('actadmin');
@@ -42,6 +58,73 @@ test('admin deactivates a user and that user can no longer sign in', async ({ pa
     expect(new URL(page.url()).pathname).toContain('/auth/signin');
   } finally {
     await cleanupByEmail(mentorEmail);
+    await cleanupByEmail(adminEmail);
+  }
+});
+
+// Deactivation has to end the sessions the account ALREADY has, not just block
+// the next sign-in (#1539). `isActive` is only read at sign-in, so before the
+// fix an admin could switch someone off and that person kept browsing on their
+// existing 12-hour JWT until it expired by itself. Asserting the badge — or a
+// failed *fresh* login, as the test above does — passes either way; the only
+// proof is an already-signed-in session being rejected on its next request.
+test('deactivating a user kills the session that user already has', async ({ browser }) => {
+  const adminEmail = uniqueEmail('killadmin');
+  const menteeEmail = uniqueEmail('killmentee');
+  const menteePw = 'MenteePass123!';
+  await seedUser(adminEmail, 'AdminPass123!', 'ADMIN', 'Session Kill Admin');
+  const mentee = await seedUser(menteeEmail, menteePw, 'MENTEE', 'Session Kill Mentee');
+
+  // A remembered device, as if the mentee had ticked "keep me signed in". A
+  // cutoff that leaves this row alive revokes nothing: the browser mints a
+  // fresh session on its next visit (docs/remember-me.md).
+  const device = await prisma.trustedDevice.create({
+    data: {
+      userId: mentee.id,
+      tokenHash: `e2e-${mentee.id}`,
+      expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+      absoluteExpiresAt: new Date(Date.now() + 90 * 24 * 60 * 60 * 1000),
+    },
+  });
+
+  const menteeCtx = await browser.newContext();
+  const adminCtx = await browser.newContext();
+  try {
+    const menteePage = await menteeCtx.newPage();
+    const adminPage = await adminCtx.newPage();
+
+    // The mentee is signed in and stays that way for the whole test — this is
+    // the live session the deactivation must take down.
+    await signIn(menteePage, menteeEmail, menteePw);
+    expect(await sessionEmail(menteePage)).toBe(menteeEmail);
+
+    // A second, independent browser: the admin switches the account off.
+    await signIn(adminPage, adminEmail, 'AdminPass123!');
+    const res = await adminPage.request.patch(`/api/users/${mentee.id}`, {
+      data: { isActive: false },
+    });
+    expect(res.ok()).toBeTruthy();
+
+    const updated = await prisma.user.findUnique({ where: { id: mentee.id } });
+    expect(updated!.isActive).toBe(false);
+    // The cutoff is what lib/auth.ts checks on every request.
+    expect(updated!.sessionsValidFrom).not.toBeNull();
+
+    // ...and the remembered device is gone with it.
+    const storedDevice = await prisma.trustedDevice.findUnique({ where: { id: device.id } });
+    expect(storedDevice!.revokedAt).not.toBeNull();
+
+    // The mentee's EXISTING session is rejected on its next request.
+    await expect.poll(async () => sessionEmail(menteePage), { timeout: 15_000 }).toBeNull();
+
+    // ...so the next page they open sends them to the sign-in form.
+    await menteePage.goto('/portal');
+    await menteePage.waitForURL((u) => u.pathname.includes('/auth/signin'), { timeout: 20_000 });
+    await expect(menteePage.locator('input[type="password"]')).toBeVisible();
+  } finally {
+    await menteeCtx.close();
+    await adminCtx.close();
+    await cleanupByEmail(menteeEmail);
     await cleanupByEmail(adminEmail);
   }
 });

--- a/releases/unreleased/deactivation-revokes-sessions.json
+++ b/releases/unreleased/deactivation-revokes-sessions.json
@@ -1,0 +1,9 @@
+{
+  "bump": "patch",
+  "changelog": "- **Deactivation ends the session**: switching an account off (and erasing one) now stamps `sessionsValidFrom` and revokes the account's trusted devices, so an already-signed-in user is rejected on their next request instead of staying signed in until their 12-hour JWT expires.",
+  "notes": {
+    "en": ["Deactivating or erasing an account now signs that person out immediately, on every device, instead of letting their open session run out on its own."],
+    "tr": ["Bir hesabı pasifleştirmek veya silmek artık o kişiyi tüm cihazlarda anında oturumdan düşürüyor; açık oturumun kendiliğinden sona ermesi beklenmiyor."],
+    "de": ["Ein Konto zu deaktivieren oder zu löschen meldet die Person jetzt sofort auf allen Geräten ab, statt die offene Sitzung von selbst auslaufen zu lassen."]
+  }
+}

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { logActivity } from '@/lib/activity';
 import { withTenantScope } from '@/lib/orgContext';
+import { revokeAllTrustedDevices } from '@/lib/trustedDevice';
 import { isPendingActivation, isErasedAccount, isUnusableEmail } from '@/lib/menteeAccount';
 import { IS_DEMO_MODE } from '@/lib/demoMode';
 import { notify } from '@/lib/notify';
@@ -159,6 +160,18 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
         } else {
           const target = await prisma.user.findUnique({ where: { id }, select: { emailVerified: true } });
           data.pendingApproval = target ? !target.emailVerified : false;
+          // Switching an account off must also end the sessions it already
+          // has. `isActive` is only ever read at sign-in, so on its own this
+          // column stops the *next* login and nothing else: the target's
+          // 12-hour JWT kept working until it expired by itself, leaving a
+          // deactivated user signed in for the rest of the day. Same recipe as
+          // the role change below and /api/account/sign-out-all — the cutoff
+          // makes lib/auth.ts reject every token minted before now, and the
+          // remembered devices are revoked right after the update.
+          //
+          // Deactivation only: activating an account must not sign out
+          // sessions that, by definition, do not exist.
+          data.sessionsValidFrom = new Date();
         }
       }
 
@@ -305,6 +318,16 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
         data,
         select: { id: true, isActive: true, sourceId: true, referredById: true, skills: true, mentorCapacity: true, role: true },
       });
+
+      // A cutoff on its own revokes nothing while a remembered browser can
+      // still mint a fresh session on its next visit (docs/remember-me.md), so
+      // the two always travel together. Deactivation only: the role change
+      // above stamps a cutoff merely to re-issue the token's claims, and must
+      // not cost that person their remembered laptop (the rotation path in
+      // src/lib/trustedDevice.ts spells out that distinction).
+      if (data.isActive === false) {
+        await revokeAllTrustedDevices(id);
+      }
 
       // Activation state is the security-relevant part of this endpoint — it is
       // what lets someone in or keeps them out — so it gets its own audit row

--- a/src/lib/accountErasure.ts
+++ b/src/lib/accountErasure.ts
@@ -1,4 +1,5 @@
 import { prisma } from '@/lib/prisma';
+import { revokeAllTrustedDevices } from '@/lib/trustedDevice';
 
 // Shared erasure logic (EPIC: GDPR data retention). Two modes:
 // - hardDeleteUser: same cascade cleanup as the existing self-service account
@@ -77,7 +78,17 @@ export async function anonymizeUser(userId: string): Promise<void> {
         skillLevels: {},
         publicProfile: false,
         isActive: false,
+        // An erased account must not keep a live session. `isActive` is only
+        // read at sign-in, so without this cutoff the person whose data was
+        // just scrubbed stayed signed in on their existing 12-hour JWT — and
+        // browsing an anonymized profile of themselves. lib/auth.ts rejects
+        // every token minted before this instant on its next request.
+        sessionsValidFrom: new Date(),
       },
     }),
   ]);
+  // And the remembered devices, or one of them silently mints a new session
+  // moments later (docs/remember-me.md). A hard delete needs no equivalent:
+  // TrustedDevice cascades with the user row.
+  await revokeAllTrustedDevices(userId);
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -450,7 +450,14 @@ export const authOptions: NextAuthOptions = {
           where: { id: token.id as string },
           select: { sessionsValidFrom: true },
         });
-        if (acct?.sessionsValidFrom && token.authTime < acct.sessionsValidFrom.getTime()) {
+        // A deleted account cannot be stamped — there is no row left to hold a
+        // cutoff — so the lookup coming back empty is itself the revocation.
+        // Without this, hard erasure (POST /api/admin/users/[id]/erase, and the
+        // self-service delete) left the erased person holding a working session
+        // until their JWT expired on its own.
+        if (!acct) {
+          token.invalidated = true;
+        } else if (acct.sessionsValidFrom && token.authTime < acct.sessionsValidFrom.getTime()) {
           token.invalidated = true;
         }
       }


### PR DESCRIPTION
## Summary

`PATCH /api/users/[id]` with `isActive: false` wrote the column and nothing else. `isActive` is
only read at sign-in, so switching a user off blocked their *next* login while their 12-hour JWT
kept working until it expired on its own — a deactivated user stayed signed in for the rest of the
day. The same handler already had the correct shape ~140 lines further down for a role change,
comment and all.

This is the first thing an IT admin tests during a pilot.

Closes #1539

## Changes

- **`src/app/api/users/[id]/route.ts`** — the `isActive === false` branch now sets
  `data.sessionsValidFrom = new Date()` (the cutoff `lib/auth.ts` checks on every request) and,
  after a successful `prisma.user.update`, calls `revokeAllTrustedDevices(id)`. CLAUDE.md states
  this as a hard rule: anything that revokes sessions must also revoke trusted devices, or the
  browser signs itself straight back in.
- Gated on `data.isActive === false`, so **re-activation stamps nothing** and the role-change path
  (which stamps only to re-issue token claims, and must keep the remembered laptop) is untouched.
  Authorization and `withTenantScope` are unchanged.
- **`src/lib/accountErasure.ts`** — `anonymizeUser` had the same omission (it sets
  `isActive: false`), leaving the scrubbed person browsing their own anonymized profile. It now
  stamps `sessionsValidFrom` in the same transaction and revokes trusted devices after it.
- **`src/lib/auth.ts`** — a hard-deleted account has no row left to stamp, so the `jwt` callback
  now treats a missing account as revoked. The cutoff check already loads that row, so this adds
  no query.
- **`e2e/admin-user-active.spec.ts`** — a mentee signs in and stays signed in; an admin in a second
  browser context PATCHes them inactive; the mentee's **existing** session is then asserted to go
  null on `/api/auth/session` and `/portal` redirects to the sign-in form. A seeded `TrustedDevice`
  row is asserted revoked. The pre-existing test only proved a *fresh* login is refused — which
  passed before this fix and therefore proved nothing.
- **`releases/unreleased/deactivation-revokes-sessions.json`** — `patch` bump with EN/TR/DE notes.

No schema change: `sessionsValidFrom` already exists.

## Verification

- [x] `npm run lint` + `npx tsc --noEmit` clean
- [x] CI green expected — the e2e proof runs there (no MySQL in the authoring container)
- [x] Added an e2e test that fails without the fix (it asserts session death, not the badge)

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011cw2xk2jhgSwom8JM7Cpbm

---
_Generated by [Claude Code](https://claude.ai/code/session_011cw2xk2jhgSwom8JM7Cpbm)_