### PR TITLE
fix: gece load testi bir yönlendirmeyi ölçüyordu (#2166)

### DIFF
--- a/.github/workflows/k6-load.yml
+++ b/.github/workflows/k6-load.yml
@@ -90,7 +90,7 @@ jobs:
           # them: a job output that holds a secret value is redacted on delivery,
           # so routing it through `needs` would blank the email's target line
           # exactly when STRESS_TARGET_URL is configured.
-          BASE_URL: ${{ github.event.inputs.base_url || secrets.STRESS_TARGET_URL || 'https://crm.ersah.in' }}
+          BASE_URL: ${{ github.event.inputs.base_url || secrets.STRESS_TARGET_URL || 'https://interncrm.com' }}
           K6_PEAK_VUS: ${{ github.event.inputs.peak_vus || '20' }}
           K6_SUMMARY_FILE: k6-summary.json
         run: k6 run --quiet k6/nightly-load.js
@@ -139,7 +139,7 @@ jobs:
           SMTP_FROM: ${{ secrets.SMTP_FROM }}
           ALERT_EMAIL_TO: ${{ secrets.ALERT_EMAIL_TO || 'mehmetersahin@gmail.com' }}
           K6_SUMMARY_FILE: k6-out/k6-summary.json
-          K6_TARGET_URL: ${{ github.event.inputs.base_url || secrets.STRESS_TARGET_URL || 'https://crm.ersah.in' }}
+          K6_TARGET_URL: ${{ github.event.inputs.base_url || secrets.STRESS_TARGET_URL || 'https://interncrm.com' }}
           K6_REPORT_MODE: ${{ vars.K6_REPORT_MODE || 'failures' }}
           K6_RUN_CONTEXT: 'k6-load · ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
         run: |

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # Prefer the manual override, then a dedicated secret, then production.
-      BASE_URL: ${{ github.event.inputs.base_url || secrets.STRESS_TARGET_URL || 'https://crm.ersah.in' }}
+      BASE_URL: ${{ github.event.inputs.base_url || secrets.STRESS_TARGET_URL || 'https://interncrm.com' }}
       STRESS_CONCURRENCY: '25'
       STRESS_DURATION_MS: '30000'
       STRESS_MAX_ERROR_RATE: '0.02'

--- a/releases/unreleased/load-test-target-after-cutover.json
+++ b/releases/unreleased/load-test-target-after-cutover.json
@@ -1,0 +1,4 @@
+{
+  "bump": "patch",
+  "changelog": "- **Fix: the nightly load test was measuring a redirect** (#2166). `k6-load.yml` and `stress.yml` fell back to `https://crm.ersah.in`, which became a 301 to the new domain at cutover — so the 2026-09-06 run breached its `checks` threshold and mailed a false alarm about production being unhealthy. The fallback now names the current production URL."
+}


### PR DESCRIPTION
Refs #2166

`k6-load.yml` ve `stress.yml`, `STRESS_TARGET_URL` ayarlı değilken sabit bir prod
URL'ine düşüyor — ve o secret hiç ayarlanmamış, yani ikisi de hep o sabiti
kullanmış. Kesmede `crm.ersah.in` `interncrm.com`'a 301 oldu; sabit onunla
birlikte taşınmadı.

Sonuç: **2026-09-06 01:18 koşusu 20 VU'yu bir yönlendirmeye rampaladı.** Her
istek 301 döndü, `checks` eşiği deldi, ve uyarı e-postası "prod sağlıksız" diye
gitti. Prod gayet iyiydi.

```
BASE_URL: https://crm.ersah.in
target:   https://crm.ersah.in
✖ 1 threshold(s) breached
level=error msg="thresholds on metrics 'checks' have been crossed"
```

Her gece kurt masalı anlatan bir monitör, monitör olmamasından kötüdür — bir
sonraki **gerçek** ihlal de aynı görünür.

Fallback artık güncel prod URL'ini söylüyor. `STRESS_TARGET_URL` hâlâ onu,
`workflow_dispatch` girdisi de onu eziyor.

## Bilerek dokunulmayan

`k6/nightly-load.js`'deki `BASE_URL` varsayılanı preview'ı göstermeye devam
ediyor — o, refleksle atılan bir `npm run test:load`'ın canlı siteyi
rampalamasını engelleyen koruma, ve **preview henüz taşınmadı**. Preview'ı taşıyan
commit'te birlikte değişmeli, yoksa koruma artık var olmayan bir hostu gösterir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)