### PR TITLE
infra: yedekleri ikinci bir makinaya kopyala (#2169)

### DIFF
--- a/infra/server/backup-offsite.sh
+++ b/infra/server/backup-offsite.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# Copy the local database dumps to a SECOND MACHINE (#2169).
+#
+# WHY THIS EXISTS
+#   infra/backup-db.sh writes dumps to /var/backups/internship-crm — the same
+#   disk as the database it just dumped. That is not a backup, it is a second
+#   copy of the same failure domain, and 2026-09-03 proved it: when the old host
+#   went unreachable the database AND every dump of it went with it. The only
+#   reason no data was lost is that the box came back for 45 minutes.
+#
+# WHAT IT DOES
+#   rsync every *.sql.gz to $OFFSITE_TARGET, then re-checks with --dry-run that
+#   the remote side has nothing left to receive.
+#
+# WHY THE VERIFY PASS
+#   The remote key is restricted to `rrsync -wo`, i.e. write-only: this host can
+#   send files there and cannot read anything back, so "did it arrive" cannot be
+#   answered by listing. A second rsync in --dry-run still exchanges the remote
+#   file list to decide what to send, so "zero files pending" is a real
+#   confirmation that the dumps are on the far side, obtained without granting
+#   read access. Without this, a silently-truncated push looks identical to a
+#   good one — which is exactly the class of failure this whole issue is about.
+#
+# NEVER --delete. The off-site copy must not be reachable-and-erasable from the
+# machine being backed up; if this host is compromised or a script here goes
+# wrong, the remote copies are what is left.
+#
+# TARGET
+#   $OFFSITE_TARGET is an rsync destination. Today it is the old IONOS box, which
+#   is a genuinely separate machine at a different provider — but it is also
+#   scheduled for retirement and has been crashing (#2169). It is an INTERIM
+#   target. Moving to object storage should be a change to this one variable
+#   (plus the key), not a rewrite: keep the target abstract.
+#
+# USAGE
+#   sudo OFFSITE_TARGET='root@s.ersah.in:/' ./backup-offsite.sh
+#
+#   Env:
+#     BACKUP_DIR       default /var/backups/internship-crm
+#     OFFSITE_TARGET   required — rsync destination
+#     OFFSITE_SSH_KEY  default /home/ubuntu/.ssh/offsite_ed25519
+#     OFFSITE_MIN_FILES  default 1 — fail if fewer dumps than this exist locally
+set -euo pipefail
+
+BACKUP_DIR="${BACKUP_DIR:-/var/backups/internship-crm}"
+OFFSITE_SSH_KEY="${OFFSITE_SSH_KEY:-/home/ubuntu/.ssh/offsite_ed25519}"
+OFFSITE_MIN_FILES="${OFFSITE_MIN_FILES:-1}"
+: "${OFFSITE_TARGET:?OFFSITE_TARGET is required (e.g. root@host:/)}"
+
+log()  { printf '\n\033[1;34m==>\033[0m %s\n' "$*"; }
+ok()   { printf '    \033[0;32m✓\033[0m %s\n' "$*"; }
+die()  { printf '\n\033[1;31mFAIL\033[0m %s\n' "$*" >&2; exit 1; }
+
+[ -d "$BACKUP_DIR" ] || die "no backup dir at $BACKUP_DIR"
+[ -f "$OFFSITE_SSH_KEY" ] || die "no ssh key at $OFFSITE_SSH_KEY"
+
+COUNT="$(find "$BACKUP_DIR" -maxdepth 1 -name '*.sql.gz' -type f | wc -l)"
+[ "$COUNT" -ge "$OFFSITE_MIN_FILES" ] \
+  || die "only $COUNT dump(s) in $BACKUP_DIR, expected at least $OFFSITE_MIN_FILES — refusing to report success on an empty push"
+
+RSH="ssh -i $OFFSITE_SSH_KEY -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=20"
+
+log "pushing $COUNT dump(s) to the off-site target"
+# --ignore-existing: dumps are immutable once written, so anything already there
+# is already correct. It also means a re-run cannot rewrite history remotely.
+rsync -e "$RSH" -a --ignore-existing --stats \
+  --include='*.sql.gz' --exclude='*' \
+  "$BACKUP_DIR"/ "$OFFSITE_TARGET" \
+  | grep -E 'Number of regular files transferred|Total transferred file size' \
+  | sed 's/^/    /'
+
+log "verifying the far side has everything"
+# See the header: write-only means we cannot list, but a dry run still negotiates
+# the remote file list, so a clean dry run is proof of arrival.
+PENDING="$(rsync -e "$RSH" -a --ignore-existing --dry-run --out-format='%n' \
+             --include='*.sql.gz' --exclude='*' \
+             "$BACKUP_DIR"/ "$OFFSITE_TARGET" | grep -c '\.sql\.gz$' || true)"
+[ "$PENDING" -eq 0 ] \
+  || die "$PENDING dump(s) still missing on the off-site target after the push"
+ok "all $COUNT dump(s) confirmed present off-site"

--- a/infra/server/bootstrap.sh
+++ b/infra/server/bootstrap.sh
@@ -466,10 +466,50 @@ RandomizedDelaySec=300
 WantedBy=timers.target
 EOF
 
+  # Off-site push, as its OWN unit and timer rather than a step of the backup.
+  # A dump that succeeded locally must still count as a success when the remote
+  # is unreachable — but the off-site failure has to be visible on its own, and
+  # not swallowed by a green backup run. That swallowing is how #2169 stayed
+  # invisible for months.
+  if [ -n "${OFFSITE_TARGET:-}" ]; then
+    curl -fsSL -o "$APP_DIR/bin/backup-offsite.sh" \
+      https://raw.githubusercontent.com/21072026/Internship/main/infra/server/backup-offsite.sh 2>/dev/null \
+      && chmod 0755 "$APP_DIR/bin/backup-offsite.sh"
+    cat > /etc/systemd/system/internship-backup-offsite.service <<EOF
+[Unit]
+Description=Copy Internship CRM dumps to the off-site target
+After=network-online.target
+
+[Service]
+Type=oneshot
+Environment=BACKUP_DIR=/var/backups/internship-crm
+Environment=OFFSITE_TARGET=${OFFSITE_TARGET}
+Environment=OFFSITE_SSH_KEY=/home/${LOGIN_USER}/.ssh/offsite_ed25519
+ExecStart=$APP_DIR/bin/backup-offsite.sh
+EOF
+    cat > /etc/systemd/system/internship-backup-offsite.timer <<'EOF'
+[Unit]
+Description=Daily off-site copy of the Internship CRM dumps
+
+[Timer]
+# 30 minutes after the local dump, so it has something fresh to send.
+OnCalendar=*-*-* 03:10:00 UTC
+Persistent=true
+RandomizedDelaySec=300
+
+[Install]
+WantedBy=timers.target
+EOF
+    systemctl daemon-reload
+    systemctl enable --now internship-backup-offsite.timer >/dev/null
+    ok "off-site push timer active -> ${OFFSITE_TARGET}"
+  else
+    warn "OFFSITE_TARGET unset — dumps stay on the same disk as the database, which is not a backup (#2169)"
+  fi
+
   systemctl daemon-reload
   systemctl enable --now internship-backup.timer >/dev/null
   ok "daily backup timer active ($(systemctl show internship-backup.timer -p NextElapseUSecRealtime --value | cut -c1-24))"
-  warn "OFF-SITE copy is still missing — a dump on the same disk as the database is not a backup (#2169)"
 }
 
 # -------------------------------------------------------------------- tools --

