### PR TITLE
fix: preview deploy'u yeni hostta veritabanına ulaşamıyordu (#2166)

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -264,19 +264,16 @@ jobs:
           #   only fetches it — no npm ci, no next build, no buildkit.
           # --no-pull: the checkout above already pinned the exact commit the
           #   image was built from; don't let the script re-sync to a moving tip.
-          # NETWORK=bridge: the preview DB user is granted from the docker
-          #   gateway (host.docker.internal), not localhost, so preview uses
-          #   bridge networking + a published port instead of host networking.
+          # NETWORK=host, not bridge. Bridge was here for a constraint of the
+          #   OLD host: preview's DB user was granted only from the docker
+          #   gateway, never from localhost, so the container had to arrive via
+          #   host.docker.internal. On the new host MySQL runs in a container
+          #   publishing on 127.0.0.1 ONLY, so that gateway address reaches
+          #   nothing and bridge fails in the first backfill with "Can't reach
+          #   database server at 127.0.0.1:3306". Host networking is also what
+          #   production uses, so the two environments now agree (#2166).
           # FORWARD_ONLY is deliberately unset — preview must stay able to deploy
           #   arbitrary/older refs on demand.
-          # NETWORK=host, not bridge. Bridge existed for a constraint that was
-          # specific to the old host: preview's DB user was granted only from
-          # the docker gateway, never from localhost, so the container had to
-          # come in via host.docker.internal. On the new host MySQL runs in a
-          # container publishing on 127.0.0.1 ONLY — so the docker gateway
-          # address reaches nothing, and bridge fails with "Can't reach database
-          # server at 127.0.0.1:3306" from inside the first backfill. Host
-          # networking is also what production uses, so the two now match.
           CONTAINER=internship-crm-preview \
           PORT=3201 \
           NETWORK=host \

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -269,9 +269,17 @@ jobs:
           #   bridge networking + a published port instead of host networking.
           # FORWARD_ONLY is deliberately unset — preview must stay able to deploy
           #   arbitrary/older refs on demand.
+          # NETWORK=host, not bridge. Bridge existed for a constraint that was
+          # specific to the old host: preview's DB user was granted only from
+          # the docker gateway, never from localhost, so the container had to
+          # come in via host.docker.internal. On the new host MySQL runs in a
+          # container publishing on 127.0.0.1 ONLY — so the docker gateway
+          # address reaches nothing, and bridge fails with "Can't reach database
+          # server at 127.0.0.1:3306" from inside the first backfill. Host
+          # networking is also what production uses, so the two now match.
           CONTAINER=internship-crm-preview \
           PORT=3201 \
-          NETWORK=bridge \
+          NETWORK=host \
           ENV_FILE="$ENV_FILE" \
           ./infra/deploy-prod.sh --no-pull --pull-image
 

--- a/releases/unreleased/preview-host-networking.json
+++ b/releases/unreleased/preview-host-networking.json
@@ -1,0 +1,4 @@
+{
+  "bump": "patch",
+  "changelog": "- **Fix: preview deploys could not reach the database on the new host** (#2166). Preview ran its containers on bridge networking, which existed for an old-host grant quirk — its DB user was granted only from the docker gateway. On the new host MySQL publishes on `127.0.0.1` only, so the gateway address reaches nothing and every preview deploy died in the first backfill. Preview now uses host networking, the same as production."
+}


### PR DESCRIPTION
Refs #2166

Preview `NETWORK=bridge` ile koşuyordu. Bu bir tercih değildi — **eski hosta özel
bir kısıtın etrafından dolaşıyordu**, ve `deploy-prod.sh`'ın kendi yorumu bunu
söylüyor: preview'ın DB kullanıcısı yalnızca docker gateway'inden yetkiliydi,
localhost'tan asla, o yüzden container `host.docker.internal` üzerinden girmek
zorundaydı.

Yeni hostta öyle bir grant yok — ve bridge orada artık **aktif olarak yanlış**.
MySQL bir container'da ve **sadece `127.0.0.1`'e** publish ediyor, yani docker
gateway adresi hiçbir yere ulaşmıyor. Her preview deploy'u ilk backfill'de
ölüyordu:

```
Can't reach database server at `127.0.0.1:3306`
    at file:///app/prisma/push-company-interest-expand.mjs
```

Bu, veritabanı kesintisi gibi okunuyor; oysa veritabanı container'a taşınınca
geçerliliğini yitirmiş bir ağ modu.

Preview artık host ağını kullanıyor — prod ile aynı. Asıl kazanç bu: iki ortamın
veritabanına **farklı yollardan** ulaşması, bir deploy yolunun yalnızca birinde
bozuk kalmasının yoludur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)