### PR TITLE
fix(seo): serve /robots.txt and /sitemap.xml

### DIFF
--- a/e2e/robots-sitemap.spec.ts
+++ b/e2e/robots-sitemap.spec.ts
@@ -1,0 +1,143 @@
+import { test, expect, type APIRequestContext, type APIResponse } from '@playwright/test';
+
+/**
+ * #1380 — /robots.txt and /sitemap.xml exist and say the right things.
+ *
+ * Both were 404 before this: nothing told a crawler what to fetch, and the
+ * public pages that are only linked from the footer were discoverable by luck.
+ * The regression these guard against is (a) either route disappearing again,
+ * and (b) an authenticated area leaking into the sitemap, which is how a login
+ * redirect ends up as a search result.
+ *
+ * Anonymous by design — a crawler has no cookies.
+ *
+ * The rules differ by deployment: production is crawlable, while preview, the
+ * per-PR topic envs and the demo close the site so the same content is not
+ * indexed three times over. Which one is under test is read from the response
+ * rather than assumed, so the spec is equally valid locally (production
+ * defaults) and against a deployed BASE_URL.
+ */
+test.use({ storageState: { cookies: [], origins: [] } });
+
+// Path prefixes that must never appear in the sitemap. Compared as
+// exact-or-subpath rather than by `startsWith`, because `/mentor` is a prefix
+// of the *public* `/mentors` directory.
+const PRIVATE_PREFIXES = [
+  '/admin',
+  '/mentor',
+  '/portal',
+  '/company',
+  '/messages',
+  '/account',
+  '/notifications',
+  '/todos',
+  '/onboarding',
+  '/interviews',
+  '/weekly-reports',
+  '/newsletter',
+  '/newsletters',
+  '/testimonials',
+  '/re-engage',
+  '/consent',
+  '/security-setup',
+  '/source',
+  '/offline',
+  '/rsvp',
+  '/m',
+  '/u',
+  '/api',
+  '/auth',
+  // Public profiles are a share link the person turned on, not an index entry
+  // (a separate consent question — see sitemap.ts).
+  '/p',
+];
+
+function isUnder(pathname: string, prefix: string): boolean {
+  return pathname === prefix || pathname.startsWith(`${prefix}/`);
+}
+
+/** The `<loc>` values of a sitemap, as pathnames. */
+function locPathnames(xml: string): string[] {
+  return [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => new URL(m[1].trim()).pathname);
+}
+
+function contentType(res: APIResponse): string {
+  return res.headers()['content-type'] ?? '';
+}
+
+async function robotsText(request: APIRequestContext): Promise<string> {
+  const res = await request.get('/robots.txt');
+  expect(res.status()).toBe(200);
+  return res.text();
+}
+
+/** True when this deployment closes the whole site (preview / topic / demo). */
+function isClosed(body: string): boolean {
+  return /^Disallow:\s*\/$/m.test(body);
+}
+
+test('robots.txt is served', { tag: '@smoke' }, async ({ request }) => {
+  const res = await request.get('/robots.txt');
+  expect(res.status()).toBe(200);
+  expect(contentType(res)).toContain('text/plain');
+  expect(await res.text()).toContain('User-Agent: *');
+});
+
+test('a crawlable deployment links the sitemap and fences off the app', { tag: '@smoke' }, async ({ request }) => {
+  const body = await robotsText(request);
+  test.skip(isClosed(body), 'this deployment is non-production and closed to crawlers entirely');
+
+  expect(body).toContain('Allow: /');
+  // An absolute URL, as the format requires — the host depends on the env.
+  const sitemapLine = body.match(/^Sitemap:\s*(\S+)$/m);
+  expect(sitemapLine, `no Sitemap: line in\n${body}`).not.toBeNull();
+  expect(new URL(sitemapLine![1]).pathname).toBe('/sitemap.xml');
+
+  for (const p of ['/admin', '/portal', '/messages', '/api/', '/auth/']) {
+    expect(body, `expected ${p} to be disallowed`).toContain(`Disallow: ${p}`);
+  }
+  // The public mentor directory must not be collateral damage of /mentor.
+  expect(body).not.toMatch(/^Disallow:\s*\/mentor$/m);
+});
+
+test('a preview or demo deployment is closed to crawlers', async ({ request }) => {
+  const body = await robotsText(request);
+  test.skip(!isClosed(body), 'this deployment is production and meant to be crawled');
+
+  expect(body).not.toContain('Allow: /');
+  // A blanket disallow with a sitemap next to it contradicts itself.
+  expect(body).not.toMatch(/^Sitemap:/m);
+});
+
+test('sitemap.xml lists the public pages and nothing behind a login', { tag: '@smoke' }, async ({ request }) => {
+  const res = await request.get('/sitemap.xml');
+  expect(res.status()).toBe(200);
+  expect(contentType(res)).toContain('xml');
+
+  const xml = await res.text();
+  expect(xml).toContain('<urlset');
+  expect(xml.trimEnd()).toMatch(/<\/urlset>$/);
+
+  const paths = locPathnames(xml);
+  // The landing plus the pages that are otherwise footer-only.
+  expect(paths).toContain('/');
+  for (const p of ['/features', '/for-companies', '/privacy', '/terms', '/imprint']) {
+    expect(paths).toContain(p);
+  }
+
+  for (const path of paths) {
+    for (const prefix of PRIVATE_PREFIXES) {
+      expect(isUnder(path, prefix), `sitemap lists ${path}, which is under ${prefix}`).toBe(false);
+    }
+  }
+});
+
+test('sitemap entries all resolve for an anonymous visitor', async ({ request }) => {
+  const xml = await (await request.get('/sitemap.xml')).text();
+  // Cap the walk: the dynamic project entries grow with the database and this
+  // spec is about the shape of the list, not a full crawl.
+  for (const path of locPathnames(xml).slice(0, 20)) {
+    const res = await request.get(path, { maxRedirects: 0 });
+    expect(res.status(), `${path} is in the sitemap but answers ${res.status()}`).toBe(200);
+  }
+});

