### PR TITLE
feat(demo): seed weekly reports, to-dos, mentor questions and document requirements (#2062)

### DIFF
--- a/prisma/seed-demo.mjs
+++ b/prisma/seed-demo.mjs
@@ -73,6 +73,139 @@ const COMPANIES = [
   { name: 'Demo Data GmbH', industry: 'Data & Analytics', size: '10-50', needs: [{ position: 'Data Engineer', count: 1, period: '2026 Fall' }] },
 ];
 
+// ---------------------------------------------------------------------------
+// The development / oversight half of the demo set (#2062): weekly reports,
+// to-dos, mentor questions and document requirements. Everything below hangs
+// off the mentors, mentees, relations and project created above rather than
+// inventing a parallel world.
+// ---------------------------------------------------------------------------
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Canonical Monday 00:00 UTC of the week `offsetWeeks` away from today — the
+ * same anchoring the app itself uses (`utcWeekStart`, src/lib/week.ts), which
+ * is what turns WeeklyReport's `@@unique([relationId, weekStart])` into the
+ * dedupe key for a re-run instead of a source of duplicates.
+ */
+function utcMonday(offsetWeeks = 0) {
+  const now = new Date();
+  const day = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  day.setUTCDate(day.getUTCDate() - ((day.getUTCDay() + 6) % 7) + offsetWeeks * 7);
+  return day;
+}
+
+// A weekly diary only makes sense once the internship is running.
+const REPORTING_STAGES = ['INTERNSHIP_IN_PROGRESS_450', 'INTERNSHIP_COMPLETED_490', 'HIREABLE_600', 'HIRED_660'];
+
+// One piece of work per interning relation, so four diaries do not read as four
+// copies of the same week. Indexed, not random — the seed stays deterministic.
+const REPORT_TOPICS = ['the reporting screen', 'the CSV export', 'the analytics dashboard', 'the notification centre'];
+
+// Three entries from the shared to-do pool, copied VERBATIM (title + all three
+// languages) from prisma/seed-goal-templates.mjs. That seeder fills the pool on
+// every prod deploy but is not part of the demo path — infra/server/demo-refresh.sh
+// and infra/server/topic-deploy.sh run seed.mjs + seed-demo.mjs and nothing else
+// — so without these three the demo has no shared template to hand out and the
+// "your mentor sent you this" rendering path (ProjectTask.templateId) is dead.
+// The Turkish wording is the pool's dedupe key, so copying it verbatim means a
+// database where seed-goal-templates already ran gains nothing here.
+const SHARED_TASK_TEMPLATES = [
+  {
+    key: 'run-locally',
+    translations: {
+      tr: 'Projeyi yerelde çalıştır: depoyu klonla, kur ve ayağa kaldır',
+      en: 'Get the project running locally: clone, install, start it',
+      de: 'Das Projekt lokal zum Laufen bringen: klonen, installieren, starten',
+    },
+  },
+  {
+    key: 'weekly-note',
+    translations: {
+      tr: 'Haftalık ilerleme notunu yaz ve mentoruna gönder',
+      en: 'Write your weekly progress note and send it to your mentor',
+      de: 'Den wöchentlichen Fortschrittsbericht schreiben und an den Mentor senden',
+    },
+  },
+  {
+    key: 'find-a-bug',
+    translations: {
+      tr: 'Bir hata (bug) bul ve nasıl tekrar edildiğini adım adım yaz',
+      en: 'Find a bug and write down the steps to reproduce it',
+      de: 'Einen Bug finden und die Schritte zum Reproduzieren aufschreiben',
+    },
+  },
+];
+
+// What the demo organisation asks every intern for. `labels` carries all three
+// languages because that JSON shape is how the app renders a requirement per
+// reader (src/lib/documentRequirements.ts). `appliesToStage` must be a real
+// pipeline-stage key (src/lib/pipeline.ts).
+const DOCUMENT_REQUIREMENTS = [
+  {
+    key: 'demo-internship-agreement',
+    order: 0,
+    appliesToStage: null,
+    labels: { en: 'Internship agreement (demo)', tr: 'Staj sözleşmesi (demo)', de: 'Praktikumsvertrag (Demo)' },
+  },
+  {
+    key: 'demo-insurance-form',
+    order: 1,
+    appliesToStage: null,
+    labels: { en: 'Accident insurance form (demo)', tr: 'Kaza sigortası formu (demo)', de: 'Unfallversicherungsformular (Demo)' },
+  },
+  {
+    key: 'demo-university-approval',
+    order: 2,
+    appliesToStage: 'INTERNSHIP_STARTING_300',
+    labels: { en: 'University approval letter (demo)', tr: 'Üniversite onay yazısı (demo)', de: 'Genehmigungsschreiben der Universität (Demo)' },
+  },
+  {
+    key: 'demo-final-report',
+    order: 3,
+    appliesToStage: 'INTERNSHIP_COMPLETED_490',
+    labels: { en: 'Final internship report (demo)', tr: 'Staj bitirme raporu (demo)', de: 'Abschlussbericht des Praktikums (Demo)' },
+  },
+];
+
+/**
+ * A real, openable one-page PDF built from a few lines of synthetic text.
+ *
+ * Document.data is required bytes, and the app both sniffs the magic bytes on
+ * upload (`contentMatchesType`, src/lib/fileType.ts) and hands the bytes back
+ * on download — so a `Buffer.from('%PDF-1.4')` stub would satisfy the column
+ * and then fail to open in front of whoever clicked it. Hand-rolled rather than
+ * pulled from pdf-lib to keep the seeder's dependencies at prisma + bcryptjs,
+ * and byte-for-byte deterministic: same text in, same bytes out, every run.
+ *
+ * The page uses the standard Helvetica font, so `lines` must be plain ASCII:
+ * anything outside it is dropped rather than drawn as a stray glyph.
+ */
+function demoPdf(lines) {
+  const escape = (value) => value.replace(/[^\x20-\x7e]/g, '').replace(/([\\()])/g, '\\$1');
+  const stream = `${lines
+    .map((line, index) => `BT /F1 12 Tf 72 ${700 - index * 18} Td (${escape(line)}) Tj ET`)
+    .join('\n')}\n`;
+  const objects = [
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>',
+    `<< /Length ${Buffer.byteLength(stream, 'latin1')} >>\nstream\n${stream}endstream`,
+    '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
+  ];
+  let body = '%PDF-1.4\n';
+  const offsets = [];
+  objects.forEach((object, index) => {
+    offsets.push(Buffer.byteLength(body, 'latin1'));
+    body += `${index + 1} 0 obj\n${object}\nendobj\n`;
+  });
+  const startxref = Buffer.byteLength(body, 'latin1');
+  body += `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`;
+  for (const offset of offsets) body += `${String(offset).padStart(10, '0')} 00000 n \n`;
+  body += `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${startxref}\n%%EOF\n`;
+  return Buffer.from(body, 'latin1');
+}
+
 async function upsertUser({ email, fullName, role, extra = {} }) {
   const existing = await prisma.user.findUnique({ where: { email } });
   if (existing) return existing;
@@ -226,6 +359,304 @@ async function main() {
     await prisma[model].updateMany({ where: { orgId: null }, data: { orgId: defaultOrg.id } });
   }
   console.log('backfilled default org onto demo rows');
+
+  // ---------------------------------------------------------------------------
+  // Development / oversight half (#2062): weekly reports, to-dos, mentor
+  // questions and document requirements. Until now these four screens seeded
+  // zero rows, so the oversight story we tell a coordinator — "you see a weekly
+  // report from every intern, the documents they still owe you, the questions
+  // they asked and the to-dos they are working through" — was four empty
+  // screens on every demo and per-PR environment.
+  //
+  // Deliberately placed AFTER the org backfill above: WeeklyReport.orgId and
+  // DocumentRequirement.orgId are REQUIRED columns, and the relations and users
+  // they read that id from only acquire theirs a few lines up.
+  // ---------------------------------------------------------------------------
+
+  const demoRelations = await prisma.mentorshipRelation.findMany({
+    where: { mentee: { email: { endsWith: `@${DEMO_DOMAIN}` } } },
+    select: { id: true, orgId: true, mentorId: true, menteeId: true, pipelineStatus: true, mentee: { select: { email: true } } },
+    // Ordered by e-mail, not by date: `startDate` is derived from the wall
+    // clock, and the content below is picked per index, so a stable order is
+    // what keeps two runs on two machines identical.
+    orderBy: { mentee: { email: 'asc' } },
+  });
+  const relationOf = (localPart) => demoRelations.find((relation) => relation.mentee.email === `${localPart}@${DEMO_DOMAIN}`);
+
+  // Weekly reports — three consecutive weeks for every relation whose
+  // internship has actually started: last-but-one reviewed and approved with a
+  // mentor comment, last week either awaiting review or sent back for changes,
+  // and this week still a draft. Monday-anchored, so the unique key makes a
+  // re-run a no-op.
+  const reportingRelations = demoRelations.filter((relation) => REPORTING_STAGES.includes(relation.pipelineStatus));
+  let reportsCreated = 0;
+  for (let index = 0; index < reportingRelations.length; index++) {
+    const relation = reportingRelations[index];
+    const topic = REPORT_TOPICS[index % REPORT_TOPICS.length];
+    const weeks = [
+      {
+        weekStart: utcMonday(-2),
+        summary: `Paired with my mentor on ${topic} and opened two pull requests. (demo)`,
+        hoursSpent: 36,
+        blockers: null,
+        status: 'APPROVED',
+        mentorComment: 'Solid week — keep the pull request descriptions this detailed. (demo)',
+        reviewed: true,
+      },
+      index % 2 === 0
+        ? {
+            weekStart: utcMonday(-1),
+            summary: `Built ${topic}, wrote its first tests and sat in on a code review. (demo)`,
+            hoursSpent: 32,
+            blockers: 'Not sure yet how to test the e-mail path. (demo)',
+            status: 'SUBMITTED',
+            mentorComment: null,
+            reviewed: false,
+          }
+        : {
+            weekStart: utcMonday(-1),
+            summary: `Finished ${topic} and started on the filters. (demo)`,
+            hoursSpent: 30,
+            blockers: null,
+            status: 'CHANGES_REQUESTED',
+            mentorComment: 'Add what you took away from the code review and I will sign this off. (demo)',
+            reviewed: true,
+          },
+      {
+        weekStart: utcMonday(0),
+        summary: `Notes so far: wrapping up ${topic}, then the print view. (demo)`,
+        hoursSpent: 8,
+        blockers: null,
+        status: 'DRAFT',
+        mentorComment: null,
+        reviewed: false,
+      },
+    ];
+    for (const week of weeks) {
+      const existing = await prisma.weeklyReport.findUnique({
+        where: { relationId_weekStart: { relationId: relation.id, weekStart: week.weekStart } },
+        select: { id: true },
+      });
+      if (existing) continue;
+      await prisma.weeklyReport.create({
+        data: {
+          orgId: relation.orgId ?? defaultOrg.id,
+          relationId: relation.id,
+          weekStart: week.weekStart,
+          summary: week.summary,
+          hoursSpent: week.hoursSpent,
+          blockers: week.blockers,
+          status: week.status,
+          mentorComment: week.mentorComment,
+          reviewedById: week.reviewed ? relation.mentorId : null,
+          // The Tuesday after the week it reviews — clamped to now, so a review
+          // is never dated in the future when the seeder runs early in the week.
+          reviewedAt: week.reviewed ? new Date(Math.min(week.weekStart.getTime() + 8 * DAY_MS, Date.now())) : null,
+        },
+      });
+      reportsCreated++;
+    }
+  }
+  console.log(`weekly reports: ${reportsCreated} created (${reportingRelations.length} interning relations × 3 weeks)`);
+
+  // The shared to-do pool: the wording of a handed-out to-do is read from the
+  // template every time it is displayed, so the pool has to exist before the
+  // to-dos that reference it.
+  const templateIdByKey = new Map();
+  for (const template of SHARED_TASK_TEMPLATES) {
+    // Dedupe on `title` exactly as prisma/seed-goal-templates.mjs does: MySQL
+    // does not enforce @@unique([projectId, title]) across NULL projectIds.
+    let row = await prisma.projectTaskTemplate.findFirst({
+      where: { projectId: null, title: template.translations.tr },
+      select: { id: true },
+    });
+    if (!row) {
+      row = await prisma.projectTaskTemplate.create({
+        data: { projectId: null, title: template.translations.tr, translations: template.translations },
+        select: { id: true },
+      });
+    }
+    templateIdByKey.set(template.key, row.id);
+  }
+
+  // To-dos (/todos). One row shape covers three cases and all three are here:
+  // a project goal nobody has taken, a to-do a mentor handed over, and a line
+  // somebody wrote for themselves. Two come from the shared pool (`templateId`
+  // set), which is what makes them render in the reader's own language.
+  // The project-scoped ones sit on Gizem's relation because that is the only
+  // relation the demo project is attached to (`projectId: i === 3` above).
+  const todoSpecs = [
+    { mentee: 'mentee.gizem', projectId: project.id, order: 3, done: false, author: 'mentor', title: 'Write the sprint demo script (demo)' },
+    { mentee: 'mentee.gizem', projectId: project.id, order: 4, done: true, author: 'mentor', templateKey: 'run-locally' },
+    { mentee: null, projectId: project.id, order: 5, done: false, author: 'mentor', title: 'Polish the analytics dashboard — anyone can take this (demo)' },
+    { mentee: 'mentee.hakan', projectId: null, order: 0, done: false, author: 'mentor', templateKey: 'weekly-note' },
+    { mentee: 'mentee.firat', projectId: null, order: 0, done: false, author: 'self', title: 'Ask about the internship paperwork (demo)' },
+    { mentee: 'mentee.firat', projectId: null, order: 1, done: true, author: 'mentor', templateKey: 'find-a-bug' },
+  ];
+  let todosCreated = 0;
+  for (const spec of todoSpecs) {
+    // An unassigned project goal (`mentee: null`) belongs to the project, not
+    // to a person, so it needs no relation to hang off.
+    const relation = spec.mentee ? relationOf(spec.mentee) : null;
+    if (spec.mentee && !relation) continue;
+    const templateId = spec.templateKey ? templateIdByKey.get(spec.templateKey) ?? null : null;
+    // The snapshot title the app would store: resolved once from the assignee's
+    // own language, which for a demo mentee (no preferredLanguage) is the
+    // default locale — English (src/lib/goalTemplates.ts).
+    const title = spec.templateKey
+      ? SHARED_TASK_TEMPLATES.find((template) => template.key === spec.templateKey).translations.en
+      : spec.title;
+    const assigneeId = relation ? relation.menteeId : null;
+    const existing = await prisma.projectTask.findFirst({
+      where: { projectId: spec.projectId, title, assigneeId },
+      select: { id: true },
+    });
+    if (existing) continue;
+    await prisma.projectTask.create({
+      data: {
+        projectId: spec.projectId,
+        title,
+        templateId,
+        assigneeId,
+        // Who wrote it, so "your mentor gave you this" and "you wrote this
+        // yourself" stay distinguishable. An unassigned project goal has no
+        // relation, so it is credited to the project's owner.
+        createdById: spec.author === 'self' ? assigneeId : (relation?.mentorId ?? mentors[0].id),
+        done: spec.done,
+        doneAt: spec.done ? new Date(Date.now() - 3 * DAY_MS) : null,
+        order: spec.order,
+      },
+    });
+    todosCreated++;
+  }
+  console.log(`to-dos: ${todosCreated} created (${todoSpecs.filter((spec) => spec.templateKey).length} from the shared pool)`);
+
+  // Mentor questions — the answered/unanswered split is the whole point of the
+  // model, so one relation carries both.
+  const questionSpecs = [
+    {
+      mentee: 'mentee.gizem',
+      question: 'How much detail should the blockers section of the weekly report have? (demo)',
+      answer: 'Enough that I can help without a follow-up question — one or two sentences per blocker. (demo)',
+    },
+    {
+      mentee: 'mentee.gizem',
+      question: 'Could we go through my pull request together before the sprint demo? (demo)',
+      answer: null,
+    },
+    {
+      mentee: 'mentee.firat',
+      question: 'Which documents do I need to hand in before the internship starts? (demo)',
+      answer: 'The internship agreement and the insurance form — both are listed on your documents page. (demo)',
+    },
+  ];
+  let questionsCreated = 0;
+  for (const spec of questionSpecs) {
+    const relation = relationOf(spec.mentee);
+    if (!relation) continue;
+    const existing = await prisma.mentorQuestion.findFirst({
+      where: { relationId: relation.id, question: spec.question },
+      select: { id: true },
+    });
+    if (existing) continue;
+    await prisma.mentorQuestion.create({
+      data: {
+        relationId: relation.id,
+        askedById: relation.menteeId,
+        question: spec.question,
+        answer: spec.answer,
+        answeredAt: spec.answer ? new Date(Date.now() - 2 * DAY_MS) : null,
+      },
+    });
+    questionsCreated++;
+  }
+  console.log(`mentor questions: ${questionsCreated} created (${questionSpecs.filter((spec) => spec.answer).length} answered)`);
+
+  // Document requirements + the documents that fulfil some of them. Completion
+  // is never stored on the requirement: it is derived from the documents that
+  // carry its id, so leaving two requirements unfulfilled is what makes the
+  // "still owed" half of the screen visible. `update: {}` on the upsert keeps
+  // whatever an admin changed on the demo.
+  const requirementIdByKey = new Map();
+  for (const requirement of DOCUMENT_REQUIREMENTS) {
+    const row = await prisma.documentRequirement.upsert({
+      where: { orgId_key: { orgId: defaultOrg.id, key: requirement.key } },
+      update: {},
+      create: {
+        orgId: defaultOrg.id,
+        key: requirement.key,
+        labels: requirement.labels,
+        appliesToStage: requirement.appliesToStage,
+        appliesToRole: 'MENTEE',
+        mandatory: true,
+        order: requirement.order,
+      },
+      select: { id: true },
+    });
+    requirementIdByKey.set(requirement.key, row.id);
+  }
+
+  const documentSpecs = [
+    {
+      mentee: 'mentee.gizem',
+      requirementKey: 'demo-internship-agreement',
+      type: 'CONTRACT',
+      title: 'Internship agreement (demo)',
+      filename: 'internship-agreement-demo.pdf',
+      uploader: 'self',
+    },
+    {
+      mentee: 'mentee.hakan',
+      requirementKey: 'demo-internship-agreement',
+      type: 'CONTRACT',
+      title: 'Internship agreement (demo)',
+      filename: 'internship-agreement-demo.pdf',
+      // Handed in on paper and scanned by the mentor — the other upload path.
+      uploader: 'mentor',
+    },
+    {
+      mentee: 'mentee.hakan',
+      requirementKey: 'demo-final-report',
+      type: 'OTHER',
+      title: 'Final internship report (demo)',
+      filename: 'final-internship-report-demo.pdf',
+      uploader: 'self',
+    },
+  ];
+  let documentsCreated = 0;
+  for (const spec of documentSpecs) {
+    const relation = relationOf(spec.mentee);
+    const requirementId = requirementIdByKey.get(spec.requirementKey);
+    if (!relation || !requirementId) continue;
+    const existing = await prisma.document.findFirst({
+      where: { ownerId: relation.menteeId, requirementId },
+      select: { id: true },
+    });
+    if (existing) continue;
+    const bytes = demoPdf([
+      spec.title,
+      'Synthetic demo document - contains no real personal data.',
+      `Demo CRM / ${spec.filename}`,
+    ]);
+    await prisma.document.create({
+      data: {
+        ownerId: relation.menteeId,
+        uploaderId: spec.uploader === 'self' ? relation.menteeId : relation.mentorId,
+        requirementId,
+        type: spec.type,
+        title: spec.title,
+        filename: spec.filename,
+        contentType: 'application/pdf',
+        size: bytes.length,
+        data: bytes,
+      },
+    });
+    documentsCreated++;
+  }
+  console.log(
+    `document requirements: ${DOCUMENT_REQUIREMENTS.length} in place, ${documentsCreated} document(s) created ` +
+    '(the insurance form and the university letter stay unfulfilled on purpose)'
+  );
 
   // Contributor terms (#1025, #1026). The demo set portrays projects that have
   // been running for a while, and someone who has been on a project for months

--- a/releases/unreleased/seed-demo-development-half.json
+++ b/releases/unreleased/seed-demo-development-half.json
@@ -1,0 +1,4 @@
+{
+  "bump": "patch",
+  "changelog": "- **Demo seed fills the development half** (#2062). `prisma/seed-demo.mjs` now creates weekly reports (reviewed, awaiting review, sent back and draft), to-dos (project goals, handed-over and personal, two from the shared `ProjectTaskTemplate` pool), mentor questions (answered and open) and trilingual `DocumentRequirement` rows with real one-page PDF `Document`s fulfilling some of them — so the weekly-report, to-do, question and document screens are no longer empty on the public demo and in per-PR environments. Idempotent (Monday-anchored `weekStart`, existence checks per row) and the non-local `DATABASE_URL` refusal is untouched."
+}


### PR DESCRIPTION
## Summary

The demo seed exists so every screen of the product shows real-looking data, but the *development half* — weekly reports, to-dos, mentor questions, document requirements — seeded zero rows. Those screens were empty on the public demo and in every per-PR topic environment, which is exactly where the product gets looked at.

`prisma/seed-demo.mjs` now creates, hanging off the existing demo mentors, mentees and relations rather than inventing a parallel set:

- **Weekly reports** in every state that matters: reviewed, awaiting review, sent back, and draft — so the reviewer&#39;s queue is not uniformly one colour.
- **To-dos** across all three origins: project goals, handed-over, and personal, including two drawn from the shared `ProjectTaskTemplate` pool.
- **Mentor questions**, answered and open.
- **Trilingual `DocumentRequirement` rows**, with real one-page PDF `Document`s fulfilling some but not all of them — a half-filled checklist reads like a real programme, a full one reads like fixture data.

Closes #2062

## Changes

- `prisma/seed-demo.mjs` — +431 lines, no existing lines touched
- `releases/unreleased/seed-demo-development-half.json` — `bump: patch`

## Determinism, idempotency and safety

- **Idempotent**: `weekStart` is Monday-anchored rather than derived from &#34;now&#34;, and every row goes through an existence check, so `npm run seed:demo` twice does not duplicate.
- **Deterministic**: no `Math.random()` anywhere in the diff (verified by grep over the added lines).
- **Safety guard untouched**: the non-local `DATABASE_URL` refusal from [`docs/DATA_ACCESS_POLICY.md`](docs/DATA_ACCESS_POLICY.md) is unchanged, so this cannot be pointed at preview or prod.
- No new synthetic email domains — nothing outside the existing `@demo.example.com` / `@sample.invalid` set.

The sibling `check:demo-fidelity` CI gate is **not** in this PR — that is issue #2063.

## Verification

- [x] `npm run lint` + `npx tsc --noEmit` clean
- [x] `npm run check:demo-blocklist` → *&#34;demo blocklist OK — 14 patterns, all matching live routes; 11 must-block routes all covered (216 API routes scanned)&#34;*
- [x] `npx prisma validate` → clean
- [x] Tested the change manually — **the seeder was executed against a real database, twice** (procedure and counts below)
- [ ] `npm run test:e2e` passing — not run here (the suite needs a booted app); CI runs the `@smoke` gate on this PR

### The seeder was run, twice — row counts unchanged

A local MariaDB was stood up in the dev container (apt MariaDB, no Docker daemon — the
procedure from `docs/security-audit-playbook.md`) and the seeder was executed for real:

```
mariadb -u root -e "CREATE DATABASE demoverify2062;"
export DATABASE_URL="mysql://demo:demopass@127.0.0.1:3306/demoverify2062"
npx prisma db push --accept-data-loss
npx prisma db seed        # first admin
npm run seed:demo         # run 1
npm run seed:demo         # run 2
```

Row counts after each run — **identical**, which is the acceptance criterion:

| Model | after run 1 | after run 2 |
|---|---|---|
| `WeeklyReport` | 12 | 12 |
| `ProjectTask` | 9 | 9 |
| `ProjectTaskTemplate` | 3 | 3 |
| `MentorQuestion` | 3 | 3 |
| `DocumentRequirement` | 4 | 4 |
| `Document` | 3 | 3 |

The second run reports `0 created` for every new block, rather than silently upserting over
existing rows:

```
run 1: weekly reports: 12 created … to-dos: 6 created … mentor questions: 3 created …
       document requirements: 4 in place, 3 document(s) created
run 2: weekly reports: 0 created  … to-dos: 0 created … mentor questions: 0 created …
       document requirements: 4 in place, 0 document(s) created
```

The safety guard was re-checked against the same build: a non-local `DATABASE_URL`
(`mysql://…@db.example.com/internship_crm`) still prints the refusal and **exits 1**.

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6d6Un93ZbLFB67tUdRmjC

---
_Generated by [Claude Code](https://claude.ai/code/session_01C6d6Un93ZbLFB67tUdRmjC)_