### PR TITLE
fix: wildcard anahtarını caddy servisi okuyabilsin (#2213)

### DIFF
--- a/.github/workflows/wildcard-cert.yml
+++ b/.github/workflows/wildcard-cert.yml
@@ -84,8 +84,15 @@ jobs:
           #
           # Caddy reads the cert files directly, so a reload is all a renewal
           # needs — no restart, no dropped connections.
+          # The reload goes through a helper rather than `systemctl reload`
+          # directly, and that matters on RENEWAL more than now: acme.sh writes
+          # the private key 0600 owner:owner every time it installs one, and
+          # Caddy runs as a different user. An unreadable key does not fail
+          # quietly — Caddy loads one config for the machine, so the whole
+          # reload fails and every site's next deploy fails with it (#2213).
+          # acme.sh stores this command and re-runs it unattended in 60 days.
           DOMAIN="$DOMAIN" CERT_DIR="$CERT_DIR" \
-            RELOAD_CMD='sudo systemctl reload caddy' \
+            RELOAD_CMD='sudo /usr/local/bin/caddy-reload-certs' \
             ./infra/acme-issue-wildcard.sh
 
       - name: Verify the cert covers the wildcard

--- a/infra/server/bootstrap.sh
+++ b/infra/server/bootstrap.sh
@@ -301,6 +301,31 @@ step_caddy() {
   # here. Group caddy so the server can read them; 0750 so nobody else can.
   install -d -o "$LOGIN_USER" -g caddy -m 0750 /etc/caddy/certs
 
+  # acme.sh writes the private key 0600 <owner>:<owner> on every install AND on
+  # every renewal, so setting the directory's group is not enough — Caddy runs
+  # as `caddy` and could not read the key. That failure is not local to one
+  # site: Caddy loads a single config for the whole machine, so an unreadable
+  # key makes the entire reload fail, and every topic environment's deploy dies
+  # with "caddy rejected the generated site file" (#2213).
+  #
+  # This runs as part of the reload, not once at setup, because the renewal 60
+  # days from now would otherwise put the permissions back and break it again
+  # with nobody touching anything.
+  cat > /usr/local/bin/caddy-reload-certs <<'EOF'
+#!/bin/sh
+# Make the installed certificates readable by the caddy service, then reload.
+# Invoked as acme.sh's --reloadcmd (see .github/workflows/wildcard-cert.yml).
+set -e
+chgrp caddy /etc/caddy/certs/*.cer /etc/caddy/certs/*.key 2>/dev/null || true
+chmod 644 /etc/caddy/certs/*.cer 2>/dev/null || true
+chmod 640 /etc/caddy/certs/*.key 2>/dev/null || true
+exec systemctl reload caddy
+EOF
+  chmod 0755 /usr/local/bin/caddy-reload-certs
+  # Fix anything already installed by an earlier run.
+  [ -n "$(ls -A /etc/caddy/certs 2>/dev/null)" ] && /usr/local/bin/caddy-reload-certs >/dev/null 2>&1 || true
+  ok "caddy cert dir + reload helper (key stays 0640, readable by caddy)"
+
   if [ ! -f /etc/caddy/Caddyfile.pre-bootstrap ] && [ -f /etc/caddy/Caddyfile ]; then
     cp -a /etc/caddy/Caddyfile /etc/caddy/Caddyfile.pre-bootstrap
   fi
@@ -348,6 +373,31 @@ step_sites() {
   # running as that user (wildcard-cert.yml), and acme.sh installs the files
   # here. Group caddy so the server can read them; 0750 so nobody else can.
   install -d -o "$LOGIN_USER" -g caddy -m 0750 /etc/caddy/certs
+
+  # acme.sh writes the private key 0600 <owner>:<owner> on every install AND on
+  # every renewal, so setting the directory's group is not enough — Caddy runs
+  # as `caddy` and could not read the key. That failure is not local to one
+  # site: Caddy loads a single config for the whole machine, so an unreadable
+  # key makes the entire reload fail, and every topic environment's deploy dies
+  # with "caddy rejected the generated site file" (#2213).
+  #
+  # This runs as part of the reload, not once at setup, because the renewal 60
+  # days from now would otherwise put the permissions back and break it again
+  # with nobody touching anything.
+  cat > /usr/local/bin/caddy-reload-certs <<'EOF'
+#!/bin/sh
+# Make the installed certificates readable by the caddy service, then reload.
+# Invoked as acme.sh's --reloadcmd (see .github/workflows/wildcard-cert.yml).
+set -e
+chgrp caddy /etc/caddy/certs/*.cer /etc/caddy/certs/*.key 2>/dev/null || true
+chmod 644 /etc/caddy/certs/*.cer 2>/dev/null || true
+chmod 640 /etc/caddy/certs/*.key 2>/dev/null || true
+exec systemctl reload caddy
+EOF
+  chmod 0755 /usr/local/bin/caddy-reload-certs
+  # Fix anything already installed by an earlier run.
+  [ -n "$(ls -A /etc/caddy/certs 2>/dev/null)" ] && /usr/local/bin/caddy-reload-certs >/dev/null 2>&1 || true
+  ok "caddy cert dir + reload helper (key stays 0640, readable by caddy)"
 
   local my_ip
   my_ip="$(curl -fsS --max-time 10 -4 https://api.ipify.org 2>/dev/null || true)"

--- a/releases/unreleased/caddy-cert-readable-by-service.json
+++ b/releases/unreleased/caddy-cert-readable-by-service.json
@@ -1,0 +1,4 @@
+{
+  "bump": "patch",
+  "changelog": "- **Fix: every topic deploy failed because Caddy could not read the wildcard key** (#2213). acme.sh installs the private key `0600 owner:owner` and Caddy runs as a different user, so loading the config failed — and since Caddy loads one config for the whole machine, the entire reload failed and every `Deploy topic environment` job died with a misleading \"caddy rejected the generated site file\". The reload now goes through a helper that makes the certificates group-readable first, and it is registered as acme.sh's reload command so the renewal in 60 days cannot reintroduce it."
+}


### PR DESCRIPTION
Refs #2213 · #2166 — **#2214 ile birlikte gerekli, tek başına yeterli değil**

Wildcard sertifikası kurulduğundan beri **her** `Deploy topic environment` işi başarısız. Deploy'un bastığı mesaj aramayı yanlış yöne gönderiyordu:

```
ERROR: caddy rejected the generated site file; removed it and reloaded
```

Oysa hemen üstünde **iki kez** `Valid configuration` yazıyor. Caddy dosyayı kabul etti. Patlayan `systemctl reload`'du, ve sebebi yalnızca servisin kendi journal'ındaydı:

```
loading tls app module: provision tls: loading certificates:
open /etc/caddy/certs/interncrm.com.key: permission denied
```

acme.sh özel anahtarı `0600 <sahip>:<sahip>` kuruyor. Caddy `caddy` kullanıcısı olarak koşuyor. Dizinin grubunu `caddy` yapmak — bootstrap öyle yapıyordu — yetmiyor, çünkü **dosyanın** kendi modunda grup bitleri yok.

## Etki alanı, hatırlanmaya değer kısım

Caddy makinenin tamamı için **tek bir config** yüklüyor. Tek bir topic sitesinin işaret ettiği okunamayan bir anahtar, o siteyi bozmuyor — **bütün reload'ı** düşürüyor, dolayısıyla her ortamın bir sonraki deploy'u da patlıyor. Prod ayakta kaldı çünkü o Caddy'nin kendi ACME sertifikasını kullanıyor ve çalışan bir örnek başarısız bir reload'dan etkilenmiyor.

## Düzeltme neden bir helper

Elle bir kez `chmod` yapmak **60 gün sonraki yenilemeye kadar** çalışırdı — acme.sh anahtarı yine `0600` yazacak ve kimse hiçbir şeye dokunmadan aynı hata geri gelecekti. Helper acme.sh'ın `--reloadcmd`'i olarak kaydediliyor.

## Canlı doğrulama

İzinleri **kasten** `0600 sahip:sahip`'e geri çevirip helper'ı çalıştırdım:

```
bozuldu: 600 ubuntu:ubuntu
helper: OK
düzeldi: 640 ubuntu:caddy
✓ caddy okuyabiliyor
caddy: active · prod: 200
```

Ve `tls` satırı taşıyan bir topic route'u artık Let's Encrypt sertifikasıyla `200` dönüyor.

## #2214 ile ilişkisi

Bu, **host** tarafını düzeltiyor. `topic-deploy.sh`'ın kendi üç kusuru (bridge ağı, `CERT_DIR` varsayılanı, container'a verilen hostname) **#2214**'te düzeltiliyor. İkisi de gerekli — #2214 tek başına merge edilseydi, deploy yine bu izin hatasında ölürdü.
