### PR TITLE
fix: çalışan restic parolasının üstüne yazmayı reddet (#2169)

### DIFF
--- a/.github/workflows/backup-offsite-setup.yml
+++ b/.github/workflows/backup-offsite-setup.yml
@@ -60,6 +60,23 @@ jobs:
           # a new one would orphan every snapshot already in the bucket while
           # reporting success.
           EXISTING="$(sudo sh -c "grep -m1 '^RESTIC_PASSWORD=' $ENVF 2>/dev/null | cut -d= -f2-" || true)"
+
+          # A repository already exists and a secret is also set: they MUST be
+          # the same string. Preferring the secret blindly would overwrite a
+          # working password with a mistyped one and leave every existing
+          # snapshot unreadable — restic has no recovery path, so this is not a
+          # mistake you find out about later and undo. Compared by hash so
+          # neither value is ever printed.
+          if [ -n "${RESTIC_PASSWORD_SECRET:-}" ] && [ -n "$EXISTING" ]; then
+            H_SECRET="$(printf '%s' "$RESTIC_PASSWORD_SECRET" | sha256sum | cut -c1-16)"
+            H_FILE="$(printf '%s' "$EXISTING" | sha256sum | cut -c1-16)"
+            if [ "$H_SECRET" != "$H_FILE" ]; then
+              echo "::error::RESTIC_PASSWORD does not match the password this server already uses (secret ${H_SECRET}… vs server ${H_FILE}…). Overwriting it would make every existing snapshot unreadable. Fix the secret, or clear it to keep using the server's."
+              exit 1
+            fi
+            echo "repo secret matches the server's password (${H_FILE}…)"
+          fi
+
           if [ -n "${RESTIC_PASSWORD_SECRET:-}" ]; then
             PW="$RESTIC_PASSWORD_SECRET"; SRC="repo secret"
           elif [ -n "$EXISTING" ]; then

--- a/releases/unreleased/restic-password-mismatch-guard.json
+++ b/releases/unreleased/restic-password-mismatch-guard.json
@@ -1,0 +1,4 @@
+{
+  "bump": "patch",
+  "changelog": "- **Guard: the backup setup job refuses to overwrite a working repository password** (#2169). It preferred the repo secret unconditionally, so a mistyped `RESTIC_PASSWORD` would have replaced the working one and left every existing snapshot unreadable — restic has no recovery path. It now compares the two by hash, printing neither, and fails with both prefixes when they differ."
+}


### PR DESCRIPTION
Refs #2169

Kurulum işi, `secrets.RESTIC_PASSWORD` ayarlıysa onu **koşulsuz** tercih ediyordu. Temiz bir hostta doğru, deposu olan bir hostta tehlikeli: yanlış yapıştırılmış bir secret çalışan parolanın üstüne yazılır ve **mevcut bütün snapshot'lar okunamaz** hale gelir.

restic'te bunun kurtarma yolu yok — şifrelemenin bütün anlamı o. Yani haftaya fark edip geri alacağın türden bir hata değil.

İhtimal de teorik değildi: bu hafta bir secret'ı doğru yere elle koymak **üç kez** başarısız oldu, üç farklı şekilde, ve üçü de başarı gibi göründü.

Artık secret'ı sunucunun hâlihazırda kullandığı parolayla karşılaştırıyor ve farklılarsa duruyor. İkisi de hash'leniyor ve yalnızca ilk 16 hex karakter basılıyor — hata mesajı teşhis edilebilir kalıyor, ama hiçbir değer log'a düşmüyor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)