### PR TITLE
fix(mentor): use the third column on the mentee detail page

### DIFF
--- a/e2e/mentee-detail-columns.spec.ts
+++ b/e2e/mentee-detail-columns.spec.ts
@@ -92,6 +92,14 @@ test('the mentee detail overview uses both columns at desktop widths', async ({ 
       await expect(sidebar.getByText('Columns University')).toBeVisible();
       await expect(main.getByText(/Interaction Log/i)).toBeVisible();
     }
+
+    // Printing must not lose the profile. `globals.css` drops the app chrome
+    // with `@media print { aside, header, .no-print { display: none } }`, which
+    // catches *any* `aside` — the sidebar pins itself back with `print:!block`.
+    await page.emulateMedia({ media: 'print' });
+    await expect(page.getByTestId('mentee-detail-sidebar')).toBeVisible();
+    await expect(page.getByTestId('mentee-detail-main')).toBeVisible();
+    await page.emulateMedia({ media: null });
   } finally {
     await prisma.mentorshipRelation.deleteMany({ where: { id: rel.id } });
     await cleanupByEmail(menteeEmail);

--- a/e2e/mentee-detail-columns.spec.ts
+++ b/e2e/mentee-detail-columns.spec.ts
@@ -1,0 +1,139 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { signInAndSettle, gotoSettled } from './helpers/auth';
+
+/**
+ * The mentee detail page's column layout (#1370).
+ *
+ * The bug: the overview was a `lg:grid-cols-3` grid in which the profile card
+ * and the stage history took one column each and *every* working panel below
+ * them carried `lg:col-span-2`. Nothing was ever placed in the third column, so
+ * from "Interaction Log" downwards the content sat in the left two thirds and
+ * the right third of a 1280px screen was empty top to bottom.
+ *
+ * The fix splits the grid into two real children: a reference sidebar (profile +
+ * stage history) placed in the third column, and the working panels spanning the
+ * other two. This spec measures that, so it fails on the old markup:
+ *   - both columns exist, are visible and start on the same row at `lg`;
+ *   - the sidebar sits to the right of the panels and reaches the right edge of
+ *     the grid — no leftover dead column;
+ *   - the sidebar holds the reference cards, the wide column the working ones;
+ *   - on a phone the two stack in one column, profile first, with no sideways
+ *     scroll (the rule from mobile-layout-audit.spec.ts).
+ */
+
+const password = 'ColumnsPass123!';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('the mentee detail overview uses both columns at desktop widths', async ({ page }) => {
+  const mentorEmail = uniqueEmail('cols-mentor');
+  const menteeEmail = uniqueEmail('cols-mentee');
+  const mentor = await seedUser(mentorEmail, password, 'MENTOR', 'Columns Mentor');
+  const mentee = await seedUser(menteeEmail, password, 'MENTEE', 'Columns Mentee');
+  const rel = await prisma.mentorshipRelation.create({
+    data: { mentorId: mentor.id, menteeId: mentee.id },
+  });
+  // Real content in the profile card, so an empty state cannot be mistaken for a
+  // correctly placed column.
+  await prisma.user.update({
+    where: { id: mentee.id },
+    data: { university: 'Columns University', department: 'Computer Engineering', city: 'Ankara' },
+  });
+
+  try {
+    await signInAndSettle(page, mentorEmail, password, '/mentor');
+
+    for (const width of [1280, 1536]) {
+      await page.setViewportSize({ width, height: 900 });
+      await gotoSettled(page, `/mentor/mentees/${rel.id}`);
+
+      const sidebar = page.getByTestId('mentee-detail-sidebar');
+      const main = page.getByTestId('mentee-detail-main');
+      await expect(sidebar).toBeVisible({ timeout: 15_000 });
+      await expect(main).toBeVisible();
+
+      // The panels render skeletons while they fetch; measuring a half-loaded
+      // page is the usual source of flake here.
+      await expect
+        .poll(async () => page.locator('.animate-pulse').count(), { timeout: 20_000 })
+        .toBe(0);
+
+      const sidebarBox = (await sidebar.boundingBox())!;
+      const mainBox = (await main.boundingBox())!;
+      expect(sidebarBox.width, `sidebar has no width at ${width}px`).toBeGreaterThan(0);
+      expect(sidebarBox.height).toBeGreaterThan(0);
+
+      // Side by side, not stacked: the two columns start on the same row…
+      expect(Math.abs(sidebarBox.y - mainBox.y)).toBeLessThanOrEqual(2);
+      // …with the sidebar to the right of the working panels.
+      expect(sidebarBox.x).toBeGreaterThanOrEqual(mainBox.x + mainBox.width - 1);
+
+      // No dead column: the sidebar occupies roughly the last third of the grid
+      // and its right edge is the grid's right edge.
+      const gridRight = await page.evaluate(() => {
+        const el = document.querySelector('[data-testid="mentee-detail-main"]')!.parentElement!;
+        const r = el.getBoundingClientRect();
+        return { left: r.left, right: r.right };
+      });
+      const gridWidth = gridRight.right - gridRight.left;
+      expect(sidebarBox.width).toBeGreaterThan(gridWidth * 0.2);
+      expect(sidebarBox.x + sidebarBox.width).toBeGreaterThanOrEqual(gridRight.right - 2);
+      // The working panels are the wide column, and they are wider than the
+      // sidebar (2/3 vs 1/3) — this is what the old markup got backwards by
+      // leaving the third column unused.
+      expect(mainBox.width).toBeGreaterThan(sidebarBox.width);
+
+      // Each column carries the cards it was designed for.
+      await expect(sidebar.getByText('Profile', { exact: true })).toBeVisible();
+      await expect(sidebar.getByText(/Stage history/i)).toBeVisible();
+      await expect(sidebar.getByText('Columns University')).toBeVisible();
+      await expect(main.getByText(/Interaction Log/i)).toBeVisible();
+    }
+  } finally {
+    await prisma.mentorshipRelation.deleteMany({ where: { id: rel.id } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+  }
+});
+
+test('the same page still stacks in one column on a phone', async ({ page }) => {
+  const mentorEmail = uniqueEmail('cols1-mentor');
+  const menteeEmail = uniqueEmail('cols1-mentee');
+  const mentor = await seedUser(mentorEmail, password, 'MENTOR', 'Columns Phone Mentor');
+  const mentee = await seedUser(menteeEmail, password, 'MENTEE', 'Columns Phone Mentee');
+  const rel = await prisma.mentorshipRelation.create({
+    data: { mentorId: mentor.id, menteeId: mentee.id },
+  });
+
+  try {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await signInAndSettle(page, mentorEmail, password, '/mentor');
+    await gotoSettled(page, `/mentor/mentees/${rel.id}`);
+
+    const sidebar = page.getByTestId('mentee-detail-sidebar');
+    const main = page.getByTestId('mentee-detail-main');
+    await expect(sidebar).toBeVisible({ timeout: 15_000 });
+    await expect(main).toBeVisible();
+
+    const sidebarBox = (await sidebar.boundingBox())!;
+    const mainBox = (await main.boundingBox())!;
+    // One column: same left edge, same width, profile above the working panels.
+    expect(Math.abs(sidebarBox.x - mainBox.x)).toBeLessThanOrEqual(1);
+    expect(Math.abs(sidebarBox.width - mainBox.width)).toBeLessThanOrEqual(1);
+    expect(mainBox.y).toBeGreaterThan(sidebarBox.y);
+
+    // …and the page does not scroll sideways (mobile-layout-audit.spec.ts rule 1).
+    const overflow = await page.evaluate(() => {
+      const el = document.documentElement;
+      return el.scrollWidth - el.clientWidth;
+    });
+    expect(overflow).toBeLessThanOrEqual(1);
+  } finally {
+    await prisma.mentorshipRelation.deleteMany({ where: { id: rel.id } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+  }
+});

--- a/releases/unreleased/mentee-detail-right-column.json
+++ b/releases/unreleased/mentee-detail-right-column.json
@@ -1,0 +1,15 @@
+{
+  "bump": "patch",
+  "changelog": "**Mentee detail (mentor)** — the overview grid no longer leaves its third column empty: the profile and stage-history cards form a reference sidebar (`lg:col-start-3`) and the working panels span the other two columns, replacing the `lg:col-span-2` that every panel carried (#1370).",
+  "notes": {
+    "en": [
+      "Mentee detail page: the profile and stage history now sit in a side column, so the working panels use the full width instead of leaving the right third of a wide screen empty."
+    ],
+    "tr": [
+      "Mentee detay sayfası: profil ve aşama geçmişi artık yan sütunda duruyor; çalışma panelleri geniş ekranda sağ üçte biri boş bırakmak yerine tüm genişliği kullanıyor."
+    ],
+    "de": [
+      "Mentee-Detailseite: Profil und Phasenverlauf stehen jetzt in einer Seitenspalte, sodass die Arbeitsbereiche die volle Breite nutzen statt das rechte Drittel breiter Bildschirme leer zu lassen."
+    ]
+  }
+}

--- a/src/app/mentor/mentees/[id]/page.tsx
+++ b/src/app/mentor/mentees/[id]/page.tsx
@@ -250,286 +250,285 @@ export default function MenteeDetailPage() {
       />
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        {/* Mentee info */}
-        <Card>
-          <CardHeader>
-            <CardTitle>{t.mentor.profile}</CardTitle>
-          </CardHeader>
-          <div className="space-y-3">
-            {relation.mentee.university && (
-              <div>
-                <p className="text-xs text-gray-500">{t.candidateDetail.university}</p>
-                <p className="text-sm text-gray-900">{relation.mentee.university}</p>
+        {/* Who this mentee is and how they got here: reference material the
+            mentor reads while working the panels beside it. It stays first in
+            the DOM so a phone still shows the profile above the working
+            panels, and it is placed in the third column from `lg` up. Every
+            working panel used to carry `lg:col-span-2` in this three-column
+            grid, so nothing was ever placed in the third column and the right
+            third of the page was empty top to bottom (#1370). */}
+        <aside className="space-y-6 lg:col-start-3 lg:row-start-1" data-testid="mentee-detail-sidebar">
+          {/* Mentee info */}
+          <Card>
+            <CardHeader>
+              <CardTitle>{t.mentor.profile}</CardTitle>
+            </CardHeader>
+            <div className="space-y-3">
+              {relation.mentee.university && (
+                <div>
+                  <p className="text-xs text-gray-500">{t.candidateDetail.university}</p>
+                  <p className="text-sm text-gray-900">{relation.mentee.university}</p>
+                </div>
+              )}
+              {relation.mentee.department && (
+                <div>
+                  <p className="text-xs text-gray-500">{t.candidateDetail.department}</p>
+                  <p className="text-sm text-gray-900">{relation.mentee.department}</p>
+                </div>
+              )}
+              {relation.mentee.graduationYear && (
+                <div>
+                  <p className="text-xs text-gray-500">{t.candidateDetail.graduationYear}</p>
+                  <p className="text-sm text-gray-900">{relation.mentee.graduationYear}</p>
+                </div>
+              )}
+              {relation.mentee.phone && (
+                <div>
+                  <p className="text-xs text-gray-500">{t.candidateDetail.phone}</p>
+                  <p className="text-sm text-gray-900">{relation.mentee.phone}</p>
+                </div>
+              )}
+              {relation.mentee.whatsapp && (
+                <div>
+                  <p className="text-xs text-gray-500">{t.candidateDetail.whatsapp}</p>
+                  <p className="text-sm text-gray-900">{relation.mentee.whatsapp}</p>
+                </div>
+              )}
+              {(relation.mentee.whatsapp || relation.mentee.phone) && (
+                <ContactActions
+                  relationId={id}
+                  phone={relation.mentee.whatsapp || relation.mentee.phone || ''}
+                  onLogged={fetchRelation}
+                />
+              )}
+              {relation.mentee.city && (
+                <div>
+                  <p className="text-xs text-gray-500">{t.candidateDetail.city}</p>
+                  <p className="text-sm text-gray-900">{relation.mentee.city}</p>
+                </div>
+              )}
+              {relation.mentee.birthDate && (
+                <div>
+                  <p className="text-xs text-gray-500">{t.candidateDetail.birthDate}</p>
+                  <p className="text-sm text-gray-900">
+                    {formatDate(relation.mentee.birthDate, locale)}
+                  </p>
+                </div>
+              )}
+              {/* Who brought this mentee in — one line, whether that is a
+                  registered person, a source, or the legacy free text (#1296). */}
+              {referrerLabel(relation.mentee) && (
+                <div>
+                  <p className="text-xs text-gray-500">{t.referrer.label}</p>
+                  <p className="text-sm text-gray-900" data-testid="mentee-referrer">{referrerLabel(relation.mentee)}</p>
+                </div>
+              )}
+              {relation.mentee.skills.length > 0 && (
+                <div>
+                  <p className="text-xs text-gray-500 mb-1">{t.candidateDetail.skills}</p>
+                  <div className="flex flex-wrap gap-1">
+                    {relation.mentee.skills.map((skill) => (
+                      <Badge key={skill} variant="info" className="text-xs">{skill}</Badge>
+                    ))}
+                  </div>
+                </div>
+              )}
+              {relation.mentee.cvUrl && (
+                <a
+                  href={cvViewHref(relation.mentee.cvUrl)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-1 text-sm text-blue-600 hover:underline"
+                >
+                  <ExternalLink className="h-3 w-3" />
+                  {t.candidateDetail.viewCv}
+                </a>
+              )}
+              {relation.company && (
+                <div className="mt-4 p-3 bg-blue-50 dark:bg-blue-950/40 rounded-lg">
+                  <p className="text-xs text-blue-500 dark:text-blue-400 font-medium mb-1">{t.candidateDetail.company}</p>
+                  <p className="text-sm font-medium text-blue-900 dark:text-blue-100">{relation.company.name}</p>
+                  {relation.company.industry && (
+                    <p className="text-xs text-blue-700 dark:text-blue-300">{relation.company.industry}</p>
+                  )}
+                  {relation.companyInterest && (
+                    <div className="mt-2 pt-2 border-t border-blue-100 dark:border-blue-900">
+                      <Badge variant={relation.companyInterest.status === 'PASS' ? 'danger' : relation.companyInterest.status === 'SHORTLISTED' ? 'success' : 'info'}>
+                        {t.candidateDetail.companyInterest[relation.companyInterest.status.toLowerCase() as 'interested' | 'shortlisted' | 'pass']}
+                      </Badge>
+                      {relation.companyInterest.note && (
+                        <p className="text-xs text-blue-700 dark:text-blue-300 mt-1.5 italic">“{relation.companyInterest.note}”</p>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          </Card>
+
+          {/* Pipeline stage history */}
+          <Card>
+            <CardHeader>
+              <CardTitle>{t.mentor.stageHistory} ({relation.statusChanges.length})</CardTitle>
+            </CardHeader>
+            {relation.statusChanges.length === 0 ? (
+              <p className="text-sm text-gray-400 text-center py-6">{t.mentor.noStageChanges}</p>
+            ) : (
+              <ol className="space-y-3">
+                {relation.statusChanges.map((sc) => (
+                  <li key={sc.id} className="text-sm border-l-2 border-blue-100 pl-3">
+                    <p className="text-gray-700">
+                      <span className="text-gray-400">{label(sc.fromStatus)}</span>
+                      {' → '}
+                      <span className="font-medium text-gray-900">{label(sc.toStatus)}</span>
+                    </p>
+                    <p className="text-xs text-gray-400 mt-0.5">
+                      {sc.changedBy.fullName} · {formatDateTime(sc.createdAt, locale)}
+                    </p>
+                  </li>
+                ))}
+              </ol>
+            )}
+          </Card>
+        </aside>
+
+        {/* The working panels: two of the three columns, stacked in reading
+            order. `space-y-6` replaces the grid gap they used to inherit. */}
+        <div className="space-y-6 lg:col-start-1 lg:row-start-1 lg:col-span-2" data-testid="mentee-detail-main">
+          {/* Interactions */}
+          <Card>
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <CardTitle>{t.mentor.interactionLog} ({relation.interactions.length})</CardTitle>
+                <Button size="sm" onClick={() => setShowForm(!showForm)}>
+                  <Plus className="h-4 w-4" />
+                  {t.mentor.addLog}
+                </Button>
               </div>
-            )}
-            {relation.mentee.department && (
-              <div>
-                <p className="text-xs text-gray-500">{t.candidateDetail.department}</p>
-                <p className="text-sm text-gray-900">{relation.mentee.department}</p>
-              </div>
-            )}
-            {relation.mentee.graduationYear && (
-              <div>
-                <p className="text-xs text-gray-500">{t.candidateDetail.graduationYear}</p>
-                <p className="text-sm text-gray-900">{relation.mentee.graduationYear}</p>
-              </div>
-            )}
-            {relation.mentee.phone && (
-              <div>
-                <p className="text-xs text-gray-500">{t.candidateDetail.phone}</p>
-                <p className="text-sm text-gray-900">{relation.mentee.phone}</p>
-              </div>
-            )}
-            {relation.mentee.whatsapp && (
-              <div>
-                <p className="text-xs text-gray-500">{t.candidateDetail.whatsapp}</p>
-                <p className="text-sm text-gray-900">{relation.mentee.whatsapp}</p>
-              </div>
-            )}
-            {(relation.mentee.whatsapp || relation.mentee.phone) && (
-              <ContactActions
-                relationId={id}
-                phone={relation.mentee.whatsapp || relation.mentee.phone || ''}
-                onLogged={fetchRelation}
-              />
-            )}
-            {relation.mentee.city && (
-              <div>
-                <p className="text-xs text-gray-500">{t.candidateDetail.city}</p>
-                <p className="text-sm text-gray-900">{relation.mentee.city}</p>
-              </div>
-            )}
-            {relation.mentee.birthDate && (
-              <div>
-                <p className="text-xs text-gray-500">{t.candidateDetail.birthDate}</p>
-                <p className="text-sm text-gray-900">
-                  {formatDate(relation.mentee.birthDate, locale)}
-                </p>
-              </div>
-            )}
-            {/* Who brought this mentee in — one line, whether that is a
-                registered person, a source, or the legacy free text (#1296). */}
-            {referrerLabel(relation.mentee) && (
-              <div>
-                <p className="text-xs text-gray-500">{t.referrer.label}</p>
-                <p className="text-sm text-gray-900" data-testid="mentee-referrer">{referrerLabel(relation.mentee)}</p>
-              </div>
-            )}
-            {relation.mentee.skills.length > 0 && (
-              <div>
-                <p className="text-xs text-gray-500 mb-1">{t.candidateDetail.skills}</p>
-                <div className="flex flex-wrap gap-1">
-                  {relation.mentee.skills.map((skill) => (
-                    <Badge key={skill} variant="info" className="text-xs">{skill}</Badge>
-                  ))}
+            </CardHeader>
+
+            {relation.interactions.length > 0 && <InteractionSummary relationId={relation.id} />}
+
+            {showForm && (
+              <div data-testid="interaction-log-form" className="mb-6 p-4 bg-gray-50 rounded-xl space-y-3">
+                {formError && (
+                  <p className="text-sm text-red-600">{formError}</p>
+                )}
+                <div className="grid grid-cols-2 gap-3">
+                  <Input
+                    label={t.mentor.date}
+                    type="date"
+                    data-testid="interaction-log-date"
+                    value={formData.date}
+                    onChange={(e) => setFormData((p) => ({ ...p, date: e.target.value }))}
+                  />
+                  <Select
+                    label={t.mentor.type}
+                    options={typeOptions}
+                    value={formData.type}
+                    onChange={(e) => setFormData((p) => ({ ...p, type: e.target.value }))}
+                  />
+                </div>
+                <Input
+                  label={t.mentor.subject}
+                  data-testid="interaction-log-subject"
+                  value={formData.subject}
+                  onChange={(e) => setFormData((p) => ({ ...p, subject: e.target.value }))}
+                  placeholder={t.mentor.subjectPlaceholder}
+                />
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1.5">{t.mentor.notes}</label>
+                  <Textarea
+                    rows={3}
+                    data-testid="interaction-log-notes"
+                    value={formData.notes}
+                    onChange={(e) => setFormData((p) => ({ ...p, notes: e.target.value }))}
+                    placeholder="What was discussed..."
+                    maxLength={TEXT_LIMITS.interactionNotes}
+                    showCounter
+                  />
+                </div>
+                <div className="flex gap-2">
+                  <Button size="sm" onClick={handleAddInteraction} loading={submitting}>{t.mentor.save}</Button>
+                  <Button size="sm" variant="outline" onClick={() => setShowForm(false)}>{t.mentor.cancel}</Button>
                 </div>
               </div>
             )}
-            {relation.mentee.cvUrl && (
-              <a
-                href={cvViewHref(relation.mentee.cvUrl)}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center gap-1 text-sm text-blue-600 hover:underline"
-              >
-                <ExternalLink className="h-3 w-3" />
-                {t.candidateDetail.viewCv}
-              </a>
-            )}
-            {relation.company && (
-              <div className="mt-4 p-3 bg-blue-50 dark:bg-blue-950/40 rounded-lg">
-                <p className="text-xs text-blue-500 dark:text-blue-400 font-medium mb-1">{t.candidateDetail.company}</p>
-                <p className="text-sm font-medium text-blue-900 dark:text-blue-100">{relation.company.name}</p>
-                {relation.company.industry && (
-                  <p className="text-xs text-blue-700 dark:text-blue-300">{relation.company.industry}</p>
-                )}
-                {relation.companyInterest && (
-                  <div className="mt-2 pt-2 border-t border-blue-100 dark:border-blue-900">
-                    <Badge variant={relation.companyInterest.status === 'PASS' ? 'danger' : relation.companyInterest.status === 'SHORTLISTED' ? 'success' : 'info'}>
-                      {t.candidateDetail.companyInterest[relation.companyInterest.status.toLowerCase() as 'interested' | 'shortlisted' | 'pass']}
-                    </Badge>
-                    {relation.companyInterest.note && (
-                      <p className="text-xs text-blue-700 dark:text-blue-300 mt-1.5 italic">“{relation.companyInterest.note}”</p>
-                    )}
-                  </div>
-                )}
-              </div>
-            )}
-          </div>
-        </Card>
 
-        {/* Pipeline stage history */}
-        <Card>
-          <CardHeader>
-            <CardTitle>{t.mentor.stageHistory} ({relation.statusChanges.length})</CardTitle>
-          </CardHeader>
-          {relation.statusChanges.length === 0 ? (
-            <p className="text-sm text-gray-400 text-center py-6">{t.mentor.noStageChanges}</p>
-          ) : (
-            <ol className="space-y-3">
-              {relation.statusChanges.map((sc) => (
-                <li key={sc.id} className="text-sm border-l-2 border-blue-100 pl-3">
-                  <p className="text-gray-700">
-                    <span className="text-gray-400">{label(sc.fromStatus)}</span>
-                    {' → '}
-                    <span className="font-medium text-gray-900">{label(sc.toStatus)}</span>
-                  </p>
-                  <p className="text-xs text-gray-400 mt-0.5">
-                    {sc.changedBy.fullName} · {formatDateTime(sc.createdAt, locale)}
-                  </p>
-                </li>
-              ))}
-            </ol>
-          )}
-        </Card>
-
-        {/* Interactions */}
-        <Card className="lg:col-span-2">
-          <CardHeader>
-            <div className="flex items-center justify-between">
-              <CardTitle>{t.mentor.interactionLog} ({relation.interactions.length})</CardTitle>
-              <Button size="sm" onClick={() => setShowForm(!showForm)}>
-                <Plus className="h-4 w-4" />
-                {t.mentor.addLog}
-              </Button>
-            </div>
-          </CardHeader>
-
-          {relation.interactions.length > 0 && <InteractionSummary relationId={relation.id} />}
-
-          {showForm && (
-            <div data-testid="interaction-log-form" className="mb-6 p-4 bg-gray-50 rounded-xl space-y-3">
-              {formError && (
-                <p className="text-sm text-red-600">{formError}</p>
-              )}
-              <div className="grid grid-cols-2 gap-3">
-                <Input
-                  label={t.mentor.date}
-                  type="date"
-                  data-testid="interaction-log-date"
-                  value={formData.date}
-                  onChange={(e) => setFormData((p) => ({ ...p, date: e.target.value }))}
-                />
-                <Select
-                  label={t.mentor.type}
-                  options={typeOptions}
-                  value={formData.type}
-                  onChange={(e) => setFormData((p) => ({ ...p, type: e.target.value }))}
-                />
-              </div>
-              <Input
-                label={t.mentor.subject}
-                data-testid="interaction-log-subject"
-                value={formData.subject}
-                onChange={(e) => setFormData((p) => ({ ...p, subject: e.target.value }))}
-                placeholder={t.mentor.subjectPlaceholder}
-              />
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1.5">{t.mentor.notes}</label>
-                <Textarea
-                  rows={3}
-                  data-testid="interaction-log-notes"
-                  value={formData.notes}
-                  onChange={(e) => setFormData((p) => ({ ...p, notes: e.target.value }))}
-                  placeholder="What was discussed..."
-                  maxLength={TEXT_LIMITS.interactionNotes}
-                  showCounter
-                />
-              </div>
-              <div className="flex gap-2">
-                <Button size="sm" onClick={handleAddInteraction} loading={submitting}>{t.mentor.save}</Button>
-                <Button size="sm" variant="outline" onClick={() => setShowForm(false)}>{t.mentor.cancel}</Button>
-              </div>
-            </div>
-          )}
-
-          <div className="space-y-3">
-            {relation.interactions.length === 0 && (
-              <div>
-                <p className="text-sm text-gray-400 text-center pt-4 pb-3">{t.mentor.noInteractionsYet}</p>
-                <div className="opacity-50 pointer-events-none">
-                  <p className="text-xs font-medium text-gray-400 uppercase tracking-wide mb-2">{t.mentor.exampleLog}</p>
-                  <div className="flex items-start gap-3 py-3 border-b border-dashed border-gray-200">
-                    <InteractionTypeBadge type="Meeting" className="text-xs flex-shrink-0 mt-0.5" />
-                    <div className="flex-1 min-w-0">
-                      <p className="text-sm text-gray-700">{t.mentor.exampleLogNote}</p>
-                      <p className="text-xs text-gray-400 mt-1">{formatDate(new Date(), locale)}</p>
+            <div className="space-y-3">
+              {relation.interactions.length === 0 && (
+                <div>
+                  <p className="text-sm text-gray-400 text-center pt-4 pb-3">{t.mentor.noInteractionsYet}</p>
+                  <div className="opacity-50 pointer-events-none">
+                    <p className="text-xs font-medium text-gray-400 uppercase tracking-wide mb-2">{t.mentor.exampleLog}</p>
+                    <div className="flex items-start gap-3 py-3 border-b border-dashed border-gray-200">
+                      <InteractionTypeBadge type="Meeting" className="text-xs flex-shrink-0 mt-0.5" />
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm text-gray-700">{t.mentor.exampleLogNote}</p>
+                        <p className="text-xs text-gray-400 mt-1">{formatDate(new Date(), locale)}</p>
+                      </div>
                     </div>
                   </div>
                 </div>
+              )}
+              {relation.interactions.map((interaction) => (
+                <div key={interaction.id} className="flex items-start gap-3 py-3 border-b border-gray-50 last:border-0">
+                  <InteractionTypeBadge type={interaction.type} className="text-xs flex-shrink-0 mt-0.5" />
+                  <div className="flex-1 min-w-0">
+                    {interaction.subject && (
+                      <p className="text-sm font-medium text-gray-900">{interaction.subject}</p>
+                    )}
+                    <p className="text-sm text-gray-700">{interaction.notes}</p>
+                    <AutoLoggedBadge autoLogged={interaction.autoLogged} className="text-xs mt-1" />
+                    <p className="text-xs text-gray-400 mt-1">
+                      {formatDate(interaction.date, locale)}
+                    </p>
+                  </div>
+                  <button
+                    onClick={() => handleDeleteInteraction(interaction.id)}
+                    className="text-gray-300 hover:text-red-500 transition-colors flex-shrink-0"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          </Card>
+
+          <EvaluationPanel relationId={id} />
+
+          <GoalsPanel relationId={id} />
+
+          {/* Everything on this mentee's list — what came from a project and what a
+              mentor handed them directly — plus the box to add to it (#1113). */}
+          <PersonTodos userId={relation.mentee.id} fullName={relation.mentee.fullName} />
+
+          <MeetingRequestsPanel relationId={id} mode="manage" />
+
+          <QuestionsPanel relationId={id} mode="answer" />
+
+          <div className="flex flex-col gap-3">
+            {canIssueCertificate(relation, stages) && (
+              <div>
+                <CertificateGenerator
+                  relationId={id}
+                  eligible
+                  mentee={{ fullName: relation.mentee.fullName, skills: relation.mentee.skills }}
+                  mentor={{ fullName: relation.mentor.fullName }}
+                  companyName={relation.company?.name ?? null}
+                  startDate={relation.startDate}
+                  completedAt={relation.completedAt}
+                  onGenerated={fetchRelation}
+                />
               </div>
             )}
-            {relation.interactions.map((interaction) => (
-              <div key={interaction.id} className="flex items-start gap-3 py-3 border-b border-gray-50 last:border-0">
-                <InteractionTypeBadge type={interaction.type} className="text-xs flex-shrink-0 mt-0.5" />
-                <div className="flex-1 min-w-0">
-                  {interaction.subject && (
-                    <p className="text-sm font-medium text-gray-900">{interaction.subject}</p>
-                  )}
-                  <p className="text-sm text-gray-700">{interaction.notes}</p>
-                  <AutoLoggedBadge autoLogged={interaction.autoLogged} className="text-xs mt-1" />
-                  <p className="text-xs text-gray-400 mt-1">
-                    {formatDate(interaction.date, locale)}
-                  </p>
-                </div>
-                <button
-                  onClick={() => handleDeleteInteraction(interaction.id)}
-                  className="text-gray-300 hover:text-red-500 transition-colors flex-shrink-0"
-                >
-                  <Trash2 className="h-4 w-4" />
-                </button>
-              </div>
-            ))}
+            <DocumentsManager targetUserId={relation.mentee.id} />
           </div>
-        </Card>
 
-        <div className="lg:col-span-2">
-          <EvaluationPanel relationId={id} />
-        </div>
-
-        <div className="lg:col-span-2">
-          <GoalsPanel relationId={id} />
-        </div>
-
-        {/* Everything on this mentee's list — what came from a project and what a
-            mentor handed them directly — plus the box to add to it (#1113). */}
-        <div className="lg:col-span-2">
-          <PersonTodos userId={relation.mentee.id} fullName={relation.mentee.fullName} />
-        </div>
-
-        <div className="lg:col-span-2">
-          <MeetingRequestsPanel relationId={id} mode="manage" />
-        </div>
-
-        <div className="lg:col-span-2">
-          <QuestionsPanel relationId={id} mode="answer" />
-        </div>
-
-        <div className="lg:col-span-2 flex flex-col gap-3">
-          {canIssueCertificate(relation, stages) && (
-            <div>
-              <CertificateGenerator
-                relationId={id}
-                eligible
-                mentee={{ fullName: relation.mentee.fullName, skills: relation.mentee.skills }}
-                mentor={{ fullName: relation.mentor.fullName }}
-                companyName={relation.company?.name ?? null}
-                startDate={relation.startDate}
-                completedAt={relation.completedAt}
-                onGenerated={fetchRelation}
-              />
-            </div>
-          )}
-          <DocumentsManager targetUserId={relation.mentee.id} />
-        </div>
-
-        <div className="lg:col-span-2">
           <RelationNotesPanel relationId={id} />
-        </div>
 
-        {/* Activity feed sits last — it's the least frequently acted-on panel,
-            so private notes and the working panels stay above the fold. */}
-        <div className="lg:col-span-2">
+          {/* Activity feed sits last — it's the least frequently acted-on panel,
+              so private notes and the working panels stay above the fold. */}
           <UserActivityPanel userId={relation.mentee.id} flagInactive />
         </div>
       </div>

--- a/src/app/mentor/mentees/[id]/page.tsx
+++ b/src/app/mentor/mentees/[id]/page.tsx
@@ -256,8 +256,13 @@ export default function MenteeDetailPage() {
             panels, and it is placed in the third column from `lg` up. Every
             working panel used to carry `lg:col-span-2` in this three-column
             grid, so nothing was ever placed in the third column and the right
-            third of the page was empty top to bottom (#1370). */}
-        <aside className="space-y-6 lg:col-start-3 lg:row-start-1" data-testid="mentee-detail-sidebar">
+            third of the page was empty top to bottom (#1370).
+            `print:!block` because the app-chrome print rule in globals.css hides
+            *every* `aside` (`@media print { aside, header, .no-print { display:
+            none !important } }`) — without it this content sidebar would vanish
+            from a printed / saved-as-PDF mentee page, which the two cards used to
+            survive as plain grid children. */}
+        <aside className="space-y-6 print:!block lg:col-start-3 lg:row-start-1" data-testid="mentee-detail-sidebar">
           {/* Mentee info */}
           <Card>
             <CardHeader>


### PR DESCRIPTION
## Summary

The mentee detail overview was a `lg:grid-cols-3` grid in which the profile card and the stage history took one column each and **every** working panel below them carried `lg:col-span-2`. Grid auto-placement therefore never put anything in the third column: from "Etkileşim Kaydı" downwards everything sat in the left two thirds and the right third of a 1280px screen was empty top to bottom — on the page a mentor looks at longest.

Rather than adding more utility classes, the grid now has two real children:

- a **reference sidebar** — profile + stage history — placed in the third column (`lg:col-start-3 lg:row-start-1`);
- the **working panels** as one column spanning the other two (`lg:col-start-1 lg:row-start-1 lg:col-span-2`), stacked with `space-y-6` in place of the grid gap they used to inherit, so `lg:col-span-2` disappears from every panel.

The sidebar stays **first in the DOM**, so the phone/tablet view (`grid-cols-1`) is byte-for-byte the same reading order as before: profile → stage history → working panels.

**What went in the right column and why:** the two cards the page already fetches and that are pure reference material — who the mentee is (university, department, contact, referrer, skills, CV, company) and how their stage changed over time. A mentor reads those *while* working the panels next to them, which is exactly what a side column is for; the interactive panels (interactions, evaluation, goals, todos, meetings, questions, documents, notes, activity) keep the wide column because their forms and lists need the width.

**Deliberately not sticky:** the role shell's `<main>` carries `overflow-auto` (`src/components/ResponsiveShell.tsx`) while the shell root is only `min-h-screen`, so `main` is a scroll container that never actually scrolls — the document does. A `lg:sticky` sidebar inside it would silently do nothing. Option 1 from the issue minus the sticky, therefore; happy to revisit if the shell's scrolling moves to the document.

**Follow-up commit (`358adc5`), found in self-review:** `globals.css` hides the app chrome on printed pages with `@media print { aside, header, .no-print { display: none !important } }` — a rule that matches *every* `aside`, so the new content sidebar disappeared from a printed / saved-as-PDF mentee page (the two cards survived it before, as plain grid children). It now carries `print:!block`, a class selector that outranks the bare `aside` type selector regardless of stylesheet order, and the spec asserts it under `emulateMedia({ media: 'print' })`.

Closes #1370

## Changes

- `src/app/mentor/mentees/[id]/page.tsx` — grid split into an `<aside data-testid="mentee-detail-sidebar">` (third column) and a `<div data-testid="mentee-detail-main">` (two columns); removed the nine `lg:col-span-2` wrappers/classes; the sidebar keeps `print:!block` so the print rule for app chrome does not swallow it. Logical diff is ~15 lines (`git diff -w`); the rest of the file diff is the indentation shift from the two new wrappers.
- `e2e/mentee-detail-columns.spec.ts` — new spec that fails on the old markup: at 1280px and 1536px both columns are visible, start on the same row, the sidebar sits to the right of the panels, is wider than 20% of the grid and its right edge *is* the grid's right edge (no dead column), each column holds its expected cards, and both columns stay visible with print media emulated; a second test asserts the phone view (390px) is one column, profile first, with no sideways scroll (rule 1 of `e2e/mobile-layout-audit.spec.ts`).
- `releases/unreleased/mentee-detail-right-column.json` — `patch` fragment with EN/TR/DE notes.

## Verification

- [x] `npm run lint` + `npx tsc --noEmit` clean (lint prints only the pre-existing warnings from unrelated files)
- [x] `npm run build` green; `npm run check:i18n` and `npm run check:release-fragments` green (fragment ships as `0.135.1-beta`)
- [x] Geometry verified in headless Chromium against the **built** Tailwind stylesheet with a static replica of the new markup, at 1536/1280/1024/768/390px: from `lg` up the panels are the wide left column and the sidebar is the last third, both starting on the same row, with the sidebar's right edge exactly on the grid's right edge (e.g. 1280px: grid right 1256, sidebar `x=861 w=395`); at 768px and 390px one column, sidebar above the panels, `scrollWidth - clientWidth = 0`. With print media emulated the sidebar computes `display: block` (it computed `none` before commit `358adc5`). Also confirmed in the generated CSS that `col-span-2` (the `grid-column` shorthand) is emitted *before* `col-start-1`, so the wide column really is columns 1–2.
- [ ] `npm run test:e2e` / `test:e2e:smoke` — **not executed**: no MySQL and no Docker daemon in this container, so neither the new spec nor the suite was run. Note the new spec is deliberately **not** tagged `@smoke`, so the PR gate (`e2e.yml`, smoke subset only) will not run it either — it first runs in the scheduled full suite (`e2e-full.yml`) after merge. Its assertions are pure geometry against the two new testids; the browser-measured replica above is the closest thing to a run this container allows.
- [ ] Not viewed in the running app (no DB to sign in against) — the PR environment at `https://crm-pr2137.ersah.in` is the place to eyeball it.

Acceptance criteria: no permanently empty column at 1280/1536 ✅ (measured, incl. `xl`); phone/tablet unchanged ✅ (DOM order and single-column layout preserved, measured at 390/768); tabs (Genel bakış / Haftalık raporlar) and all panels still present ✅ (no panel added, removed or reordered — only their wrappers changed); `npm run build` green ✅.

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JgY7mKwLmq9KdtnBFYYQu3


---
_Generated by [Claude Code](https://claude.ai/code/session_01JgY7mKwLmq9KdtnBFYYQu3)_