### PR TITLE
infra: DNS script'i tüm kayıt setini yönetsin, gri bulutla (#2166)

### DIFF
--- a/.github/workflows/dns-records.yml
+++ b/.github/workflows/dns-records.yml
@@ -1,0 +1,71 @@
+name: DNS records (manual)
+
+# Create or correct this project's public DNS records from the Actions tab,
+# using the CF_API_TOKEN repo secret (#2166).
+#
+# WHY A WORKFLOW: the alternative is pasting a Cloudflare token into a shell on
+# the server, which puts a live credential in a scrollback and a history file
+# for no gain — the repo already holds one, encrypted, for exactly this. It also
+# means the record set is applied the same way every time instead of by
+# clicking, and the run log records what changed.
+#
+# The script is idempotent: a correct record is left alone, a wrong one is
+# updated in place, a missing one is created. Safe to re-run.
+#
+# NOTE ON `proxied`: defaults to false, and that is not cosmetic — see the
+# header of infra/setup-dns-cloudflare.sh. Turning it on for a CRM hostname
+# requires bumping TRUSTED_PROXY_COUNT to 2 for that host in the same change.
+on:
+  workflow_dispatch:
+    inputs:
+      domain:
+        description: 'Zone, e.g. interncrm.com'
+        required: true
+        type: string
+      records:
+        description: "Space-separated names ('@' = apex)"
+        required: false
+        default: '* www crm'
+        type: string
+      server_ip:
+        description: 'Target IPv4 (leave empty to use SERVER_IP secret/var)'
+        required: false
+        type: string
+      proxied:
+        description: 'Cloudflare proxy (orange cloud) — read the note above'
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: dns-records
+  cancel-in-progress: false
+
+jobs:
+  apply:
+    name: Apply DNS records
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Apply
+        env:
+          CF_Token: ${{ secrets.CF_API_TOKEN }}
+          DOMAIN: ${{ inputs.domain }}
+          RECORDS: ${{ inputs.records }}
+          PROXIED: ${{ inputs.proxied }}
+          SERVER_IP: ${{ inputs.server_ip }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CF_Token:-}" ]; then
+            echo "::error::CF_API_TOKEN secret is not set (or is empty). Add/rotate it in Settings → Secrets → Actions."
+            exit 1
+          fi
+          # The script auto-detects SERVER_IP from the machine it runs on, which
+          # here would be the GitHub runner — never what we want. Require it.
+          if [ -z "${SERVER_IP:-}" ]; then
+            echo "::error::server_ip is required: this runs on a GitHub runner, so auto-detection would point DNS at the runner."
+            exit 1
+          fi
+          chmod +x infra/setup-dns-cloudflare.sh
+          ./infra/setup-dns-cloudflare.sh

--- a/infra/setup-dns-cloudflare.sh
+++ b/infra/setup-dns-cloudflare.sh
@@ -1,48 +1,90 @@
 #!/usr/bin/env bash
 #
-# CI-independent wildcard DNS setup (#636 / #583).
+# Create/update this project's public DNS records via the Cloudflare API
+# (#636 / #583, extended for the server migration #2166).
 #
-# Creates the wildcard `*.ersah.in` A record via the Cloudflare API so every
-# topic subdomain (crm-topicN.ersah.in) resolves to the server. Idempotent:
-# if a `*` A record already exists it does nothing. This is the same logic as
-# the `dns` step of .github/workflows/infra-setup.yml, extracted so it can run
-# from a laptop without GitHub Actions minutes.
+# WHY A SCRIPT: the records have to agree with two things that are easy to get
+# wrong by clicking — the server IP, and whether Cloudflare proxies the name.
+#
+# PROXIED DEFAULTS TO FALSE, AND THAT IS LOAD-BEARING.
+#   `src/lib/rateLimit.ts` counts back from the right of X-Forwarded-For by
+#   TRUSTED_PROXY_COUNT hops, which is 1 in every environment. Cloudflare's
+#   proxy adds a second hop, so an orange-clouded hostname makes the limiter
+#   bucket every visitor as the Cloudflare edge — one person's traffic then
+#   throttles everybody. Turning the proxy on for a CRM hostname is therefore
+#   not a free toggle: it has to happen in the same change as bumping
+#   TRUSTED_PROXY_COUNT to 2 for that host. See infra/README.md.
+#   (The old ersah.in wildcard was created proxied, before that was understood.)
 #
 # USAGE
-#   export CF_Token="<scoped Cloudflare token: Zone:DNS:Edit + Zone:Read, ersah.in>"
-#   SERVER_IP=<server public IP> ./infra/setup-dns-cloudflare.sh
-#   # SERVER_IP optional if you run it ON the server (auto-detected).
+#   export CF_Token="<scoped token: Zone:DNS:Edit + Zone:Read, this zone only>"
+#   DOMAIN=interncrm.com ./infra/setup-dns-cloudflare.sh
+#   # SERVER_IP is auto-detected when run ON the server.
 #
