### PR TITLE
fix: demo yeni hostta veritabanına ulaşamıyordu (#2166)

### DIFF
--- a/infra/server/demo-refresh.sh
+++ b/infra/server/demo-refresh.sh
@@ -66,13 +66,23 @@ if [ "$DATA_ONLY" = 0 ]; then
     docker rm   "$CONTAINER" >/dev/null 2>&1 || true
     # The env file is the single source of truth for the demo's configuration —
     # nothing is passed in from CI, so no secret of the demo's ever reaches an
-    # Actions log. DATABASE_URL there points at host.docker.internal, hence
-    # bridge networking with a published port.
+    # Actions log.
+    #
+    # NETWORK follows deploy-prod.sh. It used to be bridge unconditionally,
+    # because on the old host DATABASE_URL pointed at host.docker.internal. On a
+    # host where MySQL itself runs in a container publishing on 127.0.0.1, that
+    # gateway address reaches nothing — the container starts, and the reset then
+    # fails inside it with "Can't reach database server at 127.0.0.1:3306"
+    # (#2166). Host networking matches production and preview.
+    if [ "${NETWORK:-host}" = host ]; then
+      NET_ARGS=(--network=host -e PORT="$PORT")
+    else
+      NET_ARGS=(--add-host=host.docker.internal:host-gateway -p "${PORT}:3000")
+    fi
     docker run -d \
       --name "$CONTAINER" \
       --env-file "$ENV_FILE" \
-      --add-host=host.docker.internal:host-gateway \
-      -p "${PORT}:3000" \
+      "${NET_ARGS[@]}" \
       --restart=unless-stopped \
       "$IMAGE" >/dev/null
     RECREATED=1

--- a/releases/unreleased/demo-host-networking.json
+++ b/releases/unreleased/demo-host-networking.json
@@ -1,0 +1,4 @@
+{
+  "bump": "patch",
+  "changelog": "- **Fix: the public demo could not reach the database on the new host** (#2166). `demo-refresh.sh` hardcoded bridge networking because the old host's demo `DATABASE_URL` pointed at `host.docker.internal`. Where MySQL itself runs in a container publishing on `127.0.0.1`, that address reaches nothing — the container started and every reset failed inside it. It now follows `NETWORK` like `deploy-prod.sh`, defaulting to host."
+}


### PR DESCRIPTION
Refs #2166 · #2186 ile aynı kök neden, farklı dosya

`demo-refresh.sh`, `--add-host=host.docker.internal:host-gateway -p PORT:3000`'i
**sabit** yazmıştı — yorumu da demo'nun `DATABASE_URL`'inin
`host.docker.internal`'ı gösterdiğini açıklıyordu. Yeni hostta göstermiyor ve
gösteremez: MySQL bir container'da ve sadece `127.0.0.1`'e publish ediyor, yani
docker gateway adresi hiçbir yere ulaşmıyor.

Container **sağlıklı kalkıyordu**, ve her reset onun **içinde** patlıyordu:

```
Can't reach database server at `127.0.0.1:3306`
    at file:///app/prisma/reset-demo.mjs:57:16
```

Container'ın iyi görünürken içindeki işin patlaması, bunu veritabanı sorunu
sanmayı kolaylaştıran şey.

`NETWORK` artık `deploy-prod.sh`'ı takip ediyor ve varsayılanı host — prod ve
preview ile aynı. Bridge dalı, ihtiyacı olan bir host için duruyor.

## Bir sonraki kişiye not

Başarısız deploy demo container'ını **zaten bridge ile oluşturmuştu**, o yüzden
düzeltilmiş script'i tekrar koşturmak "already runs $IMAGE — leaving the
container alone" yoluna girdi ve hiçbir şeyi değiştirmedi. Ağ modu değişikliğinin
uygulanması için container'ın kaldırılması gerekiyor; o kısa devre yalnızca
imajları karşılaştırıyor.

## Canlı doğrulama

```
https://interncrm.com/          200 ssl=0   sha efd3087
https://preview.interncrm.com/  200 ssl=0   sha efd3087
https://demo.interncrm.com/     200 ssl=0   sha efd3087
```

Üçü de aynı sha'da.

🤖 Generated with [Claude Code](https://claude.com/claude-code)