### PR TITLE
feat(surveys): the built-in instrument library in EN/TR/DE (#1883)

### DIFF
--- a/releases/unreleased/survey-instrument-library.json
+++ b/releases/unreleased/survey-instrument-library.json
@@ -1,0 +1,4 @@
+{
+  "bump": "minor",
+  "changelog": "- **Built-in survey instrument library** (#1883). New `src/lib/surveyTemplates.ts` ships six ready instruments — `program_pre`, `program_mid`, `program_post`, `pulse`, `nps_only`, `post_meeting` — each complete in EN/TR/DE and each capped at three questions plus one NPS item (the #836 rule: more questions, fewer responses). Labels are dictionary *selectors*, so the already-shipped `programSurvey` NPS and role-specific questions are reused rather than copied; new wording lives in a `surveyTemplates` namespace in all three dictionaries. The file imports nothing from Prisma or `node:*` so a future admin picker can preview an instrument client-side; `listSurveyTemplates()`, `getSurveyTemplate(key)` and `renderSurveyTemplate(template, locale, role)` are the accessors. Content and types only — no schema, no routes, no UI (those are #1879 and its siblings)."
+}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -1239,6 +1239,65 @@ const en = {
       message: 'Your feedback means a lot — it helps us keep improving the program.',
     },
   },
+  // Wording for the built-in instrument library (src/lib/surveyTemplates.ts).
+  // The NPS question and the four role-specific program questions live in
+  // `programSurvey` above and are reused from there, not repeated here.
+  surveyTemplates: {
+    scale: {
+      low: '1 · Not at all',
+      high: '5 · Very much',
+    },
+    programPre: {
+      title: 'Starting point',
+      description: 'Asked once at the beginning: what each side wants out of this, and how confident they are today.',
+      q: {
+        goals: 'What do you most want to get out of this program?',
+        goalsMentor: 'What do you most want your mentee to get out of this program?',
+        confidence: 'How confident are you today that this will happen?',
+        concerns: 'Is there anything you think could get in the way?',
+      },
+    },
+    programMid: {
+      title: 'Halfway check',
+      description: 'Asked in the middle, while there is still time to fix something.',
+      q: {
+        progress: 'How much has moved forward since you started?',
+        blockers: 'What would help you most in the second half?',
+      },
+    },
+    programPost: {
+      title: 'Closing survey',
+      description: 'Asked at the end: did it deliver, and would they recommend it.',
+      q: {
+        npsWhy: 'What is the main reason for your score?',
+      },
+    },
+    pulse: {
+      title: 'Pulse (2 questions)',
+      description: 'Short enough to send on a repeating cadence without wearing anyone out.',
+      q: {
+        mood: 'How is the mentorship going right now?',
+        needHelp: 'Do you need anything from us this week?',
+      },
+      options: {
+        allGood: 'No, all good',
+        smallThing: 'Yes, a small thing',
+        contactMe: 'Yes, please get in touch with me',
+      },
+    },
+    npsOnly: {
+      title: 'Recommendation score only',
+      description: 'One number and one reason — the shortest survey that still tells you something.',
+    },
+    postMeeting: {
+      title: 'After a meeting',
+      description: 'Sent right after a meeting, while it is still fresh.',
+      q: {
+        helpfulness: 'How helpful was this meeting for you?',
+        note: 'Anything you want to add about this meeting?',
+      },
+    },
+  },
   cv: {
     title: 'CV / Resume',
     upload: 'Upload CV',
@@ -4763,6 +4822,62 @@ const tr: Dict = {
       message: 'Geri bildirimin bizim için değerli — programı geliştirmemize yardımcı oluyor.',
     },
   },
