### PR TITLE
feat(release-notes): RSS feed at /release-notes/feed.xml

### DIFF
--- a/e2e/release-notes-feed.spec.ts
+++ b/e2e/release-notes-feed.spec.ts
@@ -95,9 +95,13 @@ test('the feed is localized by ?lang and linked from the page', async ({ page })
 
   expect(en.language).toBe('en');
   expect(tr.language).toBe('tr');
-  // Same releases, different prose.
+  // Same releases, different prose. Compared over the WHOLE window rather than
+  // the newest item alone: item 0 is whichever fragment merged last, and a
+  // single note whose Turkish text happens to equal its English one (a product
+  // name, a forgotten translation) would fail that narrower assertion on an
+  // unrelated PR without anything being wrong with the feed.
   expect(tr.guids).toEqual(en.guids);
-  expect(tr.descriptions[0]).not.toBe(en.descriptions[0]);
+  expect(tr.descriptions).not.toEqual(en.descriptions);
   // An unknown language falls back to the default rather than erroring.
   expect(bogus.language).toBe('en');
 

--- a/e2e/release-notes-feed.spec.ts
+++ b/e2e/release-notes-feed.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect, type Page } from '@playwright/test';
+import { readFileSync } from 'fs';
+import path from 'path';
+
+/**
+ * The /release-notes RSS feed (#1383).
+ *
+ * The contract that matters is the HTTP one — a feed reader fetches the URL with
+ * no cookies and either parses the document or shows the subscription as broken
+ * — so everything here goes through `page.request`, and well-formedness is
+ * checked with a real XML parser (the browser's DOMParser) instead of by string
+ * matching.
+ */
+
+const repoRoot = path.join(__dirname, '..');
+const pkg = JSON.parse(readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+// The newest release the PAGE shows: one entry per change that carries
+// user-facing notes (#1275/#1457). Derived with the same code next.config.js
+// uses, exactly like e2e/version-release-notes.spec.ts.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const release = require(path.join(repoRoot, 'scripts', 'release-derive.cjs'));
+const { timeline } = release.resolveRelease(repoRoot, pkg.version);
+const newestNoted = [...timeline].reverse().find((entry: { notes?: unknown }) => entry.notes);
+const newestCanonical = readFileSync(path.join(repoRoot, 'src', 'lib', 'releaseNotes.ts'), 'utf8')
+  .match(/^\s+version: '(.+?)',$/m)?.[1];
+const topEntryVersion: string = newestNoted ? newestNoted.version : newestCanonical ?? pkg.version;
+
+/** Fetch a feed URL and report what a reader's parser would see. */
+async function fetchFeed(page: Page, url: string) {
+  const res = await page.request.get(url);
+  expect(res.status()).toBe(200);
+  expect(res.headers()['content-type']).toContain('application/rss+xml');
+  const xml = await res.text();
+
+  return page.evaluate((body) => {
+    const doc = new DOMParser().parseFromString(body, 'application/xml');
+    const error = doc.querySelector('parsererror');
+    const texts = (selector: string) =>
+      Array.from(doc.querySelectorAll(selector)).map((n) => n.textContent ?? '');
+    return {
+      error: error ? error.textContent : null,
+      root: doc.documentElement.nodeName,
+      language: doc.querySelector('channel > language')?.textContent ?? null,
+      self: doc.querySelector('channel > link')?.textContent ?? null,
+      titles: texts('channel > item > title'),
+      links: texts('channel > item > link'),
+      guids: texts('channel > item > guid'),
+      dates: texts('channel > item > pubDate'),
+      descriptions: texts('channel > item > description'),
+    };
+  }, xml);
+}
+
+test('the release-notes feed is a well-formed RSS document', async ({ page }) => {
+  // The page is both the subject of the next assertion and the host DOMParser
+  // runs in, so it is loaded once up front.
+  await page.goto('/release-notes');
+  const feed = await fetchFeed(page, '/release-notes/feed.xml');
+
+  expect(feed.error).toBeNull();
+  expect(feed.root).toBe('rss');
+  expect(feed.titles.length).toBeGreaterThan(0);
+  expect(feed.self).toMatch(/^https?:\/\/.+\/release-notes$/);
+
+  // The newest item is the newest release the page itself shows.
+  expect(feed.titles[0]).toContain(`v${topEntryVersion}`);
+  await expect(page.getByRole('heading', { name: `v${topEntryVersion}` })).toBeVisible();
+
+  // Absolute permalinks and unique, stable GUIDs.
+  expect(feed.links[0]).toMatch(/^https?:\/\/.+\/release-notes#v/);
+  expect(feed.guids[0]).toMatch(/^urn:internship-crm:release:/);
+  expect(new Set(feed.guids).size).toBe(feed.guids.length);
+
+  // Publication dates come from the release data, never from the clock — and a
+  // pending fragment that git cannot date (this job checks out shallow, so the
+  // add-commit is the boundary) legitimately ships without one rather than with
+  // an invented date. Every date that IS present must be a real RFC 822 date.
+  for (const date of feed.dates) {
+    expect(Number.isNaN(new Date(date).getTime())).toBe(false);
+  }
+
+  // The highlights ride along as escaped HTML: the parser hands the markup back
+  // as text, which is what proves nothing leaked into the document as raw
+  // `<` or `&` — the failure mode a markdown-bearing note would cause.
+  expect(feed.descriptions[0]).toContain('<ul>');
+  expect(feed.descriptions[0]).toContain('<li>');
+});
+
+test('the feed is localized by ?lang and linked from the page', async ({ page }) => {
+  await page.goto('/release-notes');
+
+  const en = await fetchFeed(page, '/release-notes/feed.xml');
+  const tr = await fetchFeed(page, '/release-notes/feed.xml?lang=tr');
+  const bogus = await fetchFeed(page, '/release-notes/feed.xml?lang=klingon');
+
+  expect(en.language).toBe('en');
+  expect(tr.language).toBe('tr');
+  // Same releases, different prose.
+  expect(tr.guids).toEqual(en.guids);
+  expect(tr.descriptions[0]).not.toBe(en.descriptions[0]);
+  // An unknown language falls back to the default rather than erroring.
+  expect(bogus.language).toBe('en');
+
+  const alternate = page.locator('link[rel="alternate"][type="application/rss+xml"]');
+  await expect(alternate).toHaveCount(1);
+  expect(await alternate.getAttribute('href')).toContain('/release-notes/feed.xml');
+  await expect(page.getByTestId('release-notes-feed-link')).toBeVisible();
+});

--- a/releases/unreleased/release-notes-feed.json
+++ b/releases/unreleased/release-notes-feed.json
@@ -1,0 +1,15 @@
+{
+  "bump": "minor",
+  "changelog": "- **RSS feed for /release-notes** (#1383). New `GET /release-notes/feed.xml` renders `getAllReleaseNotes()` as RSS 2.0 (`src/lib/releaseFeed.ts`, pure + escaped, 50 newest items, absolute links from the configured origin, `urn:internship-crm:release:<version>` GUIDs, RFC 822 dates). Localized by `?lang=tr|de`, cached `s-maxage=3600`; the page advertises it via `rel=\"alternate\"` plus a visible link, and its release cards gained `id=\"v<version>\"` anchors so feed items deep-link.",
+  "notes": {
+    "en": [
+      "Follow new releases without an account: the \"What's new\" page now has an RSS feed you can subscribe to or pipe into Slack or Discord."
+    ],
+    "tr": [
+      "Yeni sürümleri hesap açmadan takip edin: \"Yenilikler\" sayfasının artık abone olabileceğiniz ya da Slack/Discord'a bağlayabileceğiniz bir RSS akışı var."
+    ],
+    "de": [
+      "Neue Releases ohne Konto verfolgen: Die Seite \"Neuigkeiten\" hat jetzt einen RSS-Feed, den du abonnieren oder in Slack oder Discord einbinden kannst."
+    ]
+  }
+}

--- a/src/app/release-notes/feed.xml/route.ts
+++ b/src/app/release-notes/feed.xml/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import { defaultLocale, isLocale } from '@/i18n/config';
+import { publicOrigin, releaseFeedXml } from '@/lib/releaseFeed';
+
+// GET /release-notes/feed.xml — the public "what's new" page as an RSS 2.0 feed
+// (#1383), so releases can be followed without an account and piped somewhere
+// else (Slack/Discord webhook, auto-posting). Served next to the page rather
+// than under /api, so the feed URL is the one a reader would guess.
+//
+// Localized by query parameter (`?lang=tr`, `?lang=de`, default `en`) instead
+// of the locale cookie: a feed reader sends no cookies, so the language has to
+// live in the URL it subscribed to.
+//
+// Deliberately NOT rate-limited, unlike the other anonymous endpoints: this
+// handler touches no database and no session — it renders build-time data — and
+// polling on a schedule is exactly what a feed reader is supposed to do. The
+// s-maxage/stale-while-revalidate pair is the protection that fits.
+export async function GET(request: Request) {
+  const lang = new URL(request.url).searchParams.get('lang');
+  const locale = isLocale(lang) ? lang : defaultLocale;
+
+  return new NextResponse(releaseFeedXml({ origin: publicOrigin(request.url), locale }), {
+    headers: {
+      // The type the page's `rel="alternate"` link advertises. Readers and
+      // browsers both accept it, and it stays parseable as plain XML.
+      'Content-Type': 'application/rss+xml; charset=utf-8',
+      'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=600',
+    },
+  });
+}

--- a/src/app/release-notes/page.tsx
+++ b/src/app/release-notes/page.tsx
@@ -1,15 +1,32 @@
+import type { Metadata } from 'next';
 import Link from 'next/link';
-import { GraduationCap, Sparkles } from 'lucide-react';
+import { GraduationCap, Rss, Sparkles } from 'lucide-react';
 import { getServerDictionary } from '@/i18n/server';
 import { getAllReleaseNotes } from '@/lib/releaseNotes';
+import { publicOrigin, releaseFeedUrl } from '@/lib/releaseFeed';
 import { APP_VERSION, GIT_SHA } from '@/lib/version';
 import { PublicShell } from '@/components/landing/PublicShell';
 import { GITHUB_URL } from '@/components/landing/links';
+
+// Discoverability half of the feed (#1383): browsers and readers pick a feed up
+// from this link, so subscribing is one click from the page. Static metadata is
+// locale-independent, hence the default-locale feed — the other two languages
+// are the same URL with `?lang=`, and the visible link below follows the reader.
+export const metadata: Metadata = {
+  alternates: {
+    types: {
+      'application/rss+xml': [
+        { url: releaseFeedUrl(publicOrigin()), title: 'Internship CRM — release notes' },
+      ],
+    },
+  },
+};
 
 // Public, user-facing "what's new" page — friendly feature highlights per
 // release, localized. Distinct from CHANGELOG.md (developer-facing, in the repo).
 export default async function ReleaseNotesPage() {
   const { locale, t } = await getServerDictionary();
+  const feedUrl = releaseFeedUrl(publicOrigin(), locale);
 
   return (
     <PublicShell>
@@ -23,7 +40,12 @@ export default async function ReleaseNotesPage() {
 
         <div className="space-y-6">
           {getAllReleaseNotes().map((r) => (
-            <div key={r.version} className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-800 p-6">
+            <div
+              key={r.version}
+              /* The permalink the feed items point at (#1383). */
+              id={`v${r.version}`}
+              className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-800 p-6 scroll-mt-20"
+            >
               {/* Stacks on a phone: version + "2026-08-25 09:25 UTC · b174c20"
                   side by side is wider than 360px (e2e/mobile-layout-audit). */}
               <div className="flex flex-col sm:flex-row sm:items-baseline sm:justify-between gap-1 sm:gap-3 mb-3">
@@ -55,9 +77,18 @@ export default async function ReleaseNotesPage() {
           ))}
         </div>
 
-        <Link href="/" className="inline-flex items-center gap-1.5 mt-8 text-sm text-blue-600 hover:underline">
-          <GraduationCap className="h-4 w-4" /> {t.releaseNotes.back}
-        </Link>
+        <div className="flex flex-wrap items-center gap-x-6 gap-y-2 mt-8">
+          <Link href="/" className="inline-flex items-center gap-1.5 text-sm text-blue-600 hover:underline">
+            <GraduationCap className="h-4 w-4" /> {t.releaseNotes.back}
+          </Link>
+          <a
+            href={feedUrl}
+            data-testid="release-notes-feed-link"
+            className="inline-flex items-center gap-1.5 text-sm text-blue-600 hover:underline"
+          >
+            <Rss className="h-4 w-4" /> {t.releaseNotes.feed}
+          </a>
+        </div>
       </div>
     </PublicShell>
   );

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -3280,7 +3280,12 @@ const en = {
     functionalRoles: { DEVELOPER: 'Developer', TESTER: 'Tester', MARKETING: 'Marketing' },
     tasksCompleted: '{n} tasks completed',
   },
-  releaseNotes: { title: 'What’s new', back: 'Back to home' },
+  releaseNotes: {
+    title: 'What’s new',
+    back: 'Back to home',
+    feed: 'RSS feed',
+    feedDescription: 'New features and improvements in Internship CRM.',
+  },
   consentRenew: {
     title: 'Keep your data',
     body: 'Confirm that you still want us to store your data (profile, CV and interaction history). This renews your consent.',
@@ -6946,7 +6951,12 @@ const tr: Dict = {
     functionalRoles: { DEVELOPER: 'Geliştirici', TESTER: 'Test', MARKETING: 'Pazarlama' },
     tasksCompleted: '{n} görev tamamlandı',
   },
-  releaseNotes: { title: 'Yenilikler', back: 'Ana sayfaya dön' },
+  releaseNotes: {
+    title: 'Yenilikler',
+    back: 'Ana sayfaya dön',
+    feed: 'RSS akışı',
+    feedDescription: 'Internship CRM’deki yeni özellikler ve iyileştirmeler.',
+  },
   consentRenew: {
     title: 'Verini sakla',
     body: 'Verini (profil, CV ve etkileşim geçmişi) saklamamıza devam etmek istediğini onayla. Bu, rızanı yeniler.',
@@ -10608,7 +10618,12 @@ const de: Dict = {
     functionalRoles: { DEVELOPER: 'Entwicklung', TESTER: 'Test', MARKETING: 'Marketing' },
     tasksCompleted: '{n} Aufgaben abgeschlossen',
   },
-  releaseNotes: { title: 'Neuigkeiten', back: 'Zurück zur Startseite' },
+  releaseNotes: {
+    title: 'Neuigkeiten',
+    back: 'Zurück zur Startseite',
+    feed: 'RSS-Feed',
+    feedDescription: 'Neue Funktionen und Verbesserungen im Internship CRM.',
+  },
   consentRenew: {
     title: 'Deine Daten behalten',
     body: 'Bestätige, dass wir deine Daten (Profil, Lebenslauf und Interaktionsverlauf) weiter speichern dürfen. Damit erneuerst du deine Einwilligung.',

--- a/src/lib/releaseFeed.ts
+++ b/src/lib/releaseFeed.ts
@@ -1,0 +1,128 @@
+// RSS 2.0 feed for /release-notes (#1383). The public "what's new" page is a
+// content asset — the product ships often and the landing uses that as proof —
+// but until now the only way to follow it was to open the page by hand. A feed
+// lets an interested reader subscribe without an account, and lets a release
+// be piped somewhere else (Slack/Discord webhook, auto-posting) for free.
+//
+// Pure + string-returning on purpose: the same data the page renders
+// (getAllReleaseNotes(), i.e. releaseNotes.ts plus the pending fragments
+// inlined at build time) goes through here, so the feed can never drift from
+// the page, and the document is verifiable without a server.
+
+import { defaultLocale, type Locale } from '@/i18n/config';
+import { getDictionary } from '@/i18n/dictionaries';
+import { getAllReleaseNotes, type ReleaseNote } from '@/lib/releaseNotes';
+
+/** Where the feed is served — one constant, so the route, the page's
+ *  `rel="alternate"` metadata and the visible link cannot disagree. */
+export const RELEASE_FEED_PATH = '/release-notes/feed.xml';
+
+/** A feed is a subscription, not an archive: readers only ever show the recent
+ *  entries, and the full history is 200+ releases of XML nobody reads. */
+const MAX_ITEMS = 50;
+
+/**
+ * The origin absolute links are built from. Same precedence as
+ * `appBase()` in lib/ssoSaml.ts — configured value first, never a hardcoded
+ * domain — with the request's own origin as a last resort so a deployment that
+ * sets neither still emits working links instead of localhost ones.
+ */
+export function publicOrigin(requestUrl?: string): string {
+  const configured = process.env.NEXTAUTH_URL || process.env.NEXT_PUBLIC_APP_URL;
+  if (configured) return configured.replace(/\/$/, '');
+  if (requestUrl) {
+    try {
+      return new URL(requestUrl).origin;
+    } catch {
+      // fall through to the local default
+    }
+  }
+  return 'http://localhost:3000';
+}
+
+/** The feed URL for one locale. `en` is the default, so it carries no query. */
+export function releaseFeedUrl(origin: string, locale: Locale = defaultLocale): string {
+  return locale === defaultLocale
+    ? `${origin}${RELEASE_FEED_PATH}`
+    : `${origin}${RELEASE_FEED_PATH}?lang=${locale}`;
+}
+
+// Every interpolated value goes through this. Release notes are user-facing
+// prose that may contain `&`, quotes or markdown, and a raw `&` alone is enough
+// to make the document unparseable — which is exactly the failure a reader
+// reports as "your feed is broken". Deliberately NOT CDATA: a CDATA section is
+// itself escaping that breaks on a literal `]]>`, so there is nothing to gain.
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+/** The highlights as an HTML fragment, then escaped once more as XML text —
+ *  the standard way to carry markup in `<description>` without a CDATA block. */
+function descriptionHtml(highlights: string[]): string {
+  const items = highlights.map((h) => `<li>${escapeXml(h)}</li>`).join('');
+  return escapeXml(`<ul>${items}</ul>`);
+}
+
+/** RFC 822 date, which is what RSS 2.0 wants. `''` when the release carries no
+ *  usable stamp (an uncommitted fragment has no merge date yet) — the item then
+ *  simply ships without a pubDate rather than with a made-up one. */
+function rfc822(note: ReleaseNote): string {
+  if (!note.date) return '';
+  const at = new Date(`${note.date}T${note.time || '00:00'}:00Z`);
+  return Number.isNaN(at.getTime()) ? '' : at.toUTCString();
+}
+
+/** A GUID that survives a move to another domain and a re-render of the page:
+ *  the version identifies the release, and one fragment = one release (#1457),
+ *  so it is unique and stable. `isPermaLink="false"` says it is not a URL. */
+function guid(note: ReleaseNote): string {
+  return `urn:internship-crm:release:${note.version}`;
+}
+
+export function releaseFeedXml({ origin, locale }: { origin: string; locale: Locale }): string {
+  const t = getDictionary(locale);
+  const notes = getAllReleaseNotes().slice(0, MAX_ITEMS);
+  const pageUrl = `${origin}/release-notes`;
+  const selfUrl = releaseFeedUrl(origin, locale);
+
+  const items = notes.map((note) => {
+    const highlights = note.highlights[locale] ?? note.highlights[defaultLocale] ?? [];
+    // The version alone is a poor headline in a reader or a chat webhook, so
+    // the first highlight rides along; the full list stays in the description.
+    const title = highlights[0] ? `v${note.version} — ${highlights[0]}` : `v${note.version}`;
+    const published = rfc822(note);
+    return [
+      '    <item>',
+      `      <title>${escapeXml(title)}</title>`,
+      `      <link>${escapeXml(`${pageUrl}#v${note.version}`)}</link>`,
+      `      <guid isPermaLink="false">${escapeXml(guid(note))}</guid>`,
+      published ? `      <pubDate>${escapeXml(published)}</pubDate>` : null,
+      `      <description>${descriptionHtml(highlights)}</description>`,
+      '    </item>',
+    ]
+      .filter((line): line is string => line !== null)
+      .join('\n');
+  });
+
+  // lastBuildDate is the newest release, not "now": the feed is a pure function
+  // of the release data, so a clock-based value would only defeat caching.
+  const lastBuild = notes.map(rfc822).find(Boolean);
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>${escapeXml(`Internship CRM — ${t.releaseNotes.title}`)}</title>
+    <link>${escapeXml(pageUrl)}</link>
+    <description>${escapeXml(t.releaseNotes.feedDescription)}</description>
+    <language>${escapeXml(locale)}</language>${lastBuild ? `\n    <lastBuildDate>${escapeXml(lastBuild)}</lastBuildDate>` : ''}
+    <atom:link href="${escapeXml(selfUrl)}" rel="self" type="application/rss+xml"/>
+${items.join('\n')}
+  </channel>
+</rss>
+`;
+}


### PR DESCRIPTION
## Summary

`/release-notes` is a content asset — the product ships often and the landing uses that as proof (`landing.trans2T`) — but following it required opening the page by hand. This adds `GET /release-notes/feed.xml`, so releases can be followed without an account and piped somewhere else (Slack/Discord webhook, auto-posting).

The feed renders the **same source the page renders** (`getAllReleaseNotes()` — `releaseNotes.ts` plus the pending fragments inlined at build time), so it cannot drift from the page.

Closes #1383

## Changes

- **`src/lib/releaseFeed.ts`** (new) — pure, string-returning RSS 2.0 builder, verifiable without a server:
  - **Explicit XML escaping** on every interpolated value; deliberately *not* CDATA (a CDATA section is itself escaping, and it breaks on a literal `]]>`). Highlights are emitted as an HTML `<ul>` escaped once more as XML text — the standard way to carry markup in `<description>`.
  - **50 newest items** (a feed is a subscription, not a 200-release archive).
  - **Absolute links** built from the configured origin — `NEXTAUTH_URL` → `NEXT_PUBLIC_APP_URL`, the same precedence as `appBase()` in `lib/ssoSaml.ts` — with the request's own origin as a last resort. No hardcoded domain.
  - **Stable GUIDs**: `urn:internship-crm:release:<version>`, `isPermaLink="false"` (one fragment = one release, #1457), so a domain move or a re-render does not re-announce everything.
  - **Real publication dates** (RFC 822) from the release data, never from the clock; `lastBuildDate` is the newest release for the same reason. A pending fragment git cannot date yet ships *without* a `pubDate` rather than with an invented one.
- **`src/app/release-notes/feed.xml/route.ts`** (new) — `Content-Type: application/rss+xml; charset=utf-8`, `Cache-Control: public, s-maxage=3600, stale-while-revalidate=600`. `?lang=tr|de` (default `en`), because a feed reader sends no cookies so the language must live in the subscribed URL; an unknown value falls back to the default instead of erroring (`isLocale`, so a crafted `lang` cannot reach the document). Not rate-limited on purpose — no database, no session, build-time data only, and polling is exactly what a reader does; the cache headers are the protection that fits.
- **`src/app/release-notes/page.tsx`** — `rel="alternate" type="application/rss+xml"` in the page metadata, a visible RSS link next to "Back to home" (`data-testid="release-notes-feed-link"`, follows the reader's locale), and `id="v<version>"` anchors on the release cards so feed items deep-link to the entry they announce.
- **`src/i18n/dictionaries.ts`** — two new strings (`releaseNotes.feed`, `releaseNotes.feedDescription`) in EN/TR/DE.
- **`e2e/release-notes-feed.spec.ts`** (new) — HTTP-level, like `e2e/sso-sp-metadata.spec.ts`: 200 + content type, well-formedness via a **real XML parser** (the browser's `DOMParser`, asserting no `parsererror`), item titles/links/GUIDs/dates, and the newest item matching the newest release the page shows (derived with `scripts/release-derive.cjs`, same as `e2e/version-release-notes.spec.ts`). Second test covers `?lang=tr` vs `en` (same GUIDs, different prose), the unknown-language fallback, the `rel="alternate"` link and the visible link. Not tagged `@smoke` — the smoke set stays small.
- **`releases/unreleased/release-notes-feed.json`** — `minor` + EN/TR/DE notes.

### Note on one spec detail

The issue asks for `Content-Type: application/xml`; this ships `application/rss+xml; charset=utf-8` instead, so the header matches the `type` the page's `rel="alternate"` link advertises (readers and browsers both accept it, and it is still parsed as XML). Everything else follows the issue as written.

## Verification

- [x] `npm run lint` + `npx tsc --noEmit` clean (only the three pre-existing warnings in unrelated files)
- [x] `npm run test:e2e` passing (or CI green) — **the new spec only**: ran `e2e/release-notes-feed.spec.ts` against a local `next start` of this build, 2/2 passed. The rest of the suite was **not** run here: no MySQL and no Docker daemon in this container, so DB-backed specs cannot run — CI must confirm them.
- [x] Tested the change manually / added an e2e test — against the production build (`npm run build` green, then `next start`): `curl /release-notes/feed.xml` → **200**, `content-type: application/rss+xml; charset=utf-8`, `cache-control: public, s-maxage=3600, stale-while-revalidate=600`, 50 items; parsed clean by Python's `xml.etree` (both `en` and `?lang=tr`); `?lang=tr` returns the Turkish highlights and `<language>tr</language>`; `?lang=klingon"><x` falls back to `en` with nothing injected; the page HTML carries the `rel="alternate"` link, the visible feed link and the `id="v…"` anchors.

Also run and green: `npm run check:i18n` (3629 keys × 3 locales), `npm run check:release-fragments` (this change ships as `0.136.0-beta`), `npm run build`.

Acceptance criteria from the issue: all six satisfied — `curl` 200 + valid XML ✔, title/date/permalink/content per release ✔ (`pubDate` omitted only for a fragment git cannot date, which is the shallow-clone case, never an invented date), `?lang=tr` ✔, `rel="alternate"` ✔, markdown-bearing notes cannot break the document (explicit escaping, covered by the spec's escaped-HTML assertion) ✔, `npm run build` green ✔.

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JgY7mKwLmq9KdtnBFYYQu3


---
_Generated by [Claude Code](https://claude.ai/code/session_01JgY7mKwLmq9KdtnBFYYQu3)_