### PR TITLE
infra: cron kur — acme.sh onsuz çalışmayı reddediyor (#2166)

### DIFF
--- a/infra/server/bootstrap.sh
+++ b/infra/server/bootstrap.sh
@@ -107,12 +107,19 @@ step_packages() {
   apt-get update -qq
   # ca-certificates/curl/gnupg are needed to add the Docker and Caddy repos;
   # the rest is the "can I debug this box at 2am" set.
+  #
+  # `cron` is here for one reason: acme.sh REFUSES TO INSTALL without a crontab
+  # ("Pre-check failed, cannot install") and then the wildcard certificate cannot
+  # be issued at all. This box otherwise schedules everything with systemd
+  # timers, so nothing else would have pulled cron in — and the failure surfaces
+  # far from the cause, as a missing acme.sh binary.
   apt-get install -y -qq --no-install-recommends \
     ca-certificates curl gnupg git jq unzip zip \
     btop ncdu tmux ripgrep tree rsync \
     debian-keyring debian-archive-keyring apt-transport-https \
     mysql-client \
-    restic
+    restic \
+    cron
   ok "base packages installed"
 }
 


### PR DESCRIPTION
Refs #2166

Bu kutu her şeyi systemd timer'la zamanlıyor, o yüzden hiçbir şey `cron` paketini çekmemiş — ve Ubuntu cloud imajı onu içermiyor. acme.sh de kurulmayı tamamen reddediyor:

```
It is recommended to install crontab first.
Pre-check failed, cannot install.
Install error
./infra/acme-issue-wildcard.sh: line 56: ~/.acme.sh/acme.sh: No such file or directory
```

Hata sebebinden **iki adım ötede**, eksik bir binary olarak yüzeye çıkıyor — yani bozuk bir indirme gibi okunuyor, eksik bir paket gibi değil.

acme.sh crontab'ı otomatik yenileme için istiyor; sertifika yönetiminin sahip olmaya değer kısmı o, ve kutuyu üslupça tutarlı tutmak uğruna timer olarak yeniden yazmaya değmez.

🤖 Generated with [Claude Code](https://claude.com/claude-code)