### PR TITLE
fix(a11y): make global search a keyboard-operable, dark-mode-safe combobox (#2075)

### DIFF
--- a/e2e/global-search-combobox.spec.ts
+++ b/e2e/global-search-combobox.spec.ts
@@ -1,0 +1,180 @@
+import { test, expect, type Page } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+// Global search as an accessible combobox (#2075): dark-mode surfaces, ARIA
+// semantics, keyboard traversal and a "no results" row.
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+/** Parse a computed `rgb()` / `rgba()` string into [r, g, b]. */
+function rgb(value: string): [number, number, number] {
+  const [r, g, b] = value.match(/\d+(\.\d+)?/g)!.map(Number);
+  return [r, g, b];
+}
+
+/** WCAG relative luminance of an sRGB triple. */
+function luminance([r, g, b]: [number, number, number]) {
+  const ch = (v: number) => {
+    const s = v / 255;
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * ch(r) + 0.7152 * ch(g) + 0.0722 * ch(b);
+}
+
+function contrast(fg: string, bg: string) {
+  const [a, b] = [luminance(rgb(fg)), luminance(rgb(bg))].sort((x, y) => y - x);
+  return (a + 0.05) / (b + 0.05);
+}
+
+/**
+ * Force dark mode. Same technique as e2e/a11y-scan.spec.ts: reload rather than
+ * toggling the class on a page already rendered light, so the server and the
+ * no-flash theme script both commit to dark before anything is measured.
+ */
+async function forceDark(page: Page) {
+  await page.emulateMedia({ colorScheme: 'dark' });
+  await page.evaluate(() => {
+    document.cookie = 'theme=dark; path=/; max-age=31536000';
+    try { localStorage.setItem('theme', 'dark'); } catch { /* ignore */ }
+  });
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(() => document.documentElement.classList.contains('dark'), null, { timeout: 10_000 });
+}
+
+async function signInAsAdmin(page: Page, email: string, password: string) {
+  await page.goto('/auth/signin');
+  await page.fill('input[type="email"], input[name="email"]', email);
+  await page.fill('input[type="password"]', password);
+  await page.click('button[type="submit"]');
+  await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+}
+
+/** Type into the global search and wait for the debounced request to settle. */
+async function search(page: Page, term: string) {
+  const response = page.waitForResponse((r) => r.url().includes('/api/search') && r.url().includes(encodeURIComponent(term).slice(0, 6)));
+  await page.getByTestId('global-search-input').fill(term);
+  await response;
+  await expect(page.getByTestId('global-search-panel')).toBeVisible({ timeout: 10_000 });
+}
+
+test('global search: combobox semantics, keyboard traversal and no-results row', async ({ page }) => {
+  const adminEmail = uniqueEmail('gscombo');
+  const password = 'AdminPass123';
+  await seedUser(adminEmail, password, 'ADMIN', 'Combo Admin');
+  const a = await seedUser(uniqueEmail('gscomboa'), 'x', 'MENTEE', 'Vorplex Aardwing');
+  const b = await seedUser(uniqueEmail('gscombob'), 'x', 'MENTEE', 'Vorplex Bramblehush');
+
+  try {
+    await signInAsAdmin(page, adminEmail, password);
+
+    const input = page.getByTestId('global-search-input');
+    await expect(input).toHaveAttribute('role', 'combobox');
+    await expect(input).toHaveAttribute('aria-autocomplete', 'list');
+    await expect(input).toHaveAttribute('aria-expanded', 'false');
+
+    await search(page, 'Vorplex');
+
+    const listbox = page.getByTestId('global-search-listbox');
+    await expect(listbox).toHaveAttribute('role', 'listbox');
+    await expect(input).toHaveAttribute('aria-expanded', 'true');
+    await expect(input).toHaveAttribute('aria-controls', 'global-search-listbox');
+    // No option is active until the user arrows into the list.
+    expect(await input.getAttribute('aria-activedescendant')).toBeNull();
+
+    const first = page.getByTestId(`global-search-option-user-${a.id}`);
+    const second = page.getByTestId(`global-search-option-user-${b.id}`);
+
+    await input.press('ArrowDown');
+    await expect(input).toHaveAttribute('aria-activedescendant', `global-search-option-user-${a.id}`);
+    await expect(first).toHaveAttribute('aria-selected', 'true');
+
+    await input.press('ArrowDown');
+    await expect(input).toHaveAttribute('aria-activedescendant', `global-search-option-user-${b.id}`);
+    await expect(second).toHaveAttribute('aria-selected', 'true');
+    await expect(first).toHaveAttribute('aria-selected', 'false');
+
+    // ArrowUp walks back, and wraps past the top to the last option.
+    await input.press('ArrowUp');
+    await expect(input).toHaveAttribute('aria-activedescendant', `global-search-option-user-${a.id}`);
+    await input.press('ArrowUp');
+    await expect(input).toHaveAttribute('aria-activedescendant', `global-search-option-user-${b.id}`);
+
+    // Home / End jump to the ends.
+    await input.press('Home');
+    await expect(input).toHaveAttribute('aria-activedescendant', `global-search-option-user-${a.id}`);
+    await input.press('End');
+    await expect(input).toHaveAttribute('aria-activedescendant', `global-search-option-user-${b.id}`);
+
+    // The polite live region carries the result count.
+    await expect(page.getByTestId('global-search-status')).toHaveText(/2/);
+
+    // Escape closes the panel without navigating and leaves focus on the input.
+    await input.press('Escape');
+    await expect(page.getByTestId('global-search-panel')).toHaveCount(0);
+    await expect(input).toHaveAttribute('aria-expanded', 'false');
+    await expect(input).toBeFocused();
+
+    // A query with no matches shows a localised row instead of nothing at all.
+    await search(page, 'Zzqqxxnomatchhere');
+    await expect(page.getByTestId('global-search-empty')).toBeVisible();
+    await expect(page.getByTestId('global-search-listbox')).toHaveCount(0);
+
+    // Enter on the highlighted option navigates to that candidate.
+    await search(page, 'Vorplex Aardwing');
+    await input.press('ArrowDown');
+    await input.press('Enter');
+    await page.waitForURL((u) => u.pathname === `/admin/candidates/${a.id}`, { timeout: 15_000 });
+  } finally {
+    await cleanupByEmail(a.email);
+    await cleanupByEmail(b.email);
+    await cleanupByEmail(adminEmail);
+  }
+});
+
+test('global search dropdown is readable in dark mode (computed style, both themes)', async ({ page }) => {
+  const adminEmail = uniqueEmail('gsdark');
+  const password = 'AdminPass123';
+  await seedUser(adminEmail, password, 'ADMIN', 'Dark Admin');
+  const mentee = await seedUser(uniqueEmail('gsdarkm'), 'x', 'MENTEE', 'Krendal Duskwither');
+
+  try {
+    await signInAsAdmin(page, adminEmail, password);
+
+    // --- Light: the panel is a light surface with dark text. ---
+    await search(page, 'Krendal');
+    let panelBg = await page.getByTestId('global-search-panel').evaluate((el) => getComputedStyle(el).backgroundColor);
+    let nameColor = await page.getByTestId(`global-search-option-user-${mentee.id}`)
+      .locator('span').first().evaluate((el) => getComputedStyle(el).color);
+    expect(luminance(rgb(panelBg))).toBeGreaterThan(0.5);
+    expect(contrast(nameColor, panelBg)).toBeGreaterThan(4.5);
+
+    // --- Dark: the same surfaces must flip, not stay a white slab. ---
+    await forceDark(page);
+    await search(page, 'Krendal');
+
+    const panel = page.getByTestId('global-search-panel');
+    panelBg = await panel.evaluate((el) => getComputedStyle(el).backgroundColor);
+    const [r, g, b] = rgb(panelBg);
+    expect(r).toBeLessThan(60);
+    expect(g).toBeLessThan(60);
+    expect(b).toBeLessThan(70);
+
+    const option = page.getByTestId(`global-search-option-user-${mentee.id}`);
+    nameColor = await option.locator('span').first().evaluate((el) => getComputedStyle(el).color);
+    const metaColor = await option.locator('span').last().evaluate((el) => getComputedStyle(el).color);
+    // AA for normal text on the name, AA for the small meta line too.
+    expect(contrast(nameColor, panelBg)).toBeGreaterThan(4.5);
+    expect(contrast(metaColor, panelBg)).toBeGreaterThan(4.5);
+
+    // The keyboard-active row stays readable against its own (darker) tint.
+    await page.getByTestId('global-search-input').press('ArrowDown');
+    const activeBg = await option.evaluate((el) => getComputedStyle(el).backgroundColor);
+    expect(luminance(rgb(activeBg))).toBeLessThan(0.2);
+    expect(contrast(nameColor, activeBg)).toBeGreaterThan(4.5);
+  } finally {
+    await cleanupByEmail(mentee.email);
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/e2e/mentor-global-search.spec.ts
+++ b/e2e/mentor-global-search.spec.ts
@@ -42,7 +42,9 @@ test('mentor global search finds own mentee and navigates to their profile, not 
     const searchResponse = page.waitForResponse((r) => r.url().includes('/api/search') && r.url().includes('Quixara'));
     await page.locator('[data-testid="global-search-input"]').fill('Quixara Voltmoss');
     await searchResponse;
-    await page.getByRole('button', { name: mentee.fullName }).click();
+    // The results panel is a combobox listbox now (#2075): options carry
+    // role="option", not role="button".
+    await page.getByRole('option', { name: new RegExp(mentee.fullName) }).click();
     await page.waitForURL((u) => u.pathname === `/mentor/mentees/${relation.id}`, { timeout: 10_000 });
   } finally {
     await cleanupByEmail(menteeEmail);

--- a/releases/unreleased/global-search-combobox.json
+++ b/releases/unreleased/global-search-combobox.json
@@ -1,0 +1,9 @@
+{
+  "bump": "patch",
+  "changelog": "- **Global search is an accessible combobox** (#2075). The results dropdown in the admin/mentor header now carries `role=\"combobox\"` with `aria-expanded`/`aria-controls`/`aria-activedescendant` on the input and a `role=\"listbox\"` of `role=\"option\"` rows, and is fully keyboard-operable: ArrowUp/ArrowDown (wrapping), Home/End, Enter to open the highlighted hit, Escape to close and return focus, Tab to dismiss without navigating — with the active row scrolled into view. A polite live region announces the result count, a query with no matches now shows a localised \"no results\" row instead of rendering nothing, and the panel's dark-mode surfaces and text tones are pinned to the flat `html.dark` overrides (documented in-file so no dead `dark:` variant creeps back in) and asserted by a computed-style e2e check in both themes.",
+  "notes": {
+    "en": ["Global search can now be driven entirely from the keyboard, is announced properly by screen readers, says when there are no results, and is readable in dark mode."],
+    "tr": ["Genel arama artık tamamen klavyeyle kullanılabiliyor, ekran okuyucular tarafından doğru okunuyor, sonuç bulunamadığında bunu söylüyor ve koyu modda okunaklı."],
+    "de": ["Die globale Suche lässt sich jetzt vollständig per Tastatur bedienen, wird von Screenreadern korrekt angesagt, meldet fehlende Treffer und ist im Dunkelmodus lesbar."]
+  }
+}

--- a/src/components/GlobalSearch.tsx
+++ b/src/components/GlobalSearch.tsx
@@ -1,12 +1,24 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Search } from 'lucide-react';
 import { useT } from '@/i18n/client';
 
 interface UserHit { id: string; fullName: string; email: string; role: string; relationId?: string | null }
 interface CompanyHit { id: string; name: string }
+
+interface Option {
+  /** Stable key — also the DOM id (aria-activedescendant) and the testid suffix. */
+  key: string;
+  href: string;
+}
+
+const LISTBOX_ID = 'global-search-listbox';
+const optionDomId = (key: string) => `global-search-option-${key}`;
+
+const userHref = (u: UserHit) =>
+  u.relationId ? `/mentor/mentees/${u.relationId}` : u.role === 'MENTEE' ? `/admin/candidates/${u.id}` : `/admin/users`;
 
 export function GlobalSearch() {
   const t = useT();
@@ -15,13 +27,21 @@ export function GlobalSearch() {
   const [users, setUsers] = useState<UserHit[]>([]);
   const [companies, setCompanies] = useState<CompanyHit[]>([]);
   const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  // True once a query has actually come back, so the "no results" row only
+  // appears after the debounce settles — not while the user is still typing.
+  const [searched, setSearched] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
   const ref = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (q.trim().length < 2) {
-      setUsers([]); setCompanies([]);
+      setUsers([]); setCompanies([]); setSearched(false); setLoading(false); setActiveIndex(-1);
       return;
     }
+    setLoading(true);
     const id = setTimeout(async () => {
       try {
         const res = await fetch(`/api/search?q=${encodeURIComponent(q)}`);
@@ -30,7 +50,11 @@ export function GlobalSearch() {
         setCompanies(d.companies ?? []);
         setOpen(true);
       } catch {
-        /* ignore */
+        setUsers([]); setCompanies([]);
+      } finally {
+        setLoading(false);
+        setSearched(true);
+        setActiveIndex(-1);
       }
     }, 250);
     return () => clearTimeout(id);
@@ -44,45 +68,155 @@ export function GlobalSearch() {
     return () => document.removeEventListener('mousedown', onClick);
   }, []);
 
-  const go = (href: string) => {
+  // One flat list drives both the rendering and the keyboard cursor, so the
+  // active index can never drift out of step with what is on screen.
+  const options = useMemo<Option[]>(() => [
+    ...users.map((u) => ({ key: `user-${u.id}`, href: userHref(u) })),
+    ...companies.map((c) => ({ key: `company-${c.id}`, href: '/admin/companies' })),
+  ], [users, companies]);
+
+  const panelOpen = open && q.trim().length >= 2 && (options.length > 0 || searched || loading);
+
+  const go = useCallback((href: string) => {
     setOpen(false);
     setQ('');
+    setActiveIndex(-1);
     router.push(href);
+  }, [router]);
+
+  // Keep the highlighted option visible inside the max-h-96 scroll area.
+  useEffect(() => {
+    const key = activeIndex >= 0 ? options[activeIndex]?.key : undefined;
+    if (!key || !listRef.current) return;
+    document.getElementById(optionDomId(key))?.scrollIntoView({ block: 'nearest' });
+  }, [activeIndex, options]);
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Escape') {
+      // Close without navigating; focus stays on (or returns to) the input.
+      e.preventDefault();
+      setOpen(false);
+      setActiveIndex(-1);
+      inputRef.current?.focus();
+      return;
+    }
+    if (e.key === 'Tab') {
+      setOpen(false);
+      setActiveIndex(-1);
+      return;
+    }
+    if (e.key === 'Enter') {
+      if (panelOpen && activeIndex >= 0 && options[activeIndex]) {
+        e.preventDefault();
+        go(options[activeIndex].href);
+      }
+      return;
+    }
+    if (!['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(e.key)) return;
+    if (options.length === 0) return;
+    e.preventDefault();
+    if (!open) setOpen(true);
+    setActiveIndex((i) => {
+      if (e.key === 'Home') return 0;
+      if (e.key === 'End') return options.length - 1;
+      if (e.key === 'ArrowDown') return i >= options.length - 1 ? 0 : i + 1;
+      return i <= 0 ? options.length - 1 : i - 1;
+    });
   };
 
-  const userHref = (u: UserHit) =>
-    u.relationId ? `/mentor/mentees/${u.relationId}` : u.role === 'MENTEE' ? `/admin/candidates/${u.id}` : `/admin/users`;
+  const activeKey = activeIndex >= 0 ? options[activeIndex]?.key : undefined;
+
+  const optionClass = (index: number) =>
+    // `bg-white` / `bg-gray-50` / `text-gray-*` carry no `dark:` variants on
+    // purpose: globals.css's flat `html.dark .bg-white` (specificity 0,2,1)
+    // outranks Tailwind's `.dark .dark\:bg-*` (0,2,0), so a variant here would
+    // be dead code. The flat rules already render the panel #111827 with
+    // #f3f4f6 / #9ca3af text and a #1f2937 active row — all AA on that ground.
+    `block w-full text-left px-4 py-2.5 text-sm hover:bg-gray-50 ${
+      index === activeIndex ? 'bg-gray-50 ring-2 ring-inset ring-blue-500' : ''
+    }`;
 
   return (
     <div className="relative w-56" ref={ref}>
-      <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-gray-200 bg-white">
-        <Search className="h-4 w-4 text-gray-400" />
+      <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-gray-200 bg-white focus-within:ring-2 focus-within:ring-blue-500">
+        <Search className="h-4 w-4 text-gray-500" aria-hidden="true" />
         <input
+          ref={inputRef}
           data-testid="global-search-input"
+          role="combobox"
+          aria-expanded={panelOpen}
+          aria-controls={panelOpen && options.length > 0 ? LISTBOX_ID : undefined}
+          aria-activedescendant={activeKey ? optionDomId(activeKey) : undefined}
+          aria-autocomplete="list"
+          aria-label={t.search.placeholder}
+          autoComplete="off"
           value={q}
           onChange={(e) => setQ(e.target.value)}
           onFocus={() => q.trim().length >= 2 && setOpen(true)}
+          onKeyDown={onKeyDown}
           placeholder={t.search.placeholder}
           className="flex-1 text-sm outline-none bg-transparent"
         />
       </div>
-      {open && (users.length > 0 || companies.length > 0) && (
-        <div className="absolute right-0 mt-2 w-72 max-h-96 overflow-y-auto rounded-xl border border-gray-200 bg-white shadow-lg z-50">
-          {users.map((u) => (
-            <button key={u.id} onClick={() => go(userHref(u))} className="block w-full text-left px-4 py-2.5 hover:bg-gray-50 text-sm">
-              <span className="font-medium text-gray-900">{u.fullName}</span>
-              <span className="text-xs text-gray-400 ml-2">{u.role}</span>
-              <span className="block text-xs text-gray-500 truncate">{u.email}</span>
-            </button>
-          ))}
-          {companies.map((c) => (
-            <button key={c.id} onClick={() => go('/admin/companies')} className="block w-full text-left px-4 py-2.5 hover:bg-gray-50 text-sm">
-              <span className="font-medium text-gray-900">{c.name}</span>
-              <span className="text-xs text-gray-400 ml-2">{t.search.company}</span>
-            </button>
-          ))}
+      {panelOpen && (
+        <div
+          ref={listRef}
+          data-testid="global-search-panel"
+          className="absolute right-0 mt-2 w-72 max-h-96 overflow-y-auto rounded-xl border border-gray-200 bg-white shadow-lg z-50"
+        >
+          {options.length > 0 ? (
+            <div
+              id={LISTBOX_ID}
+              role="listbox"
+              aria-label={t.search.placeholder}
+              data-testid="global-search-listbox"
+            >
+              {users.map((u, i) => (
+                <div
+                  key={u.id}
+                  id={optionDomId(`user-${u.id}`)}
+                  data-testid={`global-search-option-user-${u.id}`}
+                  role="option"
+                  aria-selected={activeIndex === i}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => go(userHref(u))}
+                  className={optionClass(i)}
+                >
+                  <span className="font-medium text-gray-900">{u.fullName}</span>
+                  <span className="text-xs text-gray-500 ml-2">{u.role}</span>
+                  <span className="block text-xs text-gray-500 truncate">{u.email}</span>
+                </div>
+              ))}
+              {companies.map((c, ci) => (
+                <div
+                  key={c.id}
+                  id={optionDomId(`company-${c.id}`)}
+                  data-testid={`global-search-option-company-${c.id}`}
+                  role="option"
+                  aria-selected={activeIndex === users.length + ci}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => go('/admin/companies')}
+                  className={optionClass(users.length + ci)}
+                >
+                  <span className="font-medium text-gray-900">{c.name}</span>
+                  <span className="text-xs text-gray-500 ml-2">{t.search.company}</span>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p data-testid="global-search-empty" className="px-4 py-3 text-sm text-gray-500">
+              {loading ? t.search.searching : t.search.noResults}
+            </p>
+          )}
         </div>
       )}
+      {/* Status for assistive tech: the result count, announced once the
+          debounced request has settled. */}
+      <p role="status" aria-live="polite" className="sr-only" data-testid="global-search-status">
+        {searched && !loading && q.trim().length >= 2
+          ? (options.length === 0 ? t.search.noResults : t.search.resultCount.replace('{count}', String(options.length)))
+          : ''}
+      </p>
     </div>
   );
 }

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -2752,6 +2752,9 @@ const en = {
   search: {
     placeholder: 'Search people, companies…',
     company: 'Company',
+    noResults: 'No results',
+    searching: 'Searching…',
+    resultCount: '{count} results',
   },
   savedViews: {
     save: 'Save view',
@@ -6244,6 +6247,9 @@ const tr: Dict = {
   search: {
     placeholder: 'Kişi, şirket ara…',
     company: 'Şirket',
+    noResults: 'Sonuç yok',
+    searching: 'Aranıyor…',
+    resultCount: '{count} sonuç',
   },
   savedViews: {
     save: 'Görünümü kaydet',
@@ -9732,6 +9738,9 @@ const de: Dict = {
   search: {
     placeholder: 'Personen, Unternehmen suchen…',
     company: 'Unternehmen',
+    noResults: 'Keine Ergebnisse',
+    searching: 'Suche läuft…',
+    resultCount: '{count} Ergebnisse',
   },
   savedViews: {
     save: 'Ansicht speichern',


### PR DESCRIPTION
## Summary

The header global search was mouse-only and rendered its dropdown with no dark-mode intent: no combobox role, no listbox, no arrow keys, no Escape, and nothing at all shown when a query had no matches. This gives it real combobox semantics, full keyboard operation, and a panel that reads correctly in both themes.

Closes #2075

## Changes

- **ARIA**: input gets `role=combobox` + `aria-expanded` / `aria-controls` / `aria-autocomplete` / `aria-activedescendant` and an accessible name; the panel is a `role=listbox` of `role=option` rows with `aria-selected` and stable ids.
- **Keyboard**: ArrowDown/ArrowUp (wrapping), Home/End, Enter opens the highlighted hit, Escape closes and restores focus, Tab dismisses without navigating. The active row is scrolled into view inside the `max-h-96` panel.
- **Announcements**: a polite live region reports the result count; a localised "no results" (and "searching…") row replaces the panel silently not rendering.
- **Dark mode**: the panel keeps `bg-white` / `text-gray-*` and leans on the flat `html.dark` overrides in `globals.css`, with an in-file comment explaining why a `dark:` variant here would be dead code — and why `dark:bg-gray-900` would actively regress the panel into the page background.
- **Test hooks**: `global-search-listbox` / `-panel` / `-option-<key>` / `-empty` / `-status` alongside the existing `global-search-input` (per the E2E locator pitfalls in CLAUDE.md).
- **Tests**: `e2e/global-search-combobox.spec.ts` covers the ARIA wiring, full keyboard traversal, the empty row and computed-style contrast in both themes (not tagged `@smoke` — the PR gate stays small); `e2e/mentor-global-search.spec.ts` now targets `role=option`.
- Release fragment `releases/unreleased/global-search-combobox.json` (patch, EN/TR/DE notes).

The search API and its role scoping are untouched.

## Verification

- [x] `npm run lint` + `npx tsc --noEmit` clean (only pre-existing warnings in unrelated files)
- [ ] `npm run test:e2e` passing (or CI green) — not runnable here: no database and no Playwright browser build in the container; the new spec was verified to parse with `npx playwright test --list`. CI's smoke job is the real check.
- [x] `npm run check:i18n` (key parity across EN/TR/DE) and `npm run check:release-fragments` clean

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ra7wrp478VPjzHJHh4QMvZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ra7wrp478VPjzHJHh4QMvZ)_