### PR TITLE
fix(ci): authenticate git ls-remote in the deploy gate step

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -108,7 +108,15 @@ jobs:
           EVENT: ${{ github.event_name }}
           REF: ${{ inputs.ref || 'main' }}
           HEALTH_URL: http://127.0.0.1:3201/api/health
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Same inline credential helper as the fetch step above — `git
+          # ls-remote` below hit GitHub's unauthenticated-request rate limit
+          # under heavy concurrent runner load ("could not read Username for
+          # 'https://github.com'"), which failed the gate before it ever got
+          # to the health check.
+          HELPER='!f() { echo "username=x-access-token"; echo "password=$GH_TOKEN"; }; f'
+
           # Resolve the exact commit to deploy. Everything downstream (the image
           # tag, the GIT_SHA baked into it, the container that ends up running) is
           # pinned to this one sha so the build and the deploy cannot disagree.
@@ -118,11 +126,11 @@ jobs:
           # top of it (the regression #794 fixed for prod). Asking the remote also
           # beats trusting a local ref — this workspace is shared and shallow.
           if [ "$EVENT" = workflow_dispatch ]; then
-            SHA="$(git ls-remote origin "refs/heads/$REF" | cut -f1)"
-            [ -n "$SHA" ] || SHA="$(git ls-remote origin "refs/tags/$REF" | cut -f1)"
+            SHA="$(git -c credential.helper="$HELPER" ls-remote origin "refs/heads/$REF" | cut -f1)"
+            [ -n "$SHA" ] || SHA="$(git -c credential.helper="$HELPER" ls-remote origin "refs/tags/$REF" | cut -f1)"
             [ -n "$SHA" ] || SHA="$REF"   # not a branch or tag — assume a raw sha
           else
-            SHA="$(git ls-remote origin refs/heads/main | cut -f1)"
+            SHA="$(git -c credential.helper="$HELPER" ls-remote origin refs/heads/main | cut -f1)"
           fi
           [ -n "$SHA" ] || { echo "could not resolve '$REF'" >&2; exit 1; }
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -116,7 +116,15 @@ jobs:
           EVENT: ${{ github.event_name }}
           REF: ${{ inputs.ref || 'main' }}
           HEALTH_URL: http://127.0.0.1:3200/api/health
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Same inline credential helper as the fetch step above — `git
+          # ls-remote` below hit GitHub's unauthenticated-request rate limit
+          # under heavy concurrent runner load ("could not read Username for
+          # 'https://github.com'"), which failed the gate before it ever got
+          # to the health check.
+          HELPER='!f() { echo "username=x-access-token"; echo "password=$GH_TOKEN"; }; f'
+
           # Resolve the exact commit to deploy. Everything downstream (the image
           # tag, the GIT_SHA baked into it, the forward-only guard) is pinned to
           # this one sha so the build and the deploy can never disagree.
@@ -126,11 +134,11 @@ jobs:
           # top of it (the regression #794 fixed for prod). Asking the remote also
           # beats trusting a local ref — this workspace is shared and shallow.
           if [ "$EVENT" = workflow_dispatch ]; then
-            SHA="$(git ls-remote origin "refs/heads/$REF" | cut -f1)"
-            [ -n "$SHA" ] || SHA="$(git ls-remote origin "refs/tags/$REF" | cut -f1)"
+            SHA="$(git -c credential.helper="$HELPER" ls-remote origin "refs/heads/$REF" | cut -f1)"
+            [ -n "$SHA" ] || SHA="$(git -c credential.helper="$HELPER" ls-remote origin "refs/tags/$REF" | cut -f1)"
             [ -n "$SHA" ] || SHA="$REF"   # not a branch or tag — assume a raw sha
           else
-            SHA="$(git ls-remote origin refs/heads/main | cut -f1)"
+            SHA="$(git -c credential.helper="$HELPER" ls-remote origin refs/heads/main | cut -f1)"
           fi
           [ -n "$SHA" ] || { echo "could not resolve '$REF'" >&2; exit 1; }
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

<!-- What does this change and why? -->

`deploy-prod.yml` and `deploy-preview.yml`'s gate job resolves the target commit with a bare `git ls-remote origin refs/heads/main`, unlike the preceding "Fetch the repo" step which passes an inline credential helper on every git network call. Under heavy concurrent self-hosted-runner load (many simultaneous `Topic Preview` per-PR jobs), this unauthenticated call hit GitHub's anonymous git-protocol rate limit and failed with:

```
fatal: could not read Username for 'https://github.com': No such device or address
fatal: expected flush after ref listing
could not resolve 'main'
```

That failed the gate step itself (before it even reached the health-check curl), which skipped the `build`/`deploy` jobs entirely. 5 consecutive `deploy-prod` runs failed this way starting 10:37 UTC today, so none of the last 5 merges to `main` reached production or preview.

Closes #2117

## Changes

- `deploy-prod.yml`: pass `GH_TOKEN` into the "Decide whether a deploy is needed" step's env, rebuild the same inline credential helper used by the fetch step, and use it on both `git ls-remote` invocations (the `workflow_dispatch` branch/tag lookup and the push-event `refs/heads/main` lookup).
- `deploy-preview.yml`: identical fix, same step.

## Verification

- [x] `python3 -c "import yaml; yaml.safe_load(open(...))"` — both files parse as valid YAML.
- [x] Diffed against the working "Fetch the repo" step's credential-helper pattern to confirm the fix is a straight reuse, not a new mechanism.
- [ ] Could not fully reproduce end-to-end (would need a self-hosted runner under the same concurrent load), so I have **not seen this pass on the actual self-hosted runner** — the next real `push`-to-`main`-triggered gate run is the real test. If it still fails, the failure mode will be different from the one this fixes (auth is no longer the blocker).
- [ ] `npm run lint` / `tsc` not applicable — this only touches `.github/workflows/*.yml`, no `src/` changes.

No `releases/unreleased/*.json` fragment — this is a pure CI/infra change per CLAUDE.md.

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bHN1aj4vW37mdu5Anckbu

---
_Generated by [Claude Code](https://claude.ai/code/session_016bHN1aj4vW37mdu5Anckbu)_