### PR TITLE
fix(security): gate tenant management behind a super-admin capability

### DIFF
--- a/e2e/admin-organizations.spec.ts
+++ b/e2e/admin-organizations.spec.ts
@@ -17,7 +17,10 @@ test.afterAll(async () => {
 
 test('admin creates an organization and it appears in the list', async ({ page }) => {
   const adminEmail = uniqueEmail('org-admin');
-  await seedUser(adminEmail, 'AdminPass123', 'ADMIN', 'Org Admin');
+  const admin = await seedUser(adminEmail, 'AdminPass123', 'ADMIN', 'Org Admin');
+  // Tenant management is super-admin only (#1535); a plain ADMIN is a tenant
+  // admin and is covered by the third test below.
+  await prisma.user.update({ where: { id: admin.id }, data: { isSuperAdmin: true } });
   const tag = Date.now();
   const orgName = `E2E Org ${tag}`;
   const orgSlug = `e2e-org-${tag}`;
@@ -164,5 +167,105 @@ test('non-admin cannot list or create organizations', async ({ page }) => {
     expect(create.status()).toBe(401);
   } finally {
     await cleanupByEmail(mentorEmail);
+  }
+});
+
+// Cross-tenant gate (#1535). The dangerous field here is the SAML signing
+// certificate: whoever can write it decides who may mint a login for that
+// tenant. Both directions are asserted — a tenant admin keeps their own
+// organisation, and is refused everything belonging to somebody else.
+test('a tenant admin can only reach their own organization', async ({ page }) => {
+  const tag = Date.now();
+  const ownSlug = `e2e-own-${tag}`;
+  const foreignSlug = `e2e-foreign-${tag}`;
+  createdSlugs.push(ownSlug, foreignSlug);
+
+  const own = await prisma.organization.create({ data: { slug: ownSlug, name: `Own Tenant ${tag}` } });
+  const foreign = await prisma.organization.create({
+    data: {
+      slug: foreignSlug,
+      name: `Foreign Tenant ${tag}`,
+      ssoProvider: 'saml',
+      ssoIssuer: 'https://foreign-idp.test/metadata',
+      ssoEntryPoint: 'https://foreign-idp.test/sso',
+      ssoCertificate: '-----BEGIN CERTIFICATE-----\nMIIBforeign\n-----END CERTIFICATE-----',
+    },
+  });
+
+  const adminEmail = uniqueEmail('tenant-admin');
+  const admin = await seedUser(adminEmail, 'TenantPass123', 'ADMIN', 'Tenant Admin');
+  // A plain tenant ADMIN: role ADMIN, orgId set, isSuperAdmin left at false.
+  await prisma.user.update({ where: { id: admin.id }, data: { orgId: own.id } });
+
+  try {
+    await signInAndSettle(page, adminEmail, 'TenantPass123', '/admin');
+
+    // GET returns exactly one row — their own — and says they are not a super admin.
+    const listed = await (await page.request.get('/api/admin/organizations')).json();
+    expect(listed.superAdmin).toBe(false);
+    expect(listed.organizations).toHaveLength(1);
+    expect(listed.organizations[0].id).toBe(own.id);
+
+    // Creating a tenant is refused.
+    const create = await page.request.post('/api/admin/organizations', {
+      data: { name: 'Sneaky Tenant', slug: `sneaky-${tag}` },
+    });
+    expect(create.status()).toBe(403);
+    expect(await prisma.organization.findUnique({ where: { slug: `sneaky-${tag}` } })).toBeNull();
+
+    // Their own organization is still editable.
+    const ownPatch = await page.request.patch('/api/admin/organizations', {
+      data: { id: own.id, brandName: 'Own Brand' },
+    });
+    expect(ownPatch.ok()).toBeTruthy();
+    expect((await prisma.organization.findUnique({ where: { id: own.id } }))?.brandName).toBe('Own Brand');
+
+    // The foreign tenant's SSO config is refused, and untouched afterwards.
+    const foreignPatch = await page.request.patch('/api/admin/organizations', {
+      data: {
+        id: foreign.id,
+        ssoEnabled: true,
+        ssoProvider: 'saml',
+        ssoIssuer: 'https://attacker.test/metadata',
+        ssoEntryPoint: 'https://attacker.test/sso',
+        ssoCertificate: '-----BEGIN CERTIFICATE-----\nMIIBattacker\n-----END CERTIFICATE-----',
+      },
+    });
+    expect(foreignPatch.status()).toBe(403);
+    const untouched = await prisma.organization.findUnique({ where: { id: foreign.id } });
+    expect(untouched?.ssoEntryPoint).toBe('https://foreign-idp.test/sso');
+    expect(untouched?.ssoCertificate).toContain('MIIBforeign');
+    expect(untouched?.ssoEnabled).toBe(false);
+
+    // An id that does not exist is also a 403, never a 404 — the response must
+    // not tell a foreign admin which organization ids are real.
+    const missing = await page.request.patch('/api/admin/organizations', {
+      data: { id: 'no-such-org-id', brandName: 'Nope' },
+    });
+    expect(missing.status()).toBe(403);
+
+    // The sub-route follows the same rule: own org readable, foreign refused.
+    const ownStages = await page.request.get(`/api/admin/organizations/${own.id}/pipeline-stages`);
+    expect(ownStages.ok()).toBeTruthy();
+    const foreignStages = await page.request.get(`/api/admin/organizations/${foreign.id}/pipeline-stages`);
+    expect(foreignStages.status()).toBe(403);
+    const foreignStageWrite = await page.request.delete(`/api/admin/organizations/${foreign.id}/pipeline-stages`);
+    expect(foreignStageWrite.status()).toBe(403);
+
+    // The refusal is on record for an auditor.
+    await expect.poll(async () => prisma.activityLog.count({
+      where: { actorId: admin.id, action: 'authz.scope_denied' },
+    }), { timeout: 10_000 }).toBeGreaterThan(0);
+
+    // Presentation follows the capability: no create form, and a note saying why.
+    await gotoSettled(page, '/admin/organizations');
+    await expect(page.getByTestId('tenant-scope-note')).toBeVisible();
+    await expect(page.getByTestId('new-org-card')).toHaveCount(0);
+    // Their own organization is still listed (scoped to the table: the name also
+    // appears in the branding/SSO <select> options).
+    await expect(page.locator('table').getByText(`Own Tenant ${tag}`, { exact: true })).toBeVisible();
+    await expect(page.locator('table').getByText(`Foreign Tenant ${tag}`, { exact: true })).toHaveCount(0);
+  } finally {
+    await cleanupByEmail(adminEmail);
   }
 });

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -276,6 +276,17 @@ model User {
   emailVerified           Boolean       @default(true)
   // Admin can deactivate a user; inactive users cannot sign in.
   isActive                Boolean       @default(true)
+  // Instance-level capability (#1535): may manage EVERY tenant's Organization
+  // row — create tenants, change plans, and write SSO config (the IdP entry
+  // point and signing certificate, i.e. who may mint a login). A plain ADMIN is
+  // a *tenant* admin and may only ever touch their own org.
+  //
+  // Deliberately a flag, not a `SUPER_ADMIN` value on `Role`: `role` is copied
+  // into the JWT and compared to 'ADMIN' in dozens of guards, so widening the
+  // enum would change all of them at once. It is also never put in the token —
+  // `src/lib/superAdmin.ts` reads it from the database per request so revoking
+  // it takes effect on the next request, like `sessionsValidFrom`.
+  isSuperAdmin            Boolean       @default(false)
   // Set only when the `selfRegistration` setting is 'manual': the account was
   // created by open sign-up and is waiting for an admin to let it in. Lets the
   // sign-in page tell "we haven't reviewed you yet" apart from "an admin

--- a/prisma/seed-demo.mjs
+++ b/prisma/seed-demo.mjs
@@ -90,12 +90,20 @@ async function main() {
   // Admin — the identity /demo hands out for the public demo (#966). Namespaced
   // like every other demo row, so it never collides with the real first admin
   // that prisma/seed.mjs creates from SEED_ADMIN_EMAIL.
-  await upsertUser({
+  const demoAdmin = await upsertUser({
     email: `admin.demo@${DEMO_DOMAIN}`,
     fullName: 'Admin Demo',
     role: 'ADMIN',
-    extra: { emailVerified: true },
+    // Super admin (#1535): tenant management is gated on this flag, and the
+    // demo identity is the only admin on a preview/topic environment — without
+    // it /admin/organizations would be a dead screen there.
+    extra: { emailVerified: true, isSuperAdmin: true },
   });
+  // upsertUser leaves an existing row untouched, so a demo database seeded
+  // before the flag existed needs this one idempotent nudge.
+  if (!demoAdmin.isSuperAdmin) {
+    await prisma.user.update({ where: { id: demoAdmin.id }, data: { isSuperAdmin: true } });
+  }
 
   // Mentors
   const mentors = [];

--- a/prisma/seed.mjs
+++ b/prisma/seed.mjs
@@ -15,10 +15,20 @@ async function main() {
   const existing = await prisma.user.findUnique({ where: { email } });
   if (existing) {
     console.log(`User already exists: ${email} — skipping admin seed.`);
+    // Idempotent backfill (#1535): the first admin is the instance operator and
+    // must keep the super-admin capability that gates tenant management, even
+    // on a database seeded before the flag existed.
+    if (existing.role === 'ADMIN' && !existing.isSuperAdmin) {
+      await prisma.user.update({ where: { id: existing.id }, data: { isSuperAdmin: true } });
+      console.log(`Granted super admin to: ${email}`);
+    }
   } else {
     const hashedPassword = await bcrypt.hash(password, 12);
     await prisma.user.create({
-      data: { email, password: hashedPassword, fullName, role: 'ADMIN', skills: [] },
+      // isSuperAdmin (#1535): the very first admin manages the instance itself —
+      // creating tenants and configuring their SSO. Every later ADMIN is a
+      // tenant admin and gets the flag only when an operator grants it.
+      data: { email, password: hashedPassword, fullName, role: 'ADMIN', skills: [], isSuperAdmin: true },
     });
     console.log(`Created ADMIN user: ${email}`);
   }

--- a/releases/unreleased/super-admin-org-gate.json
+++ b/releases/unreleased/super-admin-org-gate.json
@@ -1,0 +1,9 @@
+{
+  "bump": "patch",
+  "changelog": "- **Super-admin gate on tenant management**: `/api/admin/organizations` (and its pipeline-stages sub-route) now require a new `User.isSuperAdmin` capability, read from the database per request. A plain tenant ADMIN sees and may edit only their own organization — cross-tenant PATCH is refused before the target row is loaded and audited as `authz.scope_denied`.",
+  "notes": {
+    "en": ["Organization settings, including single sign-on, can now only be changed by a super admin — a regular admin manages their own organization and nothing else."],
+    "tr": ["Organizasyon ayarları, tekli oturum açma dahil, artık yalnızca süper yönetici tarafından değiştirilebilir; normal yönetici sadece kendi organizasyonunu yönetir."],
+    "de": ["Organisationseinstellungen einschließlich Single Sign-on können jetzt nur noch von einem Super-Admin geändert werden — ein normaler Admin verwaltet ausschließlich die eigene Organisation."]
+  }
+}

--- a/src/app/admin/organizations/page.tsx
+++ b/src/app/admin/organizations/page.tsx
@@ -104,6 +104,9 @@ export default function AdminOrganizationsPage() {
   const t = useT();
   const [orgs, setOrgs] = useState<Organization[]>([]);
   const [plans, setPlans] = useState<OrgPlan[]>([]);
+  // Whether this admin may manage every tenant (#1535). Presentation only — the
+  // API refuses a cross-tenant write regardless of what is rendered here.
+  const [superAdmin, setSuperAdmin] = useState(false);
   const [name, setName] = useState('');
   const [slug, setSlug] = useState('');
   const [saving, setSaving] = useState(false);
@@ -117,6 +120,7 @@ export default function AdminOrganizationsPage() {
       const data = await res.json();
       setOrgs(data.organizations ?? []);
       setPlans(data.plans ?? []);
+      setSuperAdmin(!!data.superAdmin);
     }
     setLoading(false);
   }, []);
@@ -243,7 +247,14 @@ export default function AdminOrganizationsPage() {
         {t.organizations.phaseNote}
       </div>
 
-      <Card className="mb-6 max-w-2xl">
+      {!superAdmin && (
+        <div data-testid="tenant-scope-note" className="mb-6 rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 text-sm text-gray-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
+          {t.organizations.tenantScopeNote}
+        </div>
+      )}
+
+      {superAdmin && (
+      <Card className="mb-6 max-w-2xl" data-testid="new-org-card">
         <CardHeader><CardTitle>{t.organizations.newOrg}</CardTitle></CardHeader>
         <form onSubmit={create} className="flex flex-wrap items-end gap-3">
           <div className="flex-1 min-w-[180px]">
@@ -257,6 +268,7 @@ export default function AdminOrganizationsPage() {
         <p className="text-xs text-gray-500 mt-2">{t.organizations.slugHint}</p>
         {error && <p className="text-sm text-red-600 mt-2">{error}</p>}
       </Card>
+      )}
 
       {orgs.length > 0 && (
         <Card className="mb-6 max-w-2xl">

--- a/src/app/api/admin/organizations/[id]/pipeline-stages/route.ts
+++ b/src/app/api/admin/organizations/[id]/pipeline-stages/route.ts
@@ -5,14 +5,26 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { isHexColor } from '@/lib/branding';
 import { resolvePipelineStages, defaultPipelineStages } from '@/lib/pipelineStages';
+import { isSuperAdmin, logCrossTenantDenial } from '@/lib/superAdmin';
+import { resolveOrgId } from '@/lib/orgScope';
 
 // Per-tenant pipeline-stage management (#747). Admin-only; premium-gated (custom
 // stages require a paid plan). Phase A: label / order / color / on-path grouping
 // over the canonical keys — an org with no rows uses the built-in defaults.
 
-async function requireAdminOrg(id: string) {
+async function requireAdminOrg(id: string, route: string) {
   const session = await getServerSession(authOptions);
   if (!session || session.user.role !== 'ADMIN') return { error: 'Unauthorized' as const, status: 401 };
+  // Same rule as the parent route (#1535): a super admin may manage any tenant,
+  // a plain ADMIN only their own — and the refusal comes before the lookup, so
+  // it cannot confirm whether a foreign org id exists.
+  if (!(await isSuperAdmin(session))) {
+    const ownOrgId = resolveOrgId(session);
+    if (!ownOrgId || ownOrgId !== id) {
+      await logCrossTenantDenial(session, route, id);
+      return { error: 'Forbidden' as const, status: 403 };
+    }
+  }
   const org = await prisma.organization.findUnique({ where: { id } });
   if (!org) return { error: 'Organization not found' as const, status: 404 };
   return { org };
@@ -21,7 +33,7 @@ async function requireAdminOrg(id: string) {
 // GET — the org's resolved stages plus whether they are customized.
 export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  const gate = await requireAdminOrg(id);
+  const gate = await requireAdminOrg(id, 'GET /api/admin/organizations/[id]/pipeline-stages');
   if ('error' in gate) return NextResponse.json({ error: gate.error }, { status: gate.status });
 
   const count = await prisma.pipelineStage.count({ where: { orgId: id } });
@@ -42,7 +54,7 @@ const putSchema = z.object({ stages: z.array(stageSchema).min(1).max(50) });
 // PUT — replace the org's stage set. Premium-gated (not FREE). Keys must be unique.
 export async function PUT(req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  const gate = await requireAdminOrg(id);
+  const gate = await requireAdminOrg(id, 'PUT /api/admin/organizations/[id]/pipeline-stages');
   if ('error' in gate) return NextResponse.json({ error: gate.error }, { status: gate.status });
   if (gate.org.plan === 'FREE') {
     return NextResponse.json({ error: 'Custom pipeline stages require a paid plan' }, { status: 403 });
@@ -87,7 +99,7 @@ export async function PUT(req: Request, { params }: { params: Promise<{ id: stri
 // DELETE — reset to the built-in canonical stages (drop all custom rows).
 export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  const gate = await requireAdminOrg(id);
+  const gate = await requireAdminOrg(id, 'DELETE /api/admin/organizations/[id]/pipeline-stages');
   if ('error' in gate) return NextResponse.json({ error: gate.error }, { status: gate.status });
 
   await prisma.pipelineStage.deleteMany({ where: { orgId: id } });

--- a/src/app/api/admin/organizations/route.ts
+++ b/src/app/api/admin/organizations/route.ts
@@ -8,18 +8,34 @@ import { ORG_PLAN_KEYS, planLimits, isOrgPlan, type OrgPlan } from '@/lib/orgPla
 import { isHexColor, isSafeBrandLogoUrl } from '@/lib/branding';
 import { validateSsoConfig, isSsoActive } from '@/lib/sso';
 import { spEntityId, acsUrl, metadataUrl } from '@/lib/ssoSaml';
+import { isSuperAdmin, logCrossTenantDenial } from '@/lib/superAdmin';
+import { resolveOrgId } from '@/lib/orgScope';
 
 // Multi-tenancy (#544/#547): super-admin management of Organizations (tenants).
 // Phase 1 is additive/foundational — orgId is nullable and not yet enforced in
 // queries, so this screen lets an admin create tenants, set their plan, and see
 // usage vs. the plan's (advisory) limits. Query isolation lands in a later slice.
 
-// GET — all organizations with plan, limits and per-tenant usage (admin).
+// GET — organizations with plan, limits and per-tenant usage.
+// A super admin sees every tenant; a plain tenant ADMIN sees exactly their own
+// organisation, and nothing at all when they belong to none (#1535).
 export async function GET() {
   const session = await getServerSession(authOptions);
   if (!session || session.user.role !== 'ADMIN') return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
+  const superAdmin = await isSuperAdmin(session);
+  let where: { id: string } | undefined;
+  if (!superAdmin) {
+    const ownOrgId = resolveOrgId(session);
+    if (!ownOrgId) {
+      await logCrossTenantDenial(session, 'GET /api/admin/organizations', null);
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+    where = { id: ownOrgId };
+  }
+
   const orgs = await prisma.organization.findMany({
+    where,
     orderBy: { name: 'asc' },
     include: {
       _count: {
@@ -37,6 +53,9 @@ export async function GET() {
 
   return NextResponse.json({
     plans: ORG_PLAN_KEYS,
+    // Lets the admin screen hide what this account cannot use. Presentation
+    // only — the checks above and below are the actual control.
+    superAdmin,
     organizations: orgs.map((o) => {
       const plan = o.plan as OrgPlan;
       return {
@@ -97,10 +116,15 @@ const createSchema = z.object({
   plan: z.enum(['FREE', 'PRO', 'ENTERPRISE']).optional(),
 });
 
-// POST — create an organization (admin).
+// POST — create an organization. Creating tenants is an instance-level act, so
+// it is super-admin only (#1535).
 export async function POST(request: Request) {
   const session = await getServerSession(authOptions);
   if (!session || session.user.role !== 'ADMIN') return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  if (!(await isSuperAdmin(session))) {
+    await logCrossTenantDenial(session, 'POST /api/admin/organizations', null);
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
   const parsed = createSchema.safeParse(await request.json());
   if (!parsed.success) return NextResponse.json({ error: 'Validation failed' }, { status: 400 });
 
@@ -149,7 +173,11 @@ function orNull(v: string | undefined): string | null | undefined {
   return t.length ? t : null; // blank → clear
 }
 
-// PATCH — change an organization's plan, branding and/or SSO config (admin).
+// PATCH — change an organization's plan, branding and/or SSO config.
+// The target org comes from the request body, so this is where a tenant ADMIN
+// could otherwise overwrite ANOTHER customer's SAML entry point and signing
+// certificate (#1535). A super admin may target any org; a tenant ADMIN only
+// their own.
 export async function PATCH(request: Request) {
   const session = await getServerSession(authOptions);
   if (!session || session.user.role !== 'ADMIN') return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -160,6 +188,16 @@ export async function PATCH(request: Request) {
     id, plan, brandName, brandLogoUrl, brandColor, supportEmail,
     ssoEnabled, ssoProvider, ssoIssuer, ssoEntryPoint, ssoCertificate,
   } = parsed.data;
+
+  // Ownership is settled BEFORE the target row is touched: a 404-after-403
+  // ordering would let a foreign admin probe which org ids exist.
+  if (!(await isSuperAdmin(session))) {
+    const ownOrgId = resolveOrgId(session);
+    if (!ownOrgId || ownOrgId !== id) {
+      await logCrossTenantDenial(session, 'PATCH /api/admin/organizations', id);
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+  }
 
   // Validate an explicitly-set (non-blank) brand color as a hex value.
   if (brandColor && brandColor.trim() && !isHexColor(brandColor)) {

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -2017,6 +2017,7 @@ const en = {
     none: 'No organizations yet',
     searchPlaceholder: 'Search organizations...',
     phaseNote: 'Multi-tenancy is in an early phase: every existing record is assigned to a default organization and data is not yet isolated per tenant.',
+    tenantScopeNote: 'You are managing your own organization. Creating tenants and editing other organizations requires a super admin.',
   },
   sources: {
     title: 'Referral sources',
@@ -5527,6 +5528,7 @@ const tr: Dict = {
     none: 'Henüz organizasyon yok',
     searchPlaceholder: 'Organizasyon ara...',
     phaseNote: 'Çok kiracılılık erken aşamada: mevcut tüm kayıtlar varsayılan bir organizasyona atanır ve veriler henüz kiracı bazında izole edilmez.',
+    tenantScopeNote: 'Kendi organizasyonunuzu yönetiyorsunuz. Yeni kiracı oluşturmak ve başka organizasyonları düzenlemek süper yönetici yetkisi gerektirir.',
   },
   sources: {
     title: 'Başvuru kaynakları',
@@ -9028,6 +9030,7 @@ const de: Dict = {
     none: 'Noch keine Organisationen',
     searchPlaceholder: 'Organisationen suchen...',
     phaseNote: 'Mandantenfähigkeit befindet sich in einer frühen Phase: Alle bestehenden Datensätze werden einer Standardorganisation zugewiesen und die Daten sind noch nicht pro Mandant isoliert.',
+    tenantScopeNote: 'Sie verwalten Ihre eigene Organisation. Das Anlegen von Mandanten und das Bearbeiten anderer Organisationen erfordert einen Super-Admin.',
   },
   sources: {
     title: 'Empfehlungsquellen',

--- a/src/lib/superAdmin.ts
+++ b/src/lib/superAdmin.ts
@@ -1,0 +1,62 @@
+// Instance-level "super admin" capability (#1535).
+//
+// `role === 'ADMIN'` means *tenant* admin: the administrator of one customer's
+// organisation. Managing the Organization rows themselves is a different power —
+// it includes writing another tenant's SAML entry point and signing certificate,
+// i.e. deciding who may mint a login for them. Only a super admin may do that.
+//
+// Two deliberate choices:
+//
+//  * It is a flag on User (`isSuperAdmin`), not a `SUPER_ADMIN` value on `Role`.
+//    `role` is copied into the JWT and compared to 'ADMIN' in dozens of guards;
+//    widening the enum would change all of them at once.
+//  * The flag is read FROM THE DATABASE on every request, never from the JWT.
+//    A session token lives for 12h, so a capability revoked at 09:00 would
+//    otherwise keep working until the token refreshes. Same reasoning — and the
+//    same one indexed point lookup — as the `sessionsValidFrom` check in
+//    `src/lib/auth.ts`.
+//
+// SERVER-ONLY: it touches Prisma. Never import it from a client component; the
+// UI learns about the capability from an API response instead.
+
+import type { Session } from 'next-auth';
+import { prisma } from '@/lib/prisma';
+import { logActivity } from '@/lib/activity';
+
+/**
+ * Does this session belong to an active super admin? Reads the flag live, so a
+ * revoked capability is gone on the very next request.
+ */
+export async function isSuperAdmin(session: Session | null | undefined): Promise<boolean> {
+  const userId = session?.user?.id;
+  // A super admin is still an ADMIN; the flag never grants a lesser role the
+  // admin surface on its own.
+  if (!userId || session?.user?.role !== 'ADMIN') return false;
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { isSuperAdmin: true, isActive: true },
+  });
+  return !!user?.isSuperAdmin && user.isActive;
+}
+
+/**
+ * Audit a refused cross-tenant attempt at warning level — a denial is exactly
+ * the row an auditor asks for. Mirrors `logScopeDenial` in `authzScope.ts`
+ * (same `authz.scope_denied` action), but records which organisation was
+ * targeted, which is the whole question here.
+ */
+export async function logCrossTenantDenial(
+  session: Session | null | undefined,
+  route: string,
+  targetOrgId: string | null,
+): Promise<void> {
+  await logActivity({
+    action: 'authz.scope_denied',
+    level: 'warning',
+    actorId: session?.user?.id ?? null,
+    actorEmail: session?.user?.email ?? null,
+    targetType: 'route',
+    targetId: route,
+    detail: `Not a super admin; own org ${session?.user?.orgId ?? 'none'}, target org ${targetOrgId ?? 'none'}`,
+  });
+}


### PR DESCRIPTION
## Summary

All three handlers on `/api/admin/organizations` — and its `[id]/pipeline-stages` sub-route —
checked only `role === 'ADMIN'`, and `PATCH` took the target org id from the **request body** with
no ownership test. `ADMIN` means *tenant* admin, so any customer's admin could overwrite any other
customer's SAML entry point and IdP signing certificate — i.e. decide who may mint a login for them.

This is the change that turns "we have an isolation engine" from a claim into something a security
reviewer can verify.

Closes #1535

## Changes

- **`User.isSuperAdmin`** (`Boolean @default(false)`) — additive with a default, so `db push` stays
  non-destructive. Deliberately **not** a `SUPER_ADMIN` value on the `Role` enum: `role` is copied
  into the JWT and compared to `'ADMIN'` in dozens of guards; widening it changes all of them at once.
- **`src/lib/superAdmin.ts`** — `isSuperAdmin(session)` reads the flag **from the database per
  request**, never from the JWT, so a revoked capability dies on the *next* request. Same indexed
  point lookup and same reasoning as the `sessionsValidFrom` check in `lib/auth.ts`. Plus
  `logCrossTenantDenial()`, writing an `authz.scope_denied` row at level `warning` with actor, route
  and target org — a refused attempt is exactly what an auditor wants recorded.
- **`GET`** — super admin sees all; a tenant `ADMIN` sees exactly `session.user.orgId`; `403`
  (audited) when they have none. The payload gains a `superAdmin` boolean for presentation.
- **`POST`** — super admin only, `403` otherwise.
- **`PATCH`** — a tenant `ADMIN` may target only their own `orgId`, and the `403` is returned
  **before** the org is loaded, so a foreign id cannot be probed for existence (403, never 404).
- **`[id]/pipeline-stages`** `GET`/`PUT`/`DELETE` gated by the same rule inside `requireAdminOrg`,
  also before the lookup.
- **Seeds** — the first seeded `ADMIN` and the demo admin get the flag. Both are idempotent and also
  promote a pre-existing row, since neither seeder updates an existing user.
- **UI** — the create form is hidden and a scoped note shown for non-super-admins. Presentation only;
  the route check is the actual control. New `organizations.*` strings in EN/TR/DE.
- **`e2e/admin-organizations.spec.ts`** — both directions: own org allowed, foreign org refused.

## ⚠️ Two things for the reviewer

1. **Operational consequence on prod/preview.** After this merges, only users with
   `isSuperAdmin = true` can create tenants or edit another org. Existing admin rows on prod and
   preview were seeded before the flag existed, so unless `npx prisma db seed` runs against that DB
   (it promotes the `SEED_ADMIN_EMAIL` admin idempotently) or the column is flipped by hand, the
   create form disappears for them. They keep full access to their own org — prod admins have
   `orgId` backfilled to the default org by `backfill-organization.mjs`. **Topic environments are
   unaffected**: their DB is seeded fresh with the demo admin, which now carries the flag.
2. **Deliberately left for a follow-up.** A tenant `ADMIN` can still change their **own** org's
   `plan` via `PATCH` — a self-upgrade FREE→ENTERPRISE. The issue scoped this task to org
   *ownership*; restricting the `plan` field to super admins is a separate, one-field change and
   widening this PR to cover it would have made the security diff harder to review. Happy to file it.

## Verification

- [x] `npm run lint` + `npx tsc --noEmit` clean
- [x] `npm run check:i18n` green (3502 keys × 3 locales)
- [x] `npx prisma validate` / `format` / `generate` green
- [x] CI green expected — the e2e runs there (no MySQL in the authoring container)

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011cw2xk2jhgSwom8JM7Cpbm

---
_Generated by [Claude Code](https://claude.ai/code/session_011cw2xk2jhgSwom8JM7Cpbm)_