### PR TITLE
fix(e2e): repair four specs drifted from app behavior

### DIFF
--- a/e2e/admin-history-edit.spec.ts
+++ b/e2e/admin-history-edit.spec.ts
@@ -50,7 +50,7 @@ test('admin can add and delete stage-history entries', async ({ page }) => {
     }, { times: 1 });
 
     await page.getByRole('button', { name: 'Delete entry' }).click();
-    await expect(page.getByRole('status')).toContainText('Something went wrong');
+    await expect(page.getByRole('status').filter({ hasText: 'Something went wrong' })).toBeVisible();
     expect(detailReloads).toBe(0);
     expect(await prisma.statusChange.findMany({ where: { relationId: rel.id } })).toHaveLength(1);
 

--- a/e2e/async-section.spec.ts
+++ b/e2e/async-section.spec.ts
@@ -126,7 +126,7 @@ test('mentor analytics retries a failed load and renders the returned stats', as
 
   try {
     await signInAndSettle(page, email, 'AsyncPass123!', '/mentor');
-    await page.route('**/api/mentor/analytics', async (route) => { pending.push(route); });
+    await page.route('**/api/mentor/analytics**', async (route) => { pending.push(route); });
     await page.goto('/mentor/analytics');
 
     await expect.poll(() => pending.length).toBe(1);
@@ -140,7 +140,10 @@ test('mentor analytics retries a failed load and renders the returned stats', as
     await pending[1].fulfill({
       json: {
         funnel: {}, totalRelations: 3, activeRelations: 2, hired: 1,
-        conversionToHired: 33, interactions: 7, goals: { open: 1, done: 2, total: 3 }, avgDaysToHired: 12,
+        conversionToHired: 33, interactions: 7,
+        goals: { open: 1, done: 2, total: 3, doneInRange: 2 },
+        avgDaysToHired: 12, statusChanges: 4, rows: [],
+        range: { from: '2026-01-01', to: '2026-01-31' },
       },
     });
     await expect(page.getByText('Total mentees')).toBeVisible();

--- a/e2e/board-mobile.spec.ts
+++ b/e2e/board-mobile.spec.ts
@@ -77,7 +77,7 @@ test('mentor board on a phone: stage list, no sideways scrolling, stage change w
     // The filter stays put, so the card visibly leaves the stage you were looking at.
     await expect(card).toHaveCount(0);
     await expect(page.getByTestId('board-stage-filter')).toHaveValue('APPLICATION_100');
-    await expect(page.getByText('No mentees in this stage')).toBeVisible();
+    await expect(page.getByText('Nothing at this stage')).toBeVisible();
 
     // …and the move can be taken back from the toast.
     await page.getByRole('button', { name: 'Undo' }).click();

--- a/e2e/theme-density.spec.ts
+++ b/e2e/theme-density.spec.ts
@@ -127,9 +127,12 @@ test('compact density tightens spacing without shrinking a tap target', async ({
     await page.reload({ waitUntil: 'domcontentloaded' });
     await expect(html).toHaveClass(/\bdensity-compact\b/);
 
-    // The sidebar controls keep their 44px floor in compact mode.
+    // The sidebar controls keep their 44px floor in compact mode. At this
+    // viewport (800px, below `lg`) the sidebar is an off-canvas drawer, so
+    // the hamburger has to open it before the account menu is reachable.
     await page.goto('/portal');
     await expect(html).toHaveClass(/\bdensity-compact\b/);
+    await page.getByRole('button', { name: 'Open menu' }).click();
     await page.getByTestId('account-menu-button').click();
     for (const id of ['theme-toggle', 'density-control']) {
       const control = page.getByTestId(id).first();


### PR DESCRIPTION
## Summary

The scheduled `e2e-full.yml` run on `main` at 2026-09-02 18:24 UTC ([run 33667006305](https://github.com/21072026/Internship/actions/runs/33667006305), head `517148d`) failed with 8 failing tests across 3 shards. This PR fixes the 4 that were genuine test-side drift (app behavior is correct, the spec was stale). The other 4 are pre-existing app bugs already tracked in other issues — see #2140 for the full breakdown and links.

Closes #2140

## Changes

- `e2e/admin-history-edit.spec.ts`: scope `getByRole('status')` to the toast with `.filter({ hasText })` — it now also matches `GlobalSearch`'s sr-only status region, a strict-mode violation. Same pattern already used in `candidate-change-toast.spec.ts` / `mentee-detail-feedback.spec.ts`.
- `e2e/async-section.spec.ts`: widen the `/api/mentor/analytics` route glob to match the query string the page's default 6-month range always appends (`**/api/mentor/analytics**`), and fill in the retry's mocked JSON (`range`, `rows`, `statusChanges`, `goals.doneInRange`) to match the real API shape — the page reads `data.range.from` unguarded and was crashing with a client-side exception on the incomplete mock.
- `e2e/board-mobile.spec.ts`: assert the shipped empty-stage copy "Nothing at this stage" (`t.emptyStates.boardStage.title`) instead of the pre-rename "No mentees in this stage".
- `e2e/theme-density.spec.ts`: open the off-canvas mobile drawer (hamburger button) before clicking `account-menu-button` at an 800px viewport — below the `lg` breakpoint the sidebar is a drawer (`ResponsiveShell`), so the button is off-screen until opened.

## Verification

- [x] `npx tsc --noEmit` clean
- [x] All four fixed specs reproduced failing locally (local MySQL/MariaDB + dev server, per `docs/security-audit-playbook.md`), then re-run green after each fix
- [ ] `npm run test:e2e` / CI green (this PR's own topic-preview run)
- [x] Root-caused by reading the app source for each failure, not guessed

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip): my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it passes to the rights holder (Mehmet Erşahin) who may also license it commercially, it is my own work, and I make no claim over the application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7vqmtNN43kSeKnbmr2v7x

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7vqmtNN43kSeKnbmr2v7x)_