### PR TITLE
fix(privacy): erasure scrubs message bodies, attachments, support threads and notes

### DIFF
--- a/docs/pii-access-lifecycle.md
+++ b/docs/pii-access-lifecycle.md
@@ -185,7 +185,7 @@ konuşması.
 
 ### Şema değişikliği yok
 
-Boşaltmak (`''`) null'lamak yerine tercih edilmedi, **şema öyle**:
+Null'lamak yerine boşaltmak (`''`) bir tercih değil, **şemanın zorunluluğu**:
 `Message.body`, `SupportMessage.body`, `PersonalNote.body`, `RelationNote.body`
 ve `InteractionLog.notes` zorunlu kolonlar. Boş gövde bu yüzeylerde zaten
 ulaşılabilir ve zaten render edilen bir durum (yalnızca ek içeren destek

--- a/docs/pii-access-lifecycle.md
+++ b/docs/pii-access-lifecycle.md
@@ -135,6 +135,86 @@ akışını tekrar tetiklemek. Link elle paylaşılacaksa bunun için ayrı ve d
 bir yol var (#670, e-postasız davet linkleri) — "yanıt gövdesinde döndür" o yol
 değil.
 
+## Silme ne kadarına ulaşıyor (#2052)
+
+Hesap sayfası ve yönetici akışı iki seçenek sunuyor — **anonimleştir** ya da
+**tamamen sil** — ve gizlilik metni silme hakkını taahhüt ediyor. Kaynak kod:
+[`src/lib/accountErasure.ts`](../src/lib/accountErasure.ts). Her iki yol da
+**elle ve yönetici tarafından** başlatılır; `src/lib/retention.ts` kimin
+gözden geçirilmesi gerektiğini gösterir, hiçbir şeyi kendiliğinden silmez.
+
+### Önceki durum
+
+`anonymizeUser()` yalnızca `User` satırını yeniden yazıyor ve yüklenen dosyaları
+siliyordu. Kişinin yazdığı **her serbest metin** yerinde kalıyordu: mesaj
+gövdeleri ve ekleri, destek konuşması ve ekleri, hakkında yazılmış notlar,
+etkileşim kayıtları. Yani "artık kimseyi tanımlamıyor" diyen bir satırın yanında
+telefon numarası, adres ve mentörün özel notları duruyordu. `Message.senderId`'in
+`User`'a **foreign key'i yok**, dolayısıyla tamamen silmede de cascade
+çalışmıyor: `relationId` taşımayan (konuşma katmanındaki) bir mesaj hesaptan
+sonra da yaşıyordu.
+
+### İki kural
+
+Serbest metnin sahibi kim olduğuna göre davranış değişir:
+
+| | Kişinin **yazdığı** içerik | Kişi **hakkında** yazılan içerik |
+|---|---|---|
+| Ne olur | **Mezar taşı**: gövde boşaltılır, ek satırları silinir, **satır kalır** | **Temizlenir**: serbest metin gider, satırın tarihi/türü/aşaması kalır |
+| Neden | Karşı tarafın konuşması anlamsızlaşmasın — mevcut `Message.deletedForEveryoneAt` maskesi zaten "mesaj silindi" yer tutucusunu gösteriyor | Tarih, tür ve aşama kurumun operasyonel geçmişi; metin gittikten sonra PII taşımıyorlar |
+| Kapsam | `Message.body` + `MessageAttachment`, `SupportMessage.body` + `SupportAttachment`, `SupportTicket.subject` (kişinin ilk mesajının ilk 80 karakterinin birebir kopyası), `MentorshipRequest.message`, kişinin kendi `PersonalNote` satırları (yalnızca kendisine ait → doğrudan silinir) | `InteractionLog.notes`/`subject`, `RelationNote.body`, kişinin toplantısında alınmış `PersonalNote.body` |
+
+`User` satırında ayrıca gözden kaçmış üç alan temizleniyor: `country`,
+`referralSource`, `reEngageNote`.
+
+"Hakkında" kapsamı **mentee olduğu ilişkilerle** sınırlı: kişinin *mentör*
+olduğu bir ilişkideki aynı kolonlar üçüncü bir kişinin kaydıdır, onları silmek
+başkasının geçmişini silmek olur (tamamen silmede o ilişkiler cascade ile
+zaten gidiyor). `PersonalNote` **yazarına** bağlı, özneye değil; özneye tek
+bağlantı `meetingId` → toplantının ilişkisi ya da kişiyle olan `DIRECT` (1:1)
+konuşması.
+
+### İki sıra kuralı
+
+- Her iki yolda da temizlik **tek bir `$transaction`** içinde: yarım kalmış bir
+  silme mümkün olmamalı.
+- Tamamen silmede temizlik **ilişkiler silinmeden önce** çalışır.
+  `PersonalNote.meetingId` `SetNull` olduğu için, ilişki (ve onunla toplantı)
+  silindikten sonra not metniyle birlikte hayatta kalır ve özneye giden tek
+  bağı kopmuş olur — hiçbir sorgunun bir daha bulamayacağı bir PII.
+
+### Şema değişikliği yok
+
+Boşaltmak (`''`) null'lamak yerine tercih edilmedi, **şema öyle**:
+`Message.body`, `SupportMessage.body`, `PersonalNote.body`, `RelationNote.body`
+ve `InteractionLog.notes` zorunlu kolonlar. Boş gövde bu yüzeylerde zaten
+ulaşılabilir ve zaten render edilen bir durum (yalnızca ek içeren destek
+mesajı, mezar taşı yapılmış sohbet mesajı).
+
+### Ulaşılamayanlar — sessiz boşluk yok
+
+Kanıt testi: [`e2e/erasure-free-text.spec.ts`](../e2e/erasure-free-text.spec.ts)
+— bir mentee'ye ilişki, mesajlar+ekler, destek konuşması, mentörün notu ve
+etkileşim kaydı serbest metinleriyle yazılır, **iki yol da** koşulur, sonra
+tohumlanan PII dizeleri doğrudan Prisma ile aranır.
+
+Kodda `KNOWN GAPS` bloğunda sayılan ve [#2106](https://github.com/21072026/Internship/issues/2106)
+ile takip edilen kalan yüzeyler:
+
+- **Toplantısız `PersonalNote`** (`meetingId: null`): yazarına bağlı, özneye
+  hiçbir bağı yok. Bu notun bu kişi hakkında mı yoksa bir başkası hakkında mı
+  olduğunu ayırt eden bir sorgu yazılamaz — ürün kararı gerektiriyor.
+- Grup konuşması / proje toplantısında alınan notlar: not toplantı hakkındadır,
+  kişi hakkında değil.
+- `scripts/sanitize-db.mjs` başlığındaki envanterin geri kalanı (değerlendirme
+  yorumları, haftalık raporlar, hedef açıklamaları, teklif/görüşme notları,
+  bildirim metinleri, denetim kaydı `detail` alanları). Bunların çoğu **tamamen
+  silmede** cascade ile gidiyor ama **anonimleştirmede** kalıyor.
+
+Aşağıdaki bölümdeki uyarı burada da geçerli ve iki yönlü: yeni bir serbest metin
+kolonu eklerken hem `scripts/sanitize-db.mjs` envanterine hem de
+`accountErasure.ts`'e eklenmezse sızıntı olur.
+
 ## Önizleme verisi: anonimleştirme (#1186)
 
 Paylaşılan önizleme ortamı gerçek veriyle çalışıyordu. `scripts/sanitize-db.mjs`

--- a/e2e/erasure-free-text.spec.ts
+++ b/e2e/erasure-free-text.spec.ts
@@ -38,6 +38,7 @@ interface Seeded {
     support: string;
     supportSubject: string;
     meetingNote: string;
+    conversationNote: string;
     ownNote: string;
     relationNote: string;
     interactionNotes: string;
@@ -56,6 +57,7 @@ interface Seeded {
   menteeMessageIds: string[];
   interactionLogId: string;
   meetingNoteId: string;
+  conversationNoteId: string;
 }
 
 async function seedPaperTrail(prefix: string): Promise<Seeded> {
@@ -68,6 +70,7 @@ async function seedPaperTrail(prefix: string): Promise<Seeded> {
     support: `cannot sign in, my address is ${tag} avenue`,
     supportSubject: `login trouble ${tag}`,
     meetingNote: `talked about their divorce ${tag}`,
+    conversationNote: `they cried on the call ${tag}`,
     ownNote: `my own reminder ${tag}`,
     relationNote: `mentor impression ${tag}`,
     interactionNotes: `phoned them on their mobile ${tag}`,
@@ -156,6 +159,27 @@ async function seedPaperTrail(prefix: string): Promise<Seeded> {
   const meetingNote = await prisma.personalNote.create({
     data: { userId: mentor.id, meetingId: meeting.id, category: 'MEETING', body: pii.meetingNote },
   });
+  // The other half of the note lookup: a meeting hung off the DIRECT (1:1)
+  // conversation rather than off the relation (`relationId: null` — #1051 made
+  // that legal). It is reached only through
+  // `meeting.conversation.participants`, the second branch of the `OR` in
+  // scrubFreeTextOps, and nothing else in this repo covers that branch.
+  const conversationMeeting = await prisma.meeting.create({
+    data: {
+      conversationId: conversation.id,
+      title: `catch-up ${tag}`,
+      rsvpToken: crypto.randomBytes(24).toString('hex'),
+      createdById: mentor.id,
+    },
+  });
+  const conversationNote = await prisma.personalNote.create({
+    data: {
+      userId: mentor.id,
+      meetingId: conversationMeeting.id,
+      category: 'MEETING',
+      body: pii.conversationNote,
+    },
+  });
   // The person's own private note.
   await prisma.personalNote.create({ data: { userId: mentee.id, body: pii.ownNote } });
 
@@ -187,6 +211,7 @@ async function seedPaperTrail(prefix: string): Promise<Seeded> {
     menteeMessageIds: [relationMessage.id, conversationMessage.id],
     interactionLogId: interactionLog.id,
     meetingNoteId: meetingNote.id,
+    conversationNoteId: conversationNote.id,
   };
 }
 
@@ -231,6 +256,7 @@ async function expectNoFreeTextLeft(s: Seeded) {
   expect(await prisma.supportTicket.count({ where: { subject: { contains: p.supportSubject } } })).toBe(0);
   expect(await prisma.supportAttachment.count({ where: { message: { senderId: s.menteeId } } })).toBe(0);
   expect(await prisma.personalNote.count({ where: { body: { contains: p.meetingNote } } })).toBe(0);
+  expect(await prisma.personalNote.count({ where: { body: { contains: p.conversationNote } } })).toBe(0);
   expect(await prisma.personalNote.count({ where: { body: { contains: p.ownNote } } })).toBe(0);
   expect(await prisma.relationNote.count({ where: { body: { contains: p.relationNote } } })).toBe(0);
   expect(await prisma.interactionLog.count({ where: { notes: { contains: p.interactionNotes } } })).toBe(0);
@@ -328,6 +354,12 @@ test('hard-deleting an account leaves none of its free text behind, including wh
     // afterwards nothing links it to the person any more.
     const note = await prisma.personalNote.findUnique({ where: { id: s.meetingNoteId } });
     expect(note?.body).toBe('');
+    // Same for the note on the conversation meeting: that meeting survives the
+    // user (its `relationId` is null, so no cascade touches it), and the only
+    // link to the erased person — their `ConversationParticipant` row — went
+    // with the user row. So this one, too, is only reachable before the delete.
+    const convNote = await prisma.personalNote.findUnique({ where: { id: s.conversationNoteId } });
+    expect(convNote?.body).toBe('');
   } finally {
     await cleanup(s);
   }

--- a/e2e/erasure-free-text.spec.ts
+++ b/e2e/erasure-free-text.spec.ts
@@ -199,6 +199,18 @@ async function cleanup(s: Seeded) {
   await prisma.message.deleteMany({ where: { senderId: { in: [s.menteeId, s.mentorId] } } });
   await prisma.conversation.deleteMany({ where: { id: s.conversationId } });
   await prisma.personalNote.deleteMany({ where: { userId: { in: [s.menteeId, s.mentorId] } } });
+  // The seeded rows go by ID, not by e-mail: the anonymise path has already
+  // rewritten the mentee's address to erased-<id>@erased.local, so
+  // `cleanupByEmail(menteeEmail)` matches nothing and the anonymised row would
+  // stay behind — with its support ticket sitting in the admin queue and its
+  // pending mentorship request in the approval queue for every later spec in
+  // the run. e2e/candidate-erasure.spec.ts deletes by id after the same call
+  // for the same reason. Relations first: `MentorshipRelation.mentor/mentee`
+  // are FK-restrict, so the user rows cannot go while a relation points at them.
+  await prisma.mentorshipRelation.deleteMany({
+    where: { OR: [{ menteeId: s.menteeId }, { mentorId: s.mentorId }] },
+  });
+  await prisma.user.deleteMany({ where: { id: { in: [s.menteeId, s.mentorId] } } });
   await cleanupByEmail(s.menteeEmail);
   await cleanupByEmail(s.mentorEmail);
 }

--- a/e2e/erasure-free-text.spec.ts
+++ b/e2e/erasure-free-text.spec.ts
@@ -1,0 +1,322 @@
+import { test, expect } from '@playwright/test';
+import crypto from 'crypto';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { signInAndSettle } from './helpers/auth';
+// Static imports, not `await import()` inside a test: Playwright resolves the
+// `@/…` path alias when it transforms the spec's import graph, but a dynamic
+// import is resolved by Node at runtime, which knows nothing about tsconfig
+// paths (see e2e/email-hardening.spec.ts).
+import { anonymizeUser, hardDeleteUser } from '../src/lib/accountErasure';
+
+/**
+ * Erasure actually erases (#2052).
+ *
+ * `anonymizeUser()` used to rewrite the `User` row, delete the uploaded files
+ * and stop — leaving every free-text field the person had ever typed, and
+ * everything typed about them, sitting in the database under a row that claimed
+ * to be anonymous. This is the acceptance evidence the DPA (#2029) points at:
+ * seed a full paper trail, run BOTH erasure paths, then ask the database
+ * directly whether any of the seeded PII is still findable.
+ *
+ * Not `@smoke`: it seeds ~a dozen rows across eight tables and is not a
+ * runtime-critical path.
+ *
+ * NOT covered here because the code cannot reach it (see the KNOWN GAPS block
+ * in src/lib/accountErasure.ts, tracked in #2106): a free-standing
+ * `PersonalNote` with `meetingId: null` has no link to any subject, and the
+ * remaining per-person free text inventoried in scripts/sanitize-db.mjs.
+ */
+
+const PASSWORD = 'ErasurePass123';
+
+/** Everything the seed writes, so one query per table can ask "is it gone?". */
+interface Seeded {
+  tag: string;
+  pii: {
+    message: string;
+    conversationMessage: string;
+    support: string;
+    supportSubject: string;
+    meetingNote: string;
+    ownNote: string;
+    relationNote: string;
+    interactionNotes: string;
+    interactionSubject: string;
+    request: string;
+    reEngage: string;
+  };
+  mentorEmail: string;
+  menteeEmail: string;
+  mentorId: string;
+  menteeId: string;
+  relationId: string;
+  conversationId: string;
+  ticketId: string;
+  mentorMessageId: string;
+  menteeMessageIds: string[];
+  interactionLogId: string;
+  meetingNoteId: string;
+}
+
+async function seedPaperTrail(prefix: string): Promise<Seeded> {
+  // Every seeded string carries a per-run tag, so a `contains` query cannot
+  // accidentally match another spec's leftovers (or another shard's).
+  const tag = crypto.randomBytes(4).toString('hex');
+  const pii = {
+    message: `my number is 0555 ${tag} 11`,
+    conversationMessage: `I live at Kadikoy ${tag} street 4`,
+    support: `cannot sign in, my address is ${tag} avenue`,
+    supportSubject: `login trouble ${tag}`,
+    meetingNote: `talked about their divorce ${tag}`,
+    ownNote: `my own reminder ${tag}`,
+    relationNote: `mentor impression ${tag}`,
+    interactionNotes: `phoned them on their mobile ${tag}`,
+    interactionSubject: `first call ${tag}`,
+    request: `please match me, I am ${tag}`,
+    reEngage: `call back in September ${tag}`,
+  };
+
+  const mentorEmail = uniqueEmail(`${prefix}-mentor`);
+  const menteeEmail = uniqueEmail(`${prefix}-mentee`);
+  const mentor = await seedUser(mentorEmail, PASSWORD, 'MENTOR', 'Erasure Mentor');
+  const mentee = await seedUser(menteeEmail, PASSWORD, 'MENTEE', 'Erasure Mentee');
+  await prisma.user.update({
+    where: { id: mentee.id },
+    data: { city: 'Istanbul', country: 'TR', referralSource: `a friend ${tag}`, reEngageNote: pii.reEngage },
+  });
+
+  const relation = await prisma.mentorshipRelation.create({
+    data: { mentorId: mentor.id, menteeId: mentee.id },
+  });
+
+  // A 1:1 conversation as well as the legacy relation thread: a
+  // conversation-layer message has `relationId: null`, so it is NOT reached by
+  // the relation cascade a hard delete runs — and `Message.senderId` has no FK
+  // to `User`, so nothing else reaches it either.
+  const conversation = await prisma.conversation.create({
+    data: {
+      type: 'DIRECT',
+      directKey: [mentor.id, mentee.id].sort().join('|'),
+      participants: { create: [{ userId: mentor.id }, { userId: mentee.id }] },
+    },
+  });
+
+  const relationMessage = await prisma.message.create({
+    data: { relationId: relation.id, senderId: mentee.id, body: pii.message },
+  });
+  const conversationMessage = await prisma.message.create({
+    data: { conversationId: conversation.id, senderId: mentee.id, body: pii.conversationMessage },
+  });
+  await prisma.messageAttachment.createMany({
+    data: [relationMessage.id, conversationMessage.id].map((messageId) => ({
+      messageId,
+      filename: 'id-card.png',
+      contentType: 'image/png',
+      size: 3,
+      data: Buffer.from('png'),
+    })),
+  });
+  // The other side of the thread — must survive untouched, or the mentor's
+  // conversation turns into a blank page instead of a tombstoned one.
+  const mentorMessage = await prisma.message.create({
+    data: { conversationId: conversation.id, senderId: mentor.id, body: `noted, see you then (${tag})` },
+  });
+
+  // Support thread the person opened themselves. `SupportTicket.subject` is a
+  // verbatim copy of the first 80 characters of their own first message
+  // (src/app/api/support/route.ts), so it is PII too.
+  const ticket = await prisma.supportTicket.create({
+    data: { requesterId: mentee.id, subject: pii.supportSubject },
+  });
+  const supportMessage = await prisma.supportMessage.create({
+    data: { ticketId: ticket.id, senderId: mentee.id, body: pii.support },
+  });
+  await prisma.supportAttachment.create({
+    data: {
+      messageId: supportMessage.id,
+      filename: 'screenshot.png',
+      contentType: 'image/png',
+      size: 3,
+      data: Buffer.from('png'),
+    },
+  });
+
+  // A note the mentor took in a meeting with this mentee. Keyed to the note's
+  // AUTHOR, so no cascade from the subject ever reaches it; `meetingId` is the
+  // only link back to them — and it is `SetNull`, so it disappears the moment
+  // the relation (and with it the meeting) is deleted.
+  const meeting = await prisma.meeting.create({
+    data: {
+      relationId: relation.id,
+      title: `1:1 ${tag}`,
+      rsvpToken: crypto.randomBytes(24).toString('hex'),
+      createdById: mentor.id,
+    },
+  });
+  const meetingNote = await prisma.personalNote.create({
+    data: { userId: mentor.id, meetingId: meeting.id, category: 'MEETING', body: pii.meetingNote },
+  });
+  // The person's own private note.
+  await prisma.personalNote.create({ data: { userId: mentee.id, body: pii.ownNote } });
+
+  await prisma.relationNote.create({
+    data: { relationId: relation.id, authorId: mentor.id, body: pii.relationNote },
+  });
+  const interactionLog = await prisma.interactionLog.create({
+    data: {
+      relationId: relation.id,
+      date: new Date(),
+      type: 'Meeting',
+      subject: pii.interactionSubject,
+      notes: pii.interactionNotes,
+    },
+  });
+  await prisma.mentorshipRequest.create({ data: { menteeId: mentee.id, message: pii.request } });
+
+  return {
+    tag,
+    pii,
+    mentorEmail,
+    menteeEmail,
+    mentorId: mentor.id,
+    menteeId: mentee.id,
+    relationId: relation.id,
+    conversationId: conversation.id,
+    ticketId: ticket.id,
+    mentorMessageId: mentorMessage.id,
+    menteeMessageIds: [relationMessage.id, conversationMessage.id],
+    interactionLogId: interactionLog.id,
+    meetingNoteId: meetingNote.id,
+  };
+}
+
+async function cleanup(s: Seeded) {
+  // Conversation-layer messages are the one thing that outlives both the user
+  // and the conversation (`Conversation` → `Message` is SetNull), so they are
+  // removed by hand or the row leaks out of the test.
+  await prisma.messageAttachment.deleteMany({ where: { message: { conversationId: s.conversationId } } });
+  await prisma.message.deleteMany({ where: { conversationId: s.conversationId } });
+  await prisma.message.deleteMany({ where: { senderId: { in: [s.menteeId, s.mentorId] } } });
+  await prisma.conversation.deleteMany({ where: { id: s.conversationId } });
+  await prisma.personalNote.deleteMany({ where: { userId: { in: [s.menteeId, s.mentorId] } } });
+  await cleanupByEmail(s.menteeEmail);
+  await cleanupByEmail(s.mentorEmail);
+}
+
+/**
+ * The one question that matters, asked of the database rather than of the UI:
+ * does any seeded free-text string still exist anywhere?
+ *
+ * `MessageAttachment.data` / `SupportAttachment.data` are `Bytes` and cannot be
+ * searched, so those are asserted as row counts — the rows must be gone.
+ */
+async function expectNoFreeTextLeft(s: Seeded) {
+  const p = s.pii;
+  expect(await prisma.message.count({ where: { body: { contains: p.message } } })).toBe(0);
+  expect(await prisma.message.count({ where: { body: { contains: p.conversationMessage } } })).toBe(0);
+  expect(await prisma.messageAttachment.count({ where: { messageId: { in: s.menteeMessageIds } } })).toBe(0);
+  expect(await prisma.supportMessage.count({ where: { body: { contains: p.support } } })).toBe(0);
+  expect(await prisma.supportTicket.count({ where: { subject: { contains: p.supportSubject } } })).toBe(0);
+  expect(await prisma.supportAttachment.count({ where: { message: { senderId: s.menteeId } } })).toBe(0);
+  expect(await prisma.personalNote.count({ where: { body: { contains: p.meetingNote } } })).toBe(0);
+  expect(await prisma.personalNote.count({ where: { body: { contains: p.ownNote } } })).toBe(0);
+  expect(await prisma.relationNote.count({ where: { body: { contains: p.relationNote } } })).toBe(0);
+  expect(await prisma.interactionLog.count({ where: { notes: { contains: p.interactionNotes } } })).toBe(0);
+  expect(await prisma.interactionLog.count({ where: { subject: { contains: p.interactionSubject } } })).toBe(0);
+  expect(await prisma.mentorshipRequest.count({ where: { message: { contains: p.request } } })).toBe(0);
+  expect(await prisma.user.count({ where: { reEngageNote: { contains: p.reEngage } } })).toBe(0);
+}
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('anonymizing an account scrubs its messages, attachments, support thread and the notes about it', async ({
+  page,
+}) => {
+  const s = await seedPaperTrail('erase-anon');
+  try {
+    await anonymizeUser(s.menteeId);
+
+    await expectNoFreeTextLeft(s);
+
+    // The row survives — that is the point of anonymise — but nothing on it
+    // identifies anybody any more.
+    const user = await prisma.user.findUnique({ where: { id: s.menteeId } });
+    expect(user?.fullName).toBe('Erased candidate');
+    expect(user?.city).toBeNull();
+    expect(user?.country).toBeNull();
+    expect(user?.referralSource).toBeNull();
+    expect(user?.reEngageNote).toBeNull();
+
+    // Written by the person → tombstoned, not deleted: the row and its
+    // timestamp stay so the other side's thread keeps its shape, and
+    // `deletedForEveryoneAt` is exactly what the messages API masks on.
+    const messages = await prisma.message.findMany({ where: { id: { in: s.menteeMessageIds } } });
+    expect(messages).toHaveLength(2);
+    for (const m of messages) {
+      expect(m.body).toBe('');
+      expect(m.deletedForEveryoneAt).not.toBeNull();
+    }
+    // The other participant's own message is none of erasure's business.
+    const mentorMessage = await prisma.message.findUnique({ where: { id: s.mentorMessageId } });
+    expect(mentorMessage?.body).toContain(s.tag);
+    expect(mentorMessage?.deletedForEveryoneAt).toBeNull();
+
+    // Written ABOUT the person → the free text goes, the operational record
+    // (when it happened, what kind of interaction it was) stays.
+    const log = await prisma.interactionLog.findUnique({ where: { id: s.interactionLogId } });
+    expect(log).not.toBeNull();
+    expect(log?.notes).toBe('');
+    expect(log?.type).toBe('Meeting');
+    expect(log?.date).toBeInstanceOf(Date);
+    // Same for the mentor's meeting note: the row, its category and its dates
+    // survive; the prose does not.
+    const note = await prisma.personalNote.findUnique({ where: { id: s.meetingNoteId } });
+    expect(note?.body).toBe('');
+    expect(note?.category).toBe('MEETING');
+
+    // …and the conversation still renders for the other participant: the thread
+    // comes back with a tombstone, not a crash and not a blank thread.
+    await signInAndSettle(page, s.mentorEmail, PASSWORD, '/mentor');
+    const res = await page.request.get(`/api/messages?conversationId=${s.conversationId}`);
+    expect(res.ok()).toBeTruthy();
+    const payload = (await res.json()) as {
+      messages: { id: string; body: string; deleted: boolean; attachments: unknown[] }[];
+    };
+    expect(payload.messages).toHaveLength(2);
+    const erased = payload.messages.find((m) => s.menteeMessageIds.includes(m.id));
+    expect(erased?.deleted).toBe(true);
+    expect(erased?.body).toBe('');
+    expect(erased?.attachments).toEqual([]);
+    expect(payload.messages.find((m) => m.id === s.mentorMessageId)?.body).toContain(s.tag);
+  } finally {
+    await cleanup(s);
+  }
+});
+
+test('hard-deleting an account leaves none of its free text behind, including what others wrote about it', async () => {
+  const s = await seedPaperTrail('erase-hard');
+  try {
+    await hardDeleteUser(s.menteeId);
+
+    expect(await prisma.user.count({ where: { id: s.menteeId } })).toBe(0);
+    await expectNoFreeTextLeft(s);
+
+    // The relation cascade takes the relation-bound message, the interaction
+    // log and the relation note with it. The conversation-layer message has no
+    // FK to either the user or the relation, so only the explicit tombstone
+    // reaches it — it is still there, and it is empty.
+    const surviving = await prisma.message.findMany({ where: { conversationId: s.conversationId } });
+    expect(surviving.some((m) => m.senderId === s.menteeId && m.body === '')).toBe(true);
+    expect(surviving.find((m) => m.id === s.mentorMessageId)?.body).toContain(s.tag);
+
+    // The mentor's meeting note outlives the meeting (`meetingId` is SetNull),
+    // which is precisely why it has to be scrubbed BEFORE the relation goes:
+    // afterwards nothing links it to the person any more.
+    const note = await prisma.personalNote.findUnique({ where: { id: s.meetingNoteId } });
+    expect(note?.body).toBe('');
+  } finally {
+    await cleanup(s);
+  }
+});

--- a/releases/unreleased/erasure-scrubs-free-text.json
+++ b/releases/unreleased/erasure-scrubs-free-text.json
@@ -1,0 +1,15 @@
+{
+  "bump": "patch",
+  "changelog": "- **Erasure now actually erases the free text** (#2052). `anonymizeUser()` / `hardDeleteUser()` rewrote the `User` row and deleted the uploaded files, and left every free-text field the person had ever typed — and everything typed about them — in place: `Message.body` + `MessageAttachment`, `SupportMessage.body` + `SupportAttachment`, `SupportTicket.subject` (a verbatim copy of the requester's first message), `PersonalNote.body`, `RelationNote.body`, `InteractionLog.notes`/`subject`, `MentorshipRequest.message`, plus `country`, `referralSource` and `reEngageNote` on the very row being anonymised. Two rules, documented in the file header: content the person **wrote** is tombstoned (body emptied, attachment rows deleted, the row kept — reusing the existing `Message.deletedForEveryoneAt` masking so the counterpart's thread still reads as a conversation), content written **about** them is scrubbed with the row's dates, types and stage intact. Both paths keep it in one `$transaction`; the hard-delete path scrubs *before* it deletes the relations, because `PersonalNote.meetingId` is `SetNull` and the note would otherwise survive with its text intact and its only link to the subject gone. No schema change. `Message.senderId` has no FK to `User`, so a conversation-layer message used to outlive the account entirely. Remaining surfaces are named in a `KNOWN GAPS` comment and tracked in #2106; `e2e/erasure-free-text.spec.ts` seeds a full paper trail, runs both paths and queries Prisma directly for the seeded strings.",
+  "notes": {
+    "en": [
+      "Deleting or anonymising an account now also erases the messages, attachments, support conversations and notes attached to it — not just the profile."
+    ],
+    "tr": [
+      "Bir hesabı silmek ya da anonimleştirmek artık yalnızca profili değil, hesaba bağlı mesajları, ekleri, destek konuşmalarını ve notları da temizliyor."
+    ],
+    "de": [
+      "Beim Löschen oder Anonymisieren eines Kontos werden jetzt auch die zugehörigen Nachrichten, Anhänge, Support-Unterhaltungen und Notizen gelöscht — nicht nur das Profil."
+    ]
+  }
+}

--- a/src/lib/accountErasure.ts
+++ b/src/lib/accountErasure.ts
@@ -1,3 +1,4 @@
+import type { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 
 // Shared erasure logic (EPIC: GDPR data retention). Two modes:
@@ -7,6 +8,11 @@ import { prisma } from '@/lib/prisma';
 // - anonymizeUser: keeps the row (and its relations/audit trail intact for
 //   analytics) but scrubs PII and removes uploaded file bytes. Preferred when
 //   the candidate's history should stay visible to the org.
+//
+// Both modes stay MANUAL and admin-initiated (the double-gated admin endpoint,
+// or the account holder's own DELETE /api/account). Nothing in
+// src/lib/retention.ts erases on a timer — that is a deliberate product
+// decision, recorded in docs/pii-access-lifecycle.md.
 
 // The delivery log (#1194) is keyed by recipient address, not by user id, so
 // neither erasure path reaches it through a relation — it has to be cleared
@@ -27,8 +33,114 @@ async function forgetEmailLog(userId: string): Promise<void> {
   await prisma.newsletterSend.deleteMany({ where: { OR: [{ email: user.email }, { userId }] } });
 }
 
+// ── Free text: what each surface gets, and why (#2052) ───────────────────────
+//
+// Rewriting the `User` row is not erasure. Everything the person ever typed —
+// and everything typed about them — lives in other tables, most of them with no
+// FK to `User` at all, so no cascade and no `user.update` reaches it. Two
+// different rules, because "anonymise" means different things per surface:
+//
+// 1. Content the person WROTE is TOMBSTONED, not deleted: the body is emptied
+//    and the attachment rows are dropped, but the row survives. This reuses the
+//    existing "delete for everyone" mechanism (`Message.deletedForEveryoneAt`,
+//    src/app/api/messages/[id]/route.ts) so the other participant's thread
+//    still reads as a conversation with a "message deleted" placeholder instead
+//    of silently losing half its turns.
+//      Message.body + MessageAttachment, SupportMessage.body +
+//      SupportAttachment, SupportTicket.subject (copied verbatim from the first
+//      80 characters of the requester's own first message — scrubbing the body
+//      and leaving the subject would erase nothing), MentorshipRequest.message,
+//      and the person's own PersonalNote rows (private to them, nobody else's
+//      view depends on them, so those are deleted outright).
+//
+// 2. Content written ABOUT them is SCRUBBED: the free text goes, the row and
+//    its dates/types/stage stay. Those columns are the organisation's
+//    operational history and carry no PII once the prose is gone.
+//      InteractionLog.notes + subject, RelationNote.body, and any PersonalNote
+//      taken in a meeting that belongs to them.
+//
+// Scope of "about them": relation-scoped free text is scrubbed on relations
+// where the erased person is the MENTEE — the relation whose subject they are.
+// On a relation where they were the *mentor*, the same columns are a third
+// party's record and erasing them would delete someone else's history; a hard
+// delete removes those relations wholesale through the cascade anyway.
+// `PersonalNote` is keyed to its *author*, never to the subject, so it is
+// reached through `meetingId` → the meeting's relation (mentee = this person)
+// or its DIRECT (1:1) conversation with them.
+//
+// KNOWN GAPS — deliberately not silent, tracked in #2106:
+//   - a free-standing `PersonalNote` (`meetingId: null`) has no link to any
+//     subject at all; there is no query that can tell a note about this person
+//     from a note about anyone else, so it is left alone here.
+//   - notes taken in a GROUP-conversation or project meeting the person
+//     attended: the note is about the meeting, not about them.
+//   - the remaining per-person free text inventoried in the header of
+//     scripts/sanitize-db.mjs (Evaluation.comment/publicExcerpt,
+//     WeeklyReport.summary/blockers/mentorComment, MentorQuestion,
+//     MeetingRequest.topic, Goal.description, ProjectJoinRequest.message,
+//     CompanyInterest.note, InterviewRequest.note, Offer notes,
+//     StatusChange.reasonNote, Notification.text, ActivityLog/AuditLog detail).
+//     That script already lists every one of them; #2106 brings this function
+//     up to the same inventory. Anything added to the schema belongs in both.
+//
+// Emptying rather than nulling is forced by the schema: `Message.body`,
+// `SupportMessage.body`, `PersonalNote.body`, `RelationNote.body` and
+// `InteractionLog.notes` are all required columns, and an empty body is an
+// already-reachable, already-rendered state on every one of those surfaces
+// (an attachment-only support message, a tombstoned chat message). No schema
+// change — nothing here adds a column.
+function scrubFreeTextOps(userId: string, now: Date): Prisma.PrismaPromise<unknown>[] {
+  // Relations whose subject this person is. Nested filters (not a pre-read list
+  // of ids) so every statement stays inside the caller's $transaction.
+  const asSubject = { relation: { menteeId: userId } };
+  return [
+    // ── Content the person WROTE → tombstone ────────────────────────────────
+    // Attachments first: once the message row is masked there is no way back to
+    // its bytes, and `MessageAttachment` is reached only through the message.
+    prisma.messageAttachment.deleteMany({ where: { message: { senderId: userId } } }),
+    // `Message.senderId` has NO foreign key to `User` (see prisma/schema.prisma
+    // — the model declares `relation`, `conversation`, `attachments`,
+    // `hiddenFor` and `reactions`, but no `sender`), so a hard delete does not
+    // cascade here either: a conversation-layer message (`relationId: null`)
+    // outlives the account entirely. Already-tombstoned rows keep their own
+    // timestamp — re-stamping would rewrite when the sender deleted it.
+    prisma.message.updateMany({
+      where: { senderId: userId, deletedForEveryoneAt: null },
+      data: { body: '', deletedForEveryoneAt: now },
+    }),
+    prisma.supportAttachment.deleteMany({ where: { message: { senderId: userId } } }),
+    prisma.supportMessage.updateMany({ where: { senderId: userId }, data: { body: '' } }),
+    prisma.supportTicket.updateMany({ where: { requesterId: userId }, data: { subject: null } }),
+    // The person's own private notes: theirs alone, so deleted rather than kept
+    // as an empty row. (A hard delete cascades these; anonymise does not.)
+    prisma.personalNote.deleteMany({ where: { userId } }),
+    // The mentee's own words in their self-serve mentorship request.
+    prisma.mentorshipRequest.updateMany({ where: { menteeId: userId }, data: { message: null } }),
+
+    // ── Content written ABOUT the person → scrub, keep the row ──────────────
+    prisma.interactionLog.updateMany({ where: asSubject, data: { notes: '', subject: null } }),
+    prisma.relationNote.updateMany({ where: asSubject, data: { body: '' } }),
+    prisma.personalNote.updateMany({
+      where: {
+        OR: [
+          { meeting: { relation: { menteeId: userId } } },
+          { meeting: { conversation: { type: 'DIRECT', participants: { some: { userId } } } } },
+        ],
+      },
+      data: { body: '' },
+    }),
+  ];
+}
+
 export async function hardDeleteUser(userId: string): Promise<void> {
   await forgetEmailLog(userId);
+  // BEFORE the relations go: deleting a relation cascades to its meetings, and
+  // `PersonalNote.meetingId` is SetNull — so a note taken in this person's
+  // meeting would survive with its text intact and its only link to them
+  // nulled, unreachable by any later query (#2052). One $transaction so a
+  // partial scrub cannot happen; the deletes below keep their existing failure
+  // mode (an FK that neither cascades nor is detached).
+  await prisma.$transaction(scrubFreeTextOps(userId, new Date()));
   await prisma.mentorshipRelation.deleteMany({ where: { OR: [{ mentorId: userId }, { menteeId: userId }] } });
   await prisma.statusChange.deleteMany({ where: { changedById: userId } });
   // Optional references without a DB-level cascade (FK restrict) would abort
@@ -51,6 +163,11 @@ export async function anonymizeUser(userId: string): Promise<void> {
     prisma.cvFile.deleteMany({ where: { userId } }),
     prisma.avatarFile.deleteMany({ where: { userId } }),
     prisma.document.deleteMany({ where: { ownerId: userId } }),
+    // Every free-text surface outside the User row — see scrubFreeTextOps. This
+    // is the half that used to be missing: the row claimed to be anonymous
+    // while the person's messages, their support thread and the notes written
+    // about them sat untouched next to it.
+    ...scrubFreeTextOps(userId, new Date()),
     // Revoke consents — nothing left to process on their behalf.
     prisma.userConsent.updateMany({ where: { userId }, data: { revokedAt: new Date() } }),
     prisma.user.update({
@@ -61,6 +178,11 @@ export async function anonymizeUser(userId: string): Promise<void> {
         phone: null,
         whatsapp: null,
         city: null,
+        // country and referralSource sit on the very row this rewrites and are
+        // as identifying as the rest of it (scripts/sanitize-db.mjs treats all
+        // three as PII); they were simply missed.
+        country: null,
+        referralSource: null,
         birthDate: null,
         university: null,
         department: null,
@@ -73,6 +195,10 @@ export async function anonymizeUser(userId: string): Promise<void> {
         portfolioUrl: null,
         interests: null,
         targetPosition: null,
+        // Free text an admin wrote about this person ("call them in September,
+        // they said …"). The re-engagement promise is void once the account is
+        // erased, so the note goes with it.
+        reEngageNote: null,
         skills: [],
         skillLevels: {},
         publicProfile: false,


### PR DESCRIPTION
## Summary

`anonymizeUser()` rewrote the `User` row, deleted the uploaded files, and stopped. Every
free-text field the person had ever typed — and everything typed **about** them — stayed in
the database under a row that claimed to be anonymous: message bodies and their attachment
bytes, the support conversation they opened (including `SupportTicket.subject`, which is a
verbatim copy of the first 80 characters of their own first message), the mentor's notes
about them, and the interaction log of every call. A data-subject request we cannot actually
fulfil is a live compliance defect, so this is a fix.

`hardDeleteUser()` was narrower but not clean either:

- `Message.senderId` has **no foreign key to `User`** (the model declares `relation`,
  `conversation`, `attachments`, `hiddenFor`, `reactions` — no `sender`), so a
  conversation-layer message (`relationId: null`) outlived the account entirely;
- a `PersonalNote` taken in the person's meeting survived the relation cascade with its text
  intact and its only link to them nulled — `PersonalNote.meetingId` is `SetNull`, so after
  the relation goes no query can ever find it again.

Closes #2052

## Changes

**Two rules, written down in the `accountErasure.ts` header next to the existing rationale:**

| | content the person **wrote** | content written **about** them |
|---|---|---|
| what happens | **tombstoned** — body emptied, attachment rows deleted, **row kept** | **scrubbed** — free text goes, the row's dates/types/stage stay |
| why | reuses the existing `Message.deletedForEveryoneAt` masking, so the counterpart's thread still reads as a conversation with a "message deleted" placeholder instead of silently losing half its turns | dates, types and stages are the org's operational history and carry no PII once the prose is gone |
| surfaces | `Message.body` + `MessageAttachment`, `SupportMessage.body` + `SupportAttachment`, `SupportTicket.subject`, `MentorshipRequest.message`, the person's own `PersonalNote` rows (private to them → deleted outright) | `InteractionLog.notes`/`subject`, `RelationNote.body`, `PersonalNote.body` for notes taken in one of their meetings |

- "About them" is scoped to relations where the erased person is the **mentee** — on a
  relation where they were the *mentor* those columns are a third party's record, and a hard
  delete removes those relations wholesale through the cascade anyway. `PersonalNote` is
  keyed to its **author**, never to the subject, so it is reached through `meetingId` → the
  meeting's relation, or its `DIRECT` (1:1) conversation with them.
- Both paths keep the work in **one `$transaction`**, and the hard-delete path runs it
  **before** the relation deletes, for the `SetNull` reason above.
- Also nulls three columns the anonymise path simply missed on the row it already rewrites:
  `country`, `referralSource`, `reEngageNote`.
- **No schema change** — emptying (`''`) rather than nulling is forced by the schema
  (`Message.body`, `SupportMessage.body`, `PersonalNote.body`, `RelationNote.body`,
  `InteractionLog.notes` are required columns), and an empty body is an already-reachable,
  already-rendered state on all of them (an attachment-only support message, a tombstoned
  chat message).
- Erasure stays **manual and admin-initiated**; nothing here touches `src/lib/retention.ts`.
- `docs/pii-access-lifecycle.md` gains a "Silme ne kadarına ulaşıyor (#2052)" section: the
  two rules, the ordering constraint, the gaps, and the two-way rule that a new free-text
  column must land in **both** `scripts/sanitize-db.mjs`'s inventory and this function.

**No silent gap.** What erasure still does not reach is named in a `KNOWN GAPS` comment in
the file and tracked in **#2106** (filed as part of this work): a free-standing
`PersonalNote` (`meetingId: null`) has no link to any subject at all — no query can tell a
note about this person from a note about anybody else — notes taken in a group/project
meeting, and the remaining per-person free text already inventoried in
`scripts/sanitize-db.mjs` (evaluations, weekly reports, goal descriptions, offer/interview
notes, notification text, audit-log detail). Most of those cascade on a hard delete and
survive anonymise, which is the mode the account page advertises as the gentler one.

**Proof spec** — `e2e/erasure-free-text.spec.ts` (not `@smoke`; slow and not a
runtime-critical path). Seeds a mentee with a relation, a legacy relation message *and* a
conversation-layer message (each with an attachment), a support ticket + message +
attachment, the mentor's `PersonalNote` on a meeting, the mentee's own note, a
`RelationNote`, an `InteractionLog` and a `MentorshipRequest`, then runs **both** paths and
asks Prisma directly whether any seeded string survives. It also asserts the positives: the
tombstoned rows still exist with `deletedForEveryoneAt` set, the interaction log keeps its
date and type, the counterpart's own message is untouched — and it signs in as the mentor
and checks `GET /api/messages?conversationId=…` returns `deleted: true` with an empty body
and no attachments, i.e. the thread renders as a tombstone rather than a crash or a blank
page.

## Verification

- [x] `npm run lint` + `npx tsc --noEmit` clean (lint: only the three pre-existing warnings
      on untouched files)
- [x] `npm run build` passes
- [x] `npm run check:i18n` (3490 keys × 3 locales) and `npm run check:release-fragments`
      pass — this change ships as `0.128.4-beta`
- [x] Added an e2e test — **both new tests actually executed and passed locally**
      (apt MariaDB in the container + `prisma db push`, Playwright with an
      `executablePath` override for the browser build present here):
      `2 passed (36.2s)`
- [x] Neighbouring specs run locally and green: `candidate-erasure` (2/2),
      `admin-user-erase`, `email-hardening` (which calls `hardDeleteUser`),
      `account-self-service` (3/3, including the self-service delete)
- [ ] `npx prisma validate` — **not run**, and not needed: no schema change
- [ ] Full `npm run test:e2e` — **not run** (only the specs listed above). CI must confirm
      the rest.

One caveat, honestly: in a batched local run `e2e/gdpr-retention.spec.ts:52` failed on a
`page.waitForURL` sign-in timeout. I re-ran it **with my change reverted** and it failed the
same way, so it is environmental/pre-existing in this container, not a regression;
`candidate-erasure.spec.ts:56` failed in that same batch and passes standalone. Neither
touches the erasure code path this PR changes.

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JgY7mKwLmq9KdtnBFYYQu3

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgY7mKwLmq9KdtnBFYYQu3)_