-# The cert (wildcard TLS) is issued by infra/acme-issue-wildcard.sh — run that
-# ON the server. Both together complete the topic-preview foundations.
+#   Env:
+#     DOMAIN      default ersah.in
+#     RECORDS     space-separated names, default "* www crm"  ('@' = apex)
+#     SERVER_IP   default: this host's public IP
+#     PROXIED     default false — read the note above before setting true
 #
+# Idempotent: an existing record with the right content and proxy setting is
+# left alone; a wrong one is UPDATED rather than duplicated (Cloudflare happily
+# holds two A records for one name and then answers with both).
+#
+# The wildcard TLS cert is a separate step — infra/acme-issue-wildcard.sh, run
+# ON the server. DNS alone gets you a name that resolves and cannot do HTTPS.
 set -euo pipefail
 
 DOMAIN="${DOMAIN:-ersah.in}"
+RECORDS="${RECORDS:-* www crm}"
+PROXIED="${PROXIED:-false}"
 : "${CF_Token:?export CF_Token with a scoped Cloudflare API token first}"
 
 SERVER_IP="${SERVER_IP:-}"
 if [ -z "$SERVER_IP" ]; then
-  SERVER_IP="$(curl -fsS https://api.ipify.org 2>/dev/null || true)"
+  SERVER_IP="$(curl -fsS --max-time 10 https://api.ipify.org 2>/dev/null || true)"
 fi
 [ -n "$SERVER_IP" ] || { echo "ERROR: set SERVER_IP=<public ip>" >&2; exit 1; }
-echo "==> Target server IP: $SERVER_IP"
+
+case "$PROXIED" in true|false) ;; *) echo "ERROR: PROXIED must be true or false" >&2; exit 1 ;; esac
+
+echo "==> Zone ${DOMAIN}, target ${SERVER_IP}, proxied=${PROXIED}"
 
 api() { curl -sS -H "Authorization: Bearer $CF_Token" -H "Content-Type: application/json" "$@"; }
 
 ZONE_ID="$(api "https://api.cloudflare.com/client/v4/zones?name=${DOMAIN}" \
   | python3 -c "import sys,json;r=json.load(sys.stdin);print(r['result'][0]['id'] if r.get('result') else '')")"
-[ -n "$ZONE_ID" ] || { echo "ERROR: zone ${DOMAIN} not found with this token (needs Zone:Read)" >&2; exit 1; }
+[ -n "$ZONE_ID" ] || { echo "ERROR: zone ${DOMAIN} not visible to this token (needs Zone:Read on ${DOMAIN})" >&2; exit 1; }
 
-EXISTING="$(api "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records?type=A&name=%2A.${DOMAIN}" \
-  | python3 -c "import sys,json;print(len(json.load(sys.stdin).get('result',[])))")"
+for name in $RECORDS; do
+  if [ "$name" = "@" ]; then fqdn="$DOMAIN"; else fqdn="${name}.${DOMAIN}"; fi
 
-if [ "$EXISTING" != "0" ]; then
-  echo "==> Wildcard *.${DOMAIN} A record already exists — nothing to do."
-  exit 0
-fi
+  # url-encode the '*' so the query matches the wildcard record.
+  q="$(printf '%s' "$fqdn" | sed 's/\*/%2A/')"
+  existing="$(api "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records?type=A&name=${q}")"
 
