### PR TITLE
test: two-tenant fixture and an `isolation` Playwright project with the flag on (#1566)

### DIFF
--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -2,7 +2,9 @@ name: E2E Full Suite (scheduled)
 
 # The PR gate (e2e.yml) runs only the @smoke subset; this workflow is the safety
 # net behind it (#621/#624): the FULL Playwright suite, 4× a day, 4-way sharded,
-# with a Turkish summary email when a run goes red — the failing tests with
+# plus the `isolation` project in a job of its own (#1566 — it needs a second
+# Next server with MT_ENFORCE_ISOLATION=true and cannot share a run with the
+# default project), with a Turkish summary email when a run goes red — the failing tests with
 # error snippets (scripts/e2e-report-email.mjs). Red-only is the default since
 # 2026-08-23 (maintainer request: green heartbeats were noise); set the repo
 # variable E2E_REPORT_MODE=always to bring the "✅ N/N test geçti" heartbeat
@@ -155,6 +157,102 @@ jobs:
           # detects the gap via E2E_EXPECTED_REPORTS instead.
           if-no-files-found: warn
 
+  # The `isolation` Playwright project (#1566), which no other gate runs.
+  #
+  # It cannot join the sharded job above: it needs its own Next server, booted
+  # with MT_ENFORCE_ISOLATION=true, and playwright.config.ts deliberately
+  # refuses to assemble both projects in one run (two servers compiling into the
+  # same .next/). The PR gate can't run it either — that gate is the @smoke
+  # subset and these specs are excluded from the default project. So it rides
+  # along here: same 4×/day cadence, same drift gate, and its JSON report is
+  # named `e2e-json-shard-isolation` so the summary email below picks it up like
+  # any other shard (a red isolation run therefore mails, and a crash that
+  # writes no report is caught by E2E_EXPECTED_REPORTS).
+  isolation:
+    name: Playwright tenant isolation
+    runs-on: ubuntu-latest
+    needs: [gate]
+    if: needs.gate.outputs.run == 'true'
+
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: internship_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -proot"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=15
+
+    env:
+      DATABASE_URL: "mysql://root:root@127.0.0.1:3306/internship_test"
+      NEXTAUTH_SECRET: "ci-test-secret-not-for-production"
+      # The isolation webServer overrides this to its own origin (port 3010);
+      # left at the default, NextAuth's post-sign-in redirect walks off it.
+      NEXTAUTH_URL: "http://localhost:3010"
+      SEED_ADMIN_EMAIL: "admin@example.com"
+      SEED_ADMIN_PASSWORD: "ChangeMe123!"
+      ADMIN_EMAIL: "admin@example.com"
+      ADMIN_PASSWORD: "ChangeMe123!"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Apply DB schema
+        run: npx prisma db push
+
+      - name: Seed admin user
+        run: npx prisma db seed
+
+      - name: Build app
+        run: npm run build
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: playwright-${{ runner.os }}-
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run the isolation project
+        env:
+          PLAYWRIGHT_JSON_OUTPUT_NAME: e2e-results-shard-isolation.json
+        run: npx playwright test --project=isolation --reporter=list,html,json
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report-isolation
+          path: playwright-report/
+          retention-days: 7
+
+      - name: Upload JSON result (for the summary email)
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-json-shard-isolation
+          path: e2e-results-shard-isolation.json
+          retention-days: 7
+          if-no-files-found: warn
+
   # Single Turkish summary email for the whole run — red-only by default since
   # 2026-08-23 (maintainer request: the earlier every-run heartbeat became
   # noise). Aggregates the per-shard JSON reports; a shard that crashed before
@@ -164,7 +262,7 @@ jobs:
   report:
     name: Summary email (red runs)
     runs-on: ubuntu-latest
-    needs: [gate, e2e-full]
+    needs: [gate, e2e-full, isolation]
     if: always() && needs.gate.outputs.run == 'true'
     steps:
       - uses: actions/checkout@v7
@@ -189,7 +287,8 @@ jobs:
           SMTP_FROM: ${{ secrets.SMTP_FROM }}
           ALERT_EMAIL_TO: ${{ secrets.ALERT_EMAIL_TO || 'mehmetersahin@gmail.com' }}
           PLAYWRIGHT_JSON_REPORT: e2e-json-reports
-          E2E_EXPECTED_REPORTS: '4'
+          # 4 shards + the isolation job, each writing one JSON report.
+          E2E_EXPECTED_REPORTS: '5'
           E2E_REPORT_MODE: ${{ vars.E2E_REPORT_MODE || 'failures' }}
           E2E_RUN_CONTEXT: 'e2e-full · ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
         run: |

--- a/docs/tenant-isolation.md
+++ b/docs/tenant-isolation.md
@@ -62,6 +62,14 @@ All of this is exercised against a real DB by `e2e/org-isolation.spec.ts` and
 never called `orgScoped()`** is still isolated purely because it ran inside
 `runWithOrg()` with the flag on, and is a no-op with the flag off.
 
+Both of those run **in the Playwright process**, though: they flip
+`MT_ENFORCE_ISOLATION` in their own env and call the helpers directly, so they
+say nothing about the deployed server. The `isolation` Playwright project
+(#1566) covers that half — `npm run test:e2e:isolation` boots a second app
+server on port 3010 with the flag genuinely on and runs `e2e/isolation/**`
+against it, using the two-tenant fixture in `e2e/helpers/tenants.ts`. See
+[`docs/testing.md`](testing.md#tenant-isolation-the-isolation-playwright-project-1566).
+
 ### Keeping the registry honest (`npm run check:tenant-models`)
 
 The middleware only scopes models that are named in `TENANT_MODELS`. An

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -18,7 +18,7 @@ the newer non-functional tests (stress + nightly automation) are wired.
 | **Responsive / mobile** | Layout at small viewports | `e2e/mobile.spec.ts`, `e2e/users-responsive.spec.ts` | with E2E |
 | **PWA / offline** | Manifest, service worker, offline page | `e2e/pwa.spec.ts`, `e2e/offline-page.spec.ts` | with E2E |
 | **Health probe** | `/api/health` liveness + optional DB readiness | `e2e/health.spec.ts` | with E2E |
-| **Tenant isolation** | One tenant cannot read another's rows, against a server that really has `MT_ENFORCE_ISOLATION=true` | `e2e/isolation/*.spec.ts` (the `isolation` Playwright project) | `npm run test:e2e:isolation`, on demand |
+| **Tenant isolation** | One tenant cannot read another's rows, against a server that really has `MT_ENFORCE_ISOLATION=true` | `e2e/isolation/*.spec.ts` (the `isolation` Playwright project) | its own job in `e2e-full.yml` (**4× a day**) + `npm run test:e2e:isolation` locally |
 | **Stress / load** | Latency percentiles, throughput, error rate under sustained concurrency | `scripts/stress-test.mjs` | **weekly cron**, Mon 02:30 UTC (`stress.yml`) + on demand |
 | **Load / performance (k6)** | Staged VU ramp: per-endpoint latency budgets, error rate, "was this endpoint even reached" | `k6/nightly-load.js` | **nightly cron**, 23:40 UTC (`k6-load.yml`) + on demand |
 | **Demo-seed fidelity** | Every differentiating screen has demo rows behind it | `scripts/check-demo-fidelity.mjs` + `scripts/demo-fidelity.json` | CI (`ci.yml`, `demo-fidelity` job) on every PR |
@@ -61,22 +61,52 @@ behaviour the flag switches off, and the flag is still un-flipped in production
 (`docs/tenant-isolation.md`). So `e2e/isolation/**` is `testIgnore`d by the default
 `chromium` project, and the isolation server is only started when the run asks for that
 project — an ordinary `npm run test:e2e` and the CI smoke gate never pay for a second
-`next start`. Two consequences worth knowing:
+`next start`. Three consequences worth knowing:
 
 - `playwright test` with **no** `--project` runs the default suite only; the isolation
   project is not in the config unless it was selected (or `E2E_ISOLATION=1` is set).
+- The two projects are **mutually exclusive in one run**, and asking for both
+  (`--project=isolation --project=chromium`, or `E2E_ISOLATION=1 --project=chromium`)
+  throws with an explanation. Each needs its own Next server started from this working
+  directory, and Next has no per-port `distDir`: two of them compile into the same
+  `.next/` and overwrite each other's build manifests and webpack cache, which surfaces
+  as intermittent `/_next/static/chunks/*` 404s rather than as a config problem. Run them
+  as two commands. `E2E_ISOLATION=1` on its own therefore means *isolation only* — the
+  default project is dropped from the config, so an IDE runner or a `--grep` that selects
+  an isolation spec gets exactly one server.
 - `BASE_URL=… npm run test:e2e:isolation` **throws** rather than running. A deployed
   environment's flag is whatever it is (today: off), and testing enforcement against a
   server that does not enforce is worse than not testing it.
 
+**Where it runs.** `e2e-full.yml` has an `isolation` job beside the four shards: same
+4×/day cadence, same drift gate, and its JSON report is named
+`e2e-json-shard-isolation` so a red isolation run reaches the same Turkish summary email
+(`E2E_EXPECTED_REPORTS` counts it as the fifth report, so a job that crashes before
+writing one is caught too). It is deliberately **not** in the PR gate: that gate is the
+`@smoke` subset, and a second `next build` + `next start` per PR for a project that only
+guards a flag which is still off in production is not worth the wall clock.
+
 **The two-tenant fixture.** `e2e/helpers/tenants.ts` → `seedTwoTenants()` creates two
 organizations (`iso-a-<stamp>` / `iso-b-<stamp>`), each with an ADMIN, MENTOR, MENTEE and
-COMPANY actor and one row in every model the leak matrix probes — `Company`,
+COMPANY actor and a row in every model the leak matrix probes — `Company`,
 `MentorshipRelation`, `Tag`, `PipelineStage`, `InvitationToken`, `Offer`. It returns typed
 handles (`tenants.orgA.company.id`, `tenants.orgB.admin`, …), `signInAsTenantActor(page,
 actor)` for signing in as any of them, and a `cleanup()` that deletes everything in
 foreign-key order (child rows → users → companies → organizations). Always call it from
-`afterAll`.
+`afterAll`. Seeding is not transactional, so a failure partway through tears down
+whatever it had already created before rethrowing — a `beforeAll` that rejects never
+hands the spec a `cleanup()` to call.
+
+`PipelineStage` is the one model seeded as a **set** rather than a single row: each
+tenant gets the whole canonical catalogue (`defaultPipelineStages()`), relabelled with
+its own prefix. `resolvePipelineStages()` returns a tenant's rows *instead of* the
+built-in catalogue as soon as one exists, so a lone custom stage would make both tenants
+custom-pipeline orgs whose catalogue does not contain the stage their own relation sits
+on — every board, funnel and pipeline bar renders empty, and a leak assertion against two
+empty boards passes in both directions without reading a row. The keys stay canonical and
+therefore identical across the two tenants (which is the point — `@@unique([orgId, key])`
+allows it, and a lookup by key alone is exactly how a scoping bug shows up); only the
+labels differ, so B's wording on A's board is a visible leak.
 
 Only some of those models are enforced today: `TENANT_MODELS` in `src/lib/orgContext.ts`
 is the set the Prisma middleware auto-scopes, and `npm run check:tenant-models` (#1560)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -18,6 +18,7 @@ the newer non-functional tests (stress + nightly automation) are wired.
 | **Responsive / mobile** | Layout at small viewports | `e2e/mobile.spec.ts`, `e2e/users-responsive.spec.ts` | with E2E |
 | **PWA / offline** | Manifest, service worker, offline page | `e2e/pwa.spec.ts`, `e2e/offline-page.spec.ts` | with E2E |
 | **Health probe** | `/api/health` liveness + optional DB readiness | `e2e/health.spec.ts` | with E2E |
+| **Tenant isolation** | One tenant cannot read another's rows, against a server that really has `MT_ENFORCE_ISOLATION=true` | `e2e/isolation/*.spec.ts` (the `isolation` Playwright project) | `npm run test:e2e:isolation`, on demand |
 | **Stress / load** | Latency percentiles, throughput, error rate under sustained concurrency | `scripts/stress-test.mjs` | **weekly cron**, Mon 02:30 UTC (`stress.yml`) + on demand |
 | **Load / performance (k6)** | Staged VU ramp: per-endpoint latency budgets, error rate, "was this endpoint even reached" | `k6/nightly-load.js` | **nightly cron**, 23:40 UTC (`k6-load.yml`) + on demand |
 | **Demo-seed fidelity** | Every differentiating screen has demo rows behind it | `scripts/check-demo-fidelity.mjs` + `scripts/demo-fidelity.json` | CI (`ci.yml`, `demo-fidelity` job) on every PR |
@@ -38,6 +39,57 @@ Use `AsyncSection` for new asynchronous lists and panels: loading, error and emp
 Loading must never render the empty state, and errors should offer a retry when the caller can reload.
 The component owns presentation only; fetching, state and retry behavior stay in the caller.
 Choose the smallest matching `list`, `card` or `stats` skeleton variant.
+
+## Tenant isolation: the `isolation` Playwright project (#1566)
+
+```bash
+npm run test:e2e:isolation      # = playwright test --project=isolation
+```
+
+**What it proves.** Multi-tenancy has one criterion — a signed-in member of tenant A
+never sees a row belonging to tenant B — and it can only be proved against a server
+that is actually enforcing it. The isolation tests written before this project could
+not: `e2e/tenant-isolation.spec.ts` sets `process.env.MT_ENFORCE_ISOLATION` inside the
+*Playwright* process (the app never reads that), and `e2e/org-isolation.spec.ts` calls
+`orgScoped()` by hand and checks what Prisma returns. Both pass against a server that
+leaks everything. This project boots its own Next server on **port 3010** with
+`MT_ENFORCE_ISOLATION=true` in its env and points `baseURL` at it, so every assertion
+under `e2e/isolation/` is a statement about the running application's HTTP surface.
+
+**The default project keeps the flag off.** Around 150 specs assume the single-tenant
+behaviour the flag switches off, and the flag is still un-flipped in production
+(`docs/tenant-isolation.md`). So `e2e/isolation/**` is `testIgnore`d by the default
+`chromium` project, and the isolation server is only started when the run asks for that
+project — an ordinary `npm run test:e2e` and the CI smoke gate never pay for a second
+`next start`. Two consequences worth knowing:
+
+- `playwright test` with **no** `--project` runs the default suite only; the isolation
+  project is not in the config unless it was selected (or `E2E_ISOLATION=1` is set).
+- `BASE_URL=… npm run test:e2e:isolation` **throws** rather than running. A deployed
+  environment's flag is whatever it is (today: off), and testing enforcement against a
+  server that does not enforce is worse than not testing it.
+
+**The two-tenant fixture.** `e2e/helpers/tenants.ts` → `seedTwoTenants()` creates two
+organizations (`iso-a-<stamp>` / `iso-b-<stamp>`), each with an ADMIN, MENTOR, MENTEE and
+COMPANY actor and one row in every model the leak matrix probes — `Company`,
+`MentorshipRelation`, `Tag`, `PipelineStage`, `InvitationToken`, `Offer`. It returns typed
+handles (`tenants.orgA.company.id`, `tenants.orgB.admin`, …), `signInAsTenantActor(page,
+actor)` for signing in as any of them, and a `cleanup()` that deletes everything in
+foreign-key order (child rows → users → companies → organizations). Always call it from
+`afterAll`.
+
+Only some of those models are enforced today: `TENANT_MODELS` in `src/lib/orgContext.ts`
+is the set the Prisma middleware auto-scopes, and `npm run check:tenant-models` (#1560)
+pins the rest in its `PENDING_REGISTRATION` ratchet. Of what the fixture seeds, `User`,
+`Company` and `MentorshipRelation` are enforced; `Tag`, `PipelineStage`, `InvitationToken`
+and `Offer` are seeded but **not yet** — they are registered in #1559. A leak found on one
+of those four is a documented gap, not a fresh regression.
+
+**Writing a new isolation spec.** Put it in `e2e/isolation/`, seed with
+`seedTwoTenants()`, and assert in **both** directions (A must not see B *and* B must not
+see A) — a filter accidentally pinned to one tenant passes one direction. Do not add
+`@smoke` to anything there: the PR gate runs the default project, where these specs are
+excluded and would not run anyway.
 
 ## Stress / load test
 

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,6 +1,7 @@
 import { writeFileSync, mkdirSync } from 'fs';
 import path from 'path';
 import { COOKIE_CONSENT_KEY, COOKIE_CONSENT_VERSION } from '../src/lib/cookieConsent';
+import { ISOLATION_URL } from '../playwright.config';
 
 // Pre-seed the cookie-consent choice so the consent banner doesn't overlap
 // bottom-of-page actions during tests (a returning visitor wouldn't see it).
@@ -9,16 +10,17 @@ import { COOKIE_CONSENT_KEY, COOKIE_CONSENT_VERSION } from '../src/lib/cookieCon
 // put the banner back in front of every test in the suite.
 export default async function globalSetup() {
   const origin = process.env.BASE_URL || 'http://localhost:3000';
+  const consent = [
+    { name: COOKIE_CONSENT_KEY, value: JSON.stringify({ version: COOKIE_CONSENT_VERSION, necessary: true, analytics: false, marketing: false, ts: '2026-01-01T00:00:00.000Z' }) },
+  ];
+  // localStorage is per-origin, and the `isolation` project (#1566) talks to a
+  // second server on its own port — a different origin, which would otherwise
+  // start every isolation spec with the consent banner over the form. Seeding
+  // both origins costs nothing for a run that only uses one of them.
+  const origins = [origin, ISOLATION_URL].filter((o, i, all) => all.indexOf(o) === i);
   const state = {
     cookies: [],
-    origins: [
-      {
-        origin,
-        localStorage: [
-          { name: COOKIE_CONSENT_KEY, value: JSON.stringify({ version: COOKIE_CONSENT_VERSION, necessary: true, analytics: false, marketing: false, ts: '2026-01-01T00:00:00.000Z' }) },
-        ],
-      },
-    ],
+    origins: origins.map((o) => ({ origin: o, localStorage: consent })),
   };
   const dir = path.join(process.cwd(), 'e2e', '.state');
   mkdirSync(dir, { recursive: true });

--- a/e2e/helpers/tenants.ts
+++ b/e2e/helpers/tenants.ts
@@ -1,0 +1,299 @@
+import crypto from 'crypto';
+import type { Page } from '@playwright/test';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './db';
+import { signInAsFreshUser } from './auth';
+import { roleHome } from '../../src/lib/roleHome';
+
+/**
+ * Two fully populated tenants, for tests that run against a server with
+ * `MT_ENFORCE_ISOLATION=true` (#1566).
+ *
+ * WHY THIS EXISTS
+ *   Every isolation test written before this one proved something about a
+ *   *helper function*, not about the running application:
+ *     • `e2e/tenant-isolation.spec.ts` flips `process.env.MT_ENFORCE_ISOLATION`
+ *       inside the Playwright process, which the app under test never reads;
+ *     • `e2e/org-isolation.spec.ts` calls `orgScoped()` by hand and asserts on
+ *       the rows Prisma returns.
+ *   Both pass on a server that leaks every row across tenants. The `isolation`
+ *   Playwright project (see `playwright.config.ts`) boots a server that really
+ *   has the flag on; this fixture gives that project the two tenants it needs
+ *   to ask "can A see B?" over HTTP.
+ *
+ * WHAT IT SEEDS
+ *   Two organizations (`iso-a-<stamp>` / `iso-b-<stamp>`), each with an ADMIN, a
+ *   MENTOR, a MENTEE and a COMPANY actor plus one row in every model the leak
+ *   matrix will probe: Company, MentorshipRelation, Tag, PipelineStage,
+ *   InvitationToken and Offer. The two tenants are deliberately symmetric —
+ *   every assertion the next task writes can be run in both directions, and a
+ *   filter that happens to be right only for the tenant that was seeded first
+ *   fails in one of them.
+ *
+ * WHICH OF THOSE MODELS ARE ACTUALLY ENFORCED TODAY
+ *   Only some. `TENANT_MODELS` (`src/lib/orgContext.ts`) is the set the Prisma
+ *   middleware auto-scopes; `scripts/check-tenant-models.mjs` (#1560) pins the
+ *   rest in its `PENDING_REGISTRATION` ratchet. Of what this fixture seeds:
+ *     enforced by the middleware   User, Company, MentorshipRelation
+ *     seeded but NOT yet enforced  Tag, PipelineStage, InvitationToken, Offer
+ *   The unenforced four are seeded on purpose. They are exactly where a leak is
+ *   expected today, so a spec that probes them is documenting a known gap
+ *   (#1559 registers them), not reporting a fresh regression — and the day they
+ *   are registered, the rows the assertions need are already here.
+ *
+ * SYNTHETIC ONLY. Everything is minted per run with a random stamp, and
+ * `cleanup()` removes it again in FK order. Nothing here reads or copies real
+ * data (docs/DATA_ACCESS_POLICY.md), and `prisma/seed-demo.mjs` is deliberately
+ * untouched: it is single-org by design.
+ */
+
+/** The password every seeded actor signs in with. */
+export const TENANT_PASSWORD = 'IsoTenant123!';
+
+export type TenantRole = 'ADMIN' | 'MENTOR' | 'MENTEE' | 'COMPANY';
+
+export type TenantActor = {
+  id: string;
+  email: string;
+  fullName: string;
+  role: TenantRole;
+  /** Always {@link TENANT_PASSWORD}; carried on the actor so sign-in helpers need one argument. */
+  password: string;
+  /** Where this actor lands after sign-in (`src/lib/roleHome.ts`). */
+  landing: string;
+};
+
+export type SeededTenant = {
+  /** 'A' or 'B' — only for readable assertion messages. */
+  label: string;
+  org: { id: string; slug: string; name: string };
+  admin: TenantActor;
+  mentor: TenantActor;
+  mentee: TenantActor;
+  /** A COMPANY-role user, linked to this tenant's company. */
+  companyUser: TenantActor;
+  company: { id: string; name: string };
+  relation: { id: string };
+  tag: { id: string; name: string };
+  stage: { id: string; key: string; label: string };
+  invitation: { id: string; token: string; email: string };
+  offer: { id: string; position: string };
+  /** Every actor, in a stable order, for tests that loop over all of them. */
+  actors: TenantActor[];
+};
+
+export type TwoTenants = {
+  orgA: SeededTenant;
+  orgB: SeededTenant;
+  /** Both org ids, for `where: { orgId: { in: … } }` assertions and teardown. */
+  orgIds: string[];
+  /** Removes everything this fixture created, in FK order. Idempotent. */
+  cleanup: () => Promise<void>;
+};
+
+/** Models this fixture writes to, and how to count what is left of them. */
+const LEFTOVER_COUNTS = {
+  offer: (orgIds: string[]) => prisma.offer.count({ where: { orgId: { in: orgIds } } }),
+  tag: (orgIds: string[]) => prisma.tag.count({ where: { orgId: { in: orgIds } } }),
+  pipelineStage: (orgIds: string[]) => prisma.pipelineStage.count({ where: { orgId: { in: orgIds } } }),
+  invitationToken: (orgIds: string[]) => prisma.invitationToken.count({ where: { orgId: { in: orgIds } } }),
+  mentorshipRelation: (orgIds: string[]) => prisma.mentorshipRelation.count({ where: { orgId: { in: orgIds } } }),
+  user: (orgIds: string[]) => prisma.user.count({ where: { orgId: { in: orgIds } } }),
+  company: (orgIds: string[]) => prisma.company.count({ where: { orgId: { in: orgIds } } }),
+  organization: (orgIds: string[]) => prisma.organization.count({ where: { id: { in: orgIds } } }),
+} as const;
+
+/**
+ * How many rows each seeded model still has for the given orgs.
+ *
+ * The acceptance criterion for the fixture is "cleans up after itself, leaving
+ * no rows behind", and the only honest way to assert that is to ask the
+ * database afterwards — a `cleanup()` that silently swallowed a foreign-key
+ * error looks identical to one that worked.
+ */
+export async function remainingTenantRows(orgIds: string[]): Promise<Record<string, number>> {
+  const entries = await Promise.all(
+    Object.entries(LEFTOVER_COUNTS).map(async ([model, count]) => [model, await count(orgIds)] as const)
+  );
+  return Object.fromEntries(entries);
+}
+
+async function seedActor(
+  orgId: string,
+  prefix: string,
+  role: TenantRole,
+  fullName: string,
+  companyId?: string
+): Promise<TenantActor> {
+  const email = uniqueEmail(prefix);
+  const user = await seedUser(email, TENANT_PASSWORD, role, fullName);
+  await prisma.user.update({
+    where: { id: user.id },
+    data: { orgId, ...(companyId ? { companyId } : {}) },
+  });
+  return { id: user.id, email, fullName, role, password: TENANT_PASSWORD, landing: roleHome(role) };
+}
+
+async function seedTenant(label: string, slugPrefix: string, stamp: string): Promise<SeededTenant> {
+  const name = `Iso ${label}`;
+  const org = await prisma.organization.create({
+    data: { name: `${name} Org ${stamp}`, slug: `${slugPrefix}-${stamp}` },
+  });
+
+  // The company comes first: the COMPANY actor points at it, and the offer
+  // needs both it and the relation.
+  const company = await prisma.company.create({
+    data: { orgId: org.id, name: `${name} Company ${stamp}`, industry: 'Software' },
+  });
+
+  const admin = await seedActor(org.id, `iso-${slugPrefix}-admin`, 'ADMIN', `${name} Admin`);
+  const mentor = await seedActor(org.id, `iso-${slugPrefix}-mentor`, 'MENTOR', `${name} Mentor`);
+  const mentee = await seedActor(org.id, `iso-${slugPrefix}-mentee`, 'MENTEE', `${name} Mentee`);
+  const companyUser = await seedActor(
+    org.id,
+    `iso-${slugPrefix}-company`,
+    'COMPANY',
+    `${name} Company User`,
+    company.id
+  );
+
+  const relation = await prisma.mentorshipRelation.create({
+    data: {
+      orgId: org.id,
+      mentorId: mentor.id,
+      menteeId: mentee.id,
+      companyId: company.id,
+      status: 'ACTIVE',
+      // Mid-pipeline: a relation parked in the first stage is what the dormant
+      // sweep targets and a terminal one is finished — neither is the ordinary
+      // in-progress row the boards and the leak matrix are about.
+      pipelineStatus: 'INTERNSHIP_IN_PROGRESS_450',
+      startDate: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
+    },
+  });
+
+  const tag = await prisma.tag.create({
+    data: { orgId: org.id, name: `${name} Tag ${stamp}`, color: '#2563eb', createdById: admin.id },
+  });
+
+  // A single custom stage, keyed per tenant. Two tenants must be able to hold
+  // the SAME stage key without colliding (`@@unique([orgId, key])`), so the key
+  // is deliberately not stamped — that is part of what the fixture proves.
+  const stage = await prisma.pipelineStage.create({
+    data: {
+      orgId: org.id,
+      key: 'ISO_STAGE',
+      label: `${name} Stage`,
+      order: 0,
+      isTerminal: false,
+      isOffPath: false,
+    },
+  });
+
+  const invitationEmail = uniqueEmail(`iso-${slugPrefix}-invite`);
+  const invitation = await prisma.invitationToken.create({
+    data: {
+      orgId: org.id,
+      token: crypto.randomBytes(32).toString('hex'),
+      email: invitationEmail,
+      role: 'MENTEE',
+      invitedById: admin.id,
+      expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+    },
+  });
+
+  const offer = await prisma.offer.create({
+    data: {
+      orgId: org.id,
+      relationId: relation.id,
+      companyId: company.id,
+      position: `${name} Intern`,
+      status: 'DRAFT',
+      createdById: admin.id,
+    },
+  });
+
+  return {
+    label,
+    org: { id: org.id, slug: org.slug, name: org.name },
+    admin,
+    mentor,
+    mentee,
+    companyUser,
+    company: { id: company.id, name: company.name },
+    relation: { id: relation.id },
+    tag: { id: tag.id, name: tag.name },
+    stage: { id: stage.id, key: stage.key, label: stage.label },
+    invitation: { id: invitation.id, token: invitation.token, email: invitationEmail },
+    offer: { id: offer.id, position: offer.position },
+    actors: [admin, mentor, mentee, companyUser],
+  };
+}
+
+/**
+ * Create the two tenants. Call from `test.beforeAll` and `await
+ * tenants.cleanup()` from `test.afterAll` — including on failure, or the next
+ * run inherits the rows.
+ */
+export async function seedTwoTenants(): Promise<TwoTenants> {
+  const stamp = `${Date.now()}-${crypto.randomBytes(3).toString('hex')}`;
+  const orgA = await seedTenant('A', 'iso-a', stamp);
+  const orgB = await seedTenant('B', 'iso-b', stamp);
+  const orgIds = [orgA.org.id, orgB.org.id];
+
+  return {
+    orgA,
+    orgB,
+    orgIds,
+    cleanup: () => cleanupTenants([orgA, orgB]),
+  };
+}
+
+/**
+ * Teardown, in foreign-key order: the rows that point at other rows go first.
+ *
+ * Organization → Tag / PipelineStage cascades in the schema and deleting a user
+ * takes their relations with them, but relying on that is how a partial failure
+ * leaves half a tenant behind. Every step is explicit and every delete is
+ * scoped to the seeded org ids, so it can never reach a row this fixture did
+ * not create.
+ */
+async function cleanupTenants(tenants: SeededTenant[]): Promise<void> {
+  const orgIds = tenants.map((t) => t.org.id);
+  const orgFilter = { orgId: { in: orgIds } };
+
+  // 1. Rows that reference a user, a relation or a company.
+  await prisma.offer.deleteMany({ where: orgFilter });
+  // UserTag cascades from Tag, so the label rows go with it.
+  await prisma.tag.deleteMany({ where: orgFilter });
+  await prisma.pipelineStage.deleteMany({ where: orgFilter });
+  await prisma.invitationToken.deleteMany({ where: orgFilter });
+  await prisma.mentorshipRelation.deleteMany({ where: orgFilter });
+
+  // 2. The users. cleanupByEmail also drops their invitation tokens (matched by
+  //    address, which the org-scoped delete above would miss if a spec created
+  //    one of its own) and their brute-force lockouts, which carry no FK.
+  for (const tenant of tenants) {
+    for (const actor of tenant.actors) await cleanupByEmail(actor.email);
+    await cleanupByEmail(tenant.invitation.email);
+  }
+  // Anything a spec added to a tenant — or a user whose delete above was
+  // swallowed — must not survive into the organization delete, which would then
+  // fail on the foreign key and leave the tenant behind.
+  await prisma.user.deleteMany({ where: orgFilter });
+
+  // 3. The tenant's own rows, innermost last.
+  await prisma.company.deleteMany({ where: orgFilter });
+  await prisma.organization.deleteMany({ where: { id: { in: orgIds } } });
+}
+
+/**
+ * Sign in as one of the fixture's actors and wait for their role landing page.
+ *
+ * Wraps `signInAsFreshUser` rather than `signInAndSettle`: an isolation spec
+ * hops between tenants inside one test, and that helper carries the guards for
+ * signing in as a *different* user than the one currently signed in (see the
+ * doc comment in `e2e/helpers/auth.ts`).
+ */
+export async function signInAsTenantActor(page: Page, actor: TenantActor): Promise<void> {
+  await signInAsFreshUser(page, actor.email, actor.password, actor.landing);
+}

--- a/e2e/helpers/tenants.ts
+++ b/e2e/helpers/tenants.ts
@@ -3,6 +3,7 @@ import type { Page } from '@playwright/test';
 import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './db';
 import { signInAsFreshUser } from './auth';
 import { roleHome } from '../../src/lib/roleHome';
+import { defaultPipelineStages } from '../../src/lib/pipeline';
 
 /**
  * Two fully populated tenants, for tests that run against a server with
@@ -22,9 +23,12 @@ import { roleHome } from '../../src/lib/roleHome';
  *
  * WHAT IT SEEDS
  *   Two organizations (`iso-a-<stamp>` / `iso-b-<stamp>`), each with an ADMIN, a
- *   MENTOR, a MENTEE and a COMPANY actor plus one row in every model the leak
+ *   MENTOR, a MENTEE and a COMPANY actor plus a row in every model the leak
  *   matrix will probe: Company, MentorshipRelation, Tag, PipelineStage,
- *   InvitationToken and Offer. The two tenants are deliberately symmetric —
+ *   InvitationToken and Offer. `PipelineStage` is the one seeded as a *set*
+ *   rather than a single row — the canonical catalogue, relabelled per tenant,
+ *   because a lone custom stage would empty every board (see the comment on the
+ *   seed itself). The two tenants are deliberately symmetric —
  *   every assertion the next task writes can be run in both directions, and a
  *   filter that happens to be right only for the tenant that was seeded first
  *   fails in one of them.
@@ -48,6 +52,21 @@ import { roleHome } from '../../src/lib/roleHome';
 
 /** The password every seeded actor signs in with. */
 export const TENANT_PASSWORD = 'IsoTenant123!';
+
+/**
+ * The stage each tenant's relation sits on.
+ *
+ * Mid-pipeline on purpose: a relation parked in the first stage is what the
+ * dormant sweep targets and a terminal one is finished — neither is the
+ * ordinary in-progress row the boards and the leak matrix are about. It is a
+ * key of the canonical catalogue, and `seedTenant()` gives every tenant that
+ * whole catalogue, so the stage is always one the tenant can actually render
+ * (see the comment on the PipelineStage seed).
+ */
+export const TENANT_RELATION_STAGE = 'INTERNSHIP_IN_PROGRESS_450';
+
+/** How many `PipelineStage` rows each tenant gets. */
+export const TENANT_STAGE_COUNT = defaultPipelineStages().length;
 
 export type TenantRole = 'ADMIN' | 'MENTOR' | 'MENTEE' | 'COMPANY';
 
@@ -74,6 +93,12 @@ export type SeededTenant = {
   company: { id: string; name: string };
   relation: { id: string };
   tag: { id: string; name: string };
+  /**
+   * This tenant's own row for {@link TENANT_RELATION_STAGE} — the stage its
+   * relation sits on. The tenant holds the whole canonical catalogue
+   * ({@link TENANT_STAGE_COUNT} rows); this is the one the boards put the
+   * relation in.
+   */
   stage: { id: string; key: string; label: string };
   invitation: { id: string; token: string; email: string };
   offer: { id: string; position: string };
@@ -117,7 +142,20 @@ export async function remainingTenantRows(orgIds: string[]): Promise<Record<stri
   return Object.fromEntries(entries);
 }
 
+/**
+ * What has been written so far, recorded as it is written.
+ *
+ * `seedTwoTenants()` is many creates and no transaction, so a failure halfway
+ * through leaves rows nobody will ever delete: the caller's `tenants` is never
+ * assigned and its `afterAll` runs `tenants?.cleanup()`, which is a no-op on
+ * `undefined`. The scratch record is what lets the failure path clean up
+ * anyway: each id and address is recorded before (or as soon as) the row
+ * exists, so whatever the seed managed to write is in it when it throws.
+ */
+type SeedScratch = { orgIds: string[]; emails: string[] };
+
 async function seedActor(
+  scratch: SeedScratch,
   orgId: string,
   prefix: string,
   role: TenantRole,
@@ -125,6 +163,7 @@ async function seedActor(
   companyId?: string
 ): Promise<TenantActor> {
   const email = uniqueEmail(prefix);
+  scratch.emails.push(email);
   const user = await seedUser(email, TENANT_PASSWORD, role, fullName);
   await prisma.user.update({
     where: { id: user.id },
@@ -133,11 +172,17 @@ async function seedActor(
   return { id: user.id, email, fullName, role, password: TENANT_PASSWORD, landing: roleHome(role) };
 }
 
-async function seedTenant(label: string, slugPrefix: string, stamp: string): Promise<SeededTenant> {
+async function seedTenant(
+  scratch: SeedScratch,
+  label: string,
+  slugPrefix: string,
+  stamp: string
+): Promise<SeededTenant> {
   const name = `Iso ${label}`;
   const org = await prisma.organization.create({
     data: { name: `${name} Org ${stamp}`, slug: `${slugPrefix}-${stamp}` },
   });
+  scratch.orgIds.push(org.id);
 
   // The company comes first: the COMPANY actor points at it, and the offer
   // needs both it and the relation.
@@ -145,16 +190,52 @@ async function seedTenant(label: string, slugPrefix: string, stamp: string): Pro
     data: { orgId: org.id, name: `${name} Company ${stamp}`, industry: 'Software' },
   });
 
-  const admin = await seedActor(org.id, `iso-${slugPrefix}-admin`, 'ADMIN', `${name} Admin`);
-  const mentor = await seedActor(org.id, `iso-${slugPrefix}-mentor`, 'MENTOR', `${name} Mentor`);
-  const mentee = await seedActor(org.id, `iso-${slugPrefix}-mentee`, 'MENTEE', `${name} Mentee`);
+  const admin = await seedActor(scratch, org.id, `iso-${slugPrefix}-admin`, 'ADMIN', `${name} Admin`);
+  const mentor = await seedActor(scratch, org.id, `iso-${slugPrefix}-mentor`, 'MENTOR', `${name} Mentor`);
+  const mentee = await seedActor(scratch, org.id, `iso-${slugPrefix}-mentee`, 'MENTEE', `${name} Mentee`);
   const companyUser = await seedActor(
+    scratch,
     org.id,
     `iso-${slugPrefix}-company`,
     'COMPANY',
     `${name} Company User`,
     company.id
   );
+
+  // The tenant's pipeline, seeded as the CANONICAL stage set relabelled per
+  // tenant — not as one lone custom row.
+  //
+  // `PipelineStage` is one of the models the leak matrix probes, so each tenant
+  // needs rows of its own. But `resolvePipelineStages()` (src/lib/pipelineStages.ts)
+  // returns a tenant's rows *instead of* the built-in catalogue the moment one
+  // exists, so writing a single `ISO_STAGE` row would quietly make both tenants
+  // custom-pipeline orgs whose entire catalogue is that one stage — a catalogue
+  // that does not contain the stage the relation below sits on. Every
+  // stage-driven screen (`/mentor/board`, `/admin`'s pipeline overview, the
+  // funnel) iterates the resolved stages, so both tenants would render one
+  // empty column and the leak matrix would report "A cannot see B" in both
+  // directions without ever having read a row. Seeding the whole catalogue
+  // keeps the relation visible, keeps the two tenants symmetric, and still
+  // exercises the custom-stage path.
+  //
+  // The keys are the canonical ones and therefore IDENTICAL in both tenants,
+  // which is the point: `@@unique([orgId, key])` makes that legal, and it is the
+  // shape a scoping bug shows up in — a lookup by key alone resolves to
+  // whichever row the database happened to return. The labels are prefixed per
+  // tenant, so B's wording appearing on A's board is a visible leak.
+  await prisma.pipelineStage.createMany({
+    data: defaultPipelineStages().map((s) => ({
+      orgId: org.id,
+      key: s.key,
+      label: `${name} · ${s.label}`,
+      order: s.order,
+      isTerminal: s.isTerminal,
+      isOffPath: s.isOffPath,
+    })),
+  });
+  const stage = await prisma.pipelineStage.findFirstOrThrow({
+    where: { orgId: org.id, key: TENANT_RELATION_STAGE },
+  });
 
   const relation = await prisma.mentorshipRelation.create({
     data: {
@@ -163,10 +244,7 @@ async function seedTenant(label: string, slugPrefix: string, stamp: string): Pro
       menteeId: mentee.id,
       companyId: company.id,
       status: 'ACTIVE',
-      // Mid-pipeline: a relation parked in the first stage is what the dormant
-      // sweep targets and a terminal one is finished — neither is the ordinary
-      // in-progress row the boards and the leak matrix are about.
-      pipelineStatus: 'INTERNSHIP_IN_PROGRESS_450',
+      pipelineStatus: TENANT_RELATION_STAGE,
       startDate: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
     },
   });
@@ -175,21 +253,8 @@ async function seedTenant(label: string, slugPrefix: string, stamp: string): Pro
     data: { orgId: org.id, name: `${name} Tag ${stamp}`, color: '#2563eb', createdById: admin.id },
   });
 
-  // A single custom stage, keyed per tenant. Two tenants must be able to hold
-  // the SAME stage key without colliding (`@@unique([orgId, key])`), so the key
-  // is deliberately not stamped — that is part of what the fixture proves.
-  const stage = await prisma.pipelineStage.create({
-    data: {
-      orgId: org.id,
-      key: 'ISO_STAGE',
-      label: `${name} Stage`,
-      order: 0,
-      isTerminal: false,
-      isOffPath: false,
-    },
-  });
-
   const invitationEmail = uniqueEmail(`iso-${slugPrefix}-invite`);
+  scratch.emails.push(invitationEmail);
   const invitation = await prisma.invitationToken.create({
     data: {
       orgId: org.id,
@@ -236,16 +301,39 @@ async function seedTenant(label: string, slugPrefix: string, stamp: string): Pro
  */
 export async function seedTwoTenants(): Promise<TwoTenants> {
   const stamp = `${Date.now()}-${crypto.randomBytes(3).toString('hex')}`;
-  const orgA = await seedTenant('A', 'iso-a', stamp);
-  const orgB = await seedTenant('B', 'iso-b', stamp);
-  const orgIds = [orgA.org.id, orgB.org.id];
+  // Seeding is not a transaction, and a caller that never received a handle
+  // cannot tear anything down: `beforeAll` rejects, `tenants` stays undefined
+  // and `afterAll`'s `tenants?.cleanup()` does nothing. So a partial seed
+  // removes its own rows before the error is rethrown — otherwise a stale
+  // Prisma client or a dropped connection halfway through tenant B leaves an
+  // orphan organization, up to eight `iso-*@e2e.local` users and their rows in
+  // the database for good, with no failure that names the leak.
+  const scratch: SeedScratch = { orgIds: [], emails: [] };
+  try {
+    const orgA = await seedTenant(scratch, 'A', 'iso-a', stamp);
+    const orgB = await seedTenant(scratch, 'B', 'iso-b', stamp);
+    const orgIds = [orgA.org.id, orgB.org.id];
 
-  return {
-    orgA,
-    orgB,
-    orgIds,
-    cleanup: () => cleanupTenants([orgA, orgB]),
-  };
+    return {
+      orgA,
+      orgB,
+      orgIds,
+      cleanup: () => cleanupTenants([orgA, orgB]),
+    };
+  } catch (error) {
+    // Best effort, and deliberately silent: the seeding failure is the one the
+    // caller must see, so a teardown that also fails must not replace it.
+    await removeSeededRows(scratch).catch(() => {});
+    throw error;
+  }
+}
+
+/** Teardown for fully seeded tenants; see {@link removeSeededRows}. */
+async function cleanupTenants(tenants: SeededTenant[]): Promise<void> {
+  await removeSeededRows({
+    orgIds: tenants.map((t) => t.org.id),
+    emails: tenants.flatMap((t) => [...t.actors.map((a) => a.email), t.invitation.email]),
+  });
 }
 
 /**
@@ -256,9 +344,13 @@ export async function seedTwoTenants(): Promise<TwoTenants> {
  * leaves half a tenant behind. Every step is explicit and every delete is
  * scoped to the seeded org ids, so it can never reach a row this fixture did
  * not create.
+ *
+ * Driven by ids and addresses rather than by handles, so the failure path in
+ * `seedTwoTenants()` can call it with whatever a partial seed managed to
+ * create, and the happy path can call it with the full set.
  */
-async function cleanupTenants(tenants: SeededTenant[]): Promise<void> {
-  const orgIds = tenants.map((t) => t.org.id);
+async function removeSeededRows({ orgIds, emails }: SeedScratch): Promise<void> {
+  if (orgIds.length === 0 && emails.length === 0) return;
   const orgFilter = { orgId: { in: orgIds } };
 
   // 1. Rows that reference a user, a relation or a company.
@@ -272,10 +364,7 @@ async function cleanupTenants(tenants: SeededTenant[]): Promise<void> {
   // 2. The users. cleanupByEmail also drops their invitation tokens (matched by
   //    address, which the org-scoped delete above would miss if a spec created
   //    one of its own) and their brute-force lockouts, which carry no FK.
-  for (const tenant of tenants) {
-    for (const actor of tenant.actors) await cleanupByEmail(actor.email);
-    await cleanupByEmail(tenant.invitation.email);
-  }
+  for (const email of emails) await cleanupByEmail(email);
   // Anything a spec added to a tenant — or a user whose delete above was
   // swallowed — must not survive into the organization delete, which would then
   // fail on the foreign key and leave the tenant behind.

--- a/e2e/isolation/flag-on.spec.ts
+++ b/e2e/isolation/flag-on.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from '@playwright/test';
+import { prisma } from '../helpers/db';
+import { seedTwoTenants, signInAsTenantActor, type TwoTenants } from '../helpers/tenants';
+
+/**
+ * The gate spec for the `isolation` Playwright project (#1566).
+ *
+ * Everything else in e2e/isolation/ is worthless if the server behind
+ * `baseURL` did not actually come up with `MT_ENFORCE_ISOLATION=true` — a
+ * cross-tenant assertion against an unenforced server passes for the wrong
+ * reason as often as not. So this file proves the flag first, and it proves it
+ * the only way a test can: by observing behaviour that exists ONLY when the
+ * flag is on.
+ *
+ * `GET /api/companies` is that behaviour. The handler runs
+ * `prisma.company.findMany()` with no `where` at all, inside
+ * `withTenantScope(session, …)`. `Company` is registered in `TENANT_MODELS`, so:
+ *
+ *   flag ON   the middleware injects the caller's orgId → tenant A's admin sees
+ *             tenant A's company and not tenant B's;
+ *   flag OFF  the middleware early-returns → the same call lists every company
+ *             in the database, tenant B's included.
+ *
+ * That makes the assertion below a live check of the server's env, not a
+ * restatement of it. Run the same file under the default project and it fails,
+ * which is exactly why `playwright.config.ts` keeps e2e/isolation/** out of it.
+ */
+
+let tenants: TwoTenants;
+
+test.beforeAll(async () => {
+  tenants = await seedTwoTenants();
+});
+
+test.afterAll(async () => {
+  await tenants?.cleanup();
+  await prisma.$disconnect();
+});
+
+test('the app under test answers at all', async ({ request }) => {
+  // A liveness probe, so a server that failed to boot fails here with a clear
+  // message instead of inside a sign-in timeout further down.
+  const res = await request.get('/api/health');
+  expect(res.status()).toBe(200);
+});
+
+test('the server enforces tenant isolation (MT_ENFORCE_ISOLATION is on)', async ({ page }) => {
+  await signInAsTenantActor(page, tenants.orgA.admin);
+
+  // page.request shares the browser context's cookies, so this is the signed-in
+  // admin's own call — the same one the companies screen makes.
+  const res = await page.request.get('/api/companies');
+  expect(res.status()).toBe(200);
+  const body = (await res.json()) as { companies: Array<{ id: string; name: string }> };
+  const ids = body.companies.map((c) => c.id);
+
+  expect(ids).toContain(tenants.orgA.company.id);
+  expect(
+    ids,
+    'tenant B’s company is visible to tenant A — either MT_ENFORCE_ISOLATION is not set on ' +
+      'this server, or Company fell out of TENANT_MODELS in src/lib/orgContext.ts'
+  ).not.toContain(tenants.orgB.company.id);
+});
+
+test('enforcement holds in both directions', async ({ page }) => {
+  // The mirror image of the test above. A filter that is accidentally pinned to
+  // one tenant — the first one seeded, the caller's own row, a stale closure —
+  // passes one direction and fails the other; asking both is what makes the
+  // pass mean "scoped by the caller's org".
+  await signInAsTenantActor(page, tenants.orgB.admin);
+
+  const res = await page.request.get('/api/companies');
+  expect(res.status()).toBe(200);
+  const body = (await res.json()) as { companies: Array<{ id: string }> };
+  const ids = body.companies.map((c) => c.id);
+
+  expect(ids).toContain(tenants.orgB.company.id);
+  expect(ids).not.toContain(tenants.orgA.company.id);
+});

--- a/e2e/isolation/two-tenant-fixture.spec.ts
+++ b/e2e/isolation/two-tenant-fixture.spec.ts
@@ -1,0 +1,113 @@
+import { test, expect } from '@playwright/test';
+import { prisma } from '../helpers/db';
+import {
+  seedTwoTenants,
+  signInAsTenantActor,
+  remainingTenantRows,
+  type TwoTenants,
+} from '../helpers/tenants';
+
+/**
+ * The fixture's own tests (#1566).
+ *
+ * `e2e/helpers/tenants.ts` is about to be the foundation every cross-tenant
+ * assertion stands on, so it gets the same treatment as the app: if it seeds a
+ * tenant that is missing a row, the leak matrix probes an empty table and
+ * reports "no leak" for a model nobody tested. And if it fails to tear a tenant
+ * down, the next run's `@@unique([orgId, key])` collisions and stray
+ * `iso-*@e2e.local` users are somebody's afternoon.
+ */
+
+let tenants: TwoTenants;
+
+test.beforeAll(async () => {
+  tenants = await seedTwoTenants();
+});
+
+test.afterAll(async () => {
+  await tenants?.cleanup();
+  await prisma.$disconnect();
+});
+
+test('both tenants are fully populated and separate', async () => {
+  const { orgA, orgB } = tenants;
+
+  // Distinct tenants, distinct rows — nothing is shared by accident.
+  expect(orgA.org.id).not.toBe(orgB.org.id);
+  expect(orgA.org.slug).not.toBe(orgB.org.slug);
+  expect(orgA.company.id).not.toBe(orgB.company.id);
+
+  for (const tenant of [orgA, orgB]) {
+    const orgId = tenant.org.id;
+
+    // Four actors, one per role, all anchored to this tenant.
+    const users = await prisma.user.findMany({ where: { orgId }, select: { id: true, role: true } });
+    expect(users.map((u) => u.role).sort()).toEqual(['ADMIN', 'COMPANY', 'MENTEE', 'MENTOR']);
+    // The COMPANY actor observes this tenant's company, not some other one.
+    const companyUser = await prisma.user.findUnique({
+      where: { id: tenant.companyUser.id },
+      select: { companyId: true },
+    });
+    expect(companyUser?.companyId).toBe(tenant.company.id);
+
+    // One row in every model the leak matrix will probe.
+    expect(await prisma.company.count({ where: { orgId } })).toBe(1);
+    expect(await prisma.mentorshipRelation.count({ where: { orgId } })).toBe(1);
+    expect(await prisma.tag.count({ where: { orgId } })).toBe(1);
+    expect(await prisma.pipelineStage.count({ where: { orgId } })).toBe(1);
+    expect(await prisma.invitationToken.count({ where: { orgId } })).toBe(1);
+    expect(await prisma.offer.count({ where: { orgId } })).toBe(1);
+  }
+
+  // The two tenants hold the SAME pipeline stage key. `@@unique([orgId, key])`
+  // means that is legal, and it is the shape a scoping bug shows up in: a lookup
+  // by key alone resolves to whichever row the database happened to return.
+  expect(orgA.stage.key).toBe(orgB.stage.key);
+  expect(orgA.stage.id).not.toBe(orgB.stage.id);
+});
+
+test('every actor in both tenants can sign in', async ({ page }) => {
+  // Eight sign-ins through the real form, one after another. Slow, and worth
+  // it: a seeded user who cannot actually authenticate (a role the sign-in path
+  // rejects, an address the email input refuses — see `uniqueEmail`) is a
+  // failure the leak matrix would report as "no access", i.e. as a pass.
+  test.setTimeout(240_000);
+
+  for (const tenant of [tenants.orgA, tenants.orgB]) {
+    for (const actor of tenant.actors) {
+      await signInAsTenantActor(page, actor);
+      expect(page.url(), `${actor.role} of tenant ${tenant.label} landed elsewhere`)
+        .toContain(actor.landing);
+    }
+  }
+});
+
+test('cleanup() leaves nothing behind', async () => {
+  // A second, throwaway pair: asserting on the shared one would pull the rug
+  // out from under the tests above (Playwright's file order is not a contract).
+  const throwaway = await seedTwoTenants();
+  const orgIds = throwaway.orgIds;
+
+  // Exact counts rather than "more than zero": a fixture that quietly stopped
+  // seeding one of the models would still satisfy the loose version, and the
+  // model it stopped seeding is the one nobody would then be testing.
+  expect(await remainingTenantRows(orgIds)).toEqual({
+    offer: 2,
+    tag: 2,
+    pipelineStage: 2,
+    invitationToken: 2,
+    mentorshipRelation: 2,
+    user: 8,
+    company: 2,
+    organization: 2,
+  });
+
+  await throwaway.cleanup();
+  const after = await remainingTenantRows(orgIds);
+  expect(after).toEqual(Object.fromEntries(Object.keys(after).map((model) => [model, 0])));
+
+  // Idempotent: a spec that cleans up after a failed assertion AND again in
+  // `afterAll` must not blow up on the second call.
+  await throwaway.cleanup();
+  expect(await remainingTenantRows(orgIds)).toEqual(after);
+});

--- a/e2e/isolation/two-tenant-fixture.spec.ts
+++ b/e2e/isolation/two-tenant-fixture.spec.ts
@@ -4,8 +4,12 @@ import {
   seedTwoTenants,
   signInAsTenantActor,
   remainingTenantRows,
+  TENANT_RELATION_STAGE,
+  TENANT_STAGE_COUNT,
   type TwoTenants,
 } from '../helpers/tenants';
+import { resolvePipelineStages } from '@/lib/pipelineStages';
+import { prisma as appPrisma } from '@/lib/prisma';
 
 /**
  * The fixture's own tests (#1566).
@@ -27,6 +31,8 @@ test.beforeAll(async () => {
 test.afterAll(async () => {
   await tenants?.cleanup();
   await prisma.$disconnect();
+  // resolvePipelineStages() runs on the app's own client, not the helper's.
+  await appPrisma.$disconnect();
 });
 
 test('both tenants are fully populated and separate', async () => {
@@ -54,16 +60,48 @@ test('both tenants are fully populated and separate', async () => {
     expect(await prisma.company.count({ where: { orgId } })).toBe(1);
     expect(await prisma.mentorshipRelation.count({ where: { orgId } })).toBe(1);
     expect(await prisma.tag.count({ where: { orgId } })).toBe(1);
-    expect(await prisma.pipelineStage.count({ where: { orgId } })).toBe(1);
     expect(await prisma.invitationToken.count({ where: { orgId } })).toBe(1);
     expect(await prisma.offer.count({ where: { orgId } })).toBe(1);
+
+    // PipelineStage is the one model seeded as a set: the whole canonical
+    // catalogue, relabelled for this tenant.
+    expect(await prisma.pipelineStage.count({ where: { orgId } })).toBe(TENANT_STAGE_COUNT);
   }
 
-  // The two tenants hold the SAME pipeline stage key. `@@unique([orgId, key])`
+  // The two tenants hold the SAME pipeline stage keys. `@@unique([orgId, key])`
   // means that is legal, and it is the shape a scoping bug shows up in: a lookup
   // by key alone resolves to whichever row the database happened to return.
+  // Distinct rows, distinct labels — so a leaked column is recognisable.
   expect(orgA.stage.key).toBe(orgB.stage.key);
   expect(orgA.stage.id).not.toBe(orgB.stage.id);
+  expect(orgA.stage.label).not.toBe(orgB.stage.label);
+});
+
+test('each tenant’s relation sits on a stage that tenant actually has', async () => {
+  // The fixture's least obvious way to be useless. `resolvePipelineStages()`
+  // returns a tenant's own PipelineStage rows *instead of* the built-in
+  // catalogue as soon as one row exists, and every stage-driven screen
+  // (/mentor/board, /admin's pipeline overview, the funnel) iterates exactly
+  // that set. Seed a tenant a stage catalogue that does not contain its own
+  // relation's stage and both tenants render empty everywhere — at which point
+  // the leak matrix asserts "A cannot see B's relation" against a board that
+  // has no cards in it at all, and passes without reading a single row.
+  //
+  // Asserted through the app's own resolver rather than by re-listing the keys,
+  // so the day the fixture or the resolver changes, this is what says so.
+  for (const tenant of [tenants.orgA, tenants.orgB]) {
+    const stages = await resolvePipelineStages(tenant.org.id);
+    const relation = await prisma.mentorshipRelation.findUniqueOrThrow({
+      where: { id: tenant.relation.id },
+      select: { pipelineStatus: true },
+    });
+    expect(relation.pipelineStatus).toBe(TENANT_RELATION_STAGE);
+    expect(
+      stages.map((s) => s.key),
+      `tenant ${tenant.label}'s relation is on a stage its own catalogue does not contain — ` +
+        'every board and pipeline view renders it as empty'
+    ).toContain(relation.pipelineStatus);
+  }
 });
 
 test('every actor in both tenants can sign in', async ({ page }) => {
@@ -94,7 +132,7 @@ test('cleanup() leaves nothing behind', async () => {
   expect(await remainingTenantRows(orgIds)).toEqual({
     offer: 2,
     tag: 2,
-    pipelineStage: 2,
+    pipelineStage: 2 * TENANT_STAGE_COUNT,
     invitationToken: 2,
     mentorshipRelation: 2,
     user: 8,

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "test:e2e": "playwright test",
     "test:e2e:smoke": "playwright test --grep @smoke",
     "test:e2e:headed": "playwright test --headed",
+    "test:e2e:isolation": "playwright test --project=isolation",
     "test:stress": "node scripts/stress-test.mjs",
     "test:load": "k6 run k6/nightly-load.js",
     "import:csv": "node scripts/import-csv.mjs",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,6 +12,50 @@ import { defineConfig, devices } from '@playwright/test';
 const externalBase = process.env.BASE_URL;
 const PORT = 3000;
 const localURL = `http://localhost:${PORT}`;
+
+// ── The `isolation` project (#1566) ──────────────────────────────────────────
+// A SECOND app server, on its own port, booted with MT_ENFORCE_ISOLATION=true.
+//
+// WHY A SECOND SERVER. Playwright's `webServer` is a config-level option, not a
+// per-project one, so "a project whose server has the flag on" can only mean
+// "an extra server the project points its baseURL at". The alternative — a
+// single server with the flag on — is not available to us: roughly 150 specs
+// assume the single-tenant behaviour the flag switches off, and the flag itself
+// is still un-flipped in production (docs/tenant-isolation.md). The default
+// project therefore keeps the flag OFF and its results are unchanged.
+//
+// The project (and its server) is only assembled when the run actually asks for
+// it, so `npm run test:e2e` and the CI smoke gate never pay for a second
+// `next start`. Everything under e2e/isolation/ belongs to it and is excluded
+// from the default project below — a spec there would otherwise run twice, once
+// against a server that does not enforce anything.
+export const ISOLATION_PORT = 3010;
+export const ISOLATION_URL = `http://localhost:${ISOLATION_PORT}`;
+
+// `--project=isolation` and `--project isolation` are both spellings Playwright
+// accepts, and E2E_ISOLATION=1 covers a caller who selects it some other way
+// (`--grep`, an IDE runner) and still needs the server.
+function projectRequested(name: string): boolean {
+  return process.argv.some(
+    (arg, i) => arg === `--project=${name}` || (arg === '--project' && process.argv[i + 1] === name)
+  );
+}
+const runsIsolation = process.env.E2E_ISOLATION === '1' || projectRequested('isolation');
+// The default server is skipped only when the command line selects the
+// isolation project and nothing else. E2E_ISOLATION=1 on its own adds the
+// isolation server without taking the default one away, because a run that has
+// not filtered by project still executes the chromium specs.
+const runsDefault = !projectRequested('isolation') || projectRequested('chromium');
+
+if (runsIsolation && externalBase) {
+  // Fail loudly rather than silently testing the wrong thing: the whole point
+  // of this project is a server WE started with the flag on, and a deployed
+  // environment's flag is whatever it is (today: off, everywhere).
+  throw new Error(
+    'The `isolation` Playwright project boots its own server with MT_ENFORCE_ISOLATION=true ' +
+      'and cannot run against a deployed BASE_URL. Unset BASE_URL and try again.'
+  );
+}
 // Shared with e2e/health.spec.ts, which asserts both sides of the token gate.
 export const E2E_HEALTH_TOKEN = 'e2e-health-token';
 // Shared with e2e/inbound-email.spec.ts. CI serves a production build, and
@@ -59,11 +103,32 @@ export default defineConfig({
     // and never overlaps page actions. legal-consent.spec overrides this.
     storageState: './e2e/.state/consent.json',
   },
-  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+      // e2e/isolation/** belongs to the `isolation` project below; those specs
+      // assert cross-tenant behaviour that only holds with the flag on.
+      testIgnore: '**/isolation/**',
+    },
+    ...(runsIsolation
+      ? [
+        {
+          name: 'isolation',
+          testMatch: '**/isolation/**/*.spec.ts',
+          use: { ...devices['Desktop Chrome'], baseURL: ISOLATION_URL },
+        },
+      ]
+      : []),
+  ],
   // Only spin up the app locally; when BASE_URL targets a deployed env, skip it.
+  // `runsDefault` / `runsIsolation` keep each run to the servers it needs: an
+  // ordinary run never boots the isolation server, and `--project=isolation`
+  // never boots the default one.
   webServer: externalBase
     ? undefined
     : [
+      ...(runsDefault ? [
       {
         command: `node e2e/support/google-mock.mjs`,
         url: `${googleMock}/__state`,
@@ -115,5 +180,31 @@ export default defineConfig({
           GOOGLE_CALENDAR_API_BASE: `${googleMock}/calendar/v3`,
         },
       },
+      ] : []),
+      ...(runsIsolation ? [
+      {
+        // The same app, on its own port, with tenant isolation ENFORCED (#1566).
+        // Deliberately lean: none of the stubs the default server wires up
+        // (Google Calendar, the inbound-mail secret, the throwing error routes)
+        // are involved in a cross-tenant read, and every one of them is another
+        // way for this server to differ from the default one for a reason that
+        // has nothing to do with the flag.
+        command: process.env.CI ? 'npm run start' : 'npm run dev',
+        url: ISOLATION_URL,
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+        env: {
+          MT_ENFORCE_ISOLATION: 'true',
+          PORT: String(ISOLATION_PORT),
+          // NextAuth builds its callback URLs from this; left at the default
+          // server's origin, the post-sign-in redirect walks off this server
+          // and the spec signs in to the wrong one.
+          NEXTAUTH_URL: ISOLATION_URL,
+          TRUSTED_PROXY_COUNT: '0',
+          SMTP_USER: '',
+          SMTP_BULK_USER: '',
+        },
+      },
+      ] : []),
     ],
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -41,11 +41,27 @@ function projectRequested(name: string): boolean {
   );
 }
 const runsIsolation = process.env.E2E_ISOLATION === '1' || projectRequested('isolation');
-// The default server is skipped only when the command line selects the
-// isolation project and nothing else. E2E_ISOLATION=1 on its own adds the
-// isolation server without taking the default one away, because a run that has
-// not filtered by project still executes the chromium specs.
-const runsDefault = !projectRequested('isolation') || projectRequested('chromium');
+// An isolation run is an isolation run: the default project (and therefore the
+// default server) is dropped from the config unless the command line asks for
+// chromium by name. E2E_ISOLATION=1 used to leave the default project in place,
+// which meant `E2E_ISOLATION=1 playwright test --grep …` started TWO `next dev`
+// processes in the same working directory. Next has no per-port `distDir`, so
+// both compile into `.next/` and overwrite each other's build manifests and
+// webpack cache — intermittent 404s on /_next/static/chunks/* and ENOENT
+// renames from whichever server loses the race, which reads as a flaky app
+// rather than a config problem.
+const runsDefault = projectRequested('chromium') || !runsIsolation;
+
+if (runsIsolation && runsDefault) {
+  // The only way to reach this is to name both projects explicitly (or set
+  // E2E_ISOLATION=1 and pass --project=chromium). Refuse rather than start the
+  // colliding pair described above: run the two suites as two commands.
+  throw new Error(
+    'The `chromium` and `isolation` projects each need their own Next server started from this ' +
+      'working directory, and two of them would compile into the same .next/ directory. Run them ' +
+      'as separate commands: `npm run test:e2e` and `npm run test:e2e:isolation`.'
+  );
+}
 
 if (runsIsolation && externalBase) {
   // Fail loudly rather than silently testing the wrong thing: the whole point
@@ -104,13 +120,19 @@ export default defineConfig({
     storageState: './e2e/.state/consent.json',
   },
   projects: [
-    {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
-      // e2e/isolation/** belongs to the `isolation` project below; those specs
-      // assert cross-tenant behaviour that only holds with the flag on.
-      testIgnore: '**/isolation/**',
-    },
+    // Dropped for an isolation run, so `E2E_ISOLATION=1 playwright test` (no
+    // --project) cannot point 1000+ specs at a :3000 that was never started.
+    ...(runsDefault
+      ? [
+        {
+          name: 'chromium',
+          use: { ...devices['Desktop Chrome'] },
+          // e2e/isolation/** belongs to the `isolation` project below; those specs
+          // assert cross-tenant behaviour that only holds with the flag on.
+          testIgnore: '**/isolation/**',
+        },
+      ]
+      : []),
     ...(runsIsolation
       ? [
         {


### PR DESCRIPTION
## Summary

Every isolation test we have proves something about a **helper function**, not about the running application. `e2e/tenant-isolation.spec.ts` sets `process.env.MT_ENFORCE_ISOLATION = 'true'` inside the Playwright process — which the app under test never reads — and `e2e/org-isolation.spec.ts` calls `orgScoped()` by hand and checks the rows Prisma hands back. Both pass green against a server that leaks every row across tenants.

This PR gives the suite two real tenants and a Playwright project whose web server genuinely boots with `MT_ENFORCE_ISOLATION=true`, so the next task can write its leak matrix against the real HTTP surface instead of against library calls.

The default project keeps the flag **off**: ~150 specs assume the single-tenant behaviour the flag switches off, and the flag is still un-flipped in production. `npx playwright test --list` reports the same 1058 tests in 398 files as on `main`.

Closes #1566

## Changes

- **`e2e/helpers/tenants.ts`** — `seedTwoTenants()` creates two organizations (`iso-a-<stamp>` / `iso-b-<stamp>`), each with an ADMIN, MENTOR, MENTEE and COMPANY actor plus a row in every model the leak matrix will probe: `Company`, `MentorshipRelation`, `Tag`, `PipelineStage`, `InvitationToken`, `Offer`. Returns typed handles (`tenants.orgA.company.id`, `tenants.orgB.admin`, …), a `signInAsTenantActor(page, actor)` that reuses the existing `signInAsFreshUser` guards, `remainingTenantRows()` for asserting teardown, and a `cleanup()` that deletes in foreign-key order (child rows → users → companies → organizations) and is idempotent.
  The doc comment states **which** of those models the middleware actually enforces today (`User`, `Company`, `MentorshipRelation`) and which are still in `check-tenant-models`' `PENDING_REGISTRATION` ratchet from #1560 (`Tag`, `PipelineStage`, `InvitationToken`, `Offer` → registered in #1559), so a leak found on one of the latter reads as a documented gap rather than a fresh regression.
  `PipelineStage` is the one model seeded as a **set** rather than a single row: each tenant gets the whole canonical catalogue, relabelled with its own prefix. `resolvePipelineStages()` returns a tenant's rows *instead of* the built-in catalogue as soon as one exists, so a lone custom stage would make both tenants custom-pipeline orgs whose catalogue does not contain the stage their own relation sits on — every board, funnel and pipeline bar would render empty and a leak assertion would pass in both directions without reading a row. The keys stay canonical and therefore identical across the two tenants (the shape a scoping bug surfaces in — `@@unique([orgId, key])` allows it); only the labels differ, so B's wording on A's board is a visible leak.
  Seeding is not transactional and the specs guard teardown with `tenants?.cleanup()`, so `seedTwoTenants()` records what it writes as it writes it and removes that again before rethrowing — a create that throws partway through tenant B cannot leave an orphan organization and eight `iso-*@e2e.local` users behind.
- **`playwright.config.ts`** — an `isolation` project with its own `webServer` on port **3010**, carrying `MT_ENFORCE_ISOLATION: 'true'` (and `NEXTAUTH_URL` pointed at that origin, or the post-sign-in redirect walks off to the other server). It runs only `e2e/isolation/**`, which the default `chromium` project now `testIgnore`s. Playwright's `webServer` is config-level rather than per-project, so each run assembles only the servers it needs: an ordinary `npm run test:e2e` and the CI smoke gate never pay for a second `next start`, and `--project=isolation` never boots the default one. Selecting the project with `BASE_URL` set throws with an explanation instead of quietly testing an unenforced deployment.
  The two projects are **mutually exclusive in one run**. Next has no per-port `distDir`, so two servers started from this working directory compile into the same `.next/` and overwrite each other's build manifests and webpack cache — intermittent `/_next/static/chunks/*` 404s that read as a flaky app. `E2E_ISOLATION=1` therefore means *isolation only* (the default project is dropped from the config), and naming both projects explicitly throws with an explanation.
- **`e2e/isolation/flag-on.spec.ts`** — proves the flag is really on the only way a test can: by observing behaviour that exists *only* then. `GET /api/companies` runs `prisma.company.findMany()` with no `where` inside `withTenantScope`, and `Company` is in `TENANT_MODELS` — so tenant A's admin sees tenant B's company **iff** the middleware is dormant. Asserted in both directions, plus a liveness probe so a server that failed to boot fails with a clear message.
- **`e2e/isolation/two-tenant-fixture.spec.ts`** — the fixture's own tests: both tenants fully populated and separate, each tenant's relation sits on a stage that tenant's own catalogue contains (asserted through the app's `resolvePipelineStages()`, so fixture and resolver cannot drift apart), all eight actors sign in through the real form and land on their role home, and `cleanup()` leaves exactly zero rows (exact counts, not "more than zero").
- **`.github/workflows/e2e-full.yml`** — an `isolation` job beside the four shards, so the project is actually executed by something. It cannot join the sharded job (it needs its own server, and the config refuses to assemble both projects in one run) and it is deliberately not in the PR gate (that gate is the `@smoke` subset). Same 4×/day cadence and drift gate; its JSON report is named `e2e-json-shard-isolation` so a red run reaches the same Turkish summary email, and `E2E_EXPECTED_REPORTS` is 5 so a job that crashes before writing one is caught too.
- **`package.json`** — `"test:e2e:isolation": "playwright test --project=isolation"`.
- **`e2e/global-setup.ts`** — seeds the cookie-consent `localStorage` for the second origin too; it is per-origin, so otherwise every isolation spec would start with the consent banner over the form.
- **Docs** — a section in `docs/testing.md` (how to run it, what it proves, where it runs in CI, why the default project is untouched, how to write a new isolation spec) plus a new table row, and a pointer from `docs/tenant-isolation.md`.

**No release fragment.** This is test infrastructure only — nothing user-visible ships, so per `releases/README.md` there is nothing to version. For the same reason there are no i18n keys and no schema change.

## Verification

- [x] `npm run lint` + `npx tsc --noEmit` clean (lint's two `react-hooks/exhaustive-deps` warnings are pre-existing on `main`)
- [x] `npm run check:i18n`, `npm run check:release-fragments` clean
- [x] `npx playwright test --list` → 1058 tests in 398 files, same as `main`, with no `[chromium] › isolation/…` entries; `npx playwright test --project=isolation --list` → 7 tests in 2 files
- [x] Resolved config asserted directly: default run boots the google mock + `:3000`; `--project=isolation` and `E2E_ISOLATION=1` each boot only `:3010` with `MT_ENFORCE_ISOLATION=true`; `BASE_URL=… --project=isolation` throws; naming both projects throws
- [ ] The isolation suite itself has **not been executed** in this container — no database, no browser, so it was verified statically only. Its first real run is the `isolation` job in `e2e-full.yml` (or `npm run test:e2e:isolation` against a local MySQL).

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

Preview: https://pr2242.interncrm.com
