### PR TITLE
fix: show the mentor's interaction subject to the mentee (#1421)

### DIFF
--- a/e2e/portal-interaction-subject.spec.ts
+++ b/e2e/portal-interaction-subject.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { signInAndSettle } from './helpers/auth';
+
+/**
+ * The mentor types a subject on every interaction log and the mentee never saw
+ * it (#1421): `/portal/interactions` declared no `subject` on its row type and
+ * `/portal/journey` rendered the note only. Both screens now lead with the
+ * subject when there is one, and are unchanged when there is not.
+ */
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('mentee sees the subject the mentor wrote on an interaction', async ({ page }) => {
+  const mentorEmail = uniqueEmail('isub-mentor');
+  const menteeEmail = uniqueEmail('isub-mentee');
+  const subject = `Sprint review ${Date.now()}`;
+  const titledNote = 'We walked through the demo and the open bugs.';
+  const untitledNote = `Quick check-in with no subject ${Date.now()}`;
+
+  const mentor = await seedUser(mentorEmail, 'MentorPass123', 'MENTOR', 'ISub Mentor');
+  const mentee = await seedUser(menteeEmail, 'MenteePass123', 'MENTEE', 'ISub Mentee');
+  const rel = await prisma.mentorshipRelation.create({
+    data: { mentorId: mentor.id, menteeId: mentee.id, pipelineStatus: 'INTERNSHIP_IN_PROGRESS_450' },
+  });
+  await prisma.interactionLog.createMany({
+    data: [
+      { relationId: rel.id, date: new Date(), subject, notes: titledNote, type: 'Meeting' },
+      { relationId: rel.id, date: new Date(Date.now() - 86_400_000), notes: untitledNote, type: 'Email' },
+    ],
+  });
+
+  try {
+    await signInAndSettle(page, menteeEmail, 'MenteePass123', '/portal');
+
+    // 1. The interactions list shows the subject above the note, in the same
+    //    bold treatment the mentor's own screens give it.
+    await page.goto('/portal/interactions');
+    const subjectLine = page.getByTestId('interaction-subject').filter({ hasText: subject });
+    await expect(subjectLine).toBeVisible({ timeout: 10_000 });
+    expect(await subjectLine.evaluate((el) => getComputedStyle(el).fontWeight)).toBe('500');
+    await expect(page.getByText(titledNote, { exact: true })).toBeVisible();
+
+    // 2. A log with no subject is unchanged: its note is there and it grew no
+    //    subject line of its own (only the titled log has one).
+    await expect(page.getByText(untitledNote, { exact: true })).toBeVisible();
+    await expect(page.getByTestId('interaction-subject')).toHaveCount(1);
+
+    // 3. The journey page's narrow "recent interactions" list leads with the
+    //    subject too, and stays inside a 375px viewport.
+    await page.setViewportSize({ width: 375, height: 800 });
+    await page.goto('/portal/journey');
+    await expect(page.getByTestId('journey-interaction-subject').filter({ hasText: subject }))
+      .toBeVisible({ timeout: 10_000 });
+    const overflow = await page.evaluate(
+      () => document.documentElement.scrollWidth - document.documentElement.clientWidth
+    );
+    expect(overflow).toBeLessThanOrEqual(1);
+  } finally {
+    await prisma.interactionLog.deleteMany({ where: { relationId: rel.id } });
+    await prisma.mentorshipRelation.deleteMany({ where: { id: rel.id } });
+    await cleanupByEmail(menteeEmail);
+    await cleanupByEmail(mentorEmail);
+  }
+});

--- a/releases/unreleased/mentee-sees-interaction-subject.json
+++ b/releases/unreleased/mentee-sees-interaction-subject.json
@@ -1,0 +1,15 @@
+{
+  "bump": "patch",
+  "changelog": "- **Mentees see the interaction subject** (#1421). The subject a mentor types on an interaction log reached the portal in the API payload but was never rendered: `/portal/interactions` did not declare `subject` on its row type, and `/portal/journey` showed the note only. Both now lead with the subject in the same bold treatment the mentor screens use, with the journey list truncating the subject and dropping the note to a smaller second line so a 375px row still fits. Logs without a subject render exactly as before.",
+  "notes": {
+    "en": [
+      "Interaction logs now show the subject your mentor wrote, both in your interaction list and in the recent activity on your journey page."
+    ],
+    "tr": [
+      "Etkileşim kayıtlarında mentörünüzün yazdığı başlık artık görünüyor — hem etkileşim listenizde hem de yolculuk sayfanızdaki son etkileşimlerde."
+    ],
+    "de": [
+      "Interaktionsprotokolle zeigen jetzt den Betreff, den Ihre Mentorin oder Ihr Mentor geschrieben hat — in Ihrer Interaktionsliste und in den letzten Aktivitäten auf Ihrer Journey-Seite."
+    ]
+  }
+}