-echo "==> Creating *.${DOMAIN} A → ${SERVER_IP} (proxied)"
-api -X POST "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records" \
-  --data "{\"type\":\"A\",\"name\":\"*\",\"content\":\"${SERVER_IP}\",\"proxied\":true,\"ttl\":1}" \
-  | python3 -c "import sys,json;r=json.load(sys.stdin);assert r.get('success'),r;print('OK — wildcard record created.')"
+  read -r rec_id rec_ip rec_proxied <<EOF
+$(printf '%s' "$existing" | python3 -c "
+import sys,json
+r=json.load(sys.stdin).get('result') or []
+print(r[0]['id'], r[0]['content'], str(r[0]['proxied']).lower()) if r else print('- - -')
+")
+EOF
+
+  if [ "$rec_id" = "-" ]; then
+    api -X POST "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records" \
+      --data "{\"type\":\"A\",\"name\":\"${name}\",\"content\":\"${SERVER_IP}\",\"proxied\":${PROXIED},\"ttl\":1}" \
+      | python3 -c "import sys,json;r=json.load(sys.stdin);assert r.get('success'),r" \
+      && echo "    created  ${fqdn} → ${SERVER_IP} (proxied=${PROXIED})"
+  elif [ "$rec_ip" = "$SERVER_IP" ] && [ "$rec_proxied" = "$PROXIED" ]; then
+    echo "    ok       ${fqdn} → ${SERVER_IP} (proxied=${PROXIED})"
+  else
+    api -X PATCH "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records/${rec_id}" \
+      --data "{\"content\":\"${SERVER_IP}\",\"proxied\":${PROXIED},\"ttl\":1}" \
+      | python3 -c "import sys,json;r=json.load(sys.stdin);assert r.get('success'),r" \
+      && echo "    updated  ${fqdn}: ${rec_ip}/proxied=${rec_proxied} → ${SERVER_IP}/proxied=${PROXIED}"
+  fi
+done
+
+echo "==> Done. TLS is a separate step (infra/acme-issue-wildcard.sh for the wildcard;"
+echo "    Caddy obtains per-host certs itself for names that resolve here)."

--- a/releases/unreleased/dns-records-grey-cloud.json
+++ b/releases/unreleased/dns-records-grey-cloud.json
@@ -1,0 +1,4 @@
+{
+  "bump": "patch",
+  "changelog": "- **`infra/setup-dns-cloudflare.sh` handles the whole record set** (#2166): it takes a list of names instead of only the wildcard, updates a wrong record instead of adding a duplicate, and defaults to `proxied=false`. The old hardcoded `proxied: true` conflicts with `TRUSTED_PROXY_COUNT=1` — Cloudflare's proxy adds a hop, so an orange-clouded CRM hostname makes the rate limiter bucket every visitor as the Cloudflare edge."
+}

--- a/releases/unreleased/dns-records-grey-cloud.json
+++ b/releases/unreleased/dns-records-grey-cloud.json
@@ -1,4 +1,4 @@
 {
   "bump": "patch",
-  "changelog": "- **`infra/setup-dns-cloudflare.sh` handles the whole record set** (#2166): it takes a list of names instead of only the wildcard, updates a wrong record instead of adding a duplicate, and defaults to `proxied=false`. The old hardcoded `proxied: true` conflicts with `TRUSTED_PROXY_COUNT=1` — Cloudflare's proxy adds a hop, so an orange-clouded CRM hostname makes the rate limiter bucket every visitor as the Cloudflare edge."
+  "changelog": "- **`infra/setup-dns-cloudflare.sh` handles the whole record set** (#2166): it takes a list of names instead of only the wildcard, updates a wrong record instead of adding a duplicate, and defaults to `proxied=false`. The old hardcoded `proxied: true` conflicts with `TRUSTED_PROXY_COUNT=1` \u2014 Cloudflare's proxy adds a hop, so an orange-clouded CRM hostname makes the rate limiter bucket every visitor as the Cloudflare edge. A `workflow_dispatch` workflow (`dns-records.yml`) runs it from the Actions tab with the existing `CF_API_TOKEN` secret, so applying records needs no live credential in a shell."
 }


### PR DESCRIPTION
Refs #2166

Script tek bir kayıt oluşturuyordu (`*`) ve `proxied: true` sabit yazılıydı.
Yeni alan adı için ikisi de yanlış.

## Kayıtlar

Taşınma `www` ve `crm`'i de gerektiriyor, ve sadece `*`'ı bilen bir script'i
tekrar koşturarak bunlar eklenemez. `RECORDS` artık bir liste (`@` = apex).

## Proxied — bu kod bağımlı bir karar, serbest bir anahtar değil

`src/lib/rateLimit.ts`, `X-Forwarded-For`'u sağdan `TRUSTED_PROXY_COUNT` hop
geriye sayıyor; bu değer her ortamda **1**. Cloudflare proxy'si ikinci bir hop
ekliyor, yani turuncu buluttaki bir hostname'de limiter **herkesi Cloudflare
edge IP'sine bucket'lar** ve tek kişinin trafiği hepsini throttle'lar.

Bu yüzden proxy'yi açmak, aynı değişiklikte o host için `TRUSTED_PROXY_COUNT`'u
2'ye çıkarmayı gerektirir. Varsayılan artık `false` ve gerekçe başlıkta —
alan adı kuran bir sonraki kişinin okuyacağı yerde. (Eski `ersah.in` wildcard'ı
bu anlaşılmadan önce proxied oluşturulmuştu; `infra/README.md` uyarıyı zaten
taşıyor.)

## Idempotency

Eskiden sadece **varlığa** bakıyordu: eski sunucuyu gösteren bir kayıt "zaten
var — yapacak bir şey yok" diye raporlanıp yanlış halde bırakılıyordu. Üstelik
Cloudflare tek isim için iki A kaydını memnuniyetle tutar ve ikisiyle birden
cevap verir, yani körlemesine oluşturmak faydasızdan da kötü.

Artık içerik ve proxy durumunu karşılaştırıyor, uyuşmazlığı **yerinde
güncelliyor**, doğru kaydı ellemiyor.

Dört dal da (yok / doğru / yanlış IP / yanlış proxy) sahte API cevaplarına karşı
çalıştırıldı — `result: null` dahil, ki eski tek satırlık ayrıştırıcı onda
patlardı.

🤖 Generated with [Claude Code](https://claude.com/claude-code)