--- a/releases/unreleased/offsite-backup-copy.json
+++ b/releases/unreleased/offsite-backup-copy.json
@@ -1,0 +1,4 @@
+{
+  "bump": "patch",
+  "changelog": "- **Dumps are copied to a second machine** (#2169): `infra/server/backup-offsite.sh` rsyncs them to `$OFFSITE_TARGET` on its own timer, then verifies arrival with a dry-run pass — the remote key is `rrsync -wo`, write-only, so the far side cannot be listed or read back. Never `--delete`. It runs as a separate systemd unit so a local backup still counts as a success when the remote is down, while the off-site failure stays visible on its own."
+}


### PR DESCRIPTION
Closes #2169 · Refs #2166

#2173 dump'ları zamanlayıcıya bağladı. Ama hâlâ **geldikleri veritabanıyla aynı
diske** düşüyorlar — bu yedek değil, tek bir arıza alanı içinde ikinci kopya. Ve
09-03 bunu gösterdi: eski host erişilemez olunca veritabanı da onun her dump'ı da
birlikte gitti. Hiçbir şey kaybolmamasının tek sebebi kutunun 45 dakikalığına geri
gelmesiydi.

`backup-offsite.sh` dump'ları `$OFFSITE_TARGET`'a rsync'liyor. Dört karar:

| Karar | Neden |
|---|---|
| **Kendi unit'i ve timer'ı**, yedeğin adımı değil | Yerelde başarılı bir dump, uzak taraf kapalıyken de başarı sayılmalı — ama off-site hatası yeşil bir yedek koşusunun içinde yutulmak yerine kendi başına görünür kalmalı. Bu boşluğun aylarca fark edilmemesinin sebebi tam olarak o yutma. |
| **Asla `--delete`** | Off-site kopya, yedeklenen makinadan silinebilir olmamalı. Bu host ele geçerse ya da buradaki bir script yanlış davranırsa, geriye kalan o uzak kopyalar. |
| **`--ignore-existing`** | Dump'lar yazıldıktan sonra değişmez; orada olan zaten doğru. Ayrıca yeniden koşma uzak tarafta geçmişi yeniden yazamaz. |
| **Doğrulama geçişi** | Hedefteki anahtar `rrsync -wo` ile kısıtlı: **yazma-only**. Bu host gönderebiliyor, hiçbir şey okuyamıyor — yani "gitti mi" sorusu listeleyerek cevaplanamaz. İkinci bir rsync `--dry-run` ile yine de uzak dosya listesini müzakere ediyor, dolayısıyla "bekleyen 0 dosya" okuma yetkisi vermeden alınmış **gerçek** bir varış kanıtı. Bu olmadan sessizce yarım kalmış bir push, iyi bir push'tan ayırt edilemez. |

## Hedef bilerek değişken

Bugün eski IONOS kutusu — gerçekten ayrı bir makina, ayrı sağlayıcı, ayrı ülke.
Ama aynı zamanda emekliye ayrılacak ve düşüp kalkıyor. **Geçici hedef.** Object
storage'a geçiş `OFFSITE_TARGET` + bir anahtar değişikliği olmalı, yeniden yazım
değil — script bu yüzden hedefi soyut tutuyor.

## Doğrulama (gerçek hedefe karşı)

```
==> pushing 1 dump(s) to the off-site target
    Number of regular files transferred: 1
    Total transferred file size: 19,725,673 bytes
==> verifying the far side has everything
    ✓ all 1 dump(s) confirmed present off-site
```

sha256 iki makinada **bağımsız olarak** karşılaştırıldı: `7d6387ac…` — aynı.

Hata yolu da test edildi (yönlendirilemez adrese karşı): `exit 1`, gerçek
ssh/rsync hatasıyla, ve yerel dump'a dokunulmadan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)