+  surveyTemplates: {
+    scale: {
+      low: '1 · Hiç',
+      high: '5 · Çok',
+    },
+    programPre: {
+      title: 'Başlangıç durumu',
+      description: 'Programın başında bir kez sorulur: iki taraf bundan ne bekliyor ve bugün ne kadar umutlu.',
+      q: {
+        goals: 'Bu programdan en çok ne kazanmak istiyorsun?',
+        goalsMentor: 'Mentee’nin bu programdan en çok ne kazanmasını istiyorsun?',
+        confidence: 'Bunun gerçekleşeceğine bugün ne kadar inanıyorsun?',
+        concerns: 'Önüne engel olabileceğini düşündüğün bir şey var mı?',
+      },
+    },
+    programMid: {
+      title: 'Yarı yol kontrolü',
+      description: 'Programın ortasında, bir şeyi düzeltmek için hâlâ zaman varken sorulur.',
+      q: {
+        progress: 'Başladığından bu yana ne kadar yol aldın?',
+        blockers: 'İkinci yarıda sana en çok ne yardımcı olur?',
+      },
+    },
+    programPost: {
+      title: 'Kapanış anketi',
+      description: 'Programın sonunda sorulur: beklentiyi karşıladı mı ve tavsiye eder mi.',
+      q: {
+        npsWhy: 'Bu puanı vermenin ana nedeni nedir?',
+      },
+    },
+    pulse: {
+      title: 'Nabız (2 soru)',
+      description: 'Kimseyi yormadan düzenli aralıklarla gönderilebilecek kadar kısa.',
+      q: {
+        mood: 'Mentörlük şu anda nasıl gidiyor?',
+        needHelp: 'Bu hafta bizden bir şeye ihtiyacın var mı?',
+      },
+      options: {
+        allGood: 'Hayır, her şey yolunda',
+        smallThing: 'Evet, küçük bir şey',
+        contactMe: 'Evet, benimle iletişime geçin',
+      },
+    },
+    npsOnly: {
+      title: 'Sadece tavsiye puanı',
+      description: 'Bir puan ve bir neden — yine de bir şey öğreten en kısa anket.',
+    },
+    postMeeting: {
+      title: 'Görüşme sonrası',
+      description: 'Görüşmenin hemen ardından, henüz akıldayken gönderilir.',
+      q: {
+        helpfulness: 'Bu görüşme sana ne kadar faydalı oldu?',
+        note: 'Bu görüşmeyle ilgili eklemek istediğin bir şey var mı?',
+      },
+    },
+  },
   cv: {
     title: 'CV / Özgeçmiş',
     upload: 'CV yükle',
@@ -8269,6 +8384,62 @@ const de: Dict = {
     thankYou: {
       title: 'Danke!',
       message: 'Dein Feedback ist uns wichtig — es hilft uns, das Programm weiter zu verbessern.',
+    },
+  },
+  surveyTemplates: {
+    scale: {
+      low: '1 · Gar nicht',
+      high: '5 · Sehr',
+    },
+    programPre: {
+      title: 'Ausgangslage',
+      description: 'Einmal am Anfang gefragt: was beide Seiten davon erwarten und wie zuversichtlich sie heute sind.',
+      q: {
+        goals: 'Was möchtest du aus diesem Programm vor allem mitnehmen?',
+        goalsMentor: 'Was soll dein Mentee aus diesem Programm vor allem mitnehmen?',
+        confidence: 'Wie zuversichtlich bist du heute, dass das gelingt?',
+        concerns: 'Gibt es etwas, das dir dabei im Weg stehen könnte?',
+      },
+    },
+    programMid: {
+      title: 'Zwischenstand',
+      description: 'Zur Mitte gefragt, solange noch Zeit bleibt, etwas zu ändern.',
+      q: {
+        progress: 'Wie viel hat sich seit dem Start bewegt?',
+        blockers: 'Was würde dir in der zweiten Hälfte am meisten helfen?',
+      },
+    },
+    programPost: {
+      title: 'Abschlussumfrage',
+      description: 'Am Ende gefragt: hat es gehalten, was es versprochen hat, und würdest du es weiterempfehlen.',
+      q: {
+        npsWhy: 'Was ist der Hauptgrund für deine Bewertung?',
+      },
+    },
+    pulse: {
+      title: 'Puls (2 Fragen)',
+      description: 'Kurz genug, um sie regelmäßig zu senden, ohne jemanden zu ermüden.',
+      q: {
+        mood: 'Wie läuft das Mentoring im Moment?',
+        needHelp: 'Brauchst du diese Woche etwas von uns?',
+      },
+      options: {
+        allGood: 'Nein, alles gut',
+        smallThing: 'Ja, eine Kleinigkeit',
+        contactMe: 'Ja, bitte meldet euch bei mir',
+      },
+    },
+    npsOnly: {
+      title: 'Nur Empfehlungswert',
+      description: 'Eine Zahl und ein Grund — die kürzeste Umfrage, die noch etwas verrät.',
+    },
+    postMeeting: {
+      title: 'Nach einem Gespräch',
+      description: 'Direkt nach dem Gespräch gesendet, solange es noch frisch ist.',
+      q: {
+        helpfulness: 'Wie hilfreich war dieses Gespräch für dich?',
+        note: 'Möchtest du etwas zu diesem Gespräch ergänzen?',
+      },
     },
   },
   cv: {

--- a/src/lib/surveyTemplates.ts
+++ b/src/lib/surveyTemplates.ts
@@ -1,0 +1,328 @@
+import { type Locale } from '@/i18n/config';
+import { getDictionary, type Dictionary } from '@/i18n/dictionaries';
+
+/**
+ * The built-in survey instrument library (#1883) — six ready instruments in
+ * EN/TR/DE.
+ *
+ * WHY THE CONTENT SHIPS IN THE REPO
+ *
+ * An admin should pick a survey, not write one. A builder with an empty canvas
+ * is how a feedback module dies: nobody opening `/admin` on a Tuesday
+ * afternoon has three languages of well-worded survey questions in their head.
+ * So the library ships filled, the same way the newsletter one does
+ * (`src/lib/newsletterContent.ts`) and the document templates do
+ * (`src/lib/templates.ts`).
+ *
+ * THREE QUESTIONS PLUS AN NPS ITEM — THE HARD CAP
+ *
+ * Carried over from #836: more questions means fewer responses. Every
+ * instrument here is at most three questions plus one NPS item, and the open
+ * text counts as one of the three. A PR that "improves" an instrument by adding
+ * a fifth question to collect a bit more data should be pushed back on in
+ * review — short is the feature, not a limitation of it.
+ *
+ * HOW THE WORDING IS RESOLVED
+ *
+ * A label is a *selector into the shared dictionary*, not an inline
+ * `{en,tr,de}` map. The NPS question, its scale anchors and the four
+ * role-specific program questions were already written and translated
+ * (`programSurvey` in `src/i18n/dictionaries.ts`); a selector reuses those
+ * strings instead of copying them, so re-wording one reaches every instrument
+ * that asks it. New wording goes into the `surveyTemplates` namespace of all
+ * three dictionaries.
+ *
+ * CLIENT-SAFE ON PURPOSE
+ *
+ * This file imports nothing from Prisma and nothing from `node:*`, so a future
+ * admin picker can render a live preview of an instrument in the browser. The
+ * types below are plain string unions that line up with the `Survey` /
+ * `SurveyQuestion` columns coming in #1879 — creating a survey from a template
+ * copies the resolved wording into the row, exactly like the newsletter does.
+ */
+
+/** Who an instrument is addressed to. Mirrors `SurveyAudience` (#1879). */
+export type SurveyAudience = 'MENTEE' | 'MENTOR' | 'BOTH';
+
+/** Mirrors `SurveyAnonymity` (#1879); a template only carries the default. */
+export type SurveyAnonymity = 'IDENTIFIED' | 'CONFIDENTIAL' | 'ANONYMOUS';
+
+/** Mirrors the question types these instruments need (#1879). */
+export type SurveyQuestionType = 'NPS' | 'SCALE' | 'SINGLE_CHOICE' | 'TEXT';
+
+export type SurveyTemplateKey =
+  | 'program_pre'
+  | 'program_mid'
+  | 'program_post'
+  | 'pulse'
+  | 'nps_only'
+  | 'post_meeting';
+
+/** A dictionary selector — see "HOW THE WORDING IS RESOLVED" above. */
+type Text = (d: Dictionary) => string;
+
+export interface SurveyTemplateQuestion {
+  /** Stable answer join key; never renamed once an instrument has shipped. */
+  key: string;
+  type: SurveyQuestionType;
+  label: Text;
+  /**
+   * The mentor wording for the same slot, where a mentor is genuinely being
+   * asked a different thing. Its presence is what makes an instrument `BOTH`
+   * rather than two near-identical instruments.
+   */
+  mentorLabel?: Text;
+  /** Inclusive bounds for `SCALE` (an `NPS` item is always 0–10). */
+  scale?: { min: number; max: number };
+  /** Anchor wording for the low and the high end of a scale. */
+  scaleLabels?: { low: Text; high: Text };
+  /** Choices for `SINGLE_CHOICE`, in the order they are shown. */
+  options?: Text[];
+  required: boolean;
+}
+
+export interface SurveyTemplate {
+  key: SurveyTemplateKey;
+  audience: SurveyAudience;
+  /** What the admin picker preselects; still changeable per survey. */
+  anonymityDefault: SurveyAnonymity;
+  title: Text;
+  description: Text;
+  questions: SurveyTemplateQuestion[];
+}
+
+/** The cap stated at the top of this file, in code so a reviewer can cite it. */
+export const SURVEY_TEMPLATE_MAX_QUESTIONS = 3;
+
+const FIVE_POINT: Pick<SurveyTemplateQuestion, 'scale' | 'scaleLabels'> = {
+  scale: { min: 1, max: 5 },
+  scaleLabels: {
+    low: (d) => d.surveyTemplates.scale.low,
+    high: (d) => d.surveyTemplates.scale.high,
+  },
+};
+
+/** The already-shipped NPS item, identical wherever it is asked. */
+const NPS_ITEM: SurveyTemplateQuestion = {
+  key: 'nps',
+  type: 'NPS',
+  label: (d) => d.programSurvey.npsQuestion,
+  scale: { min: 0, max: 10 },
+  scaleLabels: {
+    low: (d) => d.programSurvey.scaleLow,
+    high: (d) => d.programSurvey.scaleHigh,
+  },
+  required: true,
+};
+
+const NPS_WHY: SurveyTemplateQuestion = {
+  key: 'nps_why',
+  type: 'TEXT',
+  label: (d) => d.surveyTemplates.programPost.q.npsWhy,
+  required: false,
+};
+
+export const SURVEY_TEMPLATES: SurveyTemplate[] = [
+  {
+    key: 'program_pre',
+    audience: 'BOTH',
+    // A baseline is only worth asking if it can be compared with the closing
+    // survey for the same person, so this one is identified by default.
+    anonymityDefault: 'IDENTIFIED',
+    title: (d) => d.surveyTemplates.programPre.title,
+    description: (d) => d.surveyTemplates.programPre.description,
+    questions: [
+      {
+        key: 'goals',
+        type: 'TEXT',
+        label: (d) => d.surveyTemplates.programPre.q.goals,
+        mentorLabel: (d) => d.surveyTemplates.programPre.q.goalsMentor,
+        required: true,
+      },
+      {
+        key: 'confidence',
+        type: 'SCALE',
+        label: (d) => d.surveyTemplates.programPre.q.confidence,
+        ...FIVE_POINT,
+        required: true,
+      },
+      {
+        key: 'concerns',
+        type: 'TEXT',
+        label: (d) => d.surveyTemplates.programPre.q.concerns,
+        required: false,
+      },
+    ],
+  },
+  {
+    key: 'program_mid',
+    audience: 'BOTH',
+    anonymityDefault: 'CONFIDENTIAL',
+    title: (d) => d.surveyTemplates.programMid.title,
+    description: (d) => d.surveyTemplates.programMid.description,
+    questions: [
+      {
+        key: 'progress',
+        type: 'SCALE',
+        label: (d) => d.surveyTemplates.programMid.q.progress,
+        ...FIVE_POINT,
+        required: true,
+      },
+      {
+        // "Was the help there when you needed it?" — a mentee means their
+        // mentor, a mentor means the program. Both strings already shipped.
+        key: 'support',
+        type: 'SCALE',
+        label: (d) => d.programSurvey.mentee.communication,
+        mentorLabel: (d) => d.programSurvey.mentor.support,
+        ...FIVE_POINT,
+        required: true,
+      },
+      {
+        key: 'blockers',
+        type: 'TEXT',
+        label: (d) => d.surveyTemplates.programMid.q.blockers,
+        required: false,
+      },
+    ],
+  },
+  {
+    key: 'program_post',
+    audience: 'BOTH',
+    anonymityDefault: 'CONFIDENTIAL',
+    title: (d) => d.surveyTemplates.programPost.title,
+    description: (d) => d.surveyTemplates.programPost.description,
+    questions: [
+      {
+        // The closing "did this work for you?" differs by role: a mentee is
+        // asked about expectations, a mentor about a sustainable workload.
+        key: 'outcome',
+        type: 'SCALE',
+        label: (d) => d.programSurvey.mentee.expectations,
+        mentorLabel: (d) => d.programSurvey.mentor.workloadSustainability,
+        ...FIVE_POINT,
+        required: true,
+      },
+      NPS_ITEM,
+      NPS_WHY,
+    ],
+  },
+  {
+    key: 'pulse',
+    audience: 'BOTH',
+    anonymityDefault: 'CONFIDENTIAL',
+    title: (d) => d.surveyTemplates.pulse.title,
+    description: (d) => d.surveyTemplates.pulse.description,
+    // Two questions, deliberately: this is the one that goes out on a repeating
+    // cadence, and a recurring survey is answered only while it stays trivial.
+    questions: [
+      {
+        key: 'mood',
+        type: 'SCALE',
+        label: (d) => d.surveyTemplates.pulse.q.mood,
+        ...FIVE_POINT,
+        required: true,
+      },
+      {
+        key: 'need_help',
+        type: 'SINGLE_CHOICE',
+        label: (d) => d.surveyTemplates.pulse.q.needHelp,
+        options: [
+          (d) => d.surveyTemplates.pulse.options.allGood,
+          (d) => d.surveyTemplates.pulse.options.smallThing,
+          (d) => d.surveyTemplates.pulse.options.contactMe,
+        ],
+        required: true,
+      },
+    ],
+  },
+  {
+    key: 'nps_only',
+    audience: 'BOTH',
+    anonymityDefault: 'ANONYMOUS',
+    title: (d) => d.surveyTemplates.npsOnly.title,
+    description: (d) => d.surveyTemplates.npsOnly.description,
+    questions: [NPS_ITEM, NPS_WHY],
+  },
+  {
+    key: 'post_meeting',
+    audience: 'BOTH',
+    anonymityDefault: 'CONFIDENTIAL',
+    title: (d) => d.surveyTemplates.postMeeting.title,
+    description: (d) => d.surveyTemplates.postMeeting.description,
+    questions: [
+      {
+        key: 'helpfulness',
+        type: 'SCALE',
+        label: (d) => d.surveyTemplates.postMeeting.q.helpfulness,
+        ...FIVE_POINT,
+        required: true,
+      },
+      {
+        key: 'note',
+        type: 'TEXT',
+        label: (d) => d.surveyTemplates.postMeeting.q.note,
+        required: false,
+      },
+    ],
+  },
+];
+
+export function listSurveyTemplates(): SurveyTemplate[] {
+  return SURVEY_TEMPLATES;
+}
+
+export function getSurveyTemplate(key: string): SurveyTemplate | undefined {
+  return SURVEY_TEMPLATES.find((t) => t.key === key);
+}
+
+// The shape a picker or a preview consumes: every selector already applied, so
+// the functions above never reach a React prop or a Prisma write.
+export interface ResolvedSurveyQuestion {
+  key: string;
+  type: SurveyQuestionType;
+  label: string;
+  scale?: { min: number; max: number };
+  scaleLabels?: { low: string; high: string };
+  options?: string[];
+  required: boolean;
+}
+
+export interface ResolvedSurveyTemplate {
+  key: SurveyTemplateKey;
+  audience: SurveyAudience;
+  anonymityDefault: SurveyAnonymity;
+  title: string;
+  description: string;
+  questions: ResolvedSurveyQuestion[];
+}
+
+/**
+ * Resolve one instrument into plain strings. `role` picks the mentor wording
+ * where a question carries one; anything else gets the default label.
+ */
+export function renderSurveyTemplate(
+  template: SurveyTemplate,
+  locale: Locale,
+  role: 'MENTEE' | 'MENTOR' = 'MENTEE'
+): ResolvedSurveyTemplate {
+  const d = getDictionary(locale);
+  return {
+    key: template.key,
+    audience: template.audience,
+    anonymityDefault: template.anonymityDefault,
+    title: template.title(d),
+    description: template.description(d),
+    questions: template.questions.map((q) => ({
+      key: q.key,
+      type: q.type,
+      label: role === 'MENTOR' && q.mentorLabel ? q.mentorLabel(d) : q.label(d),
+      ...(q.scale ? { scale: q.scale } : {}),
+      ...(q.scaleLabels
+        ? { scaleLabels: { low: q.scaleLabels.low(d), high: q.scaleLabels.high(d) } }
+        : {}),
+      ...(q.options ? { options: q.options.map((o) => o(d)) } : {}),
+      required: q.required,
+    })),
+  };
+}


### PR DESCRIPTION
## Summary

The six ready-made survey instruments — pre / mid / post programme, pulse, NPS-only and post-meeting — as code-owned content, following the `src/lib/newsletterContent.ts` and `src/lib/templates.ts` pattern. No schema, no UI: this is the content layer #1879's models and the admin picker will consume.

The point of the shape is that nothing is duplicated. Question labels are **dictionary selectors** (`(d: Dictionary) => string`), not inline `{en,tr,de}` maps, so the already-shipped `programSurvey` strings (`npsQuestion`, `scaleLow`/`scaleHigh`, `mentee.communication`, `mentee.expectations`, `mentor.support`, `mentor.workloadSustainability`) are *referenced* rather than copied — several of them had been referenced from nowhere until now. A question also carries an optional `mentorLabel` for the mentor wording of the same slot, which is what lets an instrument stay a single `BOTH` audience instead of splitting into two near-identical ones.

Closes #1883

## Changes

- **`src/lib/surveyTemplates.ts`** (new) — the six instruments with `key`, `audience`, `anonymityDefault`, `title`, `description`, `questions`; accessors `listSurveyTemplates()`, `getSurveyTemplate(key)` and `renderSurveyTemplate(template, locale, role)` which resolves every selector and returns the plain-string shape a picker/preview (or a Prisma write) can consume — so no selector function ever reaches React props or the database. Client-safe by construction: no `@/lib/prisma`, no `@prisma/client`, no `node:*`.
- The question cap is documented at the top of the file and exported as `SURVEY_TEMPLATE_MAX_QUESTIONS = 3`, so a reviewer can cite it. Actual shapes: pre 3, mid 3, post 2 + NPS, pulse 2, nps_only 1 + NPS, post_meeting 2.
- `anonymityDefault` is per instrument and deliberate: `program_pre` is `IDENTIFIED` (a baseline is only useful if it can be compared to the closing survey for the same person), `nps_only` is `ANONYMOUS`, the rest `CONFIDENTIAL`.
- **`src/i18n/dictionaries.ts`** — a `surveyTemplates` namespace in EN/TR/DE placed directly after each `programSurvey` block so the two stay adjacent: six title/description pairs, the new question wordings, three `pulse` choice options and a shared 1–5 anchor pair. TR and DE are written the way a person would phrase a survey question.
- **`releases/unreleased/survey-instrument-library.json`** — `minor`, developer-facing changelog bullet only. `notes` is deliberately omitted: nothing user-visible renders these strings yet, so there is no user-facing highlight to write (per `releases/README.md`).

### Deferred, deliberately

- **No Prisma models.** `Survey`/`SurveyQuestion`/`SurveyInvitation`/`SurveyResponse` are #1879 and have not landed. The types here are local string unions that mirror #1879's stated enums, with a comment saying so — whoever lands #1879 should swap them for the generated enums and reconcile `SurveyQuestionType` with #1800's `FormFieldType`.
- **No admin picker, preview page, API route or email.** `renderSurveyTemplate` exists so that UI can be built without touching this file; nothing consumes it yet.
- **No `src/lib/features.ts` entry and no release-note `notes`** — both belong to the PR that makes this visible to a user.
- **No automated guard on the question cap.** The repo has no unit-test runner for `src/lib` (only `node --test` over two `scripts/test/*.mjs` files) and there is nothing rendered to drive a browser at, so I did not invent a new harness + CI step. `tsc` and `check:i18n` catch a removed dictionary key; they do not catch a fourth question. If the cap should be enforced mechanically, the natural home is a small `scripts/check-survey-templates.mjs` next to `check:stage-keys` — left out here as scope creep.

## Verification

- [x] `npm run lint` + `npx tsc --noEmit` clean (0 lint errors)
- [ ] `npm run test:e2e` passing (or CI green) — no spec added (nothing rendered yet); CI's existing gates cover this change
- [x] Tested the change manually / added an e2e test — resolved all six instruments in all three locales with a throwaway script (not committed); `npm run check:i18n` green at 3536 keys × 3, `npm run check:release-fragments` (ships as `0.132.0-beta`), `npm run check:openapi` and `npm run check:stage-keys` green

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qTSgQDDVBYo6gXf8xpsnR

---
_Generated by [Claude Code](https://claude.ai/code/session_017qTSgQDDVBYo6gXf8xpsnR)_