### PR TITLE
infra: off-site timer'ı şifreli depoya yönlendir (#2169)

### DIFF
--- a/infra/server/bootstrap.sh
+++ b/infra/server/bootstrap.sh
@@ -548,10 +548,23 @@ EOF
   # is unreachable — but the off-site failure has to be visible on its own, and
   # not swallowed by a green backup run. That swallowing is how #2169 stayed
   # invisible for months.
-  if [ -n "${OFFSITE_TARGET:-}" ]; then
+  # Default to the encrypted object store. OFFSITE_TARGET (rsync to another
+  # machine) still works and is selected by setting OFFSITE_MODE=rsync.
+  OFFSITE_MODE="${OFFSITE_MODE:-restic}"
+  if [ "$OFFSITE_MODE" = restic ] || [ -n "${OFFSITE_TARGET:-}" ]; then
     curl -fsSL -o "$APP_DIR/bin/backup-offsite.sh" \
       https://raw.githubusercontent.com/21072026/Internship/main/infra/server/backup-offsite.sh 2>/dev/null \
       && chmod 0755 "$APP_DIR/bin/backup-offsite.sh"
+    if [ "$OFFSITE_MODE" = restic ]; then
+      OFFSITE_ENV_LINES="Environment=OFFSITE_MODE=restic"
+    else
+      OFFSITE_ENV_LINES="Environment=OFFSITE_MODE=rsync
+Environment=OFFSITE_TARGET=${OFFSITE_TARGET}
+Environment=OFFSITE_SSH_KEY=/home/${LOGIN_USER}/.ssh/offsite_ed25519"
+    fi
+    # The restic credentials are NOT listed here. systemd unit files are
+    # world-readable; the repository password and the R2 key live in
+    # $APP_DIR/secrets/offsite.env (0600), which the script sources itself.
     cat > /etc/systemd/system/internship-backup-offsite.service <<EOF
 [Unit]
 Description=Copy Internship CRM dumps to the off-site target
@@ -560,8 +573,7 @@ After=network-online.target
 [Service]
 Type=oneshot
 Environment=BACKUP_DIR=/var/backups/internship-crm
-Environment=OFFSITE_TARGET=${OFFSITE_TARGET}
-Environment=OFFSITE_SSH_KEY=/home/${LOGIN_USER}/.ssh/offsite_ed25519
+${OFFSITE_ENV_LINES}
 ExecStart=$APP_DIR/bin/backup-offsite.sh
 EOF
     cat > /etc/systemd/system/internship-backup-offsite.timer <<'EOF'
@@ -579,9 +591,9 @@ WantedBy=timers.target
 EOF
     systemctl daemon-reload
     systemctl enable --now internship-backup-offsite.timer >/dev/null
-    ok "off-site push timer active -> ${OFFSITE_TARGET}"
+    ok "off-site push timer active (mode: ${OFFSITE_MODE})"
   else
-    warn "OFFSITE_TARGET unset — dumps stay on the same disk as the database, which is not a backup (#2169)"
+    warn "no off-site target — dumps stay on the same disk as the database, which is not a backup (#2169)"
   fi
 
   systemctl daemon-reload

--- a/releases/unreleased/offsite-timer-restic-default.json
+++ b/releases/unreleased/offsite-timer-restic-default.json
@@ -1,0 +1,4 @@
+{
+  "bump": "patch",
+  "changelog": "- **The off-site timer now targets the encrypted object store** (#2169). The restic credentials are deliberately absent from the systemd unit — unit files are world-readable, so the repository password and R2 key stay in a 0600 file the script sources itself."
+}


### PR DESCRIPTION
Closes #2169 · Refs #2166

Günlük off-site gönderim artık varsayılan olarak `restic` modunda. Başka bir
makinaya rsync hâlâ var (`OFFSITE_MODE=rsync`), sadece varsayılan değil — çünkü
gösterdiği makina emekliye ayrıldı.

## Kimlik bilgileri bilerek systemd unit'inde değil

`/etc/systemd/system` altındaki unit dosyaları **herkes tarafından okunabilir**.
Depo parolasını ve R2 anahtarını `Environment=` satırlarına koymak, düzenli
görünürken ikisini de kutudaki her kullanıcıya yayınlamak olurdu. Script bunları
0600 bir dosyadan kendisi source ediyor.

## Uçtan uca doğrulandı

```
systemctl start internship-backup-offsite  →  Result=success
    read 5.0% of data packs
    [0:00] 100.00%  1 / 1 packs
    no errors were found
    ✓ latest snapshot 2026-09-06T11:59:39
    ✓ repository: 132.6 MB
```

## Asıl önemli olan: geri yükleme provası

Yukarıdakilerin hepsi yalnızca bir **yüklemenin kabul edildiğini** kanıtlar.
Ayrıca R2'den bir dump geri çekildi:

```
  geri yüklendi: 19M
  ✓ gzip bütünlüğü OK
  ✓ tablo sayısı: 92
  ✓ sha256 orijinalle BİREBİR AYNI
```

## Eski host

Bu devreye girince oradaki son InternCRM dizini — geçici off-site kopya — ve ona
erişen SSH anahtarları kaldırıldı. **O kutuda bu projeden hiçbir iz kalmadı.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)