### PR TITLE
fix: wildcard sertifikasını sudo'suz üret (#2166)

### DIFF
--- a/.github/workflows/wildcard-cert.yml
+++ b/.github/workflows/wildcard-cert.yml
@@ -70,11 +70,23 @@ jobs:
             exit 1
           fi
           chmod +x infra/acme-issue-wildcard.sh
-          # Caddy reads the cert files directly, so a reload is all that is
-          # needed on renewal — no restart, no dropped connections.
-          sudo -E DOMAIN="$DOMAIN" CERT_DIR="$CERT_DIR" \
-               RELOAD_CMD='systemctl reload caddy' \
-               ./infra/acme-issue-wildcard.sh
+          # NOT under sudo. This box's sudoers ignores `-E`, so the token simply
+          # did not arrive and acme.sh stopped with "CF_Token is not set" while
+          # the workflow log showed the secret present — a confusing pair. The
+          # obvious repair, `sudo CF_Token="$CF_Token" ...`, does work here but
+          # puts the token in argv where any `ps` can read it.
+          #
+          # So the script runs as the runner user instead. It only needed root
+          # for two things, and both are granted narrowly: $CERT_DIR is owned by
+          # that user, and the reload goes through sudo as a single fixed command
+          # that carries no environment. acme.sh itself installs into ~/.acme.sh
+          # and registers a user crontab, neither of which wants root.
+          #
+          # Caddy reads the cert files directly, so a reload is all a renewal
+          # needs — no restart, no dropped connections.
+          DOMAIN="$DOMAIN" CERT_DIR="$CERT_DIR" \
+            RELOAD_CMD='sudo systemctl reload caddy' \
+            ./infra/acme-issue-wildcard.sh
 
       - name: Verify the cert covers the wildcard
         env:
@@ -82,8 +94,8 @@ jobs:
           CERT_DIR: ${{ inputs.cert_dir }}
         run: |
           set -euo pipefail
-          sudo test -s "${CERT_DIR}/${DOMAIN}.cer" || { echo "::error::no cert at ${CERT_DIR}/${DOMAIN}.cer"; exit 1; }
-          SANS="$(sudo openssl x509 -in "${CERT_DIR}/${DOMAIN}.cer" -noout -ext subjectAltName)"
+          test -s "${CERT_DIR}/${DOMAIN}.cer" || { echo "::error::no cert at ${CERT_DIR}/${DOMAIN}.cer"; exit 1; }
+          SANS="$(openssl x509 -in "${CERT_DIR}/${DOMAIN}.cer" -noout -ext subjectAltName)"
           echo "$SANS"
           # Fail closed: a cert without the wildcard SAN would let topic
           # environments fall back to per-hostname issuance, which is the exact

--- a/infra/server/bootstrap.sh
+++ b/infra/server/bootstrap.sh
@@ -288,6 +288,10 @@ step_caddy() {
   # crm-pr<N>.caddy in here and reload — which replaces ~200 lines of Plesk
   # subdomain creation + nginx vhost generation with a two-line file.
   install -d -o root -g caddy -m 0775 /etc/caddy/sites
+  # Owned by the deploy user: the wildcard certificate is issued by a workflow
+  # running as that user (wildcard-cert.yml), and acme.sh installs the files
+  # here. Group caddy so the server can read them; 0750 so nobody else can.
+  install -d -o "$LOGIN_USER" -g caddy -m 0750 /etc/caddy/certs
 
   if [ ! -f /etc/caddy/Caddyfile.pre-bootstrap ] && [ -f /etc/caddy/Caddyfile ]; then
     cp -a /etc/caddy/Caddyfile /etc/caddy/Caddyfile.pre-bootstrap
@@ -332,6 +336,10 @@ step_sites() {
   # rebuild of this box would silently lose them — exactly the "what was running
   # here?" problem this script exists to prevent.
   install -d -o root -g caddy -m 0775 /etc/caddy/sites
+  # Owned by the deploy user: the wildcard certificate is issued by a workflow
+  # running as that user (wildcard-cert.yml), and acme.sh installs the files
+  # here. Group caddy so the server can read them; 0750 so nobody else can.
+  install -d -o "$LOGIN_USER" -g caddy -m 0750 /etc/caddy/certs
 
   local my_ip
   my_ip="$(curl -fsS --max-time 10 -4 https://api.ipify.org 2>/dev/null || true)"


### PR DESCRIPTION
Refs #2166

Bu kutunun sudoers'ı `-E`'yi yok sayıyor, yani `sudo -E ... acme-issue-wildcard.sh` kendisine verilen ortamın hiçbiriyle koştu. acme.sh `CF_Token is not set` diyerek durdu — oysa workflow log'u iki satır yukarıda `CF_Token: ***` basıyordu. Secret oradaydı, sudo düşürdü.

Bariz onarım `sudo CF_Token="$CF_Token" ...` ve burada çalışıyor. Ama canlı bir API token'ını `argv`'ye koyuyor — kutudaki herhangi bir `ps` okuyabilir.

O yüzden script runner kullanıcısı olarak koşuyor. Root'a tam iki şey için ihtiyacı vardı, ikisi de dar verildi: `$CERT_DIR` o kullanıcıya ait, ve reload sudo'dan **tek sabit komut** olarak geçiyor, hiç ortam taşımadan. acme.sh zaten `~/.acme.sh`'e kuruluyor ve kullanıcı crontab'ı yazıyor; ikisi de root istemiyor.

`bootstrap.sh` `/etc/caddy/certs`'i o sahiplikle oluşturuyor — grup `caddy` (sunucu okuyabilsin), 0750 (başkası okuyamasın). Yoksa yeniden kurulan bir host aynı şekilde patlardı.

🤖 Generated with [Claude Code](https://claude.com/claude-code)