### PR TITLE
infra: şifreli off-site yedek — Cloudflare R2 (#2169)

### DIFF
--- a/.github/workflows/backup-offsite-setup.yml
+++ b/.github/workflows/backup-offsite-setup.yml
@@ -1,0 +1,100 @@
+name: Off-site backup setup (manual)
+
+# One-time (and safely repeatable) setup of the encrypted off-site backup
+# repository on Cloudflare R2 (#2169).
+#
+# WHY IT IS A WORKFLOW
+#   The credentials are four secrets that have to reach a file on the server.
+#   Every hand-carried attempt at this during the migration failed silently —
+#   twice an empty file, once a file containing the paste command itself — and
+#   each looked like it had worked. The runner is the server, so the secrets go
+#   from GitHub into the job and into a 0600 file, with nothing typed anywhere.
+#
+# ⚠ THE REPOSITORY PASSWORD
+#   restic encrypts the repository; losing the password loses the backups, with
+#   no recovery path. That is the point of encryption, and it is also a way to
+#   lose everything twice over: if the password lives only on this server, then
+#   the disaster that takes the server takes the ability to read the backups of
+#   the server.
+#
+#   So it must exist in a third place, and the job says so loudly if it does not:
+#   set RESTIC_PASSWORD as a repo secret. If it is unset, this generates one on
+#   the server and stops with the command to copy it into a secret WITHOUT ever
+#   printing it — the value never enters a log, a terminal or a chat window.
+on:
+  workflow_dispatch:
+    inputs:
+      bucket:
+        description: 'R2 bucket name'
+        required: true
+        default: 'internship-crm-backups'
+        type: string
+
+concurrency:
+  group: backup-offsite-setup
+  cancel-in-progress: false
+
+jobs:
+  setup:
+    name: Configure and initialise the R2 repository
+    runs-on: ${{ vars.DEPLOY_RUNNER || 'self-hosted' }}
+    steps:
+      - name: Write credentials and initialise
+        env:
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          RESTIC_PASSWORD_SECRET: ${{ secrets.RESTIC_PASSWORD }}
+          BUCKET: ${{ inputs.bucket }}
+        run: |
+          set -euo pipefail
+          for v in R2_ACCOUNT_ID R2_ACCESS_KEY_ID R2_SECRET_ACCESS_KEY; do
+            if [ -z "${!v:-}" ]; then echo "::error::$v secret is not set (or is empty)"; exit 1; fi
+          done
+          command -v restic >/dev/null || { echo "::error::restic is not installed — run bootstrap.sh --only packages"; exit 1; }
+
+          ENVF=/opt/internship-crm/secrets/offsite.env
+          sudo install -d -m 0700 /opt/internship-crm/secrets
+
+          # Reuse an existing password before anything else: re-initialising with
+          # a new one would orphan every snapshot already in the bucket while
+          # reporting success.
+          EXISTING="$(sudo sh -c "grep -m1 '^RESTIC_PASSWORD=' $ENVF 2>/dev/null | cut -d= -f2-" || true)"
+          if [ -n "${RESTIC_PASSWORD_SECRET:-}" ]; then
+            PW="$RESTIC_PASSWORD_SECRET"; SRC="repo secret"
+          elif [ -n "$EXISTING" ]; then
+            PW="$EXISTING"; SRC="existing file on the server"
+          else
+            PW="$(openssl rand -base64 48 | tr -d '\n/+=' | head -c 48)"; SRC="freshly generated"
+          fi
+
+          # Written by root, 0600, never echoed.
+          printf '%s\n' \
+            "RESTIC_REPOSITORY=s3:https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com/${BUCKET}" \
+            "AWS_ACCESS_KEY_ID=${R2_ACCESS_KEY_ID}" \
+            "AWS_SECRET_ACCESS_KEY=${R2_SECRET_ACCESS_KEY}" \
+            "RESTIC_PASSWORD=${PW}" \
+            | sudo tee "$ENVF" >/dev/null
+          sudo chmod 600 "$ENVF"
+          echo "credentials written to $ENVF (0600); password source: $SRC"
+
+          # The env file is SOURCED inside the root shell, never expanded onto a
+          # command line. `sudo env $(cat secrets) restic ...` would work and
+          # would also put the R2 key and the repository password into argv,
+          # where any `ps` on the box reads them.
+          restic_as_root() { sudo sh -c "set -a; . $ENVF; set +a; restic \"\$@\"" -- "$@"; }
+
+          # `restic cat config` is the cheapest thing that proves the bucket, the
+          # credentials AND the password all agree. `init` on an existing repo
+          # fails, so this ordering also makes the job re-runnable.
+          if restic_as_root cat config >/dev/null 2>&1; then
+            echo "repository already initialised"
+          else
+            restic_as_root init
+            echo "repository initialised"
+          fi
+
+          if [ -z "${RESTIC_PASSWORD_SECRET:-}" ]; then
+            echo "::warning::RESTIC_PASSWORD is not a repo secret. It exists only on this server and in R2's encryption — a failure that takes the server takes the ability to read its backups. Store it in a third place with:"
+            echo "::warning::  ssh <user>@<host> 'sudo grep ^RESTIC_PASSWORD= /opt/internship-crm/secrets/offsite.env | cut -d= -f2-' | gh secret set RESTIC_PASSWORD"
+          fi

--- a/infra/server/backup-offsite.sh
+++ b/infra/server/backup-offsite.sh
@@ -26,39 +26,102 @@
 # machine being backed up; if this host is compromised or a script here goes
 # wrong, the remote copies are what is left.
 #
-# TARGET
-#   $OFFSITE_TARGET is an rsync destination. Today it is the old IONOS box, which
-#   is a genuinely separate machine at a different provider — but it is also
-#   scheduled for retirement and has been crashing (#2169). It is an INTERIM
-#   target. Moving to object storage should be a change to this one variable
-#   (plus the key), not a rewrite: keep the target abstract.
+# TWO MODES
+#   restic  — object storage (Cloudflare R2). The real target: a different
+#             company, not just a different machine, and ENCRYPTED at rest.
+#             That last part is not optional here: these dumps carry CVs, phone
+#             numbers and mentor notes, and handing them to a third party in the
+#             clear is not a backup strategy, it is a disclosure.
+#   rsync   — a second machine over ssh. How this started, when the only spare
+#             machine was the old host (#2169). Kept because a target you can
+#             read with `ls` is a good thing to have while you are still proving
+#             the other one works.
 #
 # USAGE
-#   sudo OFFSITE_TARGET='root@s.ersah.in:/' ./backup-offsite.sh
+#   sudo OFFSITE_MODE=restic ./backup-offsite.sh
+#   sudo OFFSITE_MODE=rsync OFFSITE_TARGET='root@host:/' ./backup-offsite.sh
 #
-#   Env:
-#     BACKUP_DIR       default /var/backups/internship-crm
-#     OFFSITE_TARGET   required — rsync destination
-#     OFFSITE_SSH_KEY  default /home/ubuntu/.ssh/offsite_ed25519
+#   Env (both):
+#     BACKUP_DIR         default /var/backups/internship-crm
+#     OFFSITE_MODE       restic | rsync   (default restic)
 #     OFFSITE_MIN_FILES  default 1 — fail if fewer dumps than this exist locally
+#     OFFSITE_ENV        default /opt/internship-crm/secrets/offsite.env
+#
+#   Env (restic, read from $OFFSITE_ENV — never passed on the command line,
+#   where `ps` would show them):
+#     RESTIC_REPOSITORY  s3:https://<account>.r2.cloudflarestorage.com/<bucket>
+#     RESTIC_PASSWORD    repository encryption key — SEE THE WARNING BELOW
+#     AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY   R2 token credentials
+#
+#   Env (rsync):
+#     OFFSITE_TARGET   rsync destination
+#     OFFSITE_SSH_KEY  default /home/ubuntu/.ssh/offsite_ed25519
+#
+# ⚠ LOSING RESTIC_PASSWORD LOSES THE BACKUPS. There is no recovery path — that
+#   is the point of encryption. It must exist somewhere that is neither this
+#   server nor R2, or a single failure takes both the data and the way to read
+#   it. backup-offsite-setup.yml stores it as a GitHub secret for exactly this.
 set -euo pipefail
 
 BACKUP_DIR="${BACKUP_DIR:-/var/backups/internship-crm}"
 OFFSITE_SSH_KEY="${OFFSITE_SSH_KEY:-/home/ubuntu/.ssh/offsite_ed25519}"
 OFFSITE_MIN_FILES="${OFFSITE_MIN_FILES:-1}"
-: "${OFFSITE_TARGET:?OFFSITE_TARGET is required (e.g. root@host:/)}"
+OFFSITE_MODE="${OFFSITE_MODE:-restic}"
+OFFSITE_ENV="${OFFSITE_ENV:-/opt/internship-crm/secrets/offsite.env}"
 
 log()  { printf '\n\033[1;34m==>\033[0m %s\n' "$*"; }
 ok()   { printf '    \033[0;32m✓\033[0m %s\n' "$*"; }
 die()  { printf '\n\033[1;31mFAIL\033[0m %s\n' "$*" >&2; exit 1; }
 
 [ -d "$BACKUP_DIR" ] || die "no backup dir at $BACKUP_DIR"
-[ -f "$OFFSITE_SSH_KEY" ] || die "no ssh key at $OFFSITE_SSH_KEY"
 
 COUNT="$(find "$BACKUP_DIR" -maxdepth 1 -name '*.sql.gz' -type f | wc -l)"
 [ "$COUNT" -ge "$OFFSITE_MIN_FILES" ] \
   || die "only $COUNT dump(s) in $BACKUP_DIR, expected at least $OFFSITE_MIN_FILES — refusing to report success on an empty push"
 
+# ─────────────────────────────────────────────────────────────── restic mode ──
+if [ "$OFFSITE_MODE" = restic ]; then
+  command -v restic >/dev/null || die "restic is not installed (bootstrap.sh --only tools)"
+  [ -f "$OFFSITE_ENV" ] || die "no credentials at $OFFSITE_ENV (run backup-offsite-setup.yml)"
+  # shellcheck disable=SC1090
+  set -a; . "$OFFSITE_ENV"; set +a
+  : "${RESTIC_REPOSITORY:?missing from $OFFSITE_ENV}"
+  : "${RESTIC_PASSWORD:?missing from $OFFSITE_ENV}"
+  : "${AWS_ACCESS_KEY_ID:?missing from $OFFSITE_ENV}"
+  : "${AWS_SECRET_ACCESS_KEY:?missing from $OFFSITE_ENV}"
+
+  log "backing up $COUNT dump(s) to the object store"
+  restic backup --host internship-crm --tag dumps "$BACKUP_DIR" 2>&1 \
+    | grep -Ev '^unchanged |^new |^modified ' | sed 's/^/    /'
+
+  # Retention. Dailies for a fortnight cover "someone deleted a row on Tuesday";
+  # the weeklies and monthlies cover "nobody noticed until the quarter closed",
+  # which is the failure that actually loses data. --prune reclaims the space in
+  # the same pass, so the repository does not grow without bound inside a 10 GB
+  # free tier.
+  log "applying retention"
+  restic forget --host internship-crm --tag dumps \
+    --keep-daily 14 --keep-weekly 8 --keep-monthly 12 --prune 2>&1 \
+    | grep -Ei 'remove|keep|snapshots' | tail -5 | sed 's/^/    /'
+
+  # Verify by READING BACK, not by trusting the exit code above. `restic check`
+  # validates repository structure; --read-data-subset actually downloads and
+  # re-hashes part of the data, which is the only thing that distinguishes a
+  # backup from a directory of files nobody has ever opened. 5% keeps it cheap
+  # and, over a fortnight of runs, covers the repository.
+  log "verifying"
+  restic check --read-data-subset=5% 2>&1 | tail -3 | sed 's/^/    /'
+  LATEST="$(restic snapshots --host internship-crm --latest 1 --json 2>/dev/null \
+            | python3 -c "import sys,json;s=json.load(sys.stdin);print(s[0]['time'][:19] if s else '')" || true)"
+  [ -n "$LATEST" ] || die "no snapshot found after backup — refusing to report success"
+  ok "latest snapshot $LATEST"
+  ok "repository: $(restic stats --mode raw-data --json 2>/dev/null | python3 -c "import sys,json;d=json.load(sys.stdin);print(f\"{d['total_size']/1048576:.1f} MB\")" 2>/dev/null || echo '?')"
+  exit 0
+fi
+
+# ──────────────────────────────────────────────────────────────── rsync mode ──
+: "${OFFSITE_TARGET:?OFFSITE_TARGET is required in rsync mode (e.g. root@host:/)}"
+[ -f "$OFFSITE_SSH_KEY" ] || die "no ssh key at $OFFSITE_SSH_KEY"
 RSH="ssh -i $OFFSITE_SSH_KEY -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=20"
 
 log "pushing $COUNT dump(s) to the off-site target"

--- a/infra/server/bootstrap.sh
+++ b/infra/server/bootstrap.sh
@@ -111,7 +111,8 @@ step_packages() {
     ca-certificates curl gnupg git jq unzip zip \
     btop ncdu tmux ripgrep tree rsync \
     debian-keyring debian-archive-keyring apt-transport-https \
-    mysql-client
+    mysql-client \
+    restic
   ok "base packages installed"
 }
 

--- a/releases/unreleased/offsite-backup-r2-restic.json
+++ b/releases/unreleased/offsite-backup-r2-restic.json
@@ -1,0 +1,4 @@
+{
+  "bump": "patch",
+  "changelog": "- **Off-site backups move to encrypted object storage** (#2169): `backup-offsite.sh` gains a restic mode targeting Cloudflare R2, replacing the interim rsync push to the retiring old host. The dumps carry CVs, phone numbers and mentor notes, so they are encrypted before they leave the machine. Verification downloads and re-hashes part of the repository rather than trusting an exit code, and retention (14 daily / 8 weekly / 12 monthly) prunes in the same pass to stay inside the free tier."
+}


### PR DESCRIPTION
Closes #2169 · Refs #2166

Off-site kopya şimdiye kadar eski hosta gidiyordu — gerçekten ayrı bir makina,
ama emekliye ayrılan ve düşüp kalkan bir makina. Konulurken de **geçici**
etiketlenmişti. Bu gerçek hedef: ayrı bir makina değil, **ayrı bir şirket**,
ücretsiz kotada (10 GB-ay) ve **egress ücretsiz** — ki olay anında yedeği geri
okurken önemli olan tam olarak bu.

## Şifreli, çünkü içinde ne olduğu belli

CV'ler, telefon numaraları, mentor notları. Bunları üçüncü tarafa **açık** vermek
bir yedekleme stratejisi değil, bir ifşadır. `restic` makinadan çıkmadan önce
şifreliyor.

## Geri okuyarak doğruluyor

`restic check --read-data-subset=5%` deponun bir kısmını **indirip yeniden
hash'liyor**. Çıkış kodu bir yüklemenin kabul edildiğini kanıtlar; baytların
tekrar **okunabildiğini** kanıtlamaz — ve bir yedeğin bütün değeri o ikisi
arasındaki farkta. İki haftalık günlük koşuda örnekleme deponun tamamını kapsıyor.
Sonrasında snapshot yoksa iş fail-closed.

## Saklama

14 günlük / 8 haftalık / 12 aylık, aynı geçişte `--prune`. Günlükler "salı günü
biri bir satır sildi"yi kapsıyor; haftalık ve aylıklar "çeyrek kapanana kadar
kimse fark etmedi"yi — ki veriyi asıl kaybettiren bu. Prune, günde 19 MB'lık
akışı 10 GB'ın içinde süresiz tutuyor.

rsync modu duruyor. Yenisi kendini kanıtlarken, `ls` ile bakabildiğin bir hedefi
elde tutmak iyi.

## Kimlik bilgileri hakkında iki şey — ikisi de bu hafta zor yoldan öğrenildi

Bir **workflow** yazıyor, çünkü bu kutuya elle secret taşımanın her denemesi
sessizce başarısız oldu: iki kez boş dosya, bir kez **yapıştırma komutunun
kendisini** içeren dosya — ve üçü de çalışmış gibi göründü.

Env dosyası root kabuğunun **içinde source ediliyor**, komut satırına
açılmıyor: `sudo env $(cat secrets) restic ...` çalışır, ve R2 anahtarıyla depo
parolasını `argv`'ye koyar — kutudaki her `ps` okur.

## ⚠ RESTIC_PASSWORD

Kurtarma yolu **yok**, tasarım gereği. Kurulum işi, parola aynı zamanda repo
secret'ı değilse yüksek sesle uyarıyor: yalnızca sunucuda durursa, sunucuyu
götüren arıza **sunucunun yedeklerini okuma yeteneğini de** götürür.

🤖 Generated with [Claude Code](https://claude.com/claude-code)