### PR TITLE
fix(api): enforce API-key scope, expiry and org at the /api/v1 door

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,14 @@ jobs:
         run: npm run test:mentor-directory
       - name: auth path reads only the columns it needs (#1150)
         run: npm run check:auth-reads
+      # An API-key request has no session, so nothing resolves a tenant for it
+      # and the tenant middleware treats that as "do not scope": a /api/v1 route
+      # that authenticates a key and then queries reads every organisation's
+      # rows while looking ordinary (#1546). withApiKey() is the one door where
+      # expiry, revocation, scope and the org binding are decided; this keeps
+      # every route behind it.
+      - name: the public API is entered through one door (#1546)
+        run: npm run check:api-key-routes
       # MentorApplication.adminNote is private admin commentary; an e-mail
       # template that rendered it would show an applicant what an admin wrote
       # about them. Nothing in the type system says so, so a file-level guard

--- a/docs/tenant-isolation.md
+++ b/docs/tenant-isolation.md
@@ -123,6 +123,33 @@ subject from the invite/reset token, not a tenant context. Routes that only ever
 read the caller's own rows (account, profile, avatar, cv) are wrapped too for
 uniformity, though scoping is redundant there.
 
+### API-key requests have no session — so they bind their org themselves (#1546)
+
+`withTenantScope(session, …)` resolves the org from the session. A request to
+`/api/v1/*` authenticates with a Bearer API key and has **no session at all**,
+so `resolveOrgId()` returns null, `currentOrgId()` stays `undefined`, and the
+middleware reads that as *"no context — do not scope"*. A key-authenticated
+route that queried a tenant model therefore read **every** organisation's rows
+while looking entirely ordinary; that is what `GET /api/v1/candidates` did.
+
+The public API is now entered through one door, `withApiKey()`
+(`src/lib/apiKey.ts`), which — before the handler body runs — refuses an
+unknown, expired or revoked key (401), a key that does not hold the operation's
+scope (403) and a key that resolves to **no** organisation (403, never an
+unscoped read), then runs the handler inside `runWithApiKeyOrg(key.orgId, …)`.
+
+Two things keep it that way:
+
+- the handler's `where` also carries `orgId: key.orgId` **explicitly**. The
+  middleware only engages when `MT_ENFORCE_ISOLATION=true`, and a cross-tenant
+  read must not wait for a flag;
+- the absence of a tenant context is made loud rather than silent, in both
+  halves: `assertApiKeyRequestContext()` throws in development when a key is
+  authenticated outside `withApiKey()`, a development-only Prisma middleware
+  throws when a tenant-anchored model is queried inside an API-key request with
+  no org bound, and `npm run check:api-key-routes` fails the build for a
+  `/api/v1` route that queries the database without going through the door.
+
 ## Turning enforcement on (the guarded rollout)
 
 Do **not** set `MT_ENFORCE_ISOLATION=true` in production until every step below

--- a/e2e/api-v1-key-enforcement.spec.ts
+++ b/e2e/api-v1-key-enforcement.spec.ts
@@ -1,0 +1,130 @@
+import { test, expect } from '@playwright/test';
+import { createHash, randomBytes } from 'crypto';
+import { prisma, cleanupByEmail, seedUser, uniqueEmail } from './helpers/db';
+
+// Enforcement of the API-key lifecycle at the /api/v1 door (#1546).
+//
+// #1545 gave a key an expiry, a scope list, a soft revoke and an organisation;
+// none of it changed anything, because `authenticateApiKey` returned `{ id }`
+// for any key that existed and `/api/v1/candidates` then read every MENTEE in
+// the database. These are the four refusals that close that hole, plus the
+// scoping that makes an accepted key see one organisation and no other.
+//
+// API-only: no page, no browser, no sign-in — the keys are seeded straight into
+// the database, which is also the only way to mint an already-expired one.
+
+const KEY_PREFIX = 'e2e-v1-enforce';
+const CANDIDATES = '/api/v1/candidates';
+
+function bearer(raw: string) {
+  return { authorization: `Bearer ${raw}` };
+}
+
+// Mint a key row with a known raw secret. The hash must match lib/apiKey.ts's
+// (sha256 of the raw string) — hashing it here rather than importing keeps this
+// spec free of the server-only module graph.
+async function seedKey(opts: {
+  scopes?: string;
+  orgId?: string | null;
+  expiresAt?: Date | null;
+  revokedAt?: Date | null;
+}) {
+  const raw = `icrm_${randomBytes(24).toString('hex')}`;
+  const key = await prisma.apiKey.create({
+    data: {
+      name: `${KEY_PREFIX}-${randomBytes(4).toString('hex')}`,
+      hashedKey: createHash('sha256').update(raw).digest('hex'),
+      scopes: opts.scopes ?? 'candidates:read',
+      orgId: opts.orgId ?? null,
+      expiresAt: opts.expiresAt ?? null,
+      revokedAt: opts.revokedAt ?? null,
+    },
+  });
+  return { id: key.id, raw };
+}
+
+test.afterAll(async () => {
+  await prisma.apiKey.deleteMany({ where: { name: { startsWith: KEY_PREFIX } } });
+  await prisma.$disconnect();
+});
+
+test('a key that is expired, revoked, out of scope or org-less never reaches candidate data', {
+  tag: '@smoke',
+}, async ({ request }) => {
+  const org = await prisma.organization.create({
+    data: { name: `V1 Enforce ${Date.now()}`, slug: `v1-enforce-${Date.now()}` },
+  });
+  const hour = 60 * 60 * 1000;
+  try {
+    // No credential at all is still a 401 — unchanged.
+    expect((await request.get(CANDIDATES)).status()).toBe(401);
+    expect((await request.get(CANDIDATES, { headers: bearer('icrm_nope') })).status()).toBe(401);
+
+    // Expired: the expiry was recorded before, and ignored.
+    const expired = await seedKey({ orgId: org.id, expiresAt: new Date(Date.now() - hour) });
+    expect((await request.get(CANDIDATES, { headers: bearer(expired.raw) })).status()).toBe(401);
+
+    // Revoked: the row survives the soft revoke, the credential must not.
+    const revoked = await seedKey({ orgId: org.id, revokedAt: new Date(Date.now() - hour) });
+    expect((await request.get(CANDIDATES, { headers: bearer(revoked.raw) })).status()).toBe(401);
+
+    // Holding some other scope is holding nothing here — 403, not a filtered 200.
+    const wrongScope = await seedKey({ orgId: org.id, scopes: 'candidates:write' });
+    const scopeRes = await request.get(CANDIDATES, { headers: bearer(wrongScope.raw) });
+    expect(scopeRes.status()).toBe(403);
+    expect((await scopeRes.json()).candidates).toBeUndefined();
+
+    // No resolvable organisation: refused, never served everything.
+    const orgless = await seedKey({ orgId: null });
+    const orglessRes = await request.get(CANDIDATES, { headers: bearer(orgless.raw) });
+    expect(orglessRes.status()).toBe(403);
+    expect((await orglessRes.json()).candidates).toBeUndefined();
+
+    // The control: a live, in-scope, org-bound key is still served.
+    const good = await seedKey({ orgId: org.id });
+    const ok = await request.get(CANDIDATES, { headers: bearer(good.raw) });
+    expect(ok.status()).toBe(200);
+    expect(Array.isArray((await ok.json()).candidates)).toBeTruthy();
+  } finally {
+    await prisma.apiKey.deleteMany({ where: { name: { startsWith: KEY_PREFIX } } });
+    await prisma.organization.delete({ where: { id: org.id } }).catch(() => {});
+  }
+});
+
+test('a key sees its own organisation and no other', async ({ request }) => {
+  const stamp = Date.now();
+  const orgA = await prisma.organization.create({
+    data: { name: `V1 Org A ${stamp}`, slug: `v1-org-a-${stamp}` },
+  });
+  const orgB = await prisma.organization.create({
+    data: { name: `V1 Org B ${stamp}`, slug: `v1-org-b-${stamp}` },
+  });
+  const emailA = uniqueEmail('v1-mentee-a');
+  const emailB = uniqueEmail('v1-mentee-b');
+  try {
+    const menteeA = await seedUser(emailA, 'MenteePass123', 'MENTEE', `V1 Mentee A ${stamp}`);
+    const menteeB = await seedUser(emailB, 'MenteePass123', 'MENTEE', `V1 Mentee B ${stamp}`);
+    await prisma.user.update({ where: { id: menteeA.id }, data: { orgId: orgA.id } });
+    await prisma.user.update({ where: { id: menteeB.id }, data: { orgId: orgB.id } });
+
+    const keyA = await seedKey({ orgId: orgA.id });
+    const res = await request.get(CANDIDATES, { headers: bearer(keyA.raw) });
+    expect(res.status()).toBe(200);
+    const ids = ((await res.json()).candidates as { id: string }[]).map((c) => c.id);
+
+    expect(ids).toContain(menteeA.id);
+    // The whole point: org B's mentee is not in org A's answer — and neither is
+    // anybody else's, which is why the assertion is on the org, not on one row.
+    expect(ids).not.toContain(menteeB.id);
+    const foreign = await prisma.user.findMany({
+      where: { id: { in: ids }, NOT: { orgId: orgA.id } },
+      select: { id: true },
+    });
+    expect(foreign).toEqual([]);
+  } finally {
+    await prisma.apiKey.deleteMany({ where: { name: { startsWith: KEY_PREFIX } } });
+    await cleanupByEmail(emailA);
+    await cleanupByEmail(emailB);
+    await prisma.organization.deleteMany({ where: { id: { in: [orgA.id, orgB.id] } } });
+  }
+});

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:mentor-directory": "node --test --experimental-strip-types scripts/test/mentor-directory.test.mjs",
     "test:note-privacy": "node --test scripts/test/mentor-application-note-privacy.test.mjs",
     "check:auth-reads": "node scripts/check-auth-reads.mjs",
+    "check:api-key-routes": "node scripts/check-api-key-routes.mjs",
     "check:query-scalars": "node scripts/check-query-scalars.mjs",
     "check:locale-dates": "node scripts/check-locale-dates.mjs",
     "check:events": "node scripts/check-events.mjs",

--- a/releases/unreleased/api-key-enforcement.json
+++ b/releases/unreleased/api-key-enforcement.json
@@ -1,0 +1,21 @@
+{
+  "bump": "patch",
+  "changelog": "- **API keys are now enforced at the door, and an org-less `/api/v1` read is refused** (#1546). #1545 recorded a key's expiry, scopes, soft revoke and organisation; nothing checked them — `authenticateApiKey` returned `{ id }` for any key that existed and `GET /api/v1/candidates` then read every `MENTEE` in the database, because a key-authenticated request carries no session and the tenant middleware treats a missing org context as \"do not scope\". The public API is now entered through one door, `withApiKey()`: an unknown, expired or revoked key gets 401, a key that does not hold the operation's scope gets 403 (never a filtered 200), a key that resolves to no organisation gets 403 rather than an unscoped read, and the handler runs inside `runWithApiKeyOrg(key.orgId, …)` with `orgId` also written explicitly into the query — so the isolation does not depend on `MT_ENFORCE_ISOLATION`. The `v1` rate-limit bucket gains a per-key dimension alongside the existing per-IP one (the same limiter, the same bucket, `enforceRateLimit`'s `subject` option), so one integration can no longer spend another's allowance. Three guards keep the shape: `assertApiKeyRequestContext()` throws in development when a key is authenticated outside the door, a development-only Prisma middleware throws when a tenant model is queried in an API-key request with no org bound, and `npm run check:api-key-routes` fails CI for a `/api/v1` route that queries the database without it.",
+  "notes": {
+    "en": [
+      "API keys are now checked on every request: an expired or revoked key is refused, and a key is refused outright when it lacks the scope an endpoint requires instead of quietly returning an empty result.",
+      "The public API returns only the data of the organisation the key belongs to.",
+      "Each key now has its own request allowance, so one integration's traffic no longer uses up another's."
+    ],
+    "tr": [
+      "API anahtarları artık her istekte denetleniyor: süresi dolmuş veya iptal edilmiş anahtar reddediliyor, uç noktanın istediği kapsama sahip olmayan anahtar da sessizce boş sonuç almak yerine doğrudan geri çevriliyor.",
+      "Herkese açık API yalnızca anahtarın ait olduğu organizasyonun verisini döndürüyor.",
+      "Her anahtarın kendi istek hakkı var; bir entegrasyonun trafiği artık bir diğerinin hakkını tüketmiyor."
+    ],
+    "de": [
+      "API-Schlüssel werden jetzt bei jeder Anfrage geprüft: Ein abgelaufener oder widerrufener Schlüssel wird abgewiesen, und ein Schlüssel ohne die vom Endpunkt geforderte Berechtigung wird ebenfalls abgewiesen, statt stillschweigend ein leeres Ergebnis zu liefern.",
+      "Die öffentliche API liefert nur noch Daten der Organisation, zu der der Schlüssel gehört.",
+      "Jeder Schlüssel hat jetzt sein eigenes Anfragekontingent, sodass der Verkehr einer Integration nicht mehr das Kontingent einer anderen aufbraucht."
+    ]
+  }
+}

--- a/scripts/check-api-key-routes.mjs
+++ b/scripts/check-api-key-routes.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+// Guard: every /api/v1 route goes through the one door (#1546).
+//
+// An API-key request carries no session, so nothing in the framework resolves a
+// tenant for it: `currentOrgId()` is undefined and the Prisma tenant middleware
+// treats that as "no context, do not scope". A route that authenticates a key
+// and then queries therefore reads EVERY organisation's rows while looking
+// completely ordinary — that is exactly how GET /api/v1/candidates came to
+// return every mentee in the database.
+//
+// `withApiKey()` (src/lib/apiKey.ts) is where expiry, revocation, scope, the
+// organisation binding and the per-key rate limit are decided. There is a
+// runtime half of this guard too (assertApiKeyRequestContext throws in
+// development), but a route that is never exercised in development would still
+// ship the hole, so the shape is checked statically as well:
+//
+//   1. no module outside src/lib/apiKey.ts calls authenticateApiKey()
+//   2. every /api/v1 route that touches prisma goes through withApiKey()
+//   3. the scope each one asks for is a real scope from lib/apiScopes.ts
+//   4. every /api/v1 path is described in the public OpenAPI document
+//
+// Run: node scripts/check-api-key-routes.mjs   (npm run check:api-key-routes)
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const V1_DIR = 'src/app/api/v1';
+const DOOR = 'src/lib/apiKey.ts';
+const SPEC = 'src/app/api/v1/openapi.json/route.ts';
+// The spec route is the public description of the API, not part of it: it is
+// served anonymously on purpose so integrators can discover the surface.
+const UNAUTHENTICATED = new Set([SPEC]);
+
+const problems = [];
+
+function routeFiles(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) out.push(...routeFiles(path));
+    else if (entry === 'route.ts') out.push(path);
+  }
+  return out;
+}
+
+function sourceFiles(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) out.push(...sourceFiles(path));
+    else if (/\.tsx?$/.test(entry)) out.push(path);
+  }
+  return out;
+}
+
+// The scope vocabulary, read from its single source rather than restated here.
+const scopesSource = readFileSync('src/lib/apiScopes.ts', 'utf8');
+const scopeList = scopesSource.match(/export const API_SCOPES\s*=\s*\[([^\]]*)\]/);
+if (!scopeList) {
+  console.error('check-api-key-routes FAILED — could not read API_SCOPES from src/lib/apiScopes.ts');
+  process.exit(1);
+}
+const scopes = new Set([...scopeList[1].matchAll(/'([^']+)'/g)].map((m) => m[1]));
+
+// 1. authenticateApiKey() is the door's own internal step, not a route's tool.
+for (const file of sourceFiles('src')) {
+  if (file.replace(/\\/g, '/') === DOOR) continue;
+  const text = readFileSync(file, 'utf8');
+  if (/\bauthenticateApiKey\s*\(/.test(text)) {
+    problems.push(
+      `${file}  calls authenticateApiKey() directly — an API-key request must be opened with ` +
+        'withApiKey(), which also checks scope and binds the key\'s organisation.',
+    );
+  }
+}
+
+const files = routeFiles(V1_DIR).map((f) => f.replace(/\\/g, '/'));
+const spec = readFileSync(SPEC, 'utf8');
+
+for (const file of files) {
+  const text = readFileSync(file, 'utf8');
+  const authenticated = !UNAUTHENTICATED.has(file);
+
+  // 2. reading data requires the door.
+  if (authenticated && /\bprisma\./.test(text) && !/\bwithApiKey\s*\(/.test(text)) {
+    problems.push(
+      `${file}  queries the database without withApiKey() — the request would run with no ` +
+        'organisation bound and read every tenant.',
+    );
+  }
+
+  // 3. the scope it asks for has to exist. `withApiKey(request, '<scope>', …)`.
+  for (const m of text.matchAll(/withApiKey\s*\(\s*[A-Za-z_$][\w$]*\s*,\s*'([^']*)'/g)) {
+    if (!scopes.has(m[1])) {
+      problems.push(
+        `${file}  requires the scope '${m[1]}', which is not in API_SCOPES — no key can ever ` +
+          'hold it, so the route answers 403 to everyone.',
+      );
+    }
+  }
+
+  // 4. an undocumented endpoint is an endpoint nobody knows is scoped.
+  if (authenticated) {
+    const path = '/' + file.slice(`${V1_DIR}/`.length, -'/route.ts'.length);
+    if (!spec.includes(`'${path}'`)) {
+      problems.push(
+        `${file}  is not described in ${SPEC} — add '${path}' with the scope it requires.`,
+      );
+    }
+  }
+}
+
+if (problems.length > 0) {
+  console.error('api-key routes FAILED — the public API must be entered through one door:\n');
+  for (const problem of problems) console.error(`  • ${problem}`);
+  console.error('\nSee withApiKey() in src/lib/apiKey.ts (#1546).');
+  process.exit(1);
+}
+
+console.log(
+  `api-key routes OK — ${files.length} /api/v1 route file(s), every authenticated one behind ` +
+    `withApiKey(), scopes drawn from the ${scopes.size} known scope(s), all documented.`,
+);

--- a/scripts/openapi-generate.cjs
+++ b/scripts/openapi-generate.cjs
@@ -631,7 +631,11 @@ function classifyAuth(text, ctx = {}) {
   }
   if (denied.length && hasSession) notes.push(`Rejects these roles outright: ${denied.join(', ')}.`);
 
-  if (/authenticateApiKey\s*\(/.test(text)) classes.push('api-key');
+  // `withApiKey(` is the /api/v1 door (#1546): it authenticates the key, checks
+  // its scope and binds its organisation, so a route that calls it never calls
+  // `authenticateApiKey` itself. Missing it here would classify the public API
+  // as needing no credential at all.
+  if (/\b(?:authenticateApiKey|withApiKey)\s*\(/.test(text)) classes.push('api-key');
 
   // Shared secret in a request header, compared in constant time.
   //

--- a/src/app/api/v1/candidates/route.ts
+++ b/src/app/api/v1/candidates/route.ts
@@ -1,40 +1,41 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { authenticateApiKey } from '@/lib/apiKey';
-import { enforceRateLimit } from '@/lib/rateLimit';
+import { withApiKey } from '@/lib/apiKey';
 
 // Public, read-only programmatic API authenticated with a Bearer API key.
 // Returns a candidate (mentee) summary — no contact PII.
+//
+// Everything about the credential — is it live, does it hold `candidates:read`,
+// which organisation is it — is decided by withApiKey() before this body runs
+// (#1546). What is left here is the query, and the query is scoped EXPLICITLY
+// by the key's org: the tenant middleware only engages when
+// MT_ENFORCE_ISOLATION is on, and a cross-tenant read must not wait for a flag.
 export async function GET(request: Request) {
-  const limited = enforceRateLimit(request, 'v1', { limit: 120, windowMs: 60 * 1000 });
-  if (limited) return limited;
+  return withApiKey(request, 'candidates:read', async (key) => {
+    const mentees = await prisma.user.findMany({
+      where: { role: 'MENTEE', orgId: key.orgId },
+      orderBy: { createdAt: 'desc' },
+      take: 200,
+      select: {
+        id: true,
+        fullName: true,
+        university: true,
+        department: true,
+        graduationYear: true,
+        skills: true,
+        menteeRelations: { where: { status: 'ACTIVE' }, take: 1, select: { pipelineStatus: true } },
+      },
+    });
 
-  const key = await authenticateApiKey(request);
-  if (!key) return NextResponse.json({ error: 'Invalid or missing API key' }, { status: 401 });
-
-  const mentees = await prisma.user.findMany({
-    where: { role: 'MENTEE' },
-    orderBy: { createdAt: 'desc' },
-    take: 200,
-    select: {
-      id: true,
-      fullName: true,
-      university: true,
-      department: true,
-      graduationYear: true,
-      skills: true,
-      menteeRelations: { where: { status: 'ACTIVE' }, take: 1, select: { pipelineStatus: true } },
-    },
+    const data = mentees.map((m) => ({
+      id: m.id,
+      fullName: m.fullName,
+      university: m.university,
+      department: m.department,
+      graduationYear: m.graduationYear,
+      skills: m.skills,
+      stage: m.menteeRelations[0]?.pipelineStatus ?? null,
+    }));
+    return NextResponse.json({ candidates: data });
   });
-
-  const data = mentees.map((m) => ({
-    id: m.id,
-    fullName: m.fullName,
-    university: m.university,
-    department: m.department,
-    graduationYear: m.graduationYear,
-    skills: m.skills,
-    stage: m.menteeRelations[0]?.pipelineStatus ?? null,
-  }));
-  return NextResponse.json({ candidates: data });
 }

--- a/src/app/api/v1/openapi.json/route.ts
+++ b/src/app/api/v1/openapi.json/route.ts
@@ -12,7 +12,7 @@ export function GET() {
       title: 'Internship CRM Public API',
       version: '1.0.0',
       description:
-        'Read-only candidate access (Bearer API key) plus outgoing webhooks. Every key carries an explicit scope list and may carry an expiry; revoked keys are retained for audit rather than deleted.',
+        'Read-only candidate access (Bearer API key) plus outgoing webhooks. Every key carries an explicit scope list and may carry an expiry; revoked keys are retained for audit rather than deleted. Scope, expiry, revocation and the key’s organisation are enforced on every request: an expired or revoked key answers 401, a key missing the operation’s scope answers 403, and every response contains only the data of the organisation the key belongs to.',
     },
     servers: [{ url: '/api/v1' }],
     components: {
@@ -30,21 +30,27 @@ export function GET() {
       '/candidates': {
         get: {
           summary: 'List candidates (mentees)',
-          description: 'Requires a key holding the `candidates:read` scope.',
+          description:
+            'Requires a key holding the `candidates:read` scope. Returns only the candidates of the organisation the key belongs to.',
           security: [{ apiKey: ['candidates:read'] }],
           responses: {
             '200': {
-              description: 'Array of candidates',
+              description: 'Array of candidates, scoped to the key’s organisation',
               content: { 'application/json': { schema: { type: 'object', properties: { candidates: { type: 'array', items: { type: 'object' } } } } } },
             },
-            '401': { description: 'Missing or invalid API key' },
+            '401': { description: 'Missing, unknown, expired or revoked API key' },
+            '403': {
+              description:
+                'The key does not hold the `candidates:read` scope, or is not bound to an organisation',
+            },
+            '429': { description: 'Rate limit exceeded (counted per client address and per key)' },
           },
         },
       },
     },
     'x-api-key-scopes': {
       description:
-        'Scopes an API key can hold, in the canonical `<resource>:<action>` shape. A key must hold at least one.',
+        'Scopes an API key can hold, in the canonical `<resource>:<action>` shape. A key must hold at least one. Each operation names the scope it requires under `security`; a key presenting without it is refused with 403 rather than served a filtered result.',
       scopes: API_SCOPES,
     },
     'x-webhooks': {

--- a/src/lib/apiKey.ts
+++ b/src/lib/apiKey.ts
@@ -1,5 +1,9 @@
 import { createHash, randomBytes } from 'crypto';
+import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
+import { apiKeyStatus, parseScopes, type ApiScope } from '@/lib/apiScopes';
+import { assertApiKeyRequestContext, runAsApiKeyRequest, runWithApiKeyOrg } from '@/lib/orgContext';
+import { enforceRateLimit } from '@/lib/rateLimit';
 
 export function hashApiKey(raw: string): string {
   return createHash('sha256').update(raw).digest('hex');
@@ -10,20 +14,111 @@ export function generateApiKey(): { raw: string; hash: string } {
   return { raw, hash: hashApiKey(raw) };
 }
 
-// Authenticate a request via "Authorization: Bearer <key>". Returns the
-// ApiKey id when valid (and stamps lastUsedAt), else null.
+// What a presented key turns out to be. `orgId` is nullable here and NOT in
+// ApiKeyContext below, because "which organisation is this?" is a question the
+// door answers — a key that cannot answer it is refused, never served.
+export interface ApiKeyIdentity {
+  id: string;
+  orgId: string | null;
+  scopes: string[];
+}
+
+// The identity a handler receives: authenticated, in scope, and bound to one
+// organisation.
+export interface ApiKeyContext extends ApiKeyIdentity {
+  orgId: string;
+}
+
+// Shared by every /api/v1 route: the IP brake in front of the door and the
+// per-key allowance behind it use the same bucket and the same numbers.
+const V1_RATE_LIMIT = { limit: 120, windowMs: 60 * 1000 };
+
+// Authenticate a request via "Authorization: Bearer <key>". Returns the key's
+// identity when it is valid (and stamps lastUsedAt), else null.
 //
-// DELIBERATELY unchanged by #1545: the key's expiry, revocation and scope list
-// are now RECORDED (see prisma ApiKey / lib/apiScopes.ts) but not yet CHECKED
-// here. Refusing an expired/revoked/out-of-scope key — and an org-less
-// /api/v1 read — is #1546. Storing a lifecycle field is not enforcing it, and
-// splitting the two keeps the behaviour change reviewable on its own.
-export async function authenticateApiKey(request: Request): Promise<{ id: string } | null> {
+// #1545 recorded a key's expiry, revocation and scopes; #1546 is where they are
+// CHECKED. A revoked or expired key is indistinguishable from an unknown one
+// here on purpose — all three are a 401, and saying which would tell whoever
+// holds a stolen key what became of it.
+//
+// Not for direct use by routes: call withApiKey() instead. Doing so outside it
+// throws in development (see assertApiKeyRequestContext), because a
+// key-authenticated request that never binds an org reads every tenant.
+export async function authenticateApiKey(request: Request): Promise<ApiKeyIdentity | null> {
+  assertApiKeyRequestContext('authenticateApiKey()');
   const auth = request.headers.get('authorization') || '';
   const m = auth.match(/^Bearer\s+(.+)$/i);
   if (!m) return null;
-  const key = await prisma.apiKey.findUnique({ where: { hashedKey: hashApiKey(m[1].trim()) } });
+  const key = await prisma.apiKey.findUnique({
+    where: { hashedKey: hashApiKey(m[1].trim()) },
+    select: { id: true, orgId: true, scopes: true, expiresAt: true, revokedAt: true },
+  });
   if (!key) return null;
+  // Revocation and expiry are one derived status (lib/apiScopes.ts) so the door
+  // and the admin list can never disagree about what a key is.
+  if (apiKeyStatus(key) !== 'active') return null;
   await prisma.apiKey.update({ where: { id: key.id }, data: { lastUsedAt: new Date() } }).catch(() => {});
-  return { id: key.id };
+  return { id: key.id, orgId: key.orgId, scopes: parseScopes(key.scopes) };
+}
+
+// 403, never a filtered 200: a key asking for something it was not granted is a
+// misconfigured integration, and an empty list would hide that from whoever has
+// to fix it.
+export function requireApiScope(key: ApiKeyIdentity, scope: ApiScope): NextResponse | null {
+  if (key.scopes.includes(scope)) return null;
+  return NextResponse.json(
+    { error: `This API key does not hold the required scope: ${scope}` },
+    { status: 403 },
+  );
+}
+
+/**
+ * The single door of the public API (#1546).
+ *
+ * Every /api/v1 route goes through here, so expiry, revocation, scope, tenant
+ * binding and the rate limits are decided in ONE place instead of being
+ * re-implemented — or forgotten — per route. The handler only ever runs for a
+ * live, in-scope key that belongs to exactly one organisation, and it runs
+ * inside that organisation's tenant context.
+ *
+ * Fails closed, in this order:
+ *   - no / unknown / expired / revoked key → 401
+ *   - key does not hold `scope`            → 403
+ *   - key resolves to no organisation      → 403, never an unscoped read (the
+ *     #831 "allowlist by omission" lesson: an unlisted case is rejected)
+ */
+export async function withApiKey(
+  request: Request,
+  scope: ApiScope,
+  handler: (key: ApiKeyContext) => Promise<NextResponse>,
+): Promise<NextResponse> {
+  // The IP brake stays exactly where it was: in front of everything, so an
+  // anonymous flood is stopped before it costs a database round trip.
+  const ipLimited = enforceRateLimit(request, 'v1', V1_RATE_LIMIT);
+  if (ipLimited) return ipLimited;
+
+  return runAsApiKeyRequest(async () => {
+    const key = await authenticateApiKey(request);
+    if (!key) return NextResponse.json({ error: 'Invalid or missing API key' }, { status: 401 });
+
+    // A second dimension on the SAME limiter and the same bucket (#2028's
+    // additive `subject` option), not a second limiter and not a second store:
+    // one integration hammering the API now spends its own allowance instead of
+    // everyone else's behind the same address. The IP limit above is unchanged.
+    const keyLimited = enforceRateLimit(request, 'v1', { ...V1_RATE_LIMIT, subject: `key:${key.id}` });
+    if (keyLimited) return keyLimited;
+
+    const outOfScope = requireApiScope(key, scope);
+    if (outOfScope) return outOfScope;
+
+    const orgId = key.orgId;
+    if (!orgId) {
+      return NextResponse.json(
+        { error: 'This API key is not bound to an organization' },
+        { status: 403 },
+      );
+    }
+
+    return runWithApiKeyOrg(orgId, () => handler({ ...key, orgId }));
+  });
 }

--- a/src/lib/orgContext.ts
+++ b/src/lib/orgContext.ts
@@ -94,7 +94,10 @@ function mergeOrgWhere(where: unknown, orgId: string): Record<string, unknown> {
     : { orgId };
 }
 
-const globalForPrisma = globalThis as unknown as { tenantMiddlewareInstalled?: boolean };
+const globalForPrisma = globalThis as unknown as {
+  tenantMiddlewareInstalled?: boolean;
+  apiKeyOrgGuardInstalled?: boolean;
+};
 
 // Register the auto-scoping middleware exactly once on the prisma singleton.
 // Called lazily from runWithOrg (only when enforcement is on), so the middleware
@@ -163,6 +166,72 @@ export function runWithOrg<T>(orgId: string | null, fn: () => T): T {
       }) as T;
     }
     return result;
+  });
+}
+
+// ── API-key requests (#1546) ────────────────────────────────────────────────
+// A request authenticated by an API key carries no session, so `resolveOrgId`
+// has nothing to read and `currentOrgId()` stays `undefined` — which is exactly
+// the state the middleware above treats as "no context, do not scope". That is
+// how `/api/v1/candidates` came to read every organisation's mentees while
+// looking perfectly ordinary: nothing was missing from the query, the tenant
+// context simply never existed.
+//
+// These three helpers make that absence loud. They are deliberately INDEPENDENT
+// of `MT_ENFORCE_ISOLATION`: the flag being off is precisely when a missing
+// tenant context is silent, so the guard must not be off with it.
+const apiKeyRequestStorage = new AsyncLocalStorage<{ orgId: string | null }>();
+
+// Mark the current async context as "serving an API-key-authenticated request,
+// org not yet resolved". `withApiKey()` (src/lib/apiKey.ts) enters this BEFORE
+// looking the key up, so everything the request does afterwards is inside it.
+export function runAsApiKeyRequest<T>(fn: () => Promise<T>): Promise<T> {
+  ensureApiKeyOrgGuard();
+  return apiKeyRequestStorage.run({ orgId: null }, fn);
+}
+
+// Bind the key's organisation for the rest of the request: the marker records
+// it (so the dev guard below stops firing) and `runWithOrg` gives the Prisma
+// middleware the same tenant context a session-authenticated route has.
+export function runWithApiKeyOrg<T>(orgId: string, fn: () => T): T {
+  const store = apiKeyRequestStorage.getStore();
+  if (!store) assertApiKeyRequestContext('runWithApiKeyOrg');
+  else store.orgId = orgId;
+  return runWithOrg(orgId, fn);
+}
+
+// Loud in development, logged in production: authenticating by API key outside
+// `withApiKey()` means whatever the handler reads next is unscoped.
+export function assertApiKeyRequestContext(caller: string): void {
+  if (apiKeyRequestStorage.getStore()) return;
+  const message =
+    `${caller} ran outside runAsApiKeyRequest(): an API-key request must establish a tenant ` +
+    'context before it reads anything. Route it through withApiKey() in src/lib/apiKey.ts (#1546).';
+  if (process.env.NODE_ENV === 'production') {
+    console.error(message);
+    return;
+  }
+  throw new Error(message);
+}
+
+// The runtime half of the guard: while an API-key request has no organisation
+// bound, a query on a tenant-anchored model would read every tenant's rows. In
+// development that throws instead. `ApiKey` itself is exempt — the key lookup
+// and its `lastUsedAt` stamp are what resolve the org in the first place.
+function ensureApiKeyOrgGuard(): void {
+  if (process.env.NODE_ENV === 'production') return;
+  if (globalForPrisma.apiKeyOrgGuardInstalled) return;
+  globalForPrisma.apiKeyOrgGuardInstalled = true;
+
+  prisma.$use(async (params, next) => {
+    const store = apiKeyRequestStorage.getStore();
+    if (store && !store.orgId && params.model && params.model !== 'ApiKey' && TENANT_MODELS.has(params.model)) {
+      throw new Error(
+        `prisma.${params.model}.${params.action}() ran in an API-key request with no organisation ` +
+          'bound — it would read every tenant. Run the handler inside runWithApiKeyOrg() (#1546).',
+      );
+    }
+    return next(params);
   });
 }
 


### PR DESCRIPTION
## Summary

Storing an expiry and a scope changed nothing, because nothing checked them. `authenticateApiKey` returned `{ id }` for any key that existed, and `GET /api/v1/candidates` then read **every** `MENTEE` in the database — a key-authenticated request carries no session, so `currentOrgId()` is `undefined` and the tenant middleware reads that as *"no context, do not scope"*. The query looked entirely ordinary while returning every tenant's candidates.

This closes that hole at the one place an `/api/v1` request is authenticated, not per route. `withApiKey()` (`src/lib/apiKey.ts`) is now the single door: it refuses an unknown, expired or revoked key (**401**), a key that does not hold the operation's scope (**403**, never a filtered 200), and a key that resolves to no organisation (**403**, never an unscoped read), then runs the handler inside `runWithApiKeyOrg(key.orgId, …)`.

The org filter is **explicit in the query path** (`where: { role: 'MENTEE', orgId: key.orgId }`) as well as bound in the tenant context: the middleware only engages when `MT_ENFORCE_ISOLATION=true`, and a cross-tenant read must not wait for a flag.

Closes #1546

## Changes

- **`src/lib/apiKey.ts`** — `authenticateApiKey` returns `{ id, orgId, scopes }`, refuses a revoked or expired key (one derived `apiKeyStatus`, shared with the admin list, so the door and the UI can never disagree), keeps the `lastUsedAt` stamp and now `select`s only the columns it uses. New `requireApiScope()` (403) and the `withApiKey()` gateway described above.
- **`src/app/api/v1/candidates/route.ts`** — body reduced to the query, wrapped in `withApiKey(request, 'candidates:read', …)`, scoped by `key.orgId`.
- **`src/lib/orgContext.ts`** — `runAsApiKeyRequest` / `runWithApiKeyOrg` / `assertApiKeyRequestContext`, deliberately independent of `MT_ENFORCE_ISOLATION` (the flag being off is exactly when a missing tenant context is silent). Plus a **development-only** Prisma middleware that throws when a tenant-anchored model is queried inside an API-key request with no org bound (`ApiKey` itself exempt — that lookup is what resolves the org).
- **`scripts/check-api-key-routes.mjs`** + `npm run check:api-key-routes`, wired into `ci.yml`: no module outside `lib/apiKey.ts` may call `authenticateApiKey()`, every `/api/v1` route that touches prisma must go through `withApiKey()`, the scope it names must exist in `API_SCOPES`, and every `/api/v1` path must be described in the public OpenAPI document.
- **Rate limiting** — the `v1` bucket gains a per-key dimension *alongside* the per-IP one, reusing `enforceRateLimit`'s additive `subject` option (#2028). Same limiter, same bucket, same numbers; the IP brake still runs first, in front of any database work.
- **`src/app/api/v1/openapi.json/route.ts`** — documents the scope requirement and the 401/403/429 answers; **`scripts/openapi-generate.cjs`** learns `withApiKey(` so the public API is not re-classified as "no credential required" now that the route no longer names `authenticateApiKey` itself.
- **`docs/tenant-isolation.md`** — a section on why an API-key request has no session and how it binds its org.
- **`e2e/api-v1-key-enforcement.spec.ts`** (API-only, no browser): expired → 401, revoked → 401, wrong scope → 403, org-less → 403, live key → 200 (tagged `@smoke`); and a second test seeding two orgs, asserting a key bound to org A returns org A's mentee, not org B's, and nothing outside org A at all.
- Release fragment `releases/unreleased/api-key-enforcement.json` (`bump: patch`, EN/TR/DE notes).

## Verification

- [x] `npx prisma generate` + `npx tsc --noEmit` clean
- [x] `npm run lint` — only the two pre-existing `react-hooks/exhaustive-deps` warnings
- [x] `npm run build` passes
- [x] `npm run check:openapi` (api-key class still resolved), `check:auth-reads`, `check:query-scalars`, `check:tenant-models`, `check:release-fragments`, new `check:api-key-routes`
- [x] `npx playwright test --list e2e/api-v1-key-enforcement.spec.ts` — 2 tests; the suite itself runs in CI (no database or browser build here)
- [x] Added e2e coverage for each refusal

## Deliberately not in scope

- No schema change — #1545's columns are enforced, not re-added.
- Rate limiting is the **keying only**: no `ApiKeyUsage`, no period quota, no `RateLimit-*` headers (#2010), no counter store (#1696), no second limiter.
- `/api/v1/*` stays out of `k6/` (rate-limited, shared runner IP).
- No user-facing UI strings, so no dictionary change.

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ra7wrp478VPjzHJHh4QMvZ


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ra7wrp478VPjzHJHh4QMvZ)_