--- a/src/app/portal/interactions/page.tsx
+++ b/src/app/portal/interactions/page.tsx
@@ -13,6 +13,9 @@ import { AutoLoggedBadge } from '@/components/AutoLoggedBadge';
 interface Interaction {
   id: string;
   date: string;
+  // The mentor types a short topic line on the log; it was carried by the API
+  // all along but never declared here, so the portal dropped it silently (#1421).
+  subject?: string | null;
   notes: string;
   type: string;
   autoLogged?: boolean;
@@ -73,8 +76,16 @@ export default function PortalInteractionsPage() {
             <Card key={interaction.id}>
               <div className="flex items-start gap-4">
                 <InteractionTypeBadge type={interaction.type} className="flex-shrink-0 mt-0.5" />
-                <div className="flex-1">
-                  <p className="text-sm text-gray-700">{interaction.notes}</p>
+                <div className="flex-1 min-w-0">
+                  {interaction.subject && (
+                    <p
+                      data-testid="interaction-subject"
+                      className="text-sm font-medium text-gray-900 dark:text-gray-100 break-words"
+                    >
+                      {interaction.subject}
+                    </p>
+                  )}
+                  <p className="text-sm text-gray-700 break-words">{interaction.notes}</p>
                   <AutoLoggedBadge autoLogged={interaction.autoLogged} className="text-xs mt-2" />
                   <p className="text-xs text-gray-400 mt-2">
                     {formatDate(interaction.date, locale, {

--- a/src/app/portal/journey/page.tsx
+++ b/src/app/portal/journey/page.tsx
@@ -153,7 +153,23 @@ export default async function PortalJourneyPage() {
                     >
                       <InteractionTypeBadge type={interaction.type} className="text-xs flex-shrink-0" />
                       <div className="min-w-0">
-                        <p className="text-sm text-gray-700 truncate">{interaction.notes}</p>
+                        {/* The list is narrow and truncates (#1421): when the
+                            mentor wrote a subject it leads, and the note drops
+                            to a smaller second line — never two full-size lines
+                            competing for the same 375px row. */}
+                        {interaction.subject ? (
+                          <>
+                            <p
+                              data-testid="journey-interaction-subject"
+                              className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate"
+                            >
+                              {interaction.subject}
+                            </p>
+                            <p className="text-xs text-gray-500 truncate">{interaction.notes}</p>
+                          </>
+                        ) : (
+                          <p className="text-sm text-gray-700 truncate">{interaction.notes}</p>
+                        )}
                         <AutoLoggedBadge autoLogged={interaction.autoLogged} className="text-xs mt-1" />
                         <p className="text-xs text-gray-400">
                           {formatDate(interaction.date, locale)}


### PR DESCRIPTION
## Summary

The mentor writes a subject on every interaction log, and the mentee never saw it — the portal showed the free-form note alone, so the one line that says what the entry was *about* disappeared on its way to its audience.

The data was never missing. `GET /api/interactions` passes no field list to Prisma, so `subject` was in the JSON payload all along; it was dropped in the portal. `src/app/portal/interactions/page.tsx` did not declare `subject` on its local `Interaction` interface (so the field was invisible to the component even though it arrived), and `src/app/portal/journey/page.tsx` rendered `interaction.notes` only.

Both mentee screens now lead with the subject, using the same conditional render and the same visual weight (`text-sm font-medium`, dark text) the mentor screens give it in `src/app/mentor/mentees/[id]/page.tsx` and `src/app/mentor/interactions/page.tsx`, plus the `dark:text-gray-100` the portal needs. The "recent interactions" list on the journey page is narrow and `truncate`s, so there the subject takes the truncated first line and the note drops to a smaller second line — two full-size lines would fight over the same 375px row. A log **without** a subject renders exactly as it does today.

Closes #1421

### On the select — what was deliberately left out

No query changed, so nothing new is exposed:

- `GET /api/interactions` already returns the whole `InteractionLog` row (`include` with no field selection) and the mentee's read is scoped by `scopeForRole(session.user, 'relation')`, so the fix needed **no widening at all**. Nothing was added to any `select`.
- `/portal/journey` loads its five recent interactions server-side (`interactions: { orderBy, take: 5 }`) and renders only what it prints — `subject`, `notes`, `type`, `date`, `autoLogged`. `meetingId` (the internal auto-log idempotency key) is on the row but stays unrendered; `relationId`/`id` likewise.
- **`PersonalNote` — the mentor's private notes — is a separate model and was not touched.** It is not joined, selected or rendered anywhere in this diff. Same for the mentor-only fields on `MentorshipRelation`; the portal page's `mentor` include keeps its existing explicit `select` untouched.

## Changes

- `src/app/portal/interactions/page.tsx` — add `subject?: string | null` to the `Interaction` row type; render it as a bold line above the note (`data-testid="interaction-subject"`), `min-w-0`/`break-words` so a long unbroken subject cannot push the card wide.
- `src/app/portal/journey/page.tsx` — in "recent interactions", show a truncated subject as the lead line with the note demoted to `text-xs` underneath; unchanged (note-only) when there is no subject.
- `e2e/portal-interaction-subject.spec.ts` — new spec: seeds one titled and one untitled interaction, signs in as the mentee, asserts the subject is visible on `/portal/interactions` at `font-weight: 500`, that the untitled log grew no subject line, and that at 375px the journey list shows the subject with no horizontal overflow.
- `releases/unreleased/mentee-sees-interaction-subject.json` — patch fragment with EN/TR/DE notes.

## Verification

Static checks only — this container has no database and no Docker daemon, so the app and the Playwright suite could not be executed here. The new spec is written but unrun; CI is its first execution.

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean (only the pre-existing `react-hooks/exhaustive-deps` warnings in `admin/companies` and `admin/mentorship`)
- [x] `npm run check:i18n` — OK, 4151 keys × 3 locales (no new user-facing strings; the subject is user data)
- [x] `npm run check:release-fragments` — OK, ships as `0.156.23-beta`
- [ ] `npm run test:e2e` — not runnable in this environment; left to CI

Note: #2195 is an open PR from another contributor against the same issue. This is an independent implementation; whichever lands first, the other should be closed rather than both merged.

Preview: https://pr2209.interncrm.com

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.
