### PR TITLE
infra: prod vhost'ları elle değil, üretilerek (#2166)

### DIFF
--- a/infra/server/bootstrap.sh
+++ b/infra/server/bootstrap.sh
@@ -48,8 +48,12 @@ SWAP_GB="${SWAP_GB:-4}"
 # CI stayed green on MySQL 8. Same engine everywhere, or the tests are lying.
 MYSQL_IMAGE="${MYSQL_IMAGE:-mysql:8.0}"
 ACME_EMAIL="${ACME_EMAIL:-}"
+# Public hostnames this box serves. The apex serves the app; a bare `www.` host
+# redirects to it; anything else reverse-proxies to the app as well.
+SITES="${SITES:-interncrm.com www.interncrm.com crm.interncrm.com}"
+APP_PORT="${APP_PORT:-3200}"
 
-STEPS=(preflight packages swap journald firewall docker fail2ban caddy mysql backups tools harden summary)
+STEPS=(preflight packages swap journald firewall docker fail2ban caddy sites mysql backups tools harden summary)
 ONLY=""
 SKIP=""
 
@@ -315,6 +319,65 @@ EOF
   systemctl reload caddy || systemctl restart caddy
   ok "caddy $(caddy version | head -1 | awk '{print $1}') serving, sites dir /etc/caddy/sites"
   [ -n "$ACME_EMAIL" ] || warn "ACME_EMAIL unset — Let's Encrypt cannot mail expiry warnings"
+}
+
+# -------------------------------------------------------------------- sites --
+step_sites() {
+  # The production vhosts were hand-written during the migration, which means a
+  # rebuild of this box would silently lose them — exactly the "what was running
+  # here?" problem this script exists to prevent.
+  install -d -o root -g caddy -m 0775 /etc/caddy/sites
+
+  local my_ip
+  my_ip="$(curl -fsS --max-time 10 -4 https://api.ipify.org 2>/dev/null || true)"
+  [ -n "$my_ip" ] || warn "could not determine this host's public IP — generating every site unchecked"
+
+  local apex host resolved
+  apex="${SITES%% *}"
+
+  for host in $SITES; do
+    # A site whose DNS does not point here CANNOT pass an ACME challenge, and
+    # Let's Encrypt rate-limits FAILED validations (5 per hostname per hour).
+    # Generating it anyway would burn that budget and, worse, put the domain in
+    # a failure loop right when the cert is actually needed. So skip it, loudly.
+    if [ -n "$my_ip" ]; then
+      # `|| true` is load-bearing: getent exits 2 for a name that does not
+      # resolve, and under `set -e` that assignment would end the whole step —
+      # silently, in the middle of the loop, which is how the first version of
+      # this failed. A name that does not resolve is the case we are testing
+      # for, not an error.
+      resolved="$(getent ahostsv4 "$host" 2>/dev/null | awk 'NR==1{print $1}' || true)"
+      if [ "$resolved" != "$my_ip" ]; then
+        rm -f "/etc/caddy/sites/${host}.caddy"
+        warn "skipping ${host} — resolves to '${resolved:-nothing}', not ${my_ip} (add the DNS record, then re-run)"
+        continue
+      fi
+    fi
+
+    # No `tls` directive: Caddy obtains and renews a real certificate itself.
+    # An explicit `tls` line belongs only on names that cannot be validated that
+    # way — the wildcard the topic environments use (see topic-deploy.sh).
+    if [ "$host" = "www.${apex}" ]; then
+      cat > "/etc/caddy/sites/${host}.caddy" <<EOF
+# Managed by infra/server/bootstrap.sh — do not edit by hand.
+${host} {
+    redir https://${apex}{uri} permanent
+}
+EOF
+    else
+      cat > "/etc/caddy/sites/${host}.caddy" <<EOF
+# Managed by infra/server/bootstrap.sh — do not edit by hand.
+${host} {
+    reverse_proxy 127.0.0.1:${APP_PORT}
+}
+EOF
+    fi
+    ok "site ${host}"
+  done
+
+  caddy validate --config /etc/caddy/Caddyfile >/dev/null 2>&1 || die "generated Caddyfile does not validate"
+  systemctl reload caddy
+  ok "caddy reloaded ($(ls -1 /etc/caddy/sites/*.caddy 2>/dev/null | wc -l) site files)"
 }
 
 # -------------------------------------------------------------------- mysql --

--- a/releases/unreleased/caddy-production-sites.json
+++ b/releases/unreleased/caddy-production-sites.json
@@ -1,0 +1,4 @@
+{
+  "bump": "patch",
+  "changelog": "- **Production vhosts are generated, not hand-written** (#2166): `bootstrap.sh` gains a `sites` step that writes one Caddy site file per public hostname, with automatic Let's Encrypt. It refuses to generate a site whose DNS does not point at this host — an unresolvable name cannot pass an ACME challenge, and Let's Encrypt rate-limits failed validations, so generating it anyway would burn that budget and leave the domain looping."
+}


### PR DESCRIPTION
Refs #2166

Apex, www ve crm site dosyalarını yeni hostu ayağa kaldırırken **elle** yazmıştım.
Bu tam olarak `bootstrap.sh`'ın önlemek için var olduğu şey: kutuyu yeniden kur,
o vhost'lar yok olsun ve repoda hiç var oldukları yazmasın.

`bootstrap.sh`'a `sites` adımı eklendi. `$SITES` içindeki her hostname için bir
dosya, **`tls` direktifi olmadan** — böylece Caddy sertifikayı kendisi alıp
yeniliyor. Açık `tls` satırı yalnızca bu yolla doğrulanamayan isimlere ait, yani
topic ortamlarının kullandığı wildcard'a. Düz bir `www.` hostu apex'e yönleniyor,
diğerleri uygulamaya proxy'leniyor.

## DNS'i buraya bakmayan bir site üretmiyor

Ve varsa bayat dosyasını siliyor. Bu kutuya çözülmeyen bir isim **ACME
doğrulamasından geçemez**, ve Let's Encrypt **başarısız** doğrulamaları da
limitliyor (hostname başına saatte 5). Yine de üretmek, alınamayacak bir
sertifika için o bütçeyi harcar ve alan adını bir yeniden-deneme döngüsünde
bırakır — tam da limite takılmayı en az istediğin anda. Adım hangi ismi,
neye çözüldüğünü ve ne yapılacağını söylüyor:

```
! skipping www.interncrm.com — resolves to 'nothing', not 92.5.120.186 (add the DNS record, then re-run)
```

## Test ilk sürümde gerçek bir hata buldu

`getent` satırındaki `|| true` bu yüzden yorumlu: çözülmeyen bir isim için
`getent` 2 ile çıkıyor ve `set -e` altında o atama **bütün adımı bitiriyordu** —
sessizce, döngünün ortasında, ilk çözülmeyen isimden sonra. Adım işinin yarısını
yapmışken başarılı görünüyordu. Çözülmeyen isim, bu kodun **var olma sebebi**,
hata durumu değil.

## Canlı hostta doğrulandı

```
✓ site interncrm.com
! skipping www.interncrm.com — resolves to 'nothing', ...
! skipping crm.interncrm.com  — resolves to 'nothing', ...
✓ caddy reloaded (2 site files)
ÇIKIŞ KODU=0

https://interncrm.com -> 200  ssl_verify=0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)