### PR TITLE
feat: queue depth and DLQ size on /api/health, daily dead-letter alert (#1674)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,12 +60,16 @@ MAIL_FROM_NAME="Internship CRM"
 # See docs/EMAIL_DELIVERABILITY.md §2d.
 #UNSUBSCRIBE_MAILTO="unsubscribe@crm.ersah.in"
 
-# Automated-test alerts — these are consumed ONLY by the nightly stress GitHub
-# Actions workflow (.github/workflows/stress.yml), NOT by the running app. Set
-# them as GitHub repo secrets, not in a runtime .env. Listed here for discovery.
-#   ALERT_EMAIL_TO     comma-separated recipient(s) emailed when a test fails
+# Operator alerts.
+#   ALERT_EMAIL_TO     comma-separated recipient(s) for automated alerts. Read
+#                      by the CI workflows (stress, k6, e2e-full, backup-verify)
+#                      as a GitHub repo secret AND by the running app: the
+#                      hourly e-mail-delivery alert (#1190) and the daily
+#                      dead-letter alert (#1674) mail it. Both are silent while
+#                      everything is healthy; unset, the app only logs.
 #   STRESS_TARGET_URL  env the nightly stress test hits (defaults to production)
 # For a local stress run use BASE_URL instead: BASE_URL=... npm run test:stress
+#ALERT_EMAIL_TO=""
 
 # Inbound email (mentee/mentor replies routed back into a message thread)
 # INBOUND_EMAIL_DOMAIN: domain used in the generated reply-to address

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -278,6 +278,13 @@ As the table grows, that query — not the app — is the likeliest cause of an 
 breach. Setting `HEALTH_TOKEN` on the server removes the whole detail path from the anonymous
 probe and is the cheaper fix.
 
+The job-queue counters added in #1674 deliberately did **not** join that bill: they are read
+only for a caller who is past the detail gate *and* asks for them with `?jobs=1`, so the
+anonymous mix (`ep:health`, `ep:health_db`) issues exactly the queries it issued before.
+Anything added to `/api/health` from here on should follow the same shape — opt-in, inside
+the gated branch — and `e2e/job-queue-dlq-alert.unit.spec.ts` asserts it for the counters by
+reading the route's source.
+
 ## OS accessibility media preferences
 
 Three user preferences the browser exposes as media features are **supported and

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -279,10 +279,15 @@ breach. Setting `HEALTH_TOKEN` on the server removes the whole detail path from 
 probe and is the cheaper fix.
 
 The job-queue counters added in #1674 deliberately did **not** join that bill: they are read
-only for a caller who is past the detail gate *and* asks for them with `?jobs=1`, so the
-anonymous mix (`ep:health`, `ep:health_db`) issues exactly the queries it issued before.
-Anything added to `/api/health` from here on should follow the same shape — opt-in, inside
-the gated branch — and `e2e/job-queue-dlq-alert.unit.spec.ts` asserts it for the counters by
+only for a caller who asks for them with `?jobs=1` **and** has proved who they are — a
+matching `HEALTH_TOKEN` or an ADMIN session. Note that this is a *stricter* gate than the
+detail block above it: the detail block is fail-open when `HEALTH_TOKEN` is unset (the deploy
+drift gate parses `sha` out of it), while the counters fail closed, because nothing automated
+parses them and an un-tokened server would otherwise answer any anonymous `?jobs=1` with the
+queue's depth and three extra queries. So the anonymous mix (`ep:health`, `ep:health_db`)
+issues exactly the queries it issued before. Anything added to `/api/health` from here on
+should follow the same shape — opt-in, and gated on `access.verified` unless a deploy gate
+genuinely needs it — and `e2e/job-queue-dlq-alert.unit.spec.ts` asserts it for the counters by
 reading the route's source.
 
 ## OS accessibility media preferences

--- a/e2e/job-queue-dlq-alert.unit.spec.ts
+++ b/e2e/job-queue-dlq-alert.unit.spec.ts
@@ -19,7 +19,8 @@ import {
 //      row-by-row dump.
 //
 // The route-shape test at the bottom guards the *other* half of the issue: the
-// counters must cost an anonymous caller nothing.
+// counters must cost an anonymous caller nothing, and must not fall out of the
+// endpoint's fail-open detail branch on a server with no HEALTH_TOKEN.
 
 const empty: DeadLetterSummary = {
   total: 0,
@@ -118,18 +119,24 @@ test('a failure reason is sanitised, single-line and bounded', () => {
 // is read out of the source — the same trick e2e/email-groups-footer.unit.spec.ts
 // uses. /api/health is in the nightly k6 anonymous-GET mix with a latency
 // budget; a stray call up here would be paid by every uptime probe.
-test('the queue counters are read only behind the detail gate and ?jobs=1', () => {
+test('the queue counters are read only for a verified caller who asks for them', () => {
   const src = fs.readFileSync(path.join(process.cwd(), 'src/app/api/health/route.ts'), 'utf8');
 
-  // Exactly one call site, and it is opt-in.
+  // Exactly one call site, and it is opt-in AND behind proof of identity.
   const calls = src.match(/jobQueueHealth\(\)/g) ?? [];
   expect(calls).toHaveLength(1);
   expect(src).toContain("params.get('jobs') === '1'");
-  expect(src).toContain('...(wantsJobs ? { jobs: await jobQueueHealth() } : {})');
+  expect(src).toContain('...(wantsJobs && access.verified ? { jobs: await jobQueueHealth() } : {})');
 
-  // …and it sits after the anonymous early return, so an unauthorised caller
-  // never reaches it.
-  const anonymousReturn = src.indexOf('if (!(await maySeeDetail(request)))');
+  // `detail` is fail-open when HEALTH_TOKEN is unset — that is the bargain the
+  // deploy drift gate needs. `verified` is not, and the counters ride on
+  // `verified`, so an un-tokened server (every environment today) still refuses
+  // them to an anonymous ?jobs=1.
+  expect(src).toContain('return { detail: !expected, verified: false };');
+
+  // …and the read sits after the anonymous early return, so a caller the gate
+  // turned away never reaches it.
+  const anonymousReturn = src.indexOf('if (!access.detail)');
   expect(anonymousReturn).toBeGreaterThan(0);
   expect(src.indexOf('await jobQueueHealth()')).toBeGreaterThan(anonymousReturn);
 

--- a/e2e/job-queue-dlq-alert.unit.spec.ts
+++ b/e2e/job-queue-dlq-alert.unit.spec.ts
@@ -1,0 +1,140 @@
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+import {
+  buildDeadLetterAlert,
+  normalizeReason,
+  MAX_ROWS_SHOWN,
+  type DeadLetterSummary,
+} from '@/lib/jobs/dlqAlertMessage';
+
+// The dead-letter alert's two promises (#1674), tested without a database, a
+// mail transport or a browser:
+//
+//   1. It is SILENT when the queue is clean. That is the property the whole
+//      convention rests on, and it is one `null` return — easy to break by
+//      accident, invisible until somebody starts ignoring the alert.
+//   2. What it says is bounded and safe: counts, an age, job type names and
+//      grouped failure reasons — never a payload, never an address, never a
+//      row-by-row dump.
+//
+// The route-shape test at the bottom guards the *other* half of the issue: the
+// counters must cost an anonymous caller nothing.
+
+const empty: DeadLetterSummary = {
+  total: 0,
+  oldestAt: null,
+  byName: [],
+  reasons: [],
+  reasonsSampledFrom: 0,
+};
+
+function summary(over: Partial<DeadLetterSummary> = {}): DeadLetterSummary {
+  return {
+    total: 3,
+    oldestAt: '2026-09-01T06:15:00.000Z',
+    byName: [
+      { name: 'email.send', count: 2, lastFailedAt: '2026-09-05T21:00:00.000Z' },
+      { name: 'report.weekly', count: 1, lastFailedAt: '2026-09-04T09:30:00.000Z' },
+    ],
+    reasons: [
+      { reason: 'Connection refused', count: 2 },
+      { reason: 'ETIMEDOUT', count: 1 },
+    ],
+    reasonsSampledFrom: 3,
+    ...over,
+  };
+}
+
+test('an empty dead-letter queue produces no message at all', () => {
+  expect(buildDeadLetterAlert(empty)).toBeNull();
+  // Defensive: a count that somehow went negative is still "nothing to report",
+  // not a mail claiming -1 jobs are waiting.
+  expect(buildDeadLetterAlert({ ...empty, total: -1 })).toBeNull();
+});
+
+test('a non-empty queue produces one message naming each job type and count', () => {
+  const message = buildDeadLetterAlert(summary());
+  expect(message).not.toBeNull();
+  expect(message!.subject).toBe('[CRM] Ölü mektup kuyruğunda 3 iş bekliyor');
+  const html = message!.html;
+  // How many, since when…
+  expect(html).toContain('<b>3</b>');
+  expect(html).toContain('1 Eyl 2026');
+  // …which job types, with their counts…
+  expect(html).toContain('email.send');
+  expect(html).toContain('report.weekly');
+  // …and the distinct failure reasons with counts.
+  expect(html).toContain('<b>2×</b> Connection refused');
+  expect(html).toContain('<b>1×</b> ETIMEDOUT');
+  // The sample note only appears when the histogram really is a sample.
+  expect(html).not.toContain('kayıt üzerinden');
+});
+
+test('the reason histogram says so when it is only a sample', () => {
+  const html = buildDeadLetterAlert(summary({ total: 900, reasonsSampledFrom: 200 }))!.html;
+  expect(html).toContain('en son 200 kayıt üzerinden');
+});
+
+test('long lists are truncated with a tail instead of dumped', () => {
+  const many = Array.from({ length: MAX_ROWS_SHOWN + 4 }, (_, i) => ({
+    name: `job.type${i}`,
+    count: 1,
+    lastFailedAt: null,
+  }));
+  const html = buildDeadLetterAlert(summary({ total: many.length, byName: many }))!.html;
+  expect(html).toContain(`job.type${MAX_ROWS_SHOWN - 1}`);
+  expect(html).not.toContain(`job.type${MAX_ROWS_SHOWN}`);
+  expect(html).toContain('… ve 4 tür daha');
+});
+
+test('a job name or reason cannot inject markup into the mail', () => {
+  const html = buildDeadLetterAlert(
+    summary({
+      byName: [{ name: '<script>x</script>', count: 1, lastFailedAt: null }],
+      reasons: [{ reason: 'boom "&" <b>bold</b>', count: 1 }],
+    })
+  )!.html;
+  expect(html).not.toContain('<script>');
+  expect(html).toContain('&lt;script&gt;');
+  expect(html).toContain('&lt;b&gt;bold&lt;/b&gt;');
+});
+
+test('a failure reason is sanitised, single-line and bounded', () => {
+  // The shared sanitiser is what keeps an SMTP rejection from carrying the
+  // recipient into an operator mailbox.
+  expect(normalizeReason('550 rejected for someone@example.com')).toContain('<redacted>');
+  expect(normalizeReason('550 rejected for someone@example.com')).not.toContain('example.com');
+  // Only the first line: a stack trace differs on every row and would defeat
+  // the grouping.
+  expect(normalizeReason('Boom\n    at handler (foo.ts:1:1)')).toBe('Boom');
+  expect(normalizeReason(null)).toBe('bilinmeyen hata');
+  expect(normalizeReason('   ')).toBe('bilinmeyen hata');
+  expect(normalizeReason('x'.repeat(400)).length).toBeLessThanOrEqual(120);
+});
+
+// The counters are cheap only as long as nothing calls them on the anonymous
+// path. That is a property of the route's *shape*, not of any response, so it
+// is read out of the source — the same trick e2e/email-groups-footer.unit.spec.ts
+// uses. /api/health is in the nightly k6 anonymous-GET mix with a latency
+// budget; a stray call up here would be paid by every uptime probe.
+test('the queue counters are read only behind the detail gate and ?jobs=1', () => {
+  const src = fs.readFileSync(path.join(process.cwd(), 'src/app/api/health/route.ts'), 'utf8');
+
+  // Exactly one call site, and it is opt-in.
+  const calls = src.match(/jobQueueHealth\(\)/g) ?? [];
+  expect(calls).toHaveLength(1);
+  expect(src).toContain("params.get('jobs') === '1'");
+  expect(src).toContain('...(wantsJobs ? { jobs: await jobQueueHealth() } : {})');
+
+  // …and it sits after the anonymous early return, so an unauthorised caller
+  // never reaches it.
+  const anonymousReturn = src.indexOf('if (!(await maySeeDetail(request)))');
+  expect(anonymousReturn).toBeGreaterThan(0);
+  expect(src.indexOf('await jobQueueHealth()')).toBeGreaterThan(anonymousReturn);
+
+  // The fields the deploy gate and the uptime probes parse are still there.
+  for (const field of ['status', 'version', 'sha', 'db', 'smtp', 'uptimeMs', 'responseMs']) {
+    expect(src).toContain(`${field}`);
+  }
+});

--- a/e2e/job-queue-dlq-alert.unit.spec.ts
+++ b/e2e/job-queue-dlq-alert.unit.spec.ts
@@ -133,8 +133,10 @@ test('the queue counters are read only behind the detail gate and ?jobs=1', () =
   expect(anonymousReturn).toBeGreaterThan(0);
   expect(src.indexOf('await jobQueueHealth()')).toBeGreaterThan(anonymousReturn);
 
-  // The fields the deploy gate and the uptime probes parse are still there.
-  for (const field of ['status', 'version', 'sha', 'db', 'smtp', 'uptimeMs', 'responseMs']) {
-    expect(src).toContain(`${field}`);
-  }
+  // The fields the deploy gate and the uptime probes parse are still produced
+  // the way they were — `sha` above all, which infra/deploy-prod.sh reads to
+  // decide whether the live container has drifted.
+  expect(src).toContain('sha: GIT_SHA');
+  expect(src).toContain('version: APP_VERSION');
+  expect(src).toContain('responseMs: Date.now() - started');
 });

--- a/e2e/job-queue-health.spec.ts
+++ b/e2e/job-queue-health.spec.ts
@@ -1,0 +1,143 @@
+import { test, expect } from '@playwright/test';
+import { E2E_HEALTH_TOKEN, E2E_ALERT_EMAIL_TO } from '../playwright.config';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+
+// Job-queue visibility (#1674): queue depth and dead-letter size on the gated
+// half of /api/health, and one daily alert mail that is SILENT while the
+// dead-letter queue is empty.
+//
+// Two properties are worth more than the counters themselves and both are
+// asserted below: an anonymous caller pays nothing for this (the endpoint is in
+// the nightly k6 mix with a latency budget), and a clean queue produces no mail
+// and no EmailLog row at all.
+const local = !process.env.BASE_URL;
+
+// Every row this spec creates carries this prefix in `Job.name`, which is also
+// how the cleanup finds them again. Unique per run so parallel workers and a
+// long-lived dev database never trip over each other.
+const RUN = `e2e.jobs-${Date.now().toString(36)}`;
+const DLQ_SUBJECT_PREFIX = '[CRM] Ölü mektup';
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('queue counters are gated and opt-in, and the dead-letter alert is silent while green', async ({
+  page,
+  request,
+}) => {
+  test.skip(!local, 'seeds Job rows directly — local DB only');
+
+  const adminEmail = uniqueEmail('jobs-health-admin');
+  await seedUser(adminEmail, 'AdminPass123', 'ADMIN', 'Jobs Health Admin');
+
+  const tenMinutesAgo = new Date(Date.now() - 10 * 60 * 1000);
+  const seededJobs: string[] = [];
+  const mkJob = async (name: string, status: 'PENDING' | 'RUNNING' | 'DEAD_LETTER', over: Record<string, unknown> = {}) => {
+    const row = await prisma.job.create({
+      data: { name: `${RUN}.${name}`, payload: {}, status, ...over },
+    });
+    seededJobs.push(row.id);
+    return row;
+  };
+
+  try {
+    // Two overdue pending jobs and one running one.
+    await mkJob('pending', 'PENDING', { runAt: tenMinutesAgo });
+    await mkJob('pending', 'PENDING', { runAt: tenMinutesAgo });
+    await mkJob('running', 'RUNNING', { lockedAt: new Date(), lockedBy: 'e2e-worker' });
+
+    // 1) An anonymous caller sees liveness only — asking for the counters does
+    //    not get them, and (the point) does not cost a query either.
+    const anon = await request.get('/api/health?jobs=1');
+    expect(anon.status()).toBe(200);
+    expect((await anon.json()).jobs).toBeUndefined();
+
+    // 2) The detail view without ?jobs=1 stays exactly as expensive as it was.
+    const detailNoOptIn = await request.get('/api/health', {
+      headers: { 'X-Health-Token': E2E_HEALTH_TOKEN },
+    });
+    const detailBody = await detailNoOptIn.json();
+    expect(detailBody.version).toBeTruthy(); // the gate did open…
+    expect(detailBody.jobs).toBeUndefined(); // …and the counters still cost nothing
+
+    // 3) Gated + opted in: the counters. Other specs run in parallel and the
+    //    dev database is long-lived, so these are lower bounds.
+    const gated = await request.get('/api/health?jobs=1', {
+      headers: { 'X-Health-Token': E2E_HEALTH_TOKEN },
+    });
+    expect(gated.status()).toBe(200);
+    const jobs = (await gated.json()).jobs;
+    expect(Object.keys(jobs).sort()).toEqual([
+      'deadLetter',
+      'failedLast24h',
+      'oldestPendingAgeSec',
+      'pending',
+      'running',
+    ]);
+    expect(jobs.pending).toBeGreaterThanOrEqual(2);
+    expect(jobs.running).toBeGreaterThanOrEqual(1);
+    // Depth alone cannot tell a burst from a stalled worker; the age can.
+    expect(jobs.oldestPendingAgeSec).toBeGreaterThanOrEqual(9 * 60);
+    // Operational metadata only — no name, no payload, no tenant.
+    expect(JSON.stringify(jobs)).not.toContain(RUN);
+    expect(JSON.stringify(jobs)).not.toContain('orgId');
+
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', adminEmail);
+    await page.fill('input[type="password"]', 'AdminPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
+
+    // 4) Green is silent. Only meaningful while nothing else has dead-lettered.
+    const foreignDeadLetters = await prisma.job.count({
+      where: { status: 'DEAD_LETTER', name: { not: { startsWith: RUN } } },
+    });
+    const mailsBefore = await prisma.emailLog.count({ where: { subject: { startsWith: DLQ_SUBJECT_PREFIX } } });
+    if (foreignDeadLetters === 0) {
+      const quiet = await page.request.get('/api/cron?job=dlq-alert');
+      expect(quiet.ok()).toBeTruthy();
+      expect((await quiet.json()).dlqAlert).toEqual({ sent: false, total: 0 });
+      // The whole convention in one assertion: nothing was sent, so nothing was
+      // logged either.
+      const after = await prisma.emailLog.count({ where: { subject: { startsWith: DLQ_SUBJECT_PREFIX } } });
+      expect(after).toBe(mailsBefore);
+    }
+
+    // 5) Three dead-lettered jobs across two names and two failure reasons.
+    await mkJob('send', 'DEAD_LETTER', { attempts: 5, lastError: 'Connection refused' });
+    await mkJob('send', 'DEAD_LETTER', { attempts: 5, lastError: 'Connection refused' });
+    await mkJob('report', 'DEAD_LETTER', { attempts: 5, lastError: 'ETIMEDOUT after 30s' });
+
+    const loud = await page.request.get('/api/cron?job=dlq-alert');
+    expect(loud.ok()).toBeTruthy();
+    const result = (await loud.json()).dlqAlert;
+    expect(result.total).toBeGreaterThanOrEqual(3);
+    expect(result.sent).toBe(true);
+
+    // Exactly one mail, to the operator address, recorded in the ledger. SMTP is
+    // blanked for e2e, so the row is SKIPPED rather than SENT — what matters is
+    // that one row exists and that it is the ops-alert category.
+    const mailsAfter = await prisma.emailLog.count({ where: { subject: { startsWith: DLQ_SUBJECT_PREFIX } } });
+    expect(mailsAfter).toBe(mailsBefore + 1);
+    const mail = await prisma.emailLog.findFirst({
+      where: { subject: { startsWith: DLQ_SUBJECT_PREFIX } },
+      orderBy: { createdAt: 'desc' },
+    });
+    expect(mail?.to).toBe(E2E_ALERT_EMAIL_TO);
+    expect(mail?.category).toBe('ops-alert');
+    expect(mail?.subject).toContain('iş bekliyor');
+
+    // …and the counters now show the same three.
+    const withDlq = await request.get('/api/health?jobs=1', {
+      headers: { 'X-Health-Token': E2E_HEALTH_TOKEN },
+    });
+    const dlqCounters = (await withDlq.json()).jobs;
+    expect(dlqCounters.deadLetter).toBeGreaterThanOrEqual(3);
+    expect(dlqCounters.failedLast24h).toBeGreaterThanOrEqual(3);
+  } finally {
+    await prisma.job.deleteMany({ where: { name: { startsWith: RUN } } });
+    await prisma.emailLog.deleteMany({ where: { subject: { startsWith: DLQ_SUBJECT_PREFIX } } });
+    await cleanupByEmail(adminEmail);
+  }
+});

--- a/e2e/job-queue-health.spec.ts
+++ b/e2e/job-queue-health.spec.ts
@@ -33,6 +33,11 @@ test('queue counters are gated and opt-in, and the dead-letter alert is silent w
 
   const tenMinutesAgo = new Date(Date.now() - 10 * 60 * 1000);
   const seededJobs: string[] = [];
+  // Only the ledger row this run produced is cleaned up. Deleting every row
+  // whose subject starts with the prefix would wipe a long-lived dev database's
+  // whole dead-letter alert history — including the rows counted as
+  // pre-existing two steps below.
+  let alertMailId: string | null = null;
   const mkJob = async (name: string, status: 'PENDING' | 'RUNNING' | 'DEAD_LETTER', over: Record<string, unknown> = {}) => {
     const row = await prisma.job.create({
       data: { name: `${RUN}.${name}`, payload: {}, status, ...over },
@@ -48,7 +53,9 @@ test('queue counters are gated and opt-in, and the dead-letter alert is silent w
     await mkJob('running', 'RUNNING', { lockedAt: new Date(), lockedBy: 'e2e-worker' });
 
     // 1) An anonymous caller sees liveness only — asking for the counters does
-    //    not get them, and (the point) does not cost a query either.
+    //    not get them, and (the point) does not cost a query either. The
+    //    counters fail CLOSED, unlike the detail block: they are withheld from
+    //    an unproven caller whether or not HEALTH_TOKEN is configured.
     const anon = await request.get('/api/health?jobs=1');
     expect(anon.status()).toBe(200);
     expect((await anon.json()).jobs).toBeUndefined();
@@ -89,6 +96,11 @@ test('queue counters are gated and opt-in, and the dead-letter alert is silent w
     await page.click('button[type="submit"]');
     await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
 
+    // 3b) The other half of the gate: an ADMIN session, no token header at all.
+    const viaSession = await page.request.get('/api/health?jobs=1');
+    expect(viaSession.status()).toBe(200);
+    expect((await viaSession.json()).jobs.pending).toBeGreaterThanOrEqual(2);
+
     // 4) Green is silent. Only meaningful while nothing else has dead-lettered.
     const foreignDeadLetters = await prisma.job.count({
       where: { status: 'DEAD_LETTER', name: { not: { startsWith: RUN } } },
@@ -113,20 +125,35 @@ test('queue counters are gated and opt-in, and the dead-letter alert is silent w
     expect(loud.ok()).toBeTruthy();
     const result = (await loud.json()).dlqAlert;
     expect(result.total).toBeGreaterThanOrEqual(3);
-    expect(result.sent).toBe(true);
+    // SMTP is blanked for e2e, so sendEmail answers SKIPPED without throwing.
+    // `sent` reports delivery, not "the function returned" (#1431): a mail that
+    // never left the box must never be reported as sent.
+    expect(result.sent).toBe(false);
+    expect(result.delivery).toBe('SKIPPED');
+    expect(result.reason).toBe('not_delivered');
 
-    // Exactly one mail, to the operator address, recorded in the ledger. SMTP is
-    // blanked for e2e, so the row is SKIPPED rather than SENT — what matters is
-    // that one row exists and that it is the ops-alert category.
+    // …and the attempt is on the ledger all the same: exactly one row, to the
+    // operator address, in the ops-alert category.
     const mailsAfter = await prisma.emailLog.count({ where: { subject: { startsWith: DLQ_SUBJECT_PREFIX } } });
     expect(mailsAfter).toBe(mailsBefore + 1);
     const mail = await prisma.emailLog.findFirst({
       where: { subject: { startsWith: DLQ_SUBJECT_PREFIX } },
       orderBy: { createdAt: 'desc' },
     });
+    alertMailId = mail?.id ?? null;
     expect(mail?.to).toBe(E2E_ALERT_EMAIL_TO);
     expect(mail?.category).toBe('ops-alert');
+    expect(mail?.status).toBe('SKIPPED');
     expect(mail?.subject).toContain('iş bekliyor');
+
+    // The durable half of the alert: a filling dead-letter queue is visible in
+    // the activity log even though the mail above never left the box.
+    const activity = await prisma.activityLog.findFirst({
+      where: { action: 'jobs.dlq_alert' },
+      orderBy: { createdAt: 'desc' },
+    });
+    expect(activity?.level).toBe('ERROR');
+    expect(activity?.detail).toContain('"total"');
 
     // …and the counters now show the same three.
     const withDlq = await request.get('/api/health?jobs=1', {
@@ -137,7 +164,7 @@ test('queue counters are gated and opt-in, and the dead-letter alert is silent w
     expect(dlqCounters.failedLast24h).toBeGreaterThanOrEqual(3);
   } finally {
     await prisma.job.deleteMany({ where: { name: { startsWith: RUN } } });
-    await prisma.emailLog.deleteMany({ where: { subject: { startsWith: DLQ_SUBJECT_PREFIX } } });
+    if (alertMailId) await prisma.emailLog.deleteMany({ where: { id: alertMailId } });
     await cleanupByEmail(adminEmail);
   }
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,6 +20,9 @@ export const E2E_HEALTH_TOKEN = 'e2e-health-token';
 // the shape production actually runs (secret required AND supplied) instead of
 // the lenient path.
 export const E2E_INBOUND_SECRET = 'e2e-inbound-secret';
+// Shared with e2e/job-queue-health.spec.ts (#1674): the operator address the
+// dead-letter alert mails when the queue is not empty.
+export const E2E_ALERT_EMAIL_TO = 'ops-alert@e2e.local';
 // Shared with e2e/meeting-end.spec.ts. Unset, /api/webhooks/jaas answers 404
 // to everything and the live-room assertions would be vacuous.
 export const E2E_JAAS_WEBHOOK_SECRET = 'e2e-jaas-webhook-secret';
@@ -86,6 +89,13 @@ export default defineConfig({
           // keeps its legacy fully-public response and health.spec.ts's
           // assertions about what an anonymous caller may see would be vacuous.
           HEALTH_TOKEN: E2E_HEALTH_TOKEN,
+          // Operator alert address (#1674). Pinned to a synthetic one rather
+          // than left to whatever the environment inherits: the dead-letter
+          // alert's "silent when green, one mail when not" contract is only
+          // testable when an address exists, and a real one must never be the
+          // address a test run picks up. SMTP_USER is blank above, so the send
+          // still stops at a SKIPPED EmailLog row.
+          ALERT_EMAIL_TO: E2E_ALERT_EMAIL_TO,
           INBOUND_SECRET: E2E_INBOUND_SECRET,
           JAAS_WEBHOOK_SECRET: E2E_JAAS_WEBHOOK_SECRET,
           // Google Calendar (#709): credentials that only mean anything to the

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2957,8 +2957,11 @@ model MatchFeedback {
 // dead-letter alert. `JobRun`, `enqueue()`, the SKIP LOCKED `claim()` and the
 // worker loop are #1671/#1673 and are deliberately NOT in this file yet.
 //
-// Field names and indexes are copied verbatim from #1671's specification so the
-// two land as the same table rather than as two competing ones.
+// Field names are copied verbatim from #1671's specification so the two land as
+// the same table rather than as two competing ones — whichever PR merges second
+// deletes its copy of this block instead of resolving a conflict by hand. The
+// one deliberate addition is the `orgId`-leading index below, which #1671's
+// draft does not have and which every other TENANT_MODELS entry does.
 enum JobStatus {
   PENDING
   RUNNING
@@ -2991,6 +2994,11 @@ model Job {
   lockedBy String?   @db.VarChar(64)
 
   /// Enqueue-side de-duplication key: the same key never produces a second row.
+  /// Global rather than `@@unique([orgId, idempotencyKey])` on purpose: `orgId`
+  /// is nullable and MySQL treats NULLs in a unique index as distinct, so a
+  /// composite key would silently stop de-duplicating anything at all while
+  /// every row still has a null org (i.e. today). Revisit it together with the
+  /// backfill that makes `orgId` non-null.
   idempotencyKey String? @unique
 
   /// Tenant anchor. Nullable like the other phase-1 tenant models; the model is
@@ -3005,4 +3013,11 @@ model Job {
 
   @@index([status, runAt, priority])
   @@index([name, status])
+  /// Tenant-leading, like every other model in TENANT_MODELS (MatchFeedback's
+  /// `[orgId, createdAt]`, Requisition's `[orgId, status]`, AccountLockout's
+  /// `[orgId]`). Without it, an auto-scoped query under MT_ENFORCE_ISOLATION
+  /// would filter orgId row-by-row on top of the status index — including the
+  /// claim query `status=PENDING AND runAt<=now`, which is the hottest one this
+  /// table will ever serve.
+  @@index([orgId, status, runAt])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2948,3 +2948,61 @@ model MatchFeedback {
   @@index([mentorId])
   @@index([actorId])
 }
+
+// ── Background job queue ─────────────────────────────────────────────────────
+//
+// The durable substrate for the queue engine (#1669). Only the `Job` half is
+// here: this PR (#1674) is the *observability* task and needs somewhere to
+// count from — queue depth and dead-letter size on /api/health, plus the daily
+// dead-letter alert. `JobRun`, `enqueue()`, the SKIP LOCKED `claim()` and the
+// worker loop are #1671/#1673 and are deliberately NOT in this file yet.
+//
+// Field names and indexes are copied verbatim from #1671's specification so the
+// two land as the same table rather than as two competing ones.
+enum JobStatus {
+  PENDING
+  RUNNING
+  SUCCEEDED
+  FAILED
+  // Retries exhausted: nothing will pick this row up again. This is the state
+  // the daily alert (src/lib/jobs/dlqAlert.ts) exists to make visible.
+  DEAD_LETTER
+  CANCELLED
+}
+
+model Job {
+  id       String    @id @default(cuid())
+  name     String    @db.VarChar(64)
+  payload  Json
+  status   JobStatus @default(PENDING)
+  /// Higher runs first; the claim query orders by priority DESC, runAt ASC.
+  priority Int       @default(0)
+  /// Earliest moment the job may run — "due" means runAt <= now.
+  runAt    DateTime  @default(now())
+
+  attempts    Int     @default(0)
+  maxAttempts Int     @default(5)
+  /// Message of the most recent failure. May echo whatever the handler threw,
+  /// so every surface that renders it runs it through sanitizeError() first.
+  lastError   String? @db.Text
+
+  /// Lease held by a worker while status is RUNNING.
+  lockedAt DateTime?
+  lockedBy String?   @db.VarChar(64)
+
+  /// Enqueue-side de-duplication key: the same key never produces a second row.
+  idempotencyKey String? @unique
+
+  /// Tenant anchor. Nullable like the other phase-1 tenant models; the model is
+  /// listed in TENANT_MODELS (src/lib/orgContext.ts) so Prisma queries
+  /// auto-scope once MT_ENFORCE_ISOLATION is on. Operational readers (health,
+  /// the dead-letter alert) run outside any request scope and therefore see the
+  /// whole queue, which is what an operator alert has to do.
+  orgId String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([status, runAt, priority])
+  @@index([name, status])
+}

--- a/releases/unreleased/queue-depth-and-dlq-alert.json
+++ b/releases/unreleased/queue-depth-and-dlq-alert.json
@@ -1,4 +1,4 @@
 {
-  "bump": "patch",
-  "changelog": "- **Queue depth and dead-letter size on /api/health** (#1674). `GET /api/health?jobs=1` now reports `pending`, `running`, `deadLetter`, `oldestPendingAgeSec` and `failedLast24h` — inside the HEALTH_TOKEN/ADMIN detail branch only, so an anonymous probe issues no extra query. A daily 06:45 UTC job mails `ALERT_EMAIL_TO` (Turkish) when the dead-letter queue is not empty, listing job types with counts and the grouped, sanitised failure reasons; an empty queue sends nothing and writes no `EmailLog` row. Carries the `Job` model from #1671, which has not landed yet."
+  "bump": "minor",
+  "changelog": "- **Queue depth and dead-letter size on /api/health** (#1674). `GET /api/health?jobs=1` now reports `pending`, `running`, `deadLetter`, `oldestPendingAgeSec` and `failedLast24h` to a caller holding `HEALTH_TOKEN` or signed in as an admin — never on the endpoint's fail-open public branch, so an anonymous probe issues no extra query. A daily 06:45 UTC job mails `ALERT_EMAIL_TO` (Turkish) when the dead-letter queue is not empty, listing job types with counts and the grouped, sanitised failure reasons; it writes a `jobs.dlq_alert` activity row first, so a filling queue is visible even when the alert itself cannot be delivered, and an empty queue sends nothing at all. Carries the `Job` model from #1671, which has not landed yet."
 }

--- a/releases/unreleased/queue-depth-and-dlq-alert.json
+++ b/releases/unreleased/queue-depth-and-dlq-alert.json
@@ -1,0 +1,4 @@
+{
+  "bump": "patch",
+  "changelog": "- **Queue depth and dead-letter size on /api/health** (#1674). `GET /api/health?jobs=1` now reports `pending`, `running`, `deadLetter`, `oldestPendingAgeSec` and `failedLast24h` — inside the HEALTH_TOKEN/ADMIN detail branch only, so an anonymous probe issues no extra query. A daily 06:45 UTC job mails `ALERT_EMAIL_TO` (Turkish) when the dead-letter queue is not empty, listing job types with counts and the grouped, sanitised failure reasons; an empty queue sends nothing and writes no `EmailLog` row. Carries the `Job` model from #1671, which has not landed yet."
+}

--- a/src/app/api/cron/route.ts
+++ b/src/app/api/cron/route.ts
@@ -20,6 +20,7 @@ import { expireOffers } from '@/lib/offerNotify';
 import { sweepMeetingInteractionLogs } from '@/lib/meetingAutoLog';
 import { dispatchDueNewsletters, queueScheduledNewsletter } from '@/lib/newsletterDispatch';
 import { sweepDormantFirstContacts } from '@/lib/dormantFirstContact';
+import { runDeadLetterAlert } from '@/lib/jobs/dlqAlert';
 
 export async function GET(request: Request) {
   try {
@@ -65,6 +66,13 @@ export async function GET(request: Request) {
     if (job === 'dormant') {
       const dormantSweep = await sweepDormantFirstContacts();
       return NextResponse.json({ message: 'Dormant first contacts ran', dormantSweep, dormantCheckIns: await sendDormantCheckIns() });
+    }
+    // Dead-letter alert (#1674) — named only, deliberately NOT part of the
+    // batch below. The batch is "run everything now", which an admin may click
+    // several times while fixing something; the alert's whole contract is one
+    // mail a day, and it is silent when the queue is clean either way.
+    if (job === 'dlq-alert') {
+      return NextResponse.json({ message: 'Dead-letter alert ran', dlqAlert: await runDeadLetterAlert() });
     }
     if (job === 'missing-documents') {
       const missingDocuments = await sendWeeklyMissingDocumentReminders();

--- a/src/app/api/cron/start/route.ts
+++ b/src/app/api/cron/start/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { timingSafeEqual } from 'crypto';
 import { initCronJobs } from '@/services/emailService';
 import { initNewsletterCron } from '@/lib/newsletterDispatch';
+import { initDeadLetterAlertCron } from '@/lib/jobs/dlqAlert';
 
 // node-cron timers live in this process; nothing about them works on the edge.
 export const runtime = 'nodejs';
@@ -31,5 +32,9 @@ export async function POST(request: Request) {
   // Registered here rather than inside initCronJobs so the dependency stays
   // one-way (newsletterDispatch imports emailService, never the reverse, #1469).
   initNewsletterCron();
+  // Same reason as above (#1674): the dead-letter alert imports emailService to
+  // send its mail, so registering it inside initCronJobs would close the import
+  // graph into a cycle.
+  initDeadLetterAlertCron();
   return NextResponse.json({ ok: true, started: true });
 }

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -4,15 +4,16 @@ import { timingSafeEqual } from 'crypto';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { getEmailHealth } from '@/lib/emailHealth';
+import { jobQueueHealth } from '@/lib/jobs/health';
 import { APP_VERSION, GIT_SHA } from '@/lib/version';
 import { verifySmtpConnection } from '@/services/emailService';
 
 // Public, unauthenticated liveness/readiness probe used by uptime monitors and
 // the nightly stress test. Always cheap by default; pass ?db=1 to additionally
-// verify database connectivity, or ?smtp=1 to verify SMTP connectivity (no
+// verify database connectivity, ?smtp=1 to verify SMTP connectivity (no
 // message sent — see #483, where SMTP silently failing had no visibility
-// outside of a user reporting a missing email). Never touches or mutates
-// domain data.
+// outside of a user reporting a missing email), or ?jobs=1 for the job-queue
+// depth and dead-letter size (#1674). Never touches or mutates domain data.
 //
 // Liveness stays public — a monitor cannot log in. The *detail* (version, git
 // sha, subsystem status, uptime) is a different matter: to an attacker it is a
@@ -53,6 +54,11 @@ export async function GET(request: Request) {
   const params = new URL(request.url).searchParams;
   const wantsDb = params.get('db') === '1';
   const wantsSmtp = params.get('smtp') === '1';
+  // Queue counters are opt-in like the two probes above, and read only inside
+  // the gated branch below: an anonymous /api/health issues no query for them,
+  // which is what keeps the endpoint inside its k6 latency budget
+  // (docs/testing.md — it already pays four EmailLog queries in the detail view).
+  const wantsJobs = params.get('jobs') === '1';
 
   let db: 'ok' | 'error' | 'skipped' = 'skipped';
   if (wantsDb) {
@@ -96,6 +102,11 @@ export async function GET(request: Request) {
       // Delivery health (#1190), derived from the EmailLog ledger — recipient
       // addresses are scrubbed in the lib, so nothing here carries PII.
       email: await getEmailHealth(),
+      // Job-queue depth and dead-letter size (#1674) — counters only, no job
+      // payload, name of a user or org. Appended rather than inserted: the
+      // deploy gate parses `sha` out of this response and every existing field
+      // keeps its place.
+      ...(wantsJobs ? { jobs: await jobQueueHealth() } : {}),
       uptimeMs: Math.round(process.uptime() * 1000),
       responseMs: Date.now() - started,
       timestamp: new Date().toISOString(),

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -13,7 +13,9 @@ import { verifySmtpConnection } from '@/services/emailService';
 // verify database connectivity, ?smtp=1 to verify SMTP connectivity (no
 // message sent — see #483, where SMTP silently failing had no visibility
 // outside of a user reporting a missing email), or ?jobs=1 for the job-queue
-// depth and dead-letter size (#1674). Never touches or mutates domain data.
+// depth and dead-letter size (#1674 — those need a real HEALTH_TOKEN or an
+// ADMIN session, never the fail-open branch). Never touches or mutates domain
+// data.
 //
 // Liveness stays public — a monitor cannot log in. The *detail* (version, git
 // sha, subsystem status, uptime) is a different matter: to an attacker it is a
@@ -21,32 +23,60 @@ import { verifySmtpConnection } from '@/services/emailService';
 // released only to an admin session or a caller holding HEALTH_TOKEN.
 export const dynamic = 'force-dynamic';
 
-/**
- * Whether this caller may see the detailed fields.
- *
- * When `HEALTH_TOKEN` is unset the endpoint keeps its old, fully public shape.
- * That is deliberate rather than lazy: the production deploy gate reads `sha`
- * from this endpoint to decide whether the live container has drifted
- * (`deploy-prod.yml`, `infra/deploy-prod.sh`), and the same is true of the
- * preview gate. Defaulting to closed would blind all of them the moment this
- * merges, before anyone had a chance to configure the token. Set `HEALTH_TOKEN`
- * in the server env and on the probes, and the endpoint closes.
- */
-async function maySeeDetail(request: Request): Promise<boolean> {
-  const expected = process.env.HEALTH_TOKEN;
-  if (!expected) return true;
+interface HealthAccess {
+  /** May see the legacy detail block: version, sha, subsystem status, uptime. */
+  detail: boolean;
+  /**
+   * Proved who they are — a matching `HEALTH_TOKEN` or an ADMIN session. This
+   * is strictly stronger than `detail`, which is fail-open (see below).
+   */
+  verified: boolean;
+}
 
-  const got = request.headers.get('x-health-token') || '';
-  try {
-    if (got.length === expected.length && timingSafeEqual(Buffer.from(got), Buffer.from(expected))) {
-      return true;
+/**
+ * What this caller may see.
+ *
+ * `detail` is FAIL-OPEN: when `HEALTH_TOKEN` is unset the endpoint keeps its
+ * old, fully public shape. That is deliberate rather than lazy — the production
+ * deploy gate reads `sha` from this endpoint to decide whether the live
+ * container has drifted (`deploy-prod.yml`, `infra/deploy-prod.sh`), and the
+ * same is true of the preview gate. Defaulting to closed would blind all of
+ * them the moment this merges, before anyone had a chance to configure the
+ * token. Set `HEALTH_TOKEN` in the server env and on the probes, and the
+ * endpoint closes.
+ *
+ * `verified` is FAIL-CLOSED, and it is what the job-queue counters require
+ * (#1674). Nothing automated parses `jobs`, so those counters owe the deploy
+ * gate nothing and must not inherit its bargain: on a server with no
+ * `HEALTH_TOKEN` — which is every environment today — the fail-open branch
+ * would otherwise hand queue depth, dead-letter size and three extra DB
+ * queries to any anonymous caller who appended `?jobs=1`.
+ *
+ * Reading the session costs a JWT decode, so it is attempted only when it can
+ * change the answer: the token gate is closed, or the caller asked for
+ * something that needs proof. An anonymous liveness probe on an un-tokened
+ * server does exactly what it did before.
+ */
+async function resolveAccess(request: Request, needsProof: boolean): Promise<HealthAccess> {
+  const expected = process.env.HEALTH_TOKEN;
+
+  if (expected) {
+    const got = request.headers.get('x-health-token') || '';
+    try {
+      if (got.length === expected.length && timingSafeEqual(Buffer.from(got), Buffer.from(expected))) {
+        return { detail: true, verified: true };
+      }
+    } catch {
+      // fall through to the session check
     }
-  } catch {
-    // fall through to the session check
   }
 
-  const session = await getServerSession(authOptions);
-  return session?.user.role === 'ADMIN';
+  if (expected || needsProof) {
+    const session = await getServerSession(authOptions);
+    if (session?.user.role === 'ADMIN') return { detail: true, verified: true };
+  }
+
+  return { detail: !expected, verified: false };
 }
 
 export async function GET(request: Request) {
@@ -54,11 +84,13 @@ export async function GET(request: Request) {
   const params = new URL(request.url).searchParams;
   const wantsDb = params.get('db') === '1';
   const wantsSmtp = params.get('smtp') === '1';
-  // Queue counters are opt-in like the two probes above, and read only inside
-  // the gated branch below: an anonymous /api/health issues no query for them,
-  // which is what keeps the endpoint inside its k6 latency budget
-  // (docs/testing.md — it already pays four EmailLog queries in the detail view).
+  // Queue counters are opt-in like the two probes above, and read only for a
+  // caller who proved who they are (`access.verified`) — never on the fail-open
+  // detail path. An anonymous /api/health issues no query for them, which is
+  // what keeps the endpoint inside its k6 latency budget (docs/testing.md — it
+  // already pays four EmailLog queries in the detail view).
   const wantsJobs = params.get('jobs') === '1';
+  const access = await resolveAccess(request, wantsJobs);
 
   let db: 'ok' | 'error' | 'skipped' = 'skipped';
   if (wantsDb) {
@@ -84,7 +116,7 @@ export async function GET(request: Request) {
   // An anonymous caller learns whether the app is up, and nothing else. The
   // status code still distinguishes healthy from degraded, which is all an
   // uptime monitor acts on.
-  if (!(await maySeeDetail(request))) {
+  if (!access.detail) {
     return NextResponse.json(
       { status, timestamp: new Date().toISOString() },
       { status: healthy ? 200 : 503 }
@@ -103,10 +135,12 @@ export async function GET(request: Request) {
       // addresses are scrubbed in the lib, so nothing here carries PII.
       email: await getEmailHealth(),
       // Job-queue depth and dead-letter size (#1674) — counters only, no job
-      // payload, name of a user or org. Appended rather than inserted: the
+      // payload, name of a user or org. Requires `access.verified`, i.e. a real
+      // HEALTH_TOKEN or an ADMIN session, so an un-tokened server does not leak
+      // them on the fail-open detail path. Appended rather than inserted: the
       // deploy gate parses `sha` out of this response and every existing field
       // keeps its place.
-      ...(wantsJobs ? { jobs: await jobQueueHealth() } : {}),
+      ...(wantsJobs && access.verified ? { jobs: await jobQueueHealth() } : {}),
       uptimeMs: Math.round(process.uptime() * 1000),
       responseMs: Date.now() - started,
       timestamp: new Date().toISOString(),

--- a/src/lib/jobs/dlqAlert.ts
+++ b/src/lib/jobs/dlqAlert.ts
@@ -1,7 +1,8 @@
 import cron from 'node-cron';
 import { prisma } from '@/lib/prisma';
 import { logger } from '@/lib/logger';
-import { sendEmail } from '@/services/emailService';
+import { logActivity } from '@/lib/activity';
+import { sendEmail, type EmailDeliveryResult } from '@/services/emailService';
 import {
   buildDeadLetterAlert,
   normalizeReason,
@@ -87,14 +88,47 @@ export async function getDeadLetterSummary(): Promise<DeadLetterSummary> {
   };
 }
 
+export interface DeadLetterAlertRun {
+  /**
+   * True only when the transport actually accepted the message. A SKIPPED
+   * delivery (no SMTP configured, demo mode, preference gate) is NOT sent —
+   * see the note on the send below.
+   */
+  sent: boolean;
+  total: number;
+  /** What `sendEmail` reported. Absent when no send was attempted at all. */
+  delivery?: EmailDeliveryResult;
+  /** Why nothing was delivered, when `sent` is false and the queue is not empty. */
+  reason?: 'no_alert_address' | 'not_delivered' | 'send_failed';
+}
+
 /**
  * The daily run. Sends at most one e-mail, and none at all when the queue is
  * empty or ALERT_EMAIL_TO is unset.
+ *
+ * Two things make the *result* worth more than a boolean. First, the alert
+ * travels by the very channel it may have to report on, so — exactly as
+ * `alertEmailHealth` does (#1190) — the durable record is written FIRST, to
+ * ActivityLog, and is there even when the mail cannot leave the box. Second,
+ * "did not throw" is not "was delivered": `sendEmail` answers 'SKIPPED' without
+ * throwing on three paths (unsubscribed group, demo mode, SMTP_USER unset), and
+ * #1431 exists because four routes read that silence as success. So the outcome
+ * is captured and reported, and `sent` means SENT.
  */
-export async function runDeadLetterAlert(): Promise<{ sent: boolean; total: number; reason?: string }> {
+export async function runDeadLetterAlert(): Promise<DeadLetterAlertRun> {
   const summary = await getDeadLetterSummary();
   const message = buildDeadLetterAlert(summary);
   if (!message) return { sent: false, total: 0 };
+
+  // The durable signal. ActivityLog.detail is VARCHAR(191) and an oversized
+  // value is silently dropped (P2000, the #1268 lesson), so this is one small
+  // capped object: how many, since when, and the worst offender by name.
+  const detail = JSON.stringify({
+    total: summary.total,
+    oldestAt: summary.oldestAt,
+    topName: summary.byName[0]?.name.slice(0, 64) ?? null,
+  }).slice(0, 191);
+  await logActivity({ level: 'error', action: 'jobs.dlq_alert', targetType: 'job', detail });
 
   const alertTo = process.env.ALERT_EMAIL_TO;
   if (!alertTo) {
@@ -104,8 +138,9 @@ export async function runDeadLetterAlert(): Promise<{ sent: boolean; total: numb
     return { sent: false, total: summary.total, reason: 'no_alert_address' };
   }
 
+  let delivery: EmailDeliveryResult;
   try {
-    await sendEmail({
+    delivery = await sendEmail({
       to: alertTo,
       subject: message.subject,
       html: message.html,
@@ -116,9 +151,17 @@ export async function runDeadLetterAlert(): Promise<{ sent: boolean; total: numb
     });
   } catch (e) {
     logger.error('Dead-letter alert could not be delivered', { error: String(e), total: summary.total });
-    return { sent: false, total: summary.total, reason: 'send_failed' };
+    return { sent: false, total: summary.total, delivery: 'FAILED', reason: 'send_failed' };
   }
-  return { sent: true, total: summary.total };
+
+  if (delivery !== 'SENT') {
+    // The queue is unhealthy AND the alert about it never left. The EmailLog row
+    // records why; this line and the ActivityLog row above are what an operator
+    // can find without reading the ledger.
+    logger.warning('Dead-letter alert was not delivered', { delivery, total: summary.total });
+    return { sent: false, total: summary.total, delivery, reason: 'not_delivered' };
+  }
+  return { sent: true, total: summary.total, delivery };
 }
 
 const tasks = new Map<string, ReturnType<typeof cron.schedule>>();
@@ -147,7 +190,8 @@ export function initDeadLetterAlertCron() {
     try {
       const result = await runDeadLetterAlert();
       // Nothing to say when the queue is clean — the log stays as quiet as the
-      // mailbox does.
+      // mailbox does. When it is not clean, the line names what actually
+      // happened to the mail, not merely that the job ran.
       if (result.total > 0) logger.warning('Dead-letter alert ran', { ...result });
     } catch (e) {
       logger.error('Dead-letter alert cron failed', { error: String(e) });

--- a/src/lib/jobs/dlqAlert.ts
+++ b/src/lib/jobs/dlqAlert.ts
@@ -1,0 +1,157 @@
+import cron from 'node-cron';
+import { prisma } from '@/lib/prisma';
+import { logger } from '@/lib/logger';
+import { sendEmail } from '@/services/emailService';
+import {
+  buildDeadLetterAlert,
+  normalizeReason,
+  type DeadLetterGroup,
+  type DeadLetterReason,
+  type DeadLetterSummary,
+} from '@/lib/jobs/dlqAlertMessage';
+
+// Daily dead-letter alert (#1674).
+//
+// A dead-letter queue nobody looks at is a folder of lost work. Once a day this
+// module asks one question — is anything in it? — and mails the operator when
+// the answer is yes.
+//
+// GREEN IS SILENT. An empty queue sends nothing at all: no message, no EmailLog
+// row, no log line above debug. That is the discipline the e2e reporter
+// (scripts/e2e-report-email.mjs) and the k6 reporter (scripts/k6-report-email.mjs)
+// already follow, and for the same reason: a daily "all clear" trains the
+// reader to archive the alert unread, and then the one that matters is archived
+// too.
+//
+// WHAT THE MAIL SAYS is bounded on purpose — how many, since when, which job
+// types, and the distinct failure reasons with counts. Never a dump of every
+// row, and never a payload: the payload is the one part of a job that can carry
+// a user's data, and this mail goes to a configured address, not to a session.
+//
+// The alert address is ALERT_EMAIL_TO, the established operator address (also
+// used by the e-mail health alert and .github/workflows/backup-verify.yml).
+
+export type { DeadLetterGroup, DeadLetterReason, DeadLetterSummary };
+
+const ALERT_CATEGORY = 'ops-alert';
+
+// How many rows the failure-reason histogram is built from. The per-name counts
+// are exact (a grouped COUNT), but the reasons need the rows themselves, and a
+// dead-letter table with ten thousand rows in it is a problem this mail should
+// report rather than read end to end.
+const REASON_SAMPLE_LIMIT = 200;
+
+export async function getDeadLetterSummary(): Promise<DeadLetterSummary> {
+  const where = { status: 'DEAD_LETTER' as const };
+
+  const [total, grouped, oldest, sample] = await Promise.all([
+    prisma.job.count({ where }),
+    prisma.job.groupBy({
+      by: ['name'],
+      where,
+      _count: { _all: true },
+      _max: { updatedAt: true },
+    }),
+    prisma.job.findFirst({ where, orderBy: { createdAt: 'asc' }, select: { createdAt: true } }),
+    prisma.job.findMany({
+      where,
+      orderBy: { updatedAt: 'desc' },
+      take: REASON_SAMPLE_LIMIT,
+      select: { lastError: true },
+    }),
+  ]);
+
+  const byName: DeadLetterGroup[] = grouped
+    .map((row) => ({
+      name: row.name,
+      count: row._count._all,
+      lastFailedAt: row._max.updatedAt?.toISOString() ?? null,
+    }))
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+
+  const histogram = new Map<string, number>();
+  for (const row of sample) {
+    const reason = normalizeReason(row.lastError);
+    histogram.set(reason, (histogram.get(reason) ?? 0) + 1);
+  }
+  const reasons: DeadLetterReason[] = [...histogram.entries()]
+    .map(([reason, count]) => ({ reason, count }))
+    .sort((a, b) => b.count - a.count || a.reason.localeCompare(b.reason));
+
+  return {
+    total,
+    oldestAt: oldest?.createdAt.toISOString() ?? null,
+    byName,
+    reasons,
+    reasonsSampledFrom: sample.length,
+  };
+}
+
+/**
+ * The daily run. Sends at most one e-mail, and none at all when the queue is
+ * empty or ALERT_EMAIL_TO is unset.
+ */
+export async function runDeadLetterAlert(): Promise<{ sent: boolean; total: number; reason?: string }> {
+  const summary = await getDeadLetterSummary();
+  const message = buildDeadLetterAlert(summary);
+  if (!message) return { sent: false, total: 0 };
+
+  const alertTo = process.env.ALERT_EMAIL_TO;
+  if (!alertTo) {
+    // Loud in the log rather than silent: the queue IS unhealthy, and the only
+    // reason nobody is being told is a missing setting.
+    logger.warning('Dead-letter jobs are waiting but ALERT_EMAIL_TO is unset', { total: summary.total });
+    return { sent: false, total: summary.total, reason: 'no_alert_address' };
+  }
+
+  try {
+    await sendEmail({
+      to: alertTo,
+      subject: message.subject,
+      html: message.html,
+      category: ALERT_CATEGORY,
+      // no-user-row: ALERT_EMAIL_TO is an operator alert address configured in
+      // the server env, not a User row — there is no preference to read and no
+      // unsubscribe token to mint for it.
+    });
+  } catch (e) {
+    logger.error('Dead-letter alert could not be delivered', { error: String(e), total: summary.total });
+    return { sent: false, total: summary.total, reason: 'send_failed' };
+  }
+  return { sent: true, total: summary.total };
+}
+
+const tasks = new Map<string, ReturnType<typeof cron.schedule>>();
+
+/**
+ * Registers the daily dead-letter check in this server process. Idempotent — a
+ * retried call from `/api/cron/start` is harmless.
+ *
+ * Registered from `/api/cron/start` rather than from `initCronJobs()`, for the
+ * same reason the newsletter cron is (#1469): this module imports
+ * `emailService`, so registering it there would make emailService import it
+ * back and turn a one-way dependency into a cycle.
+ *
+ * node-cron is the carrier only until the queue can schedule itself: #1673's
+ * worker and the scheduler story turn this into a `jobs.dlq-alert` handler
+ * registered on the queue, and this timer goes away with the other twelve.
+ * `runDeadLetterAlert()` is the handler either way.
+ */
+export function initDeadLetterAlertCron() {
+  if (tasks.has('jobs-dlq-alert')) return;
+
+  // 06:45 UTC — offset from every other daily slot (07:30 activity digests,
+  // 08:15/08:30 the Monday weeklies, 09:00 the reminder batch) so it never sits
+  // behind the mail-heavy ones.
+  const task = cron.schedule('45 6 * * *', async () => {
+    try {
+      const result = await runDeadLetterAlert();
+      // Nothing to say when the queue is clean — the log stays as quiet as the
+      // mailbox does.
+      if (result.total > 0) logger.warning('Dead-letter alert ran', { ...result });
+    } catch (e) {
+      logger.error('Dead-letter alert cron failed', { error: String(e) });
+    }
+  });
+  tasks.set('jobs-dlq-alert', task);
+}

--- a/src/lib/jobs/dlqAlertMessage.ts
+++ b/src/lib/jobs/dlqAlertMessage.ts
@@ -1,0 +1,113 @@
+import { sanitizeError } from '@/lib/sanitizeError';
+
+// The dead-letter alert's *message* (#1674) — pure string building, no Prisma,
+// no nodemailer, no node-cron.
+//
+// Split out of dlqAlert.ts on purpose, the same way lib/newsletter.ts is kept
+// free of the send path: the interesting behaviour here is "what does the
+// operator read, and when do we say nothing at all", and that is worth testing
+// without standing up a database or a mail transport
+// (e2e/job-queue-dlq-alert.unit.spec.ts imports this file and only this file).
+
+// How many lines of each list the mail actually prints. The rest is summarised
+// as a "+N more" tail — the point of the mail is "go look", not "read this".
+export const MAX_ROWS_SHOWN = 10;
+
+export interface DeadLetterGroup {
+  name: string;
+  count: number;
+  /** When this job type last landed in the dead-letter queue. */
+  lastFailedAt: string | null;
+}
+
+export interface DeadLetterReason {
+  /** Sanitised, first line only, truncated — never a raw handler dump. */
+  reason: string;
+  count: number;
+}
+
+export interface DeadLetterSummary {
+  total: number;
+  /** When the oldest dead-lettered job was first enqueued. */
+  oldestAt: string | null;
+  byName: DeadLetterGroup[];
+  reasons: DeadLetterReason[];
+  /** How many rows the reason histogram was built from. */
+  reasonsSampledFrom: number;
+}
+
+/**
+ * One failure reason, reduced to something countable.
+ *
+ * `Job.lastError` is whatever the handler threw, so it may echo an address, a
+ * token or a certificate — it goes through the shared sanitiser first, exactly
+ * like every other error surface in this repo. Only the first line survives: a
+ * stack trace differs on every row and would defeat the grouping this mail
+ * exists to do.
+ */
+export function normalizeReason(raw: string | null | undefined): string {
+  const clean = sanitizeError(raw)?.split('\n')[0]?.trim();
+  return clean && clean.length > 0 ? clean.slice(0, 120) : 'bilinmeyen hata';
+}
+
+function esc(value: string): string {
+  return value.replace(
+    /[<>&"]/g,
+    (c) => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;', '"': '&quot;' }[c] as string)
+  );
+}
+
+export function trDate(iso: string | null): string {
+  if (!iso) return 'bilinmiyor';
+  // Fixed locale and zone: this mail has exactly one reader profile (the
+  // operator) and a timestamp that shifts with the server's TZ setting is a
+  // timestamp nobody can correlate with a log line.
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return 'bilinmiyor';
+  return (
+    d.toLocaleString('tr-TR', { timeZone: 'UTC', dateStyle: 'medium', timeStyle: 'short' }) + ' UTC'
+  );
+}
+
+function listWithTail(rows: string[], total: number, unit: string): string {
+  const shown = rows.slice(0, MAX_ROWS_SHOWN);
+  const rest = total - shown.length;
+  if (rest > 0) shown.push(`<li>… ve ${rest} ${unit} daha</li>`);
+  return shown.join('');
+}
+
+/**
+ * The message for a summary, or `null` when there is nothing to report.
+ *
+ * Returning null rather than sending an "all clear" is the whole convention: a
+ * daily green mail trains the reader to archive the alert unread, and then the
+ * one that matters is archived too. Same discipline as the e2e and k6 reports.
+ */
+export function buildDeadLetterAlert(
+  summary: DeadLetterSummary
+): { subject: string; html: string } | null {
+  if (summary.total <= 0) return null;
+
+  const nameRows = summary.byName.map(
+    (g) => `<li><code>${esc(g.name)}</code> — <b>${g.count}</b> iş, son düşen: ${esc(trDate(g.lastFailedAt))}</li>`
+  );
+  const reasonRows = summary.reasons.map((r) => `<li><b>${r.count}×</b> ${esc(r.reason)}</li>`);
+  const sampleNote =
+    summary.total > summary.reasonsSampledFrom
+      ? ` (en son ${summary.reasonsSampledFrom} kayıt üzerinden)`
+      : '';
+
+  return {
+    subject: `[CRM] Ölü mektup kuyruğunda ${summary.total} iş bekliyor`,
+    html: `<div style="font-family: Arial, sans-serif; max-width: 680px; margin: 0 auto;">
+      <h2 style="color:#b91c1c;">Ölü mektup kuyruğu boş değil</h2>
+      <p>Tüm denemeleri tükenmiş <b>${summary.total}</b> iş var; en eskisi <b>${esc(trDate(summary.oldestAt))}</b> tarihinden beri bekliyor. Bu işler kendiliğinden tekrar çalışmaz — elle incelenmesi gerekir.</p>
+      <h3 style="font-size:15px;">İş türüne göre</h3>
+      <ul style="padding-left:18px;">${listWithTail(nameRows, summary.byName.length, 'tür')}</ul>
+      <h3 style="font-size:15px;">Hata nedenleri${esc(sampleNote)}</h3>
+      <ul style="padding-left:18px;">${listWithTail(reasonRows, summary.reasons.length, 'neden')}</ul>
+      <p style="font-size:13px;color:#6b7280;">Canlı sayaçlar: <code>/api/health?jobs=1</code> (HEALTH_TOKEN başlığı veya ADMIN oturumu ile).</p>
+      <p style="font-size:12px;color:#9ca3af;">Kuyruk boşaldığında bu e-posta gönderilmez; yani bir sonraki sessizlik "sorun çözüldü" demektir.</p>
+    </div>`,
+  };
+}

--- a/src/lib/jobs/health.ts
+++ b/src/lib/jobs/health.ts
@@ -17,9 +17,10 @@ import { prisma } from '@/lib/prisma';
 // Cost rule: this is THREE queries and it must stay that way. /api/health is in
 // the nightly k6 anonymous-GET mix with a latency budget, and
 // docs/testing.md warns that the endpoint already pays four EmailLog queries.
-// So the caller only reaches this module behind BOTH the detail gate and an
-// explicit `?jobs=1` — an anonymous probe issues exactly the queries it issued
-// before this landed, which is none.
+// So the caller only reaches this module behind BOTH proof of identity (a
+// matching HEALTH_TOKEN or an ADMIN session — never the route's fail-open
+// detail branch) and an explicit `?jobs=1`: an anonymous probe issues exactly
+// the queries it issued before this landed, which is none.
 
 export interface JobQueueHealth {
   // Work waiting to be claimed, whether or not it is due yet.

--- a/src/lib/jobs/health.ts
+++ b/src/lib/jobs/health.ts
@@ -1,0 +1,76 @@
+import { prisma } from '@/lib/prisma';
+
+// Job-queue health (#1674), DERIVED from the `Job` table the same way
+// `emailHealth.ts` is derived from the EmailLog ledger — there is no separate
+// counter to drift out of sync with the rows it claims to describe.
+//
+// Why this exists: a queue with a growing backlog, or a dead-letter table that
+// is quietly filling up, fails *silently*. Nothing reports either number today,
+// so the first symptom is a user noticing that an e-mail never arrived. These
+// two counters are the cheapest possible eyes on both.
+//
+// PII rule: operational metadata only. No job name is a person, no payload is
+// read, no orgId leaves this module — counters and one age in seconds. That is
+// deliberate, because /api/health is reachable by callers this app does not
+// otherwise trust (see the gating note in the route).
+//
+// Cost rule: this is THREE queries and it must stay that way. /api/health is in
+// the nightly k6 anonymous-GET mix with a latency budget, and
+// docs/testing.md warns that the endpoint already pays four EmailLog queries.
+// So the caller only reaches this module behind BOTH the detail gate and an
+// explicit `?jobs=1` — an anonymous probe issues exactly the queries it issued
+// before this landed, which is none.
+
+export interface JobQueueHealth {
+  // Work waiting to be claimed, whether or not it is due yet.
+  pending: number;
+  // Claimed by a worker and still running (or holding a stale lease).
+  running: number;
+  // Retries exhausted — nothing will pick these up again without a human.
+  deadLetter: number;
+  // How long the oldest *due* pending job has been waiting, in seconds; null
+  // when nothing is due. Depth alone cannot distinguish a healthy burst from a
+  // stalled worker — age can, which is what an uptime monitor should alert on.
+  oldestPendingAgeSec: number | null;
+  // Jobs whose last state change in the past 24h left them FAILED or
+  // DEAD_LETTER. A transient failure that later succeeded is not counted: the
+  // row has moved on to SUCCEEDED.
+  failedLast24h: number;
+}
+
+const COUNTED_STATUSES = ['PENDING', 'RUNNING', 'DEAD_LETTER'] as const;
+
+export async function jobQueueHealth(): Promise<JobQueueHealth> {
+  const now = Date.now();
+  const dayAgo = new Date(now - 24 * 60 * 60 * 1000);
+
+  const [byStatus, oldestDue, failedLast24h] = await Promise.all([
+    // One grouped count for the three depths, served by @@index([status, …]).
+    prisma.job.groupBy({
+      by: ['status'],
+      where: { status: { in: [...COUNTED_STATUSES] } },
+      _count: { _all: true },
+    }),
+    prisma.job.findFirst({
+      where: { status: 'PENDING', runAt: { lte: new Date(now) } },
+      orderBy: { runAt: 'asc' },
+      select: { runAt: true },
+    }),
+    prisma.job.count({
+      where: { status: { in: ['FAILED', 'DEAD_LETTER'] }, updatedAt: { gt: dayAgo } },
+    }),
+  ]);
+
+  const depth = (status: (typeof COUNTED_STATUSES)[number]) =>
+    byStatus.find((row) => row.status === status)?._count._all ?? 0;
+
+  return {
+    pending: depth('PENDING'),
+    running: depth('RUNNING'),
+    deadLetter: depth('DEAD_LETTER'),
+    oldestPendingAgeSec: oldestDue
+      ? Math.max(0, Math.round((now - oldestDue.runAt.getTime()) / 1000))
+      : null,
+    failedLast24h,
+  };
+}

--- a/src/lib/orgContext.ts
+++ b/src/lib/orgContext.ts
@@ -62,6 +62,12 @@ const TENANT_MODELS: ReadonlySet<Prisma.ModelName> = new Set([
   // one org must never be listed by — or authenticate into — another.
   'ApiKey',
   'MatchFeedback',
+  // Queued background work (#1674). A job's payload belongs to whichever tenant
+  // enqueued it, so the row carries orgId and is listed here. The operational
+  // readers — /api/health's counters and the daily dead-letter alert — run
+  // outside any request scope, where the middleware does not engage, so they
+  // still see the whole queue.
+  'Job',
 ]);
 
 // Actions whose `where` selects rows to read or mutate — inject orgId there.


### PR DESCRIPTION
## Summary

A job queue with a growing backlog, or a dead-letter table that is quietly filling up, fails **silently** — nothing reports either number, so the first symptom is a user noticing that an e-mail never arrived. This adds the two cheapest possible eyes on both: queue counters on the existing health endpoint, and one daily e-mail when the dead-letter queue is not empty.

`/api/health` gains a `jobs` block — `pending`, `running`, `deadLetter`, `oldestPendingAgeSec`, `failedLast24h` — read **only** for a caller who opts in with `?jobs=1` **and** has proved who they are: a matching `HEALTH_TOKEN` or an ADMIN session. That is deliberately a *stricter* gate than the detail block the counters sit in. The detail block is fail-open when `HEALTH_TOKEN` is unset (the deploy drift gate parses `sha` out of it, and closing it by default would blind every gate), but nothing automated parses `jobs` — so on the un-tokened servers we actually run today, an anonymous `?jobs=1` gets no counters and pays no query. That keeps the endpoint inside its nightly k6 `ep:health` budget (`docs/testing.md` warns it already pays four `EmailLog` queries) and makes the issue's "token or ADMIN" acceptance criterion true in the deployed configuration, not only in a configured one. No existing field moved or changed, so the deploy gate's `sha` parse is untouched.

The daily alert runs at **06:45 UTC** and mails `ALERT_EMAIL_TO` in Turkish when the dead-letter queue is not empty: how many, since when, the job types with counts, and the **distinct failure reasons with counts** — each reason sanitised through the shared `sanitizeError()` scrubber, first line only, truncated, lists capped at 10 with a "+N more" tail. Never a payload, never a row-by-row dump: the payload is the one part of a job that can carry a user's data and this mail goes to a configured address, not to a session. **An empty queue sends nothing at all** — no message, no `EmailLog` row, no activity row — the same "green is silent" discipline `scripts/e2e-report-email.mjs` and `scripts/k6-report-email.mjs` follow, because a daily "all clear" trains the reader to archive the alert unread.

### The alert reports what actually happened to the mail

The alert travels by the very channel it may have to report on, so it borrows both halves of `alertEmailHealth`'s (#1190) discipline:

- a **durable record first** — one `jobs.dlq_alert` `ActivityLog` row (total, oldest, worst job type; capped for the VARCHAR(191) column, the #1268 lesson) written *before* the send, so a dead-letter queue filling up while SMTP is broken is visible somewhere that does not depend on SMTP;
- and **`sent` means SENT**. `sendEmail()` answers `'SKIPPED'` without throwing on three paths (unsubscribed group, demo mode, `SMTP_USER` unset), and #1431 exists because four routes read that silence as success. `runDeadLetterAlert()` returns `{ sent, total, delivery, reason }`: `delivery` is the `EmailDeliveryResult` verbatim, `reason` is `no_alert_address` / `not_delivered` / `send_failed`. The e2e asserts the SKIPPED shape, because that is what the blanked-SMTP test config really produces.

### Which cron convention, and why

Registered from **`/api/cron/start`**, not from `initCronJobs()` — the same call the newsletter cron makes, for the same reason (#1469): `src/lib/jobs/dlqAlert.ts` imports `emailService` to send its mail, so registering it inside `emailService` would close a one-way import into a cycle. It is also exposed as `GET /api/cron?job=dlq-alert` for an ADMIN, deliberately *outside* the "run everything now" batch: the batch gets clicked repeatedly while somebody is fixing something, and this job's contract is one mail a day.

node-cron is only the carrier. When #1673's worker and the scheduler story land, `runDeadLetterAlert()` becomes the `jobs.dlq-alert` handler registered on the queue and this timer goes away with the other twelve — the function is already the handler either way.

### What this PR carries from a sibling task

#1671 (the `Job`/`JobRun` schema and `enqueue()`/`claim()`) **has not landed and has no PR in flight** — there is no queue table in `main` to count. Rather than ship nothing, this PR carries the `JobStatus` enum and the `Job` model, with field names and types **copied verbatim from #1671's specification**, so the two land as one table rather than as two competing ones. **Whoever merges second deletes their copy of that schema block rather than resolving a conflict by hand** — cross-linked on #1671 so it is not a surprise. `Job` is registered in `TENANT_MODELS` (`src/lib/orgContext.ts`) exactly as #1671 asks; `JobRun` is **not** here, and neither are `enqueue()`, the `SKIP LOCKED` `claim()`, `reapExpiredLeases()`, `recordRun()`, `pruneJobRuns()` or the worker loop.

One deliberate departure from #1671's index list: `@@index([orgId, status, runAt])` is added. `Job` would otherwise be the only `TENANT_MODELS` entry with no `orgId`-leading index, and under `MT_ENFORCE_ISOLATION` every auto-scoped query — including the future hot claim query — would filter `orgId` row-by-row on top of the status index. `idempotencyKey` stays a *global* `@unique` rather than `@@unique([orgId, idempotencyKey])`, and the schema now says why: `orgId` is nullable, MySQL treats NULLs in a unique index as distinct, so a composite key would silently stop de-duplicating anything while every row still has a null org (i.e. today).

## Changes

- `prisma/schema.prisma` — `enum JobStatus` + `model Job` (additive; `db push`, no migration authored).
- `src/lib/jobs/health.ts` — `jobQueueHealth()`: three queries, one grouped count plus an oldest-due lookup and a 24h failure count. Shaped after `src/lib/emailHealth.ts` (derived from the rows, never a separate counter that can drift).
- `src/lib/jobs/dlqAlertMessage.ts` — the pure message builder and reason normaliser: no Prisma, no nodemailer, no node-cron, so the "silent when green" property is unit-testable. Split out for the same reason `lib/newsletter.ts` is kept client-safe.
- `src/lib/jobs/dlqAlert.ts` — `getDeadLetterSummary()`, `runDeadLetterAlert()` (the `jobs.dlq_alert` activity row, then `sendEmail({ category: 'ops-alert' })` with the required `// no-user-row:` marker — `ALERT_EMAIL_TO` is an operator address, not a `User`), and `initDeadLetterAlertCron()`.
- `src/app/api/health/route.ts` — `?jobs=1`; the gate now answers with both `detail` (fail-open, what the deploy gate needs) and `verified` (fail-closed, what the counters need). The session is only read when it can change the answer, so an anonymous liveness probe on an un-tokened server behaves exactly as before.
- `src/app/api/cron/start/route.ts`, `src/app/api/cron/route.ts` — registration and the named manual run.
- `src/lib/orgContext.ts` — `Job` added to `TENANT_MODELS`. The operational readers run outside any request scope, where the isolation middleware does not engage, so they still see the whole queue — which is what an operator alert has to do.
- `e2e/job-queue-health.spec.ts` — seeds `Job` rows and asserts: anonymous `?jobs=1` gets nothing, the gated response without `?jobs=1` still gets nothing, both proof paths (token header, ADMIN session) get the counters (and no name, payload or tenant), an empty DLQ produces `{ sent: false, total: 0 }` and **no** `EmailLog` row, and three dead-lettered jobs produce exactly one `ops-alert` row plus the activity row — reported as `sent: false, delivery: 'SKIPPED'`, since e2e blanks SMTP. Cleanup removes only the ledger row this run created, not every dead-letter alert a long-lived dev database ever recorded.
- `e2e/job-queue-dlq-alert.unit.spec.ts` — pure: silence on empty, the message contents, HTML escaping, the truncation tail, reason sanitising, plus a source-shape assertion that `jobQueueHealth()` is called exactly once, past the gate, and behind `access.verified` rather than the fail-open branch.
- `playwright.config.ts` — pins `ALERT_EMAIL_TO` to a synthetic `ops-alert@e2e.local` so the alert's contract is testable and a real address can never be picked up by a test run (`SMTP_USER` is already blanked, so the send stops at a `SKIPPED` `EmailLog` row).
- `docs/testing.md`, `.env.example` — the `ep:health` cost note now records why the counters are opt-in *and* fail-closed; the env docs stop claiming `ALERT_EMAIL_TO` is read only by CI workflows (the app's e-mail-health alert already read it).
- `releases/unreleased/queue-depth-and-dlq-alert.json` — `minor` (a new API capability, a new scheduled mail, a new table), no `notes`: nothing here is user-visible — it is an operator endpoint and an operator mailbox.

## Verification

- [x] `npm run lint` + `npx tsc --noEmit` clean (only the two pre-existing `react-hooks/exhaustive-deps` warnings)
- [x] `npm run build` passes; `npx prisma validate` / `format` / `generate` clean
- [x] `npm run check:i18n`, `check:release-fragments`, `check:openapi`, `check:query-scalars`, `check:auth-reads`, `check:locale-dates`, `check:stage-keys` all green
- [ ] `npm run test:e2e` — **not run here**: this environment has no database and no browser, so the two new specs were written but not executed. CI is the first run.
- [x] No new user-facing strings, so no i18n keys (the operator mail is Turkish by convention, like the other alert mails)

Preview: https://pr2239.interncrm.com

Closes #1674

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.