--- a/releases/unreleased/robots-and-sitemap.json
+++ b/releases/unreleased/robots-and-sitemap.json
@@ -1,0 +1,9 @@
+{
+  "bump": "patch",
+  "changelog": "- **`/robots.txt` and `/sitemap.xml` exist** (#1380). Both were 404, so nothing told a crawler what to fetch and the footer-only public pages were discoverable by luck. Two Next metadata routes (same file convention as `manifest.ts`), both `force-dynamic` because the absolute origin comes from the runtime `NEXTAUTH_URL` (new `lib/siteUrl.ts`). `robots.ts` allows `/`, disallows the signed-in areas as exact-or-subpath pairs (`/mentor$` + `/mentor/`, so the public `/mentors` directory is not collateral damage) and links the sitemap; on any non-production `NEXT_PUBLIC_APP_ENV` and on the demo deployment it closes the whole site instead, so preview/topic/demo copies stay out of the index. `sitemap.ts` lists the 13 anonymous routes plus `isPublic` + `ACTIVE` projects, `/stories` only once a story is published and `/demo` only on the demo instance; `/p/<userId>` and `/apply/<mentorId>` are deliberately excluded, and a database error degrades to the static list rather than a 500. New spec `e2e/robots-sitemap.spec.ts` (`@smoke`) asserts both routes' status and content type, the disallow set, and that no sitemap URL sits under an authenticated prefix.",
+  "notes": {
+    "en": ["Search engines can now find the public pages: the site serves a robots.txt and a sitemap listing every page a visitor can open, while preview and demo copies stay out of search results."],
+    "tr": ["Arama motorları artık genel sayfaları bulabiliyor: site bir robots.txt ve ziyaretçiye açık tüm sayfaları içeren bir site haritası yayınlıyor; önizleme ve demo kopyaları arama sonuçlarına girmiyor."],
+    "de": ["Suchmaschinen finden jetzt die öffentlichen Seiten: Die Website liefert eine robots.txt und eine Sitemap mit allen für Besucher zugänglichen Seiten, während Vorschau- und Demo-Kopien aus den Suchergebnissen bleiben."]
+  }
+}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,74 @@
+import type { MetadataRoute } from 'next';
+import { APP_ENV } from '@/lib/appEnv';
+import { IS_DEMO_MODE } from '@/lib/demoMode';
+import { siteUrl } from '@/lib/siteUrl';
+
+// /robots.txt (#1380). Same file convention as manifest.ts — Next serves this
+// at /robots.txt, so no route handler is needed.
+//
+// Read at request time rather than prerendered: the `Sitemap:` line has to be
+// absolute, and the origin comes from NEXTAUTH_URL, which is a runtime variable
+// (see lib/siteUrl.ts).
+export const dynamic = 'force-dynamic';
+
+/**
+ * Prefixes a crawler has no business fetching. None of them are a security
+ * boundary — every one of them redirects to sign-in — but each crawled URL
+ * spends crawl budget on a login redirect and can surface as a meaningless
+ * search result.
+ *
+ * Written as an exact-or-subpath pair (`/x$`, `/x/`) rather than the bare
+ * prefix `/x`, because `Disallow` matches by prefix: a plain `/mentor` would
+ * also swallow `/mentors`, the *public* mentor directory. `$` is the Google /
+ * Bing end-anchor extension; the `/x/` line is what a crawler that ignores the
+ * anchor still honours, so the worst case is one dashboard URL being fetched
+ * and redirected to sign-in.
+ */
+const PROTECTED_PATHS = [
+  '/admin',
+  '/mentor',
+  '/portal',
+  '/company',
+  '/messages',
+  '/account',
+  '/notifications',
+  '/todos',
+  '/onboarding',
+  '/interviews',
+  '/weekly-reports',
+  '/newsletter',
+  '/newsletters',
+  '/testimonials',
+  '/re-engage',
+  '/consent',
+  '/security-setup',
+  '/source',
+  '/offline',
+  '/rsvp',
+  '/m',
+  '/u',
+];
+
+// Prefixes with no public sibling to protect, so the plain prefix is enough.
+const PROTECTED_PREFIXES = ['/api/', '/auth/'];
+
+export default function robots(): MetadataRoute.Robots {
+  // Preview, the per-PR topic environments and the public demo all serve the
+  // same content as production. Indexing them would put three or four copies
+  // of every page in the index and let a search result drop a visitor into a
+  // throwaway environment, so they are closed entirely — and a blanket
+  // disallow deliberately carries no `Sitemap:` line, which would contradict
+  // it.
+  if (APP_ENV !== 'production' || IS_DEMO_MODE) {
+    return { rules: { userAgent: '*', disallow: '/' } };
+  }
+
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: [...PROTECTED_PATHS.flatMap((p) => [`${p}$`, `${p}/`]), ...PROTECTED_PREFIXES],
+    },
+    sitemap: `${siteUrl()}/sitemap.xml`,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,124 @@
+import type { MetadataRoute } from 'next';
+import { prisma } from '@/lib/prisma';
+import { IS_DEMO_MODE } from '@/lib/demoMode';
+import { getAllReleaseNotes } from '@/lib/releaseNotes';
+import { listPublishedStories } from '@/lib/testimonials';
+import { siteUrl } from '@/lib/siteUrl';
+
+// /sitemap.xml (#1380). Most public pages are reachable only from the footer
+// (components/landing/PublicFooter.tsx), so a crawler finding them was a matter
+// of luck. This is the explicit list.
+//
+// Dynamic for two reasons: the `<loc>`s must be absolute and the origin is a
+// runtime variable (lib/siteUrl.ts), and the project/story rows below are read
+// per request — a prerendered sitemap would freeze whatever was public on the
+// day of the build (and `next build` has no database at all).
+export const dynamic = 'force-dynamic';
+
+/**
+ * What the static entries claim as their last change.
+ *
+ * These pages are code, not content: the landing copy, the feature catalogue
+ * and the legal texts change only when a release ships, and in this repo every
+ * merge deploys. So the newest release-notes date is the honest answer — and,
+ * unlike `new Date()`, it does not tell a crawler that all fifteen pages
+ * changed the instant it asked.
+ */
+const lastShipped = (): Date => {
+  const date = getAllReleaseNotes()[0]?.date;
+  const parsed = date ? new Date(`${date}T00:00:00.000Z`) : null;
+  return parsed && !Number.isNaN(parsed.getTime()) ? parsed : new Date();
+};
+
+/**
+ * Every route that renders for a signed-out visitor, with the two deliberate
+ * omissions:
+ *
+ *  - `/p/<userId>` — a public profile is a share link the person chose to turn
+ *    on; putting it in a search index is a separate consent question and is
+ *    left to its own issue.
+ *  - `/apply/<mentorId>` — the per-mentor application form is a link a mentor
+ *    hands out, not a landing page, and it duplicates /apply-as-mentor's
+ *    funnel.
+ *
+ * Authenticated areas are absent by construction, and robots.ts disallows them.
+ */
+const PUBLIC_ROUTES: readonly { path: string; priority: number; changeFrequency: 'daily' | 'weekly' | 'monthly' }[] = [
+  { path: '/', priority: 1.0, changeFrequency: 'weekly' },
+  { path: '/features', priority: 0.8, changeFrequency: 'weekly' },
+  { path: '/for-companies', priority: 0.8, changeFrequency: 'monthly' },
+  { path: '/apply-as-mentor', priority: 0.8, changeFrequency: 'monthly' },
+  { path: '/mentors', priority: 0.7, changeFrequency: 'weekly' },
+  { path: '/projects', priority: 0.7, changeFrequency: 'weekly' },
+  { path: '/announcements', priority: 0.5, changeFrequency: 'daily' },
+  { path: '/release-notes', priority: 0.5, changeFrequency: 'daily' },
+  { path: '/code-of-conduct', priority: 0.3, changeFrequency: 'monthly' },
+  { path: '/contributor-terms', priority: 0.3, changeFrequency: 'monthly' },
+  { path: '/privacy', priority: 0.3, changeFrequency: 'monthly' },
+  { path: '/terms', priority: 0.3, changeFrequency: 'monthly' },
+  { path: '/imprint', priority: 0.3, changeFrequency: 'monthly' },
+];
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const base = siteUrl();
+  const shipped = lastShipped();
+
+  const entries: MetadataRoute.Sitemap = PUBLIC_ROUTES.map((r) => ({
+    url: `${base}${r.path}`,
+    lastModified: shipped,
+    changeFrequency: r.changeFrequency,
+    priority: r.priority,
+  }));
+
+  // /demo exists only on the demo deployment — everywhere else it is a 404
+  // (app/demo/page.tsx), and a sitemap that lists 404s is worse than a short
+  // one. Note that the demo's own robots.txt closes the whole site, so this is
+  // belt-and-braces rather than an invitation.
+  if (IS_DEMO_MODE) {
+    entries.push({
+      url: `${base}/demo`,
+      lastModified: shipped,
+      changeFrequency: 'monthly',
+      priority: 0.6,
+    });
+  }
+
+  // The two database-backed public surfaces. A sitemap must not fail the whole
+  // route because the database hiccuped — the static list above is still worth
+  // serving — so a query error degrades to "no dynamic entries".
+  try {
+    // /stories 404s while nothing is published (a deliberate honesty rule, see
+    // app/stories/page.tsx), so it is listed only once there is something on
+    // it. Individual stories have no URL of their own; the page is the entry.
+    const stories = await listPublishedStories(1);
+    if (stories.length > 0) {
+      entries.push({
+        url: `${base}/stories`,
+        lastModified: new Date(stories[0].publishedAt),
+        changeFrequency: 'monthly',
+        priority: 0.7,
+      });
+    }
+
+    // Showcase projects. `isPublic` is the opt-in the detail page checks, and
+    // ACTIVE keeps drafts, cancelled and archived work out of the index even
+    // though their pages would render.
+    const projects = await prisma.project.findMany({
+      where: { isPublic: true, status: 'ACTIVE' },
+      orderBy: { updatedAt: 'desc' },
+      select: { id: true, updatedAt: true },
+    });
+    for (const p of projects) {
+      entries.push({
+        url: `${base}/projects/${p.id}`,
+        lastModified: p.updatedAt,
+        changeFrequency: 'monthly',
+        priority: 0.5,
+      });
+    }
+  } catch {
+    // ignore — serve the static routes rather than a 500
+  }
+
+  return entries;
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -30,6 +30,9 @@ const lastShipped = (): Date => {
   return parsed && !Number.isNaN(parsed.getTime()) ? parsed : new Date();
 };
 
+/** Same page size app/stories/page.tsx asks for — see the call site below. */
+const STORIES_PAGE_LIMIT = 50;
+
 /**
  * Every route that renders for a signed-out visitor, with the two deliberate
  * omissions:
@@ -90,7 +93,14 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     // /stories 404s while nothing is published (a deliberate honesty rule, see
     // app/stories/page.tsx), so it is listed only once there is something on
     // it. Individual stories have no URL of their own; the page is the entry.
-    const stories = await listPublishedStories(1);
+    //
+    // Asked with the SAME limit the page uses, not `1`: listPublishedStories
+    // applies `take` in SQL and *then* drops rows in JS (an interview
+    // scorecard has no relation, an admin-authored evaluation has no
+    // participant author — neither is ever a story). With `take: 1` a single
+    // such row at the top of the list answers "no stories" while the page
+    // renders content, and the sitemap would silently omit a live page.
+    const stories = await listPublishedStories(STORIES_PAGE_LIMIT);
     if (stories.length > 0) {
       entries.push({
         url: `${base}/stories`,

--- a/src/lib/siteUrl.ts
+++ b/src/lib/siteUrl.ts
@@ -1,0 +1,18 @@
+// The absolute origin this deployment answers on.
+//
+// Needed by the two metadata routes that must emit *absolute* URLs (robots.ts's
+// `Sitemap:` line and every `<loc>` in sitemap.ts) — a relative path is invalid
+// in both formats. `NEXTAUTH_URL` is the one variable every environment already
+// sets (it is required, see .env.example), which is why it is the source of
+// truth here rather than a new SITE_URL nobody would remember to configure;
+// `NEXT_PUBLIC_APP_URL` is accepted as the same second choice the SSO and email
+// link builders make.
+//
+// Read at request time, never baked in: the Dockerfile takes no NEXTAUTH_URL
+// build-arg, so a value resolved during `next build` would be localhost on
+// every deployment. Both callers are therefore `force-dynamic`.
+export function siteUrl(): string {
+  const raw =
+    process.env.NEXTAUTH_URL || process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+  return raw.replace(/\/+$/, '');
+}


### PR DESCRIPTION
## Summary

`/robots.txt` and `/sitemap.xml` were both 404. Nothing told a crawler what to fetch, so the public pages reachable only from the footer (`PublicFooter.tsx`) were discoverable by luck, while the signed-in app and `/api` were free to crawl — not a security problem (they all redirect to sign-in) but wasted crawl budget and meaningless search results.

Two Next metadata routes, same file convention as `src/app/manifest.ts`. Both are `force-dynamic`: the `Sitemap:` line and every `<loc>` must be absolute, and the origin comes from `NEXTAUTH_URL`, which is a **runtime** variable — the Dockerfile takes no such build-arg, so an origin resolved during `next build` would be `localhost:3000` on every deployment.

Closes #1380

## Changes

- **`src/lib/siteUrl.ts`** (new) — one place that resolves the absolute origin (`NEXTAUTH_URL` → `NEXT_PUBLIC_APP_URL` → `http://localhost:3000`, trailing slash stripped), rather than a fourth copy of the private `appUrl()` helper that `newsletterTokens`/`unsubscribeToken`/`emailActionToken` each carry.
- **`src/app/robots.ts`** (new) — `Allow: /`, a `Sitemap:` line, and the authenticated areas disallowed as **exact-or-subpath pairs** (`/mentor$` *and* `/mentor/`): `Disallow` matches by prefix, so a bare `/mentor` would also close the *public* `/mentors` directory. Covers `/admin /mentor /portal /company /messages /account /notifications /todos /onboarding /interviews /weekly-reports /newsletter(s) /testimonials /re-engage /consent /security-setup /source /offline /rsvp /m /u` plus `/api/` and `/auth/`.
- **Non-production is closed entirely**: `NEXT_PUBLIC_APP_ENV !== 'production'` (preview + every per-PR topic env) or `IS_DEMO_MODE` returns `Disallow: /` with **no** `Sitemap:` line (which would contradict it), so the same content is not indexed three or four times over and a search result can never drop a visitor into a throwaway environment.
- **`src/app/sitemap.ts`** (new) — the 13 routes that render for a signed-out visitor (`/`, `/features`, `/for-companies`, `/apply-as-mentor`, `/mentors`, `/projects`, `/announcements`, `/release-notes`, `/code-of-conduct`, `/contributor-terms`, `/privacy`, `/terms`, `/imprint`) with `lastModified`/`changefreq`/`priority`, plus:
  - `isPublic` **and** `status: ACTIVE` showcase projects (`/projects/<id>`, `lastModified` = `updatedAt`) — `ACTIVE` keeps drafts, cancelled and archived work out of the index even though their pages render;
  - `/stories` only once a story is actually published (the page 404s while empty — a deliberate honesty rule); individual stories have no URL of their own, so the page is the entry;
  - `/demo` only when `IS_DEMO_MODE` (a 404 everywhere else);
  - a database error degrades to the static list instead of a 500.
- **`e2e/robots-sitemap.spec.ts`** (new, 3 × `@smoke`) — status + content type for both routes, an absolute `Sitemap:` line pointing at `/sitemap.xml`, the disallow set (and that `/mentors` is *not* collateral damage), valid `<urlset>` XML, no sitemap URL under any authenticated prefix or under `/p`, and that every listed URL answers 200 anonymously. Which deployment shape is under test is read from the response, so the spec is valid locally, on a topic env and against `BASE_URL=https://crm-preview.ersah.in`.
- Release fragment `releases/unreleased/robots-and-sitemap.json` (`patch`, EN/TR/DE notes).

### Deliberate omissions (called out because the issue asks)

- **`/p/<userId>`** — a public profile is a share link the person turned on; putting it in a search index is a separate consent decision and is left to its own issue. It is absent from the sitemap and asserted absent by the spec; per the issue's crawl-block list it is *not* `Disallow`ed, so the links from `/stories` still work as shared.
- **`/apply/<mentorId>`** — a link a mentor hands out, not a landing page, and it duplicates the `/apply-as-mentor` funnel.
- No schema change, no i18n keys, no dependency added.

## Verification

- [x] `npm run lint` + `npx tsc --noEmit` clean (lint: only the three pre-existing warnings in untouched files)
- [ ] `npm run test:e2e` passing (or CI green) — **not run in full**: this container has no MySQL and no Docker daemon, so the suite cannot boot. See below for what *was* run.
- [x] Tested the change manually / added an e2e test

Actually run in this container:

- `npx tsc --noEmit`, `npm run lint`, `npm run check:i18n` (3490 keys × 3 locales), `npm run check:release-fragments` (this ships as `0.128.4-beta`), `npm run build` — all green; the build shows `ƒ /robots.txt` and `ƒ /sitemap.xml` as dynamic, as intended.
- `curl localhost/robots.txt` against a production build: **200**, `content-type: text/plain`, `Allow: /`, the full `Disallow` set and `Sitemap: http://localhost:3000/sitemap.xml`.
- `curl localhost/sitemap.xml`: **200**, `content-type: application/xml`, valid `<urlset>` with the 13 public URLs and nothing else (no DB here, so the project/story entries could not be exercised — CI and the topic env will).
- A second build with `NEXT_PUBLIC_APP_ENV=preview`: `/robots.txt` is exactly `User-Agent: *` + `Disallow: /`, no `Sitemap:` line. (Acceptance criterion 4.)
- `npx playwright test e2e/robots-sitemap.spec.ts` against **both** builds: 3 passed, 1 skipped (the env-specific counterpart) in each. The 5th test — "sitemap entries all resolve" — **fails locally only because there is no database** (`/` answers 500 here); every page it walks is already navigated by `e2e/public-chrome.spec.ts` in CI, so CI must confirm that one.

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JgY7mKwLmq9KdtnBFYYQu3


---
_Generated by [Claude Code](https://claude.ai/code/session_01JgY7mKwLmq9KdtnBFYYQu3)_