### PR TITLE
infra: deploy runner'ı root yapmadan yetkilendir (#2166)

### DIFF
--- a/infra/server/bootstrap.sh
+++ b/infra/server/bootstrap.sh
@@ -58,7 +58,7 @@ ACME_EMAIL="${ACME_EMAIL:-}"
 SITES="${SITES:-interncrm.com www.interncrm.com}"
 APP_PORT="${APP_PORT:-3200}"
 
-STEPS=(preflight packages swap journald firewall docker fail2ban caddy sites mysql backups tools harden summary)
+STEPS=(preflight packages swap journald firewall docker fail2ban caddy sites mysql backups runnerperms tools harden summary)
 ONLY=""
 SKIP=""
 
@@ -578,6 +578,55 @@ EOF
   systemctl daemon-reload
   systemctl enable --now internship-backup.timer >/dev/null
   ok "daily backup timer active ($(systemctl show internship-backup.timer -p NextElapseUSecRealtime --value | cut -c1-24))"
+}
+
+# -------------------------------------------------------- runner permissions --
+step_runnerperms() {
+  # infra/deploy-prod.sh needs three things the deploy user cannot reach by
+  # default: read the env file, write the deployed-sha state file next to it,
+  # and write a pre-deploy dump into the backup directory.
+  #
+  # The OLD host solved this by running the Actions runner as root, which gave
+  # every job on the box unrestricted access to the whole machine. Granting the
+  # three paths to the runner's group instead is strictly less privilege — and
+  # it is still meaningful privilege, so it is worth saying plainly: anything
+  # that runs on this runner can read the production secrets. Fork PRs already
+  # never reach a self-hosted runner (topic-preview.yml refuses them); that
+  # exclusion is what keeps this bounded, so do not relax it.
+  install -d -o root -g "$LOGIN_USER" -m 2750 /etc/internship-crm
+
+  # The backup directory is OWNED by the deploy user, not merely group-writable.
+  # backup-db.sh does `chmod 700` on it, and chmod is an owner-only operation:
+  # a group-writable directory owned by root fails there and, because the deploy
+  # treats a failed backup as a hard stop, takes the whole deploy with it. root
+  # (the systemd backup timer) can still write here either way.
+  install -d -o "$LOGIN_USER" -g "$LOGIN_USER" -m 0700 /var/backups/internship-crm
+  chown -R "$LOGIN_USER":"$LOGIN_USER" /var/backups/internship-crm 2>/dev/null || true
+
+  local f
+  for f in /etc/internship-crm/*.env; do
+    [ -e "$f" ] || continue
+    chown root:"$LOGIN_USER" "$f"
+    chmod 640 "$f"
+    ok "$(basename "$f") readable by $LOGIN_USER (was root-only)"
+  done
+
+  # The state file records which sha is live; deploy-prod.sh writes it with
+  # `|| true`, so a permission problem here does not fail a deploy — it just
+  # silently breaks the drift gate, and a missed deploy then goes unnoticed.
+  #
+  # Created here rather than leaving the directory group-writable: writing an
+  # existing file needs permission on the FILE, creating one needs permission on
+  # the DIRECTORY. Granting the directory would let anything on the runner drop
+  # or replace files next to the production secrets; granting one file does not.
+  for c in internship-crm internship-crm-preview; do
+    f="/etc/internship-crm/.${c}.deployed-sha"
+    [ -e "$f" ] || : > "$f"
+    chown root:"$LOGIN_USER" "$f"
+    chmod 664 "$f"
+  done
+
+  ok "deploy paths writable by $LOGIN_USER (runner stays non-root)"
 }
 
 # -------------------------------------------------------------------- tools --

--- a/releases/unreleased/runner-deploy-permissions.json
+++ b/releases/unreleased/runner-deploy-permissions.json
@@ -1,0 +1,4 @@
+{
+  "bump": "patch",
+  "changelog": "- **The deploy runner no longer has to be root** (#2166): `bootstrap.sh` grants the runner user exactly the three things `deploy-prod.sh` needs — read the env file, write the deployed-sha state file, own the backup directory — instead of the old host's approach of running the Actions runner as root. The backup directory must be *owned*, not merely group-writable: `backup-db.sh` chmods it, chmod is owner-only, and a failed backup is a hard stop for the deploy."
+}


### PR DESCRIPTION
Refs #2166

Eski host, Actions runner'ını **root** olarak koşuyordu — `deploy-prod.sh`'ın
`prod.env`'i okuyabilmesi, yanına `deployed-sha` yazabilmesi ve
`/var/backups/internship-crm`'e dump alabilmesi bu yüzden kimsenin aklına bile
gelmiyordu. Bedeli: o kutudaki **her job'ın makinanın tamamına sınırsız erişimi**.

Yeni host runner'ı normal kullanıcı olarak koşuyor. `bootstrap.sh` gerçekten
gereken üç yolu veriyor, fazlasını değil. İkisi göründüğünden ince, ve ikisi de
deploy patlayarak bulundu:

**Yedek dizini grup-yazılabilir değil, sahipli olmalı.** `backup-db.sh` ona
`chmod 700` uyguluyor; chmod **sadece sahibin** yapabildiği bir işlem. root'a ait
grup-yazılabilir bir dizin orada patlıyor — ve başarısız yedek deploy için sert
durdurma olduğundan, tüm deploy `chmod: Operation not permitted` ile ölüyor.
root'un yedek timer'ı her iki durumda da yazabiliyor.

**State dosyası burada oluşturuluyor, dizin grup-yazılabilir yapılmıyor.** Var
olan bir dosyaya yazmak **dosya** üzerinde, yeni dosya oluşturmak **dizin**
üzerinde izin ister. Dizini vermek, runner'da koşan her şeyin prod sırlarının
yanına dosya bırakmasına ya da dosya değiştirmesine izin verirdi. Tek bir dosyayı
vermek vermiyor.

Açıkça söylemekte fayda var, çünkü bu hâlâ gerçek bir ayrıcalık: **bu runner'da
koşan her şey prod sırlarını okuyabilir.** Fork PR'ları self-hosted runner'a hiç
ulaşmıyor (`topic-preview.yml` reddediyor) ve bunu sınırlı tutan şey o istisna —
gevşetilmemeli.

## Kesme deploy'unun kendisi doğruladı

```
==> Pulling ghcr.io/.../internship:prod-57fe816...   (arm64, çok mimarili manifest'ten)
==> Backing up the database before the schema sync
==> Canary OK — 57fe816, db ok. Promoting.
==> Health OK — serving 57fe816, db ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)