### PR TITLE
refactor: ortam hostname'lerinden `crm-` önekini kaldır (#2166)

### DIFF
--- a/.github/workflows/topic-preview.yml
+++ b/.github/workflows/topic-preview.yml
@@ -4,7 +4,7 @@ name: Topic Preview (hosted build → server swap, auto per-PR)
 #
 # Every open PR automatically gets its own isolated environment:
 #   PR #123 → container internship-crm-pr123 on a dedicated port →
-#             https://crm-pr123.ersah.in  (wildcard *.ersah.in DNS + TLS)
+#             https://pr123.<domain>  (wildcard DNS + TLS)
 # A bot comment on the PR carries the URL (updated on every push). When the PR
 # is merged or closed, the environment (container + image + Plesk route) is torn
 # down so it stops consuming server resources.
@@ -52,6 +52,10 @@ env:
   # than a PR: set vars.BASE_DOMAIN to interncrm.com at cutover. The literal
   # stays as the fallback until the old host is retired.
   BASE_DOMAIN: ${{ vars.BASE_DOMAIN || 'ersah.in' }}
+  # Hostname prefix for environment names, empty by default (pr123.<domain>).
+  # Kept as a variable only so it can be put back to `crm-` without a PR if
+  # something downstream turns out to assume it.
+  ENV_PREFIX: ${{ vars.ENV_PREFIX }}
   # Where the shared preview secrets live on the server (same as deploy-preview).
   ENV_FILE: /etc/internship-crm/preview.env
 
@@ -149,6 +153,7 @@ jobs:
           PORT: ${{ steps.t.outputs.port }}
           IMAGE: ${{ needs.build.outputs.image }}
           BASE_DOMAIN: ${{ env.BASE_DOMAIN }}
+          ENV_PREFIX: ${{ env.ENV_PREFIX }}
           ENV_FILE: ${{ env.ENV_FILE }}
           GHCR_USER: ${{ github.actor }}
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -175,7 +180,7 @@ jobs:
         with:
           script: |
             const topic = `pr${context.issue.number}`;
-            const url = `https://crm-${topic}.${{ env.BASE_DOMAIN }}`;
+            const url = `https://${{ env.ENV_PREFIX }}${topic}.${{ env.BASE_DOMAIN }}`;
             const marker = '<!-- topic-preview -->';
             const body = `${marker}\n### 🧪 Topic preview ready\n\n` +
               `Branch **\`${{ github.head_ref }}\`** → **${url}**\n\n` +
@@ -246,6 +251,7 @@ jobs:
         env:
           TOPIC: pr${{ github.event.pull_request.number }}
           BASE_DOMAIN: ${{ env.BASE_DOMAIN }}
+          ENV_PREFIX: ${{ env.ENV_PREFIX }}
         run: |
           chmod +x infra/server/topic-teardown.sh
           ./infra/server/topic-teardown.sh

--- a/.github/workflows/topic-sweep.yml
+++ b/.github/workflows/topic-sweep.yml
@@ -33,6 +33,8 @@ env:
   # than a PR: set vars.BASE_DOMAIN to interncrm.com at cutover. The literal
   # stays as the fallback until the old host is retired.
   BASE_DOMAIN: ${{ vars.BASE_DOMAIN || 'ersah.in' }}
+  # See topic-preview.yml. Teardown cleans the legacy `crm-` names regardless.
+  ENV_PREFIX: ${{ vars.ENV_PREFIX }}
 
 jobs:
   # ── 1. What is actually running on the box ──────────────────────────────────
@@ -164,6 +166,7 @@ jobs:
       - env:
           STALE: ${{ needs.resolve.outputs.stale }}
           BASE_DOMAIN: ${{ env.BASE_DOMAIN }}
+          ENV_PREFIX: ${{ env.ENV_PREFIX }}
         run: |
           set -euo pipefail
           chmod +x infra/server/topic-teardown.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,8 +145,8 @@ workaround, #636, and it compiled on every PR push).
 | Env | Container | Port | URL | Image tag | Trigger |
 |-----|-----------|------|-----|-----------|---------|
 | Production | `internship-crm` | 3200 | https://crm.ersah.in | `prod-<sha>` | push to `main` (+6h drift check, manual) |
-| Preview | `internship-crm-preview` | 3201 | https://crm-preview.ersah.in | `preview-<sha>` | push to `main` (+6h drift check, manual) |
-| Topic (per PR) | `internship-crm-pr<N>` | 33xx | `https://crm-pr<N>.ersah.in` | `topic-pr<N>` | every push to the PR |
+| Preview | `internship-crm-preview` | 3201 | `https://preview.<domain>` | `preview-<sha>` | push to `main` (+6h drift check, manual) |
+| Topic (per PR) | `internship-crm-pr<N>` | 34xx | `https://pr<N>.<domain>` | `topic-pr<N>` | every push to the PR |
 
 - `deploy-prod.yml` / `deploy-preview.yml` — **both follow `main` automatically**. Every merge
   lands on preview and prod. Three jobs: **gate** (self-hosted; resolves the target sha and
@@ -194,7 +194,7 @@ workaround, #636, and it compiled on every PR push).
   Track multi-step work with a visible task list as you go.
   **Always open the PR, without being asked** (restated 2026-08-06): the PR is how the
   maintainer *tests* the change — every PR gets its own environment at
-  `https://crm-pr<N>.ersah.in` (`topic-preview.yml`). Pushing the branch alone gives them
+  `https://pr<N>.<domain>` (`topic-preview.yml`). Pushing the branch alone gives them
   nothing to click. Open it as soon as the work is committed, even mid-review, and post the
   preview URL. If an issue for the work does not exist yet, file one and reference it
   (`Closes #N`) so the branch, the PR and the issue all point at each other.

--- a/docs/server-migration.md
+++ b/docs/server-migration.md
@@ -114,7 +114,7 @@ ona dokunmuyor.
 
 Caddy hostname başına Let's Encrypt sertifikasını kendi alabilir, **ama bu proje
 için yetmez.** Son 100 PR 9 günde merge edilmiş — haftada ~78 PR, ve her PR
-kendi `crm-pr<N>.interncrm.com` ortamını alıyor. Let's Encrypt'in limiti
+kendi `pr<N>.interncrm.com` ortamını alıyor. Let's Encrypt'in limiti
 **alan adı başına haftada 50 sertifika**. Yani hostname-başına sertifika üçüncü
 gün duvara çarpar ve topic ortamları sessizce TLS'siz kalır.
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,7 +1,8 @@
 # Infra — Wildcard TLS & topic-based preview environments
 
 Runbook for the automation behind [#583](https://github.com/21072026/Internship/issues/583)
-(per-topic ephemeral preview environments at `crm-<topic>.ersah.in`).
+(per-topic ephemeral preview environments at `<topic>.<domain>`; the hostnames
+carried a `crm-` prefix until #2166 retired it).
 
 The whole design rests on **three one-time foundations**, after which spinning a
 topic environment up or down is *only* a container + database operation — no DNS

--- a/infra/server/topic-deploy.sh
+++ b/infra/server/topic-deploy.sh
@@ -53,6 +53,7 @@
 #       set per-topic below.
 #
 # Optional overrides (server paths / commands):
+#   ENV_PREFIX        (default "") — hostname prefix, see the note at SUBLABEL
 #   CADDY_SITES_DIR   (default /etc/caddy/sites)   — one <fqdn>.caddy per topic
 #   CADDY_RELOAD_CMD  (default "caddy validate ... && systemctl reload caddy")
 #   NGINX_CONF_DIR    (default /etc/nginx/conf.d)     — Plesk branch only
@@ -68,6 +69,11 @@ set -euo pipefail
 NGINX_CONF_DIR="${NGINX_CONF_DIR:-/etc/nginx/conf.d}"
 NGINX_RELOAD_CMD="${NGINX_RELOAD_CMD:-nginx -t && systemctl reload nginx}"
 CERT_DIR="${CERT_DIR:-/etc/nginx/ssl}"
+# Hostname prefix for environment names. Empty by default: on a domain bought
+# for this product, `pr123.<domain>` says everything `crm-pr123.<domain>` did.
+# The `crm-` prefix existed because the app used to live under a personal domain
+# shared with other services, where it had to distinguish itself.
+ENV_PREFIX="${ENV_PREFIX:-}"
 CADDY_SITES_DIR="${CADDY_SITES_DIR:-/etc/caddy/sites}"
 CADDY_RELOAD_CMD="${CADDY_RELOAD_CMD:-caddy validate --config /etc/caddy/Caddyfile && systemctl reload caddy}"
 
@@ -297,8 +303,8 @@ code=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:${PORT}/api/heal
 echo "==> Container health http://127.0.0.1:${PORT}/api/health -> ${code}"
 
 # ── Routing ──────────────────────────────────────────────────────────────────
-SUBLABEL="crm-${TOPIC}"                 # e.g. crm-pr725
-FQDN="crm-${TOPIC}.${BASE_DOMAIN}"      # e.g. crm-pr725.interncrm.com
+SUBLABEL="${ENV_PREFIX}${TOPIC}"              # e.g. pr725
+FQDN="${ENV_PREFIX}${TOPIC}.${BASE_DOMAIN}"   # e.g. pr725.interncrm.com
 
 # Which reverse proxy sits in front of the containers? The new host runs Caddy and
 # has no panel; the old one runs Plesk, which owns 80/443 there. Auto-detect, so

--- a/infra/server/topic-teardown.sh
+++ b/infra/server/topic-teardown.sh
@@ -31,12 +31,19 @@ set -euo pipefail
 : "${TOPIC:?}" "${BASE_DOMAIN:?}"
 NGINX_CONF_DIR="${NGINX_CONF_DIR:-/etc/nginx/conf.d}"
 NGINX_RELOAD_CMD="${NGINX_RELOAD_CMD:-nginx -t && systemctl reload nginx}"
+ENV_PREFIX="${ENV_PREFIX:-}"
+# Environments created before the prefix was dropped still carry `crm-`. Teardown
+# has to clean BOTH, or every topic deployed under the old naming leaks its route
+# and its Plesk subdomain forever — nothing else ever revisits a closed PR.
+LEGACY_ENV_PREFIX="${LEGACY_ENV_PREFIX:-crm-}"
 CADDY_SITES_DIR="${CADDY_SITES_DIR:-/etc/caddy/sites}"
 CADDY_RELOAD_CMD="${CADDY_RELOAD_CMD:-caddy validate --config /etc/caddy/Caddyfile && systemctl reload caddy}"
 
 CONTAINER="internship-crm-${TOPIC}"
-SUBLABEL="crm-${TOPIC}"
-FQDN="crm-${TOPIC}.${BASE_DOMAIN}"
+SUBLABEL="${ENV_PREFIX}${TOPIC}"
+FQDN="${ENV_PREFIX}${TOPIC}.${BASE_DOMAIN}"
+LEGACY_SUBLABEL="${LEGACY_ENV_PREFIX}${TOPIC}"
+LEGACY_FQDN="${LEGACY_ENV_PREFIX}${TOPIC}.${BASE_DOMAIN}"
 CONF="${NGINX_CONF_DIR}/crm-${TOPIC}.${BASE_DOMAIN}.conf"
 
 echo "==> Tearing down topic '${TOPIC}'"
@@ -49,21 +56,35 @@ docker rm   "$CONTAINER" 2>/dev/null || true
 [ -n "$IMG" ] && docker rmi "$IMG" 2>/dev/null || true
 
 # Caddy route (new host): one file, remove and reload. Idempotent.
-CADDY_SITE="${CADDY_SITES_DIR}/${FQDN}.caddy"
-if [ -f "$CADDY_SITE" ]; then
-  rm -f "$CADDY_SITE"
-  echo "==> Removed Caddy route ${CADDY_SITE}; reloading"
+_removed_any=0
+for _fq in "$FQDN" "$LEGACY_FQDN"; do
+  [ -n "$_fq" ] || continue
+  _site="${CADDY_SITES_DIR}/${_fq}.caddy"
+  if [ -f "$_site" ]; then
+    rm -f "$_site"
+    echo "==> Removed Caddy route ${_site}"
+    _removed_any=1
+  fi
+done
+if [ "$_removed_any" = "1" ]; then
   eval "$CADDY_RELOAD_CMD" || true
 elif command -v caddy >/dev/null 2>&1; then
-  echo "==> No Caddy route ${CADDY_SITE} (already gone)"
+  echo "==> No Caddy route for ${FQDN} or ${LEGACY_FQDN} (already gone)"
 fi
 
 # Remove the Plesk subdomain (this drops its nginx vhost + route). Idempotent.
-if command -v plesk >/dev/null && plesk bin subdomain --info "$FQDN" >/dev/null 2>&1; then
-  echo "==> Removing Plesk subdomain ${FQDN}"
-  plesk bin subdomain --remove "$SUBLABEL" -domain "$BASE_DOMAIN" || true
-else
-  echo "==> No Plesk subdomain ${FQDN} (already gone)"
+if command -v plesk >/dev/null 2>&1; then
+  _found=0
+  for _pair in "${SUBLABEL}|${FQDN}" "${LEGACY_SUBLABEL}|${LEGACY_FQDN}"; do
+    _lbl="${_pair%%|*}"; _fq="${_pair##*|}"
+    [ -n "$_lbl" ] || continue
+    if plesk bin subdomain --info "$_fq" >/dev/null 2>&1; then
+      echo "==> Removing Plesk subdomain ${_fq}"
+      plesk bin subdomain --remove "$_lbl" -domain "$BASE_DOMAIN" || true
+      _found=1
+    fi
+  done
+  [ "$_found" = "1" ] || echo "==> No Plesk subdomain for ${FQDN} or ${LEGACY_FQDN} (already gone)"
 fi
 
 # Clean up any legacy raw-nginx route from the pre-Plesk approach.

--- a/releases/unreleased/env-hostname-prefix.json
+++ b/releases/unreleased/env-hostname-prefix.json
@@ -1,0 +1,4 @@
+{
+  "bump": "patch",
+  "changelog": "- **Environment hostnames drop the `crm-` prefix** (#2166): topic environments are now `pr<N>.<domain>` instead of `crm-pr<N>.<domain>`. The prefix existed to distinguish the app under a personal domain shared with other services; on a domain bought for this product it distinguishes nothing. `topic-teardown.sh` removes both the new and the legacy `crm-` names, so environments created under the old scheme are still cleaned up when their PR closes."
+}


### PR DESCRIPTION
Refs #2166 · #2180'in devamı

`crm.<domain>`'i kaldıran gerekçenin aynısı: önek, uygulama başka servislerle
paylaşılan kişisel bir alan adının altındayken **hangi şey olduğunu söylemek**
için vardı. Ürünün kendi alan adında hiçbir şeyi ayırt etmiyor — yani
`crm-pr123.interncrm.com`, her PR'a yapıştırılan bir URL'de üç karakterlik gürültü.

Topic ortamları `pr<N>.<domain>`, preview `preview.<domain>` oluyor.

## Asıl önemli kısım: teardown iki adlandırmayı da temizliyor

Bu değişiklikten **önce** açılmış bir PR `crm-pr<N>` olarak deploy oldu ve
**sonra** kapanabilir. Kapanmış bir PR'a hiçbir şey geri dönmez — yani sadece
yeni ismi bilen bir teardown, route'u ve Plesk subdomain'ini **kalıcı olarak**
geride bırakırdı.

`topic-teardown.sh` artık hem `${ENV_PREFIX}${TOPIC}` hem `crm-${TOPIC}`
siliyor, ikisinden biri varsa bir kez reload ediyor. `LEGACY_ENV_PREFIX`, eski
şemayla oluşturulmuş son ortam gidene kadar duruyor.

`ENV_PREFIX` repo değişkeni olarak açıldı (varsayılan boş) — sadece aşağı
akışta bir şey öneki varsayıyorsa PR açmadan geri konabilsin diye.

## Container adlarına dokunulmadı

`internship-crm-pr<N>` iç isim, kimse tarayıcıya yapıştırmıyor, ve
değiştirmek süpürücünün isimle eşleştirdiği her çalışan container'ı öksüz
bırakırdı.

## Canlı hostta doğrulandı

```
==> Caddy route pr9997.interncrm.com -> 127.0.0.1:3200     (yeni adlandırma)
    crm-pr9997.interncrm.com.caddy                          (eski ortam taklit edildi)
==> Removed Caddy route /etc/caddy/sites/pr9997.interncrm.com.caddy
==> Removed Caddy route /etc/caddy/sites/crm-pr9997.interncrm.com.caddy
https://interncrm.com -> 200 ssl_verify=0                   (prod etkilenmedi)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)