### PR TITLE
fix(e2e): CI watchdog — global-search-a11y testids, admin-offers sign-in race, /mentors leaking into the sitemap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,4 @@ e2e/.state/
 # in-progress work — internal tooling state, not a project artifact.
 /.claude/worktrees/
 playwright.local.config.ts
+playwright.repro.config.ts

--- a/e2e/admin-offers.spec.ts
+++ b/e2e/admin-offers.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect, type Page } from '@playwright/test';
 import bcrypt from 'bcryptjs';
 import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { signInAsFreshUser } from './helpers/auth';
 
 // The /admin/offers index (#1873): the three saved views, a correct server-side
 // total, and the fact that the screen is admin-only while the two offer
@@ -196,7 +197,10 @@ test('the offer index is admin-only, and the new filters never widen what a comp
 
     // The company observer keeps the pre-existing contract: no DRAFT, no
     // compensationNote, and none of the admin filters buy a way in.
-    await signIn(page, s.companyEmail, s.pw, '/company');
+    // signInAsFreshUser (not the local signIn) because this switches user
+    // mid-test: a stale NextAuth session cookie races the sign-in form and
+    // detaches it under the fill (see e2e/helpers/auth.ts).
+    await signInAsFreshUser(page, s.companyEmail, s.pw, '/company');
     const res = await page.request.get(`/api/offers?status=DRAFT&q=${s.stamp}&pageSize=100`);
     expect(res.status()).toBe(200);
     const body = await res.text();

--- a/e2e/global-search-a11y.spec.ts
+++ b/e2e/global-search-a11y.spec.ts
@@ -61,7 +61,7 @@ test('global search dropdown is readable in both light and dark mode', async ({ 
 
     await search(page, token);
     const listbox = page.getByTestId('global-search-listbox');
-    const option = page.getByTestId(`global-search-option-${mentee.id}`);
+    const option = page.getByTestId(`global-search-option-user-${mentee.id}`);
     await expect(listbox).toBeVisible();
     await expect(option).toBeVisible();
     // The candidate name — the strongest text tone in the row (text-gray-900).
@@ -120,7 +120,7 @@ test('global search is a keyboard-operable combobox', async ({ page }) => {
     await seedUser(emails[2], 'x', 'MENTEE', `${token} Charlie`),
   ];
 
-  const testId = (id: string) => `global-search-option-${id}`;
+  const testId = (id: string) => `global-search-option-user-${id}`;
 
   try {
     await signIn(page, adminEmail, 'AdminPass123');

--- a/e2e/global-search-a11y.spec.ts
+++ b/e2e/global-search-a11y.spec.ts
@@ -214,21 +214,21 @@ test('global search announces its result count and shows a no-results row', asyn
 
   try {
     await signIn(page, adminEmail, 'AdminPass123');
-    const live = page.getByTestId('global-search-live');
+    const live = page.getByTestId('global-search-status');
     await expect(live).toHaveAttribute('aria-live', 'polite');
 
     await search(page, token);
     await expect(page.getByTestId('global-search-listbox')).toBeVisible();
     // One hit → the count is announced (EN is the default locale).
-    await expect(live).toHaveText('Results: 1');
+    await expect(live).toHaveText('1 results');
 
     // A query that matches nothing renders an explicit row instead of an empty
     // popup — previously the panel simply did not render and the box looked broken.
     await search(page, `${token}zzqx`);
-    const empty = page.getByTestId('global-search-no-results');
+    const empty = page.getByTestId('global-search-empty');
     await expect(empty).toBeVisible();
-    await expect(empty).toHaveText('No matches found');
-    await expect(live).toHaveText('No matches found');
+    await expect(empty).toHaveText('No results');
+    await expect(live).toHaveText('No results');
   } finally {
     await cleanupByEmail(menteeEmail);
     await cleanupByEmail(adminEmail);

--- a/e2e/global-search-a11y.spec.ts
+++ b/e2e/global-search-a11y.spec.ts
@@ -61,6 +61,10 @@ test('global search dropdown is readable in both light and dark mode', async ({ 
 
     await search(page, token);
     const listbox = page.getByTestId('global-search-listbox');
+    // The visual surface (bg-white / dark override) is the panel, not the
+    // listbox it wraps — background-color doesn't inherit from parent to
+    // child, so the colour assertions below target the panel.
+    const panel = page.getByTestId('global-search-panel');
     const option = page.getByTestId(`global-search-option-user-${mentee.id}`);
     await expect(listbox).toBeVisible();
     await expect(option).toBeVisible();
@@ -68,7 +72,7 @@ test('global search dropdown is readable in both light and dark mode', async ({ 
     const name = option.locator('span').first();
 
     // --- Light mode: white panel, near-black name.
-    const [lr, lg, lb] = rgb(await listbox.evaluate((el) => getComputedStyle(el).backgroundColor));
+    const [lr, lg, lb] = rgb(await panel.evaluate((el) => getComputedStyle(el).backgroundColor));
     expect(lr).toBeGreaterThan(240);
     expect(lg).toBeGreaterThan(240);
     expect(lb).toBeGreaterThan(240);
@@ -80,7 +84,7 @@ test('global search dropdown is readable in both light and dark mode', async ({ 
     // re-render or blur the input, so the panel stays open.
     await setTheme(page, 'dark');
     await expect(listbox).toBeVisible();
-    const [dr, dg, db] = rgb(await listbox.evaluate((el) => getComputedStyle(el).backgroundColor));
+    const [dr, dg, db] = rgb(await panel.evaluate((el) => getComputedStyle(el).backgroundColor));
     expect(dr).toBeLessThan(60);
     expect(dg).toBeLessThan(60);
     expect(db).toBeLessThan(70);

--- a/e2e/robots-sitemap.spec.ts
+++ b/e2e/robots-sitemap.spec.ts
@@ -19,12 +19,14 @@ import { test, expect, type APIRequestContext, type APIResponse } from '@playwri
  */
 test.use({ storageState: { cookies: [], origins: [] } });
 
-// Path prefixes that must never appear in the sitemap. Compared as
-// exact-or-subpath rather than by `startsWith`, because `/mentor` is a prefix
-// of the *public* `/mentors` directory.
+// Path prefixes that must never appear in the sitemap. `/mentors` (the
+// signed-in mentor directory, #938) is listed explicitly rather than relying
+// on the `/mentor` prefix to catch it, so removing `/mentor` later can't
+// silently stop covering it.
 const PRIVATE_PREFIXES = [
   '/admin',
   '/mentor',
+  '/mentors',
   '/portal',
   '/company',
   '/messages',

--- a/e2e/robots-sitemap.spec.ts
+++ b/e2e/robots-sitemap.spec.ts
@@ -22,7 +22,10 @@ test.use({ storageState: { cookies: [], origins: [] } });
 // Path prefixes that must never appear in the sitemap. `/mentors` (the
 // signed-in mentor directory, #938) is listed explicitly rather than relying
 // on the `/mentor` prefix to catch it, so removing `/mentor` later can't
-// silently stop covering it.
+// silently stop covering it. `/announcements` (available to any signed-in
+// role, not a public page) has no public sibling to collide with, but is
+// listed for the same reason every other authenticated area here is: this
+// list is what the sitemap is actually checked against.
 const PRIVATE_PREFIXES = [
   '/admin',
   '/mentor',
@@ -31,6 +34,7 @@ const PRIVATE_PREFIXES = [
   '/company',
   '/messages',
   '/account',
+  '/announcements',
   '/notifications',
   '/todos',
   '/onboarding',

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -18,15 +18,19 @@ export const dynamic = 'force-dynamic';
  * search result.
  *
  * Written as an exact-or-subpath pair (`/x$`, `/x/`) rather than the bare
- * prefix `/x`, because `Disallow` matches by prefix: a plain `/mentor` would
- * also swallow `/mentors`, the *public* mentor directory. `$` is the Google /
- * Bing end-anchor extension; the `/x/` line is what a crawler that ignores the
- * anchor still honours, so the worst case is one dashboard URL being fetched
- * and redirected to sign-in.
+ * prefix `/x`, because `Disallow` matches by prefix — a plain `/mentor` would
+ * also swallow `/mentors`. That happens to be fine here: the mentor directory
+ * at `/mentors` is itself signed-in-only (its layout redirects an anonymous
+ * visitor to `/auth/signin`, #938), so it belongs disallowed too and is listed
+ * explicitly below rather than left to rely on the prefix collision. `$` is
+ * the Google / Bing end-anchor extension; the `/x/` line is what a crawler
+ * that ignores the anchor still honours, so the worst case is one dashboard
+ * URL being fetched and redirected to sign-in.
  */
 const PROTECTED_PATHS = [
   '/admin',
   '/mentor',
+  '/mentors',
   '/portal',
   '/company',
   '/messages',

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -35,6 +35,7 @@ const PROTECTED_PATHS = [
   '/company',
   '/messages',
   '/account',
+  '/announcements',
   '/notifications',
   '/todos',
   '/onboarding',

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -47,6 +47,10 @@ const STORIES_PAGE_LIMIT = 50;
  *    matching flow (#938); its layout redirects an anonymous visitor to
  *    `/auth/signin`, so it belongs with the other authenticated areas below,
  *    not here (e2e/robots-sitemap.spec.ts caught it answering 307).
+ *  - `/announcements` — same defect, same fix: its layout redirects an
+ *    anonymous visitor to `/auth/signin` (available to any signed-in role,
+ *    not a public page), and the same e2e spec caught it once `/mentors` no
+ *    longer masked it (the spec's resolve loop stops at its first failure).
  *
  * Authenticated areas are absent by construction, and robots.ts disallows them.
  */
@@ -56,7 +60,6 @@ const PUBLIC_ROUTES: readonly { path: string; priority: number; changeFrequency:
   { path: '/for-companies', priority: 0.8, changeFrequency: 'monthly' },
   { path: '/apply-as-mentor', priority: 0.8, changeFrequency: 'monthly' },
   { path: '/projects', priority: 0.7, changeFrequency: 'weekly' },
-  { path: '/announcements', priority: 0.5, changeFrequency: 'daily' },
   { path: '/release-notes', priority: 0.5, changeFrequency: 'daily' },
   { path: '/code-of-conduct', priority: 0.3, changeFrequency: 'monthly' },
   { path: '/contributor-terms', priority: 0.3, changeFrequency: 'monthly' },

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -43,6 +43,10 @@ const STORIES_PAGE_LIMIT = 50;
  *  - `/apply/<mentorId>` — the per-mentor application form is a link a mentor
  *    hands out, not a landing page, and it duplicates /apply-as-mentor's
  *    funnel.
+ *  - `/mentors` — the mentor directory is part of the signed-in mentee↔mentor
+ *    matching flow (#938); its layout redirects an anonymous visitor to
+ *    `/auth/signin`, so it belongs with the other authenticated areas below,
+ *    not here (e2e/robots-sitemap.spec.ts caught it answering 307).
  *
  * Authenticated areas are absent by construction, and robots.ts disallows them.
  */
@@ -51,7 +55,6 @@ const PUBLIC_ROUTES: readonly { path: string; priority: number; changeFrequency:
   { path: '/features', priority: 0.8, changeFrequency: 'weekly' },
   { path: '/for-companies', priority: 0.8, changeFrequency: 'monthly' },
   { path: '/apply-as-mentor', priority: 0.8, changeFrequency: 'monthly' },
-  { path: '/mentors', priority: 0.7, changeFrequency: 'weekly' },
   { path: '/projects', priority: 0.7, changeFrequency: 'weekly' },
   { path: '/announcements', priority: 0.5, changeFrequency: 'daily' },
   { path: '/release-notes', priority: 0.5, changeFrequency: 'daily' },


### PR DESCRIPTION
## Summary

Six real, distinct failures from the same `e2e-full.yml` run (main @ `f0d8295`, run [33748530754](https://github.com/21072026/Internship/actions/runs/33748530754)) plus two more found while verifying the fixes — found by re-reading the *full* job logs (my first pass only captured the first failure per shard, missing several) and by actually running the affected specs locally against a production build.

1. **`e2e/global-search-a11y.spec.ts`** — all 3 tests referenced stale testids/text, and (once that was fixed) the background-colour assertions in test 1 targeted the wrong element:
   - Issue #2075 landed as two parallel PRs: the component (`ded54e3`, #2104) shipped `global-search-status` / `global-search-empty` / `global-search-option-user-<id>` / `global-search-option-company-<id>`, but the test (`e988f77`, #2109) kept the earlier `global-search-live` / `global-search-no-results` / bare `global-search-option-<id>` names and wrong EN strings.
   - Separately (predates this PR, just masked by the above): `bg-white`/the dark override live on the `global-search-panel` div, not its child `global-search-listbox` — `background-color` doesn't inherit, so reading it off the listbox always saw transparent. Now reads it off the panel.
2. **`e2e/admin-offers.spec.ts`** — "the offer index is admin-only..." switches from a mentee session to a company session mid-test via a naive local `signIn()` with no cookie teardown — the documented stale-session-cookie race in `e2e/helpers/auth.ts`. Now uses `signInAsFreshUser` for that second sign-in.
3. **`src/app/sitemap.ts` / `src/app/robots.ts` / `e2e/robots-sitemap.spec.ts`** — both `/mentors` (#938) and `/announcements` are signed-in-only routes (their layouts redirect an anonymous visitor to `/auth/signin`) but were listed in `sitemap.ts`'s `PUBLIC_ROUTES` and absent from `robots.ts`'s `PROTECTED_PATHS` — `/announcements`'s copy of the bug was masked until `/mentors`'s was fixed, since the e2e spec's resolve loop stops at the first failing path.

Two more issues surfaced, not fixed here:
- `e2e/analytics-trends.spec.ts` (chart stays 0%) and `e2e/mobile-layout-audit.spec.ts` (`/mentor`, `/release-notes` 360px German overflow) were already tracked as #1501/#1484 and #1465/#1486/#1497.
- The support-endpoint rate-limit bucket shared across `e2e/support-attachments.spec.ts` / `e2e/support-chat.spec.ts` is filed as #2159 (needs a maintainer design call).
- A genuine, unrelated `/admin/offers` bug (preset filters dropped by a stale-closure race with the search box, 3 failing tests) found while verifying this PR is filed as #2161 (needs a product decision on intended UX, not a blind fix).

## Changes

- `e2e/global-search-a11y.spec.ts`: point all 3 tests at the testids/text the component and dictionary actually emit; read the panel's background instead of the listbox's.
- `e2e/admin-offers.spec.ts`: import `signInAsFreshUser` from `./helpers/auth`; use it for the mid-test company sign-in.
- `src/app/sitemap.ts`: remove `/mentors` and `/announcements` from `PUBLIC_ROUTES`; document why.
- `src/app/robots.ts`: add both to `PROTECTED_PATHS`; correct the comment that called `/mentors` public.
- `e2e/robots-sitemap.spec.ts`: add both to `PRIVATE_PREFIXES`; correct the same stale comment.
- `.gitignore`: ignore `playwright.repro.config.ts`, a throwaway sandbox-only Playwright config (same shape as the existing `playwright.local.config.ts` entry) used to verify these fixes locally.

## Verification

- [x] `npx tsc --noEmit` — clean.
- [x] `next lint` on the changed app files (`sitemap.ts`, `robots.ts`) — clean.
- [x] All fixes confirmed **locally against a production build** (`CI=1 npm run build && npm run start`, matching what `e2e-full.yml` actually runs, not just `npm run dev`):
  - `npx playwright test e2e/global-search-a11y.spec.ts` → **3/3 passed**
  - `npx playwright test e2e/robots-sitemap.spec.ts` → **4/4 passed** (1 correctly skipped: the preview/demo-closed variant, since local `APP_ENV` defaults to production)
  - `npx playwright test e2e/admin-offers.spec.ts -g "admin-only"` → **passed** (also re-run several times earlier in the session to rule out the race not reproducing; consistent)
- Reverting the global-search-a11y testid fix locally reproduces the exact original CI error (`getByTestId('global-search-live')` / `('global-search-option-<id>')` not found).

No release fragment: test-only / sitemap-correctness fix, not a user-visible feature (`releases/README.md`).

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip): my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it passes to the rights holder (Mehmet Erşahin) who may also license it commercially, it is my own work, and I make no claim over the application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wWCN4Bp8UUGasP7mvjMiD