### PR TITLE
ci: deploy job'ları hangi runner'ı kastettiklerini söylesin (#2166)

### DIFF
--- a/.github/workflows/backup-verify.yml
+++ b/.github/workflows/backup-verify.yml
@@ -43,7 +43,10 @@ permissions:
 jobs:
   verify:
     name: Check backup freshness
-    runs-on: self-hosted
+    # Both hosts run a self-hosted runner during the #2166 migration, and a bare
+    # `self-hosted` label would send this job to whichever one happens to be
+    # online — at random, mid-cutover. vars.DEPLOY_RUNNER names the intended box.
+    runs-on: ${{ vars.DEPLOY_RUNNER || 'self-hosted' }}
     timeout-minutes: 20
     outputs:
       report: ${{ steps.check.outputs.report }}

--- a/.github/workflows/demo-reset.yml
+++ b/.github/workflows/demo-reset.yml
@@ -36,7 +36,10 @@ concurrency:
 jobs:
   reset:
     name: Wipe + re-seed the demo database
-    runs-on: self-hosted
+    # Both hosts run a self-hosted runner during the #2166 migration, and a bare
+    # `self-hosted` label would send this job to whichever one happens to be
+    # online — at random, mid-cutover. vars.DEPLOY_RUNNER names the intended box.
+    runs-on: ${{ vars.DEPLOY_RUNNER || 'self-hosted' }}
     steps:
       - name: Fetch the repo (no action download)
         env:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -63,7 +63,10 @@ jobs:
   # exception and no auth. The cost is a curl.
   gate:
     name: Check for drift
-    runs-on: self-hosted
+    # Both hosts run a self-hosted runner during the #2166 migration, and a bare
+    # `self-hosted` label would send this job to whichever one happens to be
+    # online — at random, mid-cutover. vars.DEPLOY_RUNNER names the intended box.
+    runs-on: ${{ vars.DEPLOY_RUNNER || 'self-hosted' }}
     outputs:
       deploy: ${{ steps.gate.outputs.deploy }}
       sha: ${{ steps.gate.outputs.sha }}
@@ -192,7 +195,8 @@ jobs:
   deploy:
     name: Swap preview container
     needs: [gate, build]
-    runs-on: self-hosted
+    # See the note on the first runs-on in this file (#2166).
+    runs-on: ${{ vars.DEPLOY_RUNNER || 'self-hosted' }}
     permissions:
       contents: read
       packages: read
@@ -289,7 +293,8 @@ jobs:
     needs: [gate, build, deploy]
     if: needs.gate.outputs.deploy == 'true'
     continue-on-error: true
-    runs-on: self-hosted
+    # See the note on the first runs-on in this file (#2166).
+    runs-on: ${{ vars.DEPLOY_RUNNER || 'self-hosted' }}
     steps:
       - name: Fetch the repo (no action download)
         env:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -71,7 +71,10 @@ jobs:
   # exception and no auth. The cost is a curl.
   gate:
     name: Check for drift
-    runs-on: self-hosted
+    # Both hosts run a self-hosted runner during the #2166 migration, and a bare
+    # `self-hosted` label would send this job to whichever one happens to be
+    # online — at random, mid-cutover. vars.DEPLOY_RUNNER names the intended box.
+    runs-on: ${{ vars.DEPLOY_RUNNER || 'self-hosted' }}
     outputs:
       deploy: ${{ steps.gate.outputs.deploy }}
       sha: ${{ steps.gate.outputs.sha }}
@@ -196,7 +199,8 @@ jobs:
   deploy:
     name: Swap production container
     needs: [gate, build]
-    runs-on: self-hosted
+    # See the note on the first runs-on in this file (#2166).
+    runs-on: ${{ vars.DEPLOY_RUNNER || 'self-hosted' }}
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/topic-preview.yml
+++ b/.github/workflows/topic-preview.yml
@@ -80,7 +80,10 @@ jobs:
   deploy:
     name: Deploy topic environment
     needs: build
-    runs-on: self-hosted
+    # Both hosts run a self-hosted runner during the #2166 migration, and a bare
+    # `self-hosted` label would send this job to whichever one happens to be
+    # online — at random, mid-cutover. vars.DEPLOY_RUNNER names the intended box.
+    runs-on: ${{ vars.DEPLOY_RUNNER || 'self-hosted' }}
     permissions:
       contents: read
       packages: read
@@ -197,7 +200,8 @@ jobs:
   teardown:
     name: Tear down topic environment
     if: github.event.action == 'closed'
-    runs-on: self-hosted
+    # See the note on the first runs-on in this file (#2166).
+    runs-on: ${{ vars.DEPLOY_RUNNER || 'self-hosted' }}
     steps:
       # #1239 — NO `uses:` in a self-hosted job. Downloading an action archive
       # from codeload.github.com answers 429 from this box's IP (the GitHub-hosted

--- a/.github/workflows/topic-sweep.yml
+++ b/.github/workflows/topic-sweep.yml
@@ -38,7 +38,10 @@ jobs:
   # ── 1. What is actually running on the box ──────────────────────────────────
   collect:
     name: List topic containers
-    runs-on: self-hosted
+    # Both hosts run a self-hosted runner during the #2166 migration, and a bare
+    # `self-hosted` label would send this job to whichever one happens to be
+    # online — at random, mid-cutover. vars.DEPLOY_RUNNER names the intended box.
+    runs-on: ${{ vars.DEPLOY_RUNNER || 'self-hosted' }}
     outputs:
       numbers: ${{ steps.list.outputs.numbers }}
     steps:
@@ -119,7 +122,8 @@ jobs:
     name: Tear down leaked environments
     needs: [collect, resolve]
     if: needs.resolve.outputs.stale != ''
-    runs-on: self-hosted
+    # See the note on the first runs-on in this file (#2166).
+    runs-on: ${{ vars.DEPLOY_RUNNER || 'self-hosted' }}
     steps:
       # #1239 — NO `uses:` in a self-hosted job. Downloading an action archive
       # from codeload.github.com answers 429 from this box's IP (the GitHub-hosted

--- a/docs/server-migration.md
+++ b/docs/server-migration.md
@@ -188,13 +188,31 @@ emin ol — x64 paketi bu makinada çalışmaz.
 
 ## Faz 2 — repo tarafı (ayrı PR'lar)
 
-| # | İş | Neden |
+| # | İş | Durum |
 |---|---|---|
-| 1 | `build-image.yml` → `linux/arm64` manifest | **Gerçek blocker.** Bugünkü imaj `ubuntu-latest` üzerinde amd64 üretiliyor; bu kutuda `docker run` `exec format error` verir — pull sırasında değil, çalıştırma sırasında. buildx ile multi-arch, ya da tamamen arm64 runner. |
-| 2 | Caddy tabanlı routing | `topic-deploy.sh`/`topic-teardown.sh` içindeki Plesk'e özel her şey siliniyor. Topic başına route iki satıra iniyor: `crm-pr5.interncrm.com { reverse_proxy 127.0.0.1:3305 }` + wildcard sertifika için `tls`. |
-| 3 | `BASE_DOMAIN` = `interncrm.com` | Zaten parametrik (`topic-deploy.sh`); workflow'lardaki sabit `ersah.in`'ler taranmalı. |
-| 4 | Deploy workflow'ları yeni hosta | `deploy-prod.yml`, `deploy-preview.yml`, `topic-preview.yml`, `topic-sweep.yml`. |
-| 5 | Yedek hedefi | `infra/backup-db.sh` duruyor, `BACKUP_DIR` ve off-site hedef değişiyor. |
+| 1 | `build-image.yml` → çok mimarili manifest | **Bitti** (#2168). Her mimari kendi native runner'ında (`ubuntu-24.04-arm`), `imagetools create` ile birleştiriliyor, iki mimari de yoksa fail-closed. |
+| 2 | Caddy tabanlı routing | **Bitti** (#2172). Router auto-detect; Plesk dalı eski kutu emekli olana kadar duruyor. |
+| 3 | `BASE_DOMAIN` repo değişkeni | **Bitti** (#2172). Kesmede `vars.BASE_DOMAIN=interncrm.com`. |
+| 4 | Deploy runner'ı repo değişkeni | **Bitti**. `vars.DEPLOY_RUNNER`; aşağıya bak. |
+| 5 | Veri taşıma | **Bitti** (#2171). `infra/server/mariadb-to-mysql.sh`, prova koşuldu. |
+| 6 | Zamanlanmış yedek | **Bitti** (#2173). Off-site kopya hâlâ eksik (#2169). |
+
+### Deploy runner'ı: `vars.DEPLOY_RUNNER`
+
+Kesme sırasında **iki kutuda da** self-hosted runner çalışıyor olacak. Düz bir
+`runs-on: self-hosted` etiketi, işi o an hangi runner müsaitse ona gönderir —
+yani prod deploy'u rastgele eski ya da yeni kutuya düşebilir. Tam olarak
+kesmenin ortasında.
+
+Bu yüzden on bir job da `runs-on: ${{ vars.DEPLOY_RUNNER || 'self-hosted' }}`.
+
+Sıra:
+
+1. Yeni sunucuya runner'ı **kendine ait bir etiketle** kaydet (örn. `interncrm`).
+   Bu aşamada hiçbir şey değişmez; eski kutu deploy almaya devam eder.
+2. Hazır olduğunda repo değişkeni `DEPLOY_RUNNER` = `interncrm`. Bundan sonraki
+   her deploy yeni kutuya gider.
+3. Bir sorun çıkarsa değişkeni sil — her şey eski kutuya geri döner.
 
 ---
 

--- a/releases/unreleased/deploy-runner-variable.json
+++ b/releases/unreleased/deploy-runner-variable.json
@@ -1,0 +1,4 @@
+{
+  "bump": "patch",
+  "changelog": "- **Deploy jobs name the runner they mean** (#2166): all eleven `runs-on: self-hosted` jobs become `${{ vars.DEPLOY_RUNNER || 'self-hosted' }}`. With a self-hosted runner on both the old and the new host during the migration, a bare `self-hosted` label would have sent a production deploy to whichever box happened to be free."
+}


### PR DESCRIPTION
Refs #2166 · #2169

Kesme sırasında **iki kutuda da** self-hosted runner çalışacak: eski IONOS kutusu
hâlâ prod'u servis ederken yeni Oracle kutusu ayağa kalkıyor.

Düz bir `runs-on: self-hosted`, işi o an müsait olan runner'a gönderir. Yani bir
**prod deploy'u rastgele iki makinadan birine** düşebilir, tam da taşınmanın
ortasında. Bu teorik bir risk değil: eski runner 09-03'ten beri düşüp kalkıyor
(#2169), ki seçimi öngörülemez yapan tam olarak bu durum.

On bir self-hosted job da `runs-on: ${{ vars.DEPLOY_RUNNER || 'self-hosted' }}`
oluyor. Kesme böylece:

1. Yeni sunucuya runner'ı **kendi etiketiyle** kaydet (örn. `interncrm`) —
   bu aşamada hiçbir şey değişmez, eski kutu deploy almaya devam eder
2. Repo değişkeni `DEPLOY_RUNNER` = `interncrm` — bundan sonraki her deploy yeni
   kutuya gider
3. Sorun çıkarsa değişkeni sil, her şey eski kutuya geri döner

#2172'deki `vars.BASE_DOMAIN` ile aynı şekil: kesme bir **ayar değişikliği**,
önce merge olup deploy olması gereken bir PR değil — ki değiştirdiğin şey
deploy yolunun kendisiyken bu önemli.

`docs/server-migration.md`'deki Faz 2 tablosu da gerçekte ne shipped olduğuna
göre güncellendi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)