### PR TITLE
feat(multi-tenancy): give Setting an orgId with a global fallback

### DIFF
--- a/docs/tenant-isolation.md
+++ b/docs/tenant-isolation.md
@@ -144,6 +144,19 @@ module computes the org itself, from the bound context, and never from request
 input: `PUT /api/admin/settings` passes no org at all, so a tenant admin can only
 ever write their own row.
 
+It reaches both of those through `src/lib/tenantAmbient.ts` rather than importing
+`orgContext.ts` directly, and that indirection is load-bearing rather than
+stylistic. `orgContext.ts` imports `node:async_hooks`, and `settings.ts` sits in a
+**client** module graph — a client component imports a constant from
+`documentAccess.ts`, which reaches `settings.ts` via `retention.ts` — so a direct
+import fails the production build outright with `Reading from "node:async_hooks"
+is not handled by plugins`. `tenantAmbient.ts` imports nothing, holds two function
+slots, and `orgContext.ts` fills them as a side effect of being loaded; every
+request that binds a tenant has loaded it, because `withTenantScope` lives there.
+If it was never loaded, the fallbacks (no bound org, call `fn` directly) are the
+right answers anyway — there is no middleware installed to escape from. The same
+seam is the way in for any other client-reachable module that needs the bound org.
+
 Uniqueness has a MySQL wrinkle worth knowing: the pair is enforced by
 `@@unique([orgId, key])`, and MySQL treats `NULL`s as distinct in a unique index.
 The constraint therefore binds the per-tenant rows only; the global layer stays

--- a/docs/tenant-isolation.md
+++ b/docs/tenant-isolation.md
@@ -84,12 +84,12 @@ Two escape hatches live inside the script, and both require a written reason.
 `EXEMPT` is for a model that is deliberately never auto-scoped. Today it holds
 one name: `Organization`, which *is* the tenant rather than a row inside one and
 can never grow an `orgId` of its own. An exemption is only granted against a
-schema someone has read, so `Setting` is **not** pre-exempted even though its
-column is coming: when #1551 adds `orgId` to `Setting` this check will fail, and
-the register-vs-exempt call gets made then, against the real shape. (#1557
-records the intent — `Setting`'s legacy rows will stay `orgId = NULL` as the
-global fallback layer — but #1560 also says `Setting` must be *registered* and
-behave specially, and those two have to be reconciled with the column in hand.)
+schema someone has read. `Setting` is the worked example: it was deliberately
+left un-exempted while its column was still only planned, the check duly failed
+the day #1553 added `orgId`, and the call was then made against the real shape —
+**registered, not exempt**, with its own readers opting out (see
+[Settings: per-tenant with a global fallback](#settings-per-tenant-with-a-global-fallback-1553)
+below).
 
 `PENDING_REGISTRATION` is for a model that is known to be unprotected and is
 waiting on its own reviewed change — the eight models of #1559. It is a ratchet,
@@ -108,6 +108,53 @@ not an allowlist:
 
 So the guard's job while #1559 is open is to stop the set of unprotected models
 from *growing*, and to say on every run exactly which ones they are.
+
+### Settings: per-tenant with a global fallback (#1553)
+
+`Setting` is the one tenant model that must be able to read *outside* its tenant,
+and it is worth understanding before touching it.
+
+Eighteen product decisions — `require2fa`, `retentionMonths`, `aiMonthlyQuota`,
+`selfRegistration`, `blindReview`, the newsletter cadence — live in this one
+key/value table. It is now keyed by **(`orgId`, `key`)**:
+
+| `orgId` | meaning |
+|---------|---------|
+| a tenant id | that tenant's override |
+| `NULL` | the **global** layer: the platform-wide value every tenant inherits until it sets its own, and the only layer a single-tenant installation ever writes |
+
+Resolution is **org row → global row → `SETTING_DEFAULTS`**, and that rule lives
+in exactly one file, `src/lib/settings.ts`. Nothing else reads `prisma.setting`
+directly — `getSetting(key, orgId?)` / `getSettings(orgId?)` / `setSetting(key,
+value, orgId?)` are the whole surface. The org argument is optional: omitted, it
+resolves to the org bound by `withTenantScope()` (`currentOrgId()`), and to the
+global layer when no org is bound. That is what keeps the ~20 existing
+zero-argument call sites correct without changing any of them, and what makes a
+single-tenant deployment behave exactly as it did before.
+
+**The auto-filter had to be opted out of, on purpose.** `Setting` *is* registered
+in `TENANT_MODELS`, so any code that reaches for `prisma.setting` outside this
+module is scoped to its own tenant like everything else. But with enforcement on,
+that same middleware would rewrite the readers' query to `where: { orgId: <tenant> }`
+— which is precisely the filter that hides the `orgId = NULL` row and would turn
+step 2 of the chain into a silent "code default" for every tenant. So the queries
+in `settings.ts` run inside `runWithOrg(null, …)`, which clears the tenant context
+for the duration and lets the module see both layers. This is safe because the
+module computes the org itself, from the bound context, and never from request
+input: `PUT /api/admin/settings` passes no org at all, so a tenant admin can only
+ever write their own row.
+
+Uniqueness has a MySQL wrinkle worth knowing: the pair is enforced by
+`@@unique([orgId, key])`, and MySQL treats `NULL`s as distinct in a unique index.
+The constraint therefore binds the per-tenant rows only; the global layer stays
+single because `setSetting()` is its only writer and does a read-modify-write
+rather than a blind insert. (`upsert` is not an option either way — a compound
+unique cannot address a `NULL` component.)
+
+Existing rows keep `orgId = NULL` and go on working as the global layer;
+`prisma/backfill-organization.mjs` excludes `Setting` by name for exactly this
+reason. Stamping them with the `default` org would turn platform-wide defaults
+into one tenant's private settings and leave every other tenant with nothing.
 
 ### Per-route rollout status
 

--- a/e2e/admin-settings.spec.ts
+++ b/e2e/admin-settings.spec.ts
@@ -39,7 +39,7 @@ test('admin saves system settings and bulk-imports mentees from CSV', async ({ p
     expect(a?.role).toBe('MENTEE');
   } finally {
     await prisma.user.deleteMany({ where: { email: { in: [importedA, importedB] } } });
-    await prisma.setting.deleteMany({ where: { key: { in: ['reminderDays', 'supportEmail', 'weeklyDigest'] } } });
+    await prisma.setting.deleteMany({ where: { orgId: null, key: { in: ['reminderDays', 'supportEmail', 'weeklyDigest'] } } });
     await cleanupByEmail(adminEmail);
   }
 });

--- a/e2e/helpers/db.ts
+++ b/e2e/helpers/db.ts
@@ -24,6 +24,16 @@ export const prisma = new PrismaClient();
  * `page.waitForURL` timeout in `signInAsFreshUser`, pointing at the wait rather
  * than at the address (#2043).
  */
+// Write a Setting row in the GLOBAL layer (orgId = NULL) — the layer a
+// single-tenant test server reads, and the fallback every tenant inherits
+// (#1553). Deliberately a read-modify-write: the natural key (orgId, key)
+// contains a nullable column, so `upsert` cannot address the NULL row.
+export async function setGlobalSetting(key: string, value: string) {
+  const existing = await prisma.setting.findFirst({ where: { orgId: null, key } });
+  if (existing) await prisma.setting.update({ where: { id: existing.id }, data: { value } });
+  else await prisma.setting.create({ data: { orgId: null, key, value } });
+}
+
 export function uniqueEmail(prefix: string) {
   const slug = prefix.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^[-.]+|[-.]+$/g, '') || 'e2e';
   return `${slug}-${Date.now()}-${crypto.randomBytes(3).toString('hex')}@e2e.local`;

--- a/e2e/mentee-signup.spec.ts
+++ b/e2e/mentee-signup.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { prisma, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { prisma, cleanupByEmail, uniqueEmail, setGlobalSetting } from './helpers/db';
 
 test.afterAll(async () => {
   await prisma.$disconnect();
@@ -66,11 +66,7 @@ test('manual mode parks a self-registration for an admin', async ({ page }) => {
   const email = uniqueEmail('manualmentee');
   const password = 'MenteeSignup123!';
 
-  await prisma.setting.upsert({
-    where: { key: 'selfRegistration' },
-    create: { key: 'selfRegistration', value: 'manual' },
-    update: { value: 'manual' },
-  });
+  await setGlobalSetting('selfRegistration', 'manual');
 
   try {
     await page.goto('/auth/register');
@@ -100,11 +96,7 @@ test('manual mode parks a self-registration for an admin', async ({ page }) => {
   } finally {
     await cleanupByEmail(email);
     // Leave the shared DB on the default, or every later test inherits 'manual'.
-    await prisma.setting.upsert({
-      where: { key: 'selfRegistration' },
-      create: { key: 'selfRegistration', value: 'auto' },
-      update: { value: 'auto' },
-    });
+    await setGlobalSetting('selfRegistration', 'auto');
   }
 });
 

--- a/e2e/setting-org-scope.spec.ts
+++ b/e2e/setting-org-scope.spec.ts
@@ -1,0 +1,125 @@
+import { test, expect } from '@playwright/test';
+import { prisma, uniqueEmail } from './helpers/db';
+import { getSetting, getSettings, setSetting, SETTING_DEFAULTS } from '../src/lib/settings';
+import { runWithOrg } from '../src/lib/orgContext';
+
+// Per-tenant settings with a global fallback (#1553).
+//
+// These exercise src/lib/settings.ts + Prisma directly (no HTTP), because the
+// thing under test is the resolution ORDER — tenant row → global row (orgId =
+// NULL) → SETTING_DEFAULTS — and that has to hold whatever the server's
+// MT_ENFORCE_ISOLATION flag happens to be.
+
+async function clearGlobal(key: string) {
+  await prisma.setting.deleteMany({ where: { orgId: null, key } });
+}
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('two orgs resolve their own values, and an unset key falls back to the global row then the default', async () => {
+  const stamp = uniqueEmail('setting').replace(/[^a-z0-9]/gi, '').toLowerCase();
+  const orgA = await prisma.organization.create({ data: { name: `Set A ${stamp}`, slug: `seta-${stamp}` } });
+  const orgB = await prisma.organization.create({ data: { name: `Set B ${stamp}`, slug: `setb-${stamp}` } });
+
+  try {
+    // Tenant overrides: A requires 2FA of its admins on a 50-call AI budget,
+    // B leaves 2FA off and buys 900 calls.
+    await setSetting('require2fa', 'admins', orgA.id);
+    await setSetting('aiMonthlyQuota', '50', orgA.id);
+    await setSetting('require2fa', 'off', orgB.id);
+    await setSetting('aiMonthlyQuota', '900', orgB.id);
+
+    // 1. Each org resolves its own row — one tenant's compliance policy is not
+    //    the other's.
+    expect(await getSetting('require2fa', orgA.id)).toBe('admins');
+    expect(await getSetting('require2fa', orgB.id)).toBe('off');
+    expect(await getSetting('aiMonthlyQuota', orgA.id)).toBe('50');
+    expect(await getSetting('aiMonthlyQuota', orgB.id)).toBe('900');
+
+    // 2. A key neither org overrode falls back to the GLOBAL row.
+    await setSetting('retentionMonths', '36', null);
+    expect(await getSetting('retentionMonths', orgA.id)).toBe('36');
+    expect(await getSetting('retentionMonths', orgB.id)).toBe('36');
+    expect(await getSetting('retentionMonths', null)).toBe('36');
+
+    // …and a tenant row still wins over that global row.
+    await setSetting('retentionMonths', '6', orgB.id);
+    expect(await getSetting('retentionMonths', orgB.id)).toBe('6');
+    expect(await getSetting('retentionMonths', orgA.id)).toBe('36');
+
+    // 3. With no row at either level, the code default is the last resort.
+    await clearGlobal('earlyAccessWindowDays');
+    expect(await getSetting('earlyAccessWindowDays', orgA.id)).toBe(SETTING_DEFAULTS.earlyAccessWindowDays);
+
+    // getSettings() layers the same way in one pass.
+    const forA = await getSettings(orgA.id);
+    expect(forA.require2fa).toBe('admins');
+    expect(forA.retentionMonths).toBe('36');
+    expect(forA.earlyAccessWindowDays).toBe(SETTING_DEFAULTS.earlyAccessWindowDays);
+
+    const forB = await getSettings(orgB.id);
+    expect(forB.require2fa).toBe('off');
+    expect(forB.retentionMonths).toBe('6');
+
+    // A brand-new tenant with no rows of its own inherits the global layer —
+    // the whole reason the legacy rows stay at orgId = NULL.
+    const fresh = await getSettings('org-that-has-no-rows');
+    expect(fresh.retentionMonths).toBe('36');
+    expect(fresh.require2fa).toBe(SETTING_DEFAULTS.require2fa);
+  } finally {
+    await clearGlobal('retentionMonths');
+    await prisma.setting.deleteMany({ where: { orgId: { in: [orgA.id, orgB.id] } } });
+    await prisma.organization.deleteMany({ where: { id: { in: [orgA.id, orgB.id] } } });
+  }
+});
+
+// The zero-argument signatures (~20 existing call sites) keep working: they
+// resolve to whatever org the request bound, and to the global layer when none
+// is bound. This is also the regression guard for the auto-filter: `Setting` is
+// in TENANT_MODELS, so a naive scoped read would hide the orgId = NULL row and
+// the fallback would silently become "code default".
+test('the zero-argument readers follow the bound tenant and still see the global fallback', async () => {
+  const stamp = uniqueEmail('setambient').replace(/[^a-z0-9]/gi, '').toLowerCase();
+  const org = await prisma.organization.create({ data: { name: `Set C ${stamp}`, slug: `setc-${stamp}` } });
+  const prev = process.env.MT_ENFORCE_ISOLATION;
+
+  try {
+    // Start from a known global layer: an earlier spec may have left a row here.
+    await clearGlobal('aiMonthlyQuota');
+    await setSetting('aiMonthlyQuota', '77', org.id);
+    await setSetting('retentionMonths', '24', null);
+
+    process.env.MT_ENFORCE_ISOLATION = 'true';
+
+    // Bound to the org: its own row wins…
+    expect(await runWithOrg(org.id, () => getSetting('aiMonthlyQuota'))).toBe('77');
+    // …and the global row is STILL reachable for a key the org never set,
+    // even though the tenant middleware is live for this model.
+    expect(await runWithOrg(org.id, () => getSetting('retentionMonths'))).toBe('24');
+    expect((await runWithOrg(org.id, () => getSettings())).aiMonthlyQuota).toBe('77');
+
+    // No org bound → the global layer alone, which is exactly what a
+    // single-tenant installation reads.
+    expect(await runWithOrg(null, () => getSetting('aiMonthlyQuota'))).toBe(SETTING_DEFAULTS.aiMonthlyQuota);
+    expect(await runWithOrg(null, () => getSetting('retentionMonths'))).toBe('24');
+
+    // A write with no org bound lands on the global row, not on a tenant's.
+    await runWithOrg(null, () => setSetting('aiMonthlyQuota', '111'));
+    expect(await getSetting('aiMonthlyQuota', null)).toBe('111');
+    expect(await getSetting('aiMonthlyQuota', org.id)).toBe('77');
+
+    // A write made while bound to the org can only touch that org's row.
+    await runWithOrg(org.id, () => setSetting('aiMonthlyQuota', '88'));
+    expect(await getSetting('aiMonthlyQuota', org.id)).toBe('88');
+    expect(await getSetting('aiMonthlyQuota', null)).toBe('111');
+  } finally {
+    if (prev !== undefined) process.env.MT_ENFORCE_ISOLATION = prev;
+    else delete process.env.MT_ENFORCE_ISOLATION;
+    await clearGlobal('aiMonthlyQuota');
+    await clearGlobal('retentionMonths');
+    await prisma.setting.deleteMany({ where: { orgId: org.id } });
+    await prisma.organization.delete({ where: { id: org.id } });
+  }
+});

--- a/e2e/two-factor-enforcement.spec.ts
+++ b/e2e/two-factor-enforcement.spec.ts
@@ -1,15 +1,11 @@
 import { test, expect } from '@playwright/test';
-import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { prisma, seedUser, cleanupByEmail, uniqueEmail, setGlobalSetting } from './helpers/db';
 
 // The require2fa Setting is global and the CI DB is shared across tests, so this
 // spec MUST restore it to 'off' no matter what — otherwise every later admin
 // login would be redirected to the setup gate and cascade-fail.
 async function setPolicy(value: string) {
-  await prisma.setting.upsert({
-    where: { key: 'require2fa' },
-    create: { key: 'require2fa', value },
-    update: { value },
-  });
+  await setGlobalSetting('require2fa', value);
 }
 
 test.afterAll(async () => {

--- a/prisma/backfill-cron-baseline.mjs
+++ b/prisma/backfill-cron-baseline.mjs
@@ -35,7 +35,9 @@ const prisma = new PrismaClient();
 const BASELINE_KEY = 'cronBaselineAt';
 
 async function main() {
-  const existing = await prisma.setting.findUnique({ where: { key: BASELINE_KEY } });
+  // The GLOBAL layer (orgId = NULL) — this baseline is platform-wide, not one
+  // tenant's setting (#1553).
+  const existing = await prisma.setting.findFirst({ where: { orgId: null, key: BASELINE_KEY } });
   if (existing) {
     console.log(`backfill-cron-baseline: already applied at ${existing.value} — skipping.`);
     return;
@@ -59,7 +61,7 @@ async function main() {
     data: { deadlineReminderSentAt: now },
   });
 
-  await prisma.setting.create({ data: { key: BASELINE_KEY, value: now.toISOString() } });
+  await prisma.setting.create({ data: { orgId: null, key: BASELINE_KEY, value: now.toISOString() } });
 
   console.log(
     `backfill-cron-baseline: baselined ${digested.count} undigested message(s) and ` +

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -117,6 +117,7 @@ model Organization {
   messageTemplates     MessageTemplate[]
   apiKeys              ApiKey[]
   matchFeedback        MatchFeedback[]
+  settings             Setting[]
 }
 
 // Per-tenant customizable pipeline stages (#747, part of white-label #546).
@@ -1539,10 +1540,31 @@ model ApiKey {
 
 // Key-value system settings, admin-editable (e.g. reminder cadence, support
 // email). Values are stored as strings; callers parse as needed.
+//
+// Resolved per tenant with a global fallback (#1553) — the ONE place that rule
+// lives is src/lib/settings.ts; never read this table directly.
+//
+//   orgId = <tenant>  → that tenant's override
+//   orgId = NULL      → the GLOBAL layer, inherited by every tenant that has no
+//                       row of its own (and the only layer a single-tenant
+//                       installation ever writes)
+//
+// The natural key is (orgId, key), but a nullable column cannot be part of a
+// primary key, so the table carries a surrogate `id` and enforces the pair with
+// a unique index. MySQL treats NULLs as distinct in a unique index, so that
+// index constrains the per-tenant rows only; uniqueness of the global layer is
+// held by settings.ts being the single writer (read-modify-write, never a blind
+// insert).
 model Setting {
-  key       String   @id
+  id        String   @id @default(cuid())
+  orgId     String?
+  key       String
   value     String   @db.Text
   updatedAt DateTime @updatedAt
+
+  org Organization? @relation(fields: [orgId], references: [id], onDelete: Cascade)
+
+  @@unique([orgId, key])
 }
 
 enum ProjectStatus {

--- a/releases/unreleased/setting-org-scope.json
+++ b/releases/unreleased/setting-org-scope.json
@@ -1,0 +1,9 @@
+{
+  "bump": "minor",
+  "changelog": "- **Settings are per-tenant with a global fallback** (#1553). `Setting` is re-keyed to (`orgId`, `key`) — a surrogate `id` plus `@@unique([orgId, key])` — and resolves org row → global row (`orgId = NULL`) → `SETTING_DEFAULTS`. The rule lives only in `src/lib/settings.ts` (`getSetting`/`getSettings`/`setSetting`, org argument optional and defaulting to the request's bound tenant), so the existing zero-argument call sites are unchanged. `PUT /api/admin/settings` is wrapped in `withTenantScope` and writes only the caller's own org. `Setting` is registered in `TENANT_MODELS`; its own readers run inside `runWithOrg(null, …)` because the auto-filter would otherwise hide the global fallback row. Legacy rows stay `orgId = NULL` as the global layer. **Dangerous under `db push`** — the primary-key change is resolved as DROP + CREATE, so it needs `prisma migrate deploy` (#1515) before it reaches a database that holds real settings.",
+  "notes": {
+    "en": ["Each organisation can now hold its own settings — 2FA policy, data retention, AI quota — falling back to the platform defaults for anything it has not set."],
+    "tr": ["Her kuruluş artık kendi ayarlarını tutabiliyor — 2FA politikası, veri saklama süresi, AI kotası — ve kendi belirlemediği her ayar için platform varsayılanına düşüyor."],
+    "de": ["Jede Organisation kann jetzt eigene Einstellungen führen — 2FA-Richtlinie, Aufbewahrungsdauer, KI-Kontingent — und fällt für alles Übrige auf die Plattform-Standards zurück."]
+  }
+}

--- a/scripts/check-tenant-models.mjs
+++ b/scripts/check-tenant-models.mjs
@@ -34,14 +34,12 @@ const ORG_CONTEXT_FILE = 'src/lib/orgContext.ts';
 // entry needs a written reason, so that an intentional omission is a
 // code-review conversation and is distinguishable from a forgotten one.
 //
-// An exemption is only granted against a schema someone has actually read.
-// `Setting` is deliberately NOT listed here even though it is coming: it has no
-// `orgId` column today (#1551 adds one, and #1557 records that its legacy rows
-// will stay NULL as the global fallback layer), while #1560 says it "must be
-// registered but behaves specially". Pre-granting the exemption would keep this
-// guard green on the day the column lands and the register-vs-exempt decision
-// would never get made. Better that it fails then, loudly, against the real
-// schema.
+// An exemption is only granted against a schema someone has actually read. That
+// is what happened with `Setting`: #1553 gave it an `orgId`, this guard failed
+// against the real shape, and the call was made — it is REGISTERED, not exempt.
+// Its readers/writers (src/lib/settings.ts) clear the tenant context for their
+// own queries so the global (orgId = NULL) fallback row stays reachable; the
+// registration is what keeps every *other* `prisma.setting` caller scoped.
 //
 // `Organization` is different: it is the tenant itself and can never grow an
 // `orgId`, so the entry is permanent documentation rather than a standing

--- a/src/app/api/admin/settings/route.ts
+++ b/src/app/api/admin/settings/route.ts
@@ -1,16 +1,17 @@
 import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
-import { prisma } from '@/lib/prisma';
 import { z } from 'zod';
-import { getSettings, SETTING_DEFAULTS, type SettingKey } from '@/lib/settings';
+import { getSettings, setSetting, SETTING_DEFAULTS, type SettingKey } from '@/lib/settings';
+import { withTenantScope } from '@/lib/orgContext';
 import { logActivity } from '@/lib/activity';
 
-// GET — current settings (with defaults filled in).
+// GET — current settings for the caller's tenant, resolved org row → global row
+// → code default (see src/lib/settings.ts).
 export async function GET() {
   const session = await getServerSession(authOptions);
   if (!session || session.user.role !== 'ADMIN') return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  return NextResponse.json({ settings: await getSettings() });
+  return withTenantScope(session, async () => NextResponse.json({ settings: await getSettings() }));
 }
 
 const schema = z.object({
@@ -33,7 +34,12 @@ const schema = z.object({
   newsletterSendHour: z.string().regex(/^(?:[0-9]|1[0-9]|2[0-3])$/).optional(),
 });
 
-// PUT — upsert one or more settings.
+// PUT — write one or more settings for the CALLER'S OWN tenant.
+//
+// The layer written is never taken from the request body: `setSetting` derives it
+// from the org bound by `withTenantScope` below (and falls back to the global row
+// when no org is bound, which is what a single-tenant installation does today),
+// so tenant B's admin cannot reach tenant A's row no matter what it posts.
 export async function PUT(request: Request) {
   const session = await getServerSession(authOptions);
   if (!session || session.user.role !== 'ADMIN') return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -41,12 +47,12 @@ export async function PUT(request: Request) {
   const parsed = schema.safeParse(await request.json());
   if (!parsed.success) return NextResponse.json({ error: 'Validation failed' }, { status: 400 });
 
-  const entries = Object.entries(parsed.data).filter(([k]) => k in SETTING_DEFAULTS) as [SettingKey, string][];
-  await Promise.all(
-    entries.map(([key, value]) =>
-      prisma.setting.upsert({ where: { key }, create: { key, value }, update: { value } })
-    )
-  );
-  await logActivity({ action: 'settings.update', actorId: session.user.id, actorEmail: session.user.email ?? null });
-  return NextResponse.json({ settings: await getSettings() });
+  return withTenantScope(session, async () => {
+    const entries = Object.entries(parsed.data).filter(([k]) => k in SETTING_DEFAULTS) as [SettingKey, string][];
+    // Sequential on purpose: two writes for the same (org, key) must not race
+    // the read-modify-write inside setSetting into a duplicate row.
+    for (const [key, value] of entries) await setSetting(key, value);
+    await logActivity({ action: 'settings.update', actorId: session.user.id, actorEmail: session.user.email ?? null });
+    return NextResponse.json({ settings: await getSettings() });
+  });
 }

--- a/src/lib/orgContext.ts
+++ b/src/lib/orgContext.ts
@@ -68,6 +68,13 @@ const TENANT_MODELS: ReadonlySet<Prisma.ModelName> = new Set([
   // outside any request scope, where the middleware does not engage, so they
   // still see the whole queue.
   'Job',
+  // Product settings (#1553). Registered so that any code touching
+  // `prisma.setting` directly can only ever see its own tenant's rows. The
+  // settings readers/writers in src/lib/settings.ts deliberately opt OUT (they
+  // run inside `runWithOrg(null, …)`), because the org → GLOBAL (orgId = NULL)
+  // → code-default fallback chain needs to read a row this filter would hide;
+  // they compute the org themselves from the bound context instead.
+  'Setting',
 ]);
 
 // Actions whose `where` selects rows to read or mutate — inject orgId there.

--- a/src/lib/orgContext.ts
+++ b/src/lib/orgContext.ts
@@ -25,6 +25,7 @@ import type { Session } from 'next-auth';
 import { Prisma } from '@prisma/client';
 import { prisma } from './prisma';
 import { isIsolationEnforced, resolveOrgId } from './orgScope';
+import { registerTenantAmbient } from './tenantAmbient';
 
 // The value carried per request: the tenant id to scope to (or null when the
 // request has no resolvable org — e.g. an unauthenticated/public route).
@@ -183,3 +184,15 @@ export function runWithOrg<T>(orgId: string | null, fn: () => T): T {
 export function withTenantScope<T>(session: Session | null | undefined, fn: () => T): T {
   return runWithOrg(resolveOrgId(session), fn);
 }
+
+// Publish this engine to the client-safe seam (src/lib/tenantAmbient.ts) so
+// modules that must not import THIS file — it pulls in node:async_hooks, which
+// webpack refuses to bundle for a client graph — can still read the bound org
+// and run a query outside the tenant filter. `src/lib/settings.ts` is the one
+// that needs both; see the header there. Evaluating this module is what
+// registers it, and any request that binds a tenant has evaluated it, because
+// `withTenantScope` above is how the binding happens.
+registerTenantAmbient({
+  currentOrgId,
+  runUnscoped: (fn) => runWithOrg(null, fn),
+});

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1,5 +1,5 @@
 import { prisma } from '@/lib/prisma';
-import { currentOrgId, runWithOrg } from '@/lib/orgContext';
+import { ambientOrgId, runUnscoped } from '@/lib/tenantAmbient';
 
 // ── Settings resolution (#1553) ──────────────────────────────────────────────
 //
@@ -27,6 +27,12 @@ import { currentOrgId, runWithOrg } from '@/lib/orgContext';
 // is computed here from `settingOrgId()`, never taken from request input. The
 // registration still earns its keep: any *other* code that touches
 // `prisma.setting` directly stays auto-scoped to its own tenant.
+//
+// Both of those come from `@/lib/tenantAmbient` rather than straight from
+// `orgContext`: this module is reachable from a client component (a constant in
+// documentAccess.ts, via retention.ts), and orgContext imports node:async_hooks,
+// which webpack refuses to bundle for a client graph. The seam has no imports of
+// its own; orgContext fills it in when it loads.
 
 // Known settings with their defaults. Stored as strings; parsed on read.
 export const SETTING_DEFAULTS = {
@@ -96,15 +102,15 @@ export type SettingKey = keyof typeof SETTING_DEFAULTS;
 // tenant; otherwise none.
 export function settingOrgId(orgId?: string | null): string | null {
   if (orgId !== undefined) return orgId;
-  return currentOrgId() ?? null;
+  return ambientOrgId() ?? null;
 }
 
 // Run a Setting query with the tenant auto-filter switched off — see the header:
-// the global fallback row (orgId = NULL) is invisible to a scoped query.
-// `runWithOrg(null, …)` binds an empty tenant context, which the middleware
-// skips; with enforcement off it is a plain passthrough.
+// the global fallback row (orgId = NULL) is invisible to a scoped query. This
+// binds an empty tenant context, which the middleware skips; with enforcement
+// off (or the engine not loaded at all) it is a plain passthrough.
 function unscopedSettings<T>(fn: () => Promise<T>): Promise<T> {
-  return runWithOrg(null, fn);
+  return runUnscoped(fn);
 }
 
 type SettingRow = { orgId: string | null; key: string; value: string };

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1,4 +1,32 @@
 import { prisma } from '@/lib/prisma';
+import { currentOrgId, runWithOrg } from '@/lib/orgContext';
+
+// ── Settings resolution (#1553) ──────────────────────────────────────────────
+//
+// `Setting` is keyed by (orgId, key). A row with `orgId = NULL` is the GLOBAL
+// layer; a row with an orgId is one tenant's override. Every read resolves in
+// exactly this order, and this file is the ONLY place that rule is written:
+//
+//   1. the row for the resolved org  (orgId = <tenant>)
+//   2. the global row                (orgId = NULL)
+//   3. SETTING_DEFAULTS              (the code default, below)
+//
+// Which org a call resolves to: an explicit `orgId` argument wins; otherwise the
+// org bound to the current request by `withTenantScope()` (`currentOrgId()`);
+// otherwise none, which means the global layer alone. A single-tenant
+// installation — and every request made while `MT_ENFORCE_ISOLATION` is off —
+// therefore reads and writes the global rows exactly as it did before, so the
+// existing rows keep working untouched as the platform-wide defaults.
+//
+// WHY THESE QUERIES RUN UNSCOPED: `Setting` is registered in `TENANT_MODELS`
+// (src/lib/orgContext.ts), so with enforcement on the tenant middleware would
+// rewrite every query here to `where: { orgId: <tenant> }` — which is precisely
+// the filter that would hide the global fallback row and make step 2 above
+// unreachable. `unscopedSettings()` runs the query with the tenant context
+// explicitly cleared so this module can see both layers; the org it then honours
+// is computed here from `settingOrgId()`, never taken from request input. The
+// registration still earns its keep: any *other* code that touches
+// `prisma.setting` directly stays auto-scoped to its own tenant.
 
 // Known settings with their defaults. Stored as strings; parsed on read.
 export const SETTING_DEFAULTS = {
@@ -63,15 +91,75 @@ export const SETTING_DEFAULTS = {
 
 export type SettingKey = keyof typeof SETTING_DEFAULTS;
 
-export async function getSettings(): Promise<Record<SettingKey, string>> {
-  const rows = await prisma.setting.findMany();
+// The org a settings call applies to. An explicit argument wins (including an
+// explicit `null`, meaning "the global layer"); otherwise the request's bound
+// tenant; otherwise none.
+export function settingOrgId(orgId?: string | null): string | null {
+  if (orgId !== undefined) return orgId;
+  return currentOrgId() ?? null;
+}
+
+// Run a Setting query with the tenant auto-filter switched off — see the header:
+// the global fallback row (orgId = NULL) is invisible to a scoped query.
+// `runWithOrg(null, …)` binds an empty tenant context, which the middleware
+// skips; with enforcement off it is a plain passthrough.
+function unscopedSettings<T>(fn: () => Promise<T>): Promise<T> {
+  return runWithOrg(null, fn);
+}
+
+type SettingRow = { orgId: string | null; key: string; value: string };
+
+// Both layers for `org` (tenant rows + global rows), in one query.
+function loadRows(org: string | null, key?: SettingKey): Promise<SettingRow[]> {
+  return unscopedSettings(() =>
+    prisma.setting.findMany({
+      where: {
+        ...(key ? { key } : {}),
+        OR: org ? [{ orgId: org }, { orgId: null }] : [{ orgId: null }],
+      },
+      select: { orgId: true, key: true, value: true },
+    }),
+  );
+}
+
+// All settings for an org, with the global row and then the code default filled
+// in for every key the org has not overridden.
+export async function getSettings(orgId?: string | null): Promise<Record<SettingKey, string>> {
+  const org = settingOrgId(orgId);
+  const rows = await loadRows(org);
   const map: Record<string, string> = { ...SETTING_DEFAULTS };
-  for (const r of rows) if (r.key in SETTING_DEFAULTS) map[r.key] = r.value;
+  // Global layer first, tenant overrides on top — order matters, not the order
+  // the rows happen to come back in.
+  for (const r of rows) if (r.orgId === null && r.key in SETTING_DEFAULTS) map[r.key] = r.value;
+  for (const r of rows) if (r.orgId !== null && r.key in SETTING_DEFAULTS) map[r.key] = r.value;
   return map as Record<SettingKey, string>;
 }
 
-// Read a single setting (falls back to its default).
-export async function getSetting(key: SettingKey): Promise<string> {
-  const row = await prisma.setting.findUnique({ where: { key } });
-  return row?.value ?? SETTING_DEFAULTS[key];
+// Read a single setting: tenant row → global row → default.
+export async function getSetting(key: SettingKey, orgId?: string | null): Promise<string> {
+  const org = settingOrgId(orgId);
+  const rows = await loadRows(org, key);
+  const tenant = org ? rows.find((r) => r.orgId === org) : undefined;
+  const global = rows.find((r) => r.orgId === null);
+  return tenant?.value ?? global?.value ?? SETTING_DEFAULTS[key];
+}
+
+// Write one setting into a single layer — the org resolved exactly as reads
+// resolve it, so a tenant admin can only ever write their own org's row and a
+// single-tenant installation keeps writing the global one.
+//
+// `orgId` is a SERVER-SIDE argument (seeds, jobs, tests). Never pass a value
+// that came from a request body: the authorization for this write is that the
+// org is derived from the session's bound context, not from input.
+//
+// Deliberately a read-modify-write rather than `prisma.setting.upsert`: the
+// natural key contains a nullable column, so the compound unique cannot address
+// the global (orgId = NULL) row.
+export async function setSetting(key: SettingKey, value: string, orgId?: string | null): Promise<void> {
+  const org = settingOrgId(orgId);
+  await unscopedSettings(async () => {
+    const existing = await prisma.setting.findFirst({ where: { orgId: org, key }, select: { id: true } });
+    if (existing) await prisma.setting.update({ where: { id: existing.id }, data: { value } });
+    else await prisma.setting.create({ data: { orgId: org, key, value } });
+  });
 }

--- a/src/lib/tenantAmbient.ts
+++ b/src/lib/tenantAmbient.ts
@@ -1,0 +1,44 @@
+// A client-safe seam onto the tenant context engine (#1553).
+//
+// `src/lib/orgContext.ts` is SERVER-ONLY: it imports `node:async_hooks`, and
+// webpack fails the whole build ("Reading from node:async_hooks is not handled
+// by plugins") the moment that module lands in a client graph. `src/lib/
+// settings.ts` is in one — a client component imports a constant from
+// `documentAccess.ts`, which reaches `settings.ts` through `retention.ts` — so
+// settings.ts cannot import orgContext.ts, even though it genuinely needs two
+// things from it: the org bound to the current request, and a way to run its own
+// queries with the tenant auto-filter off so the global fallback row stays
+// visible.
+//
+// This module is that seam. It holds two function slots and imports nothing, so
+// it is safe anywhere. `orgContext.ts` fills the slots as a side effect of being
+// loaded, which happens on every request that binds a tenant — `withTenantScope`
+// lives there. When it has NOT been loaded the fallbacks below are the correct
+// answers anyway: there is no bound context to read, and no middleware installed
+// to escape from.
+
+export type TenantAmbient = {
+  // The orgId bound to the current async context; `undefined` when there is none.
+  currentOrgId: () => string | null | undefined;
+  // Run `fn` with the tenant auto-filter switched off for its queries.
+  runUnscoped: <T>(fn: () => T) => T;
+};
+
+let ambient: TenantAmbient | null = null;
+
+// Called once by src/lib/orgContext.ts when that module is evaluated.
+export function registerTenantAmbient(impl: TenantAmbient): void {
+  ambient = impl;
+}
+
+// The org bound to the current request, or `undefined` when nothing is bound
+// (including when the server-only engine was never loaded).
+export function ambientOrgId(): string | null | undefined {
+  return ambient?.currentOrgId();
+}
+
+// Run `fn` outside any tenant scope. Without the engine loaded nothing is
+// scoping in the first place, so calling `fn` directly is the same thing.
+export function runUnscoped<T>(fn: () => T): T {
+  return ambient ? ambient.runUnscoped(fn) : fn();
+}


### PR DESCRIPTION
## Summary

Eighteen product decisions — 2FA enforcement, retention window, AI quota, sign-up policy, blind review, newsletter cadence — lived in a single global key/value table. With two tenants on the box, one customer's compliance policy silently becomes everybody's.

`Setting` is now keyed by **(`orgId`, `key`)** and resolves **tenant row → global row (`orgId = NULL`) → `SETTING_DEFAULTS`**, so a fresh tenant inherits sane platform defaults instead of an empty config.

Closes #1553

## ⚠️ DANGEROUS under `db push` — needs #1515 before it reaches a real database

This changes `Setting`'s **primary key**. `prisma db push --accept-data-loss` resolves a primary-key change on a `String @id` table as **DROP + CREATE**: every stored setting is destroyed. Every PR topic environment has its **own empty database**, so this PR's own preview looks perfectly healthy and only an environment that holds real rows is hurt.

- **Do not merge/deploy before the migrations epic #1515 lands `prisma migrate deploy`.** There is no `migrations/` folder in the repo today, so there is no migration file to name — the change is applied by whatever first migration #1515 generates from this schema.
- This PR should carry the `migration:dangerous` label (#1529); I could not apply it from here.
- The non-destructive shape was chosen where there was a choice: a surrogate `id String @id @default(cuid())` + `@@unique([orgId, key])`, **not** a composite `@@id([orgId, key])` (a nullable column cannot be part of a primary key). The equivalent hand-run SQL, if the maintainer wants to pre-apply it before a `db push`, is `ALTER TABLE Setting ADD COLUMN orgId VARCHAR(191) NULL, ADD COLUMN id VARCHAR(191) NOT NULL DEFAULT (uuid()), DROP PRIMARY KEY, ADD PRIMARY KEY (id), ADD UNIQUE KEY Setting_orgId_key_key (orgId, \`key\`)` — after which the push is a no-op. I did not commit that as a migration file, per the repo's "no SQL migrations" rule.

## Changes

- **`prisma/schema.prisma`** — `Setting` gains `id String @id @default(cuid())`, `orgId String?`, an `Organization` relation (`onDelete: Cascade`) and `@@unique([orgId, key])`. `key` is no longer the primary key.
- **`src/lib/settings.ts`** — the one place the resolution rule lives:
  - `getSetting(key, orgId?)`, `getSettings(orgId?)`, new `setSetting(key, value, orgId?)`.
  - The org argument is optional. Omitted, it resolves to the org bound by `withTenantScope()` (`currentOrgId()`), and to the **global layer** when no org is bound — so the ~20 existing zero-argument call sites (#1621) are untouched, and a single-tenant installation (and every request while `MT_ENFORCE_ISOLATION` is off) reads and writes exactly the rows it does today.
  - `setSetting` is a read-modify-write, not `upsert`: a compound unique cannot address a `NULL` component.
- **`src/app/api/admin/settings/route.ts`** — GET and PUT wrapped in `withTenantScope(session, …)`; PUT writes through `setSetting`, so the layer comes from the session's bound org and **never from the request body**. Tenant B's admin cannot reach tenant A's row regardless of what it posts. Writes are sequential so two values for the same `(org, key)` cannot race into a duplicate row.
- **`src/lib/orgContext.ts`** — `Setting` added to `TENANT_MODELS`, with the reasoning in place.
- **`prisma/backfill-cron-baseline.mjs`** — reads/writes its `cronBaselineAt` row in the global layer explicitly.
- **`scripts/check-tenant-models.mjs`** — the `EXEMPT` prose said `Setting` was deliberately left un-exempted so the register-vs-exempt call would be made against the real column. That call is now made: registered, not exempt. Comment updated to record it.
- **`docs/tenant-isolation.md`** — new section "Settings: per-tenant with a global fallback", covering the layer table, the resolution order, the opt-out below, and the MySQL NULL-uniqueness wrinkle.
- **`e2e/setting-org-scope.spec.ts`** (new) + `e2e/helpers/db.ts` `setGlobalSetting()`; the three existing specs that wrote `Setting` directly moved onto the new shape.
- Release fragment `releases/unreleased/setting-org-scope.json` (`minor`, EN/TR/DE notes).

## The auto-filter question (asked explicitly in the issue)

**Yes, an org-scoped auto-filter would have broken the deliberate global-fallback read, and it is handled — not avoided.**

`Setting` **is** registered in `TENANT_MODELS`, so any code that reaches for `prisma.setting` outside `src/lib/settings.ts` is auto-scoped to its own tenant like every other tenant model. But with `MT_ENFORCE_ISOLATION=true` that same middleware rewrites *every* query to `where: { orgId: <tenant> }` — which is precisely the filter that hides the `orgId = NULL` row and would turn step 2 of the chain into a silent "code default" for every tenant.

So the queries inside `settings.ts` run through `runWithOrg(null, …)`, which binds an empty tenant context that the middleware skips (and is a plain passthrough when the flag is off). That is safe because the module computes the org **itself**, from the bound context, and never from input — the escape hatch buys back the global row, not the ability to address someone else's tenant. The second test in `e2e/setting-org-scope.spec.ts` pins exactly this: with the flag on and an org bound, a key the org never set still resolves to the global row.

## Backfill / migration path

Existing rows stay `orgId = NULL` — they *are* the global layer. `prisma/backfill-organization.mjs` already excludes `Setting` by name with that reason written down, so no backfill change was needed. Stamping the legacy rows with the `default` org would turn platform-wide defaults into one tenant's private settings and leave every other tenant with no configuration at all.

## Verification

- [x] `npx prisma format && npx prisma validate && npx prisma generate` — valid
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean (only the two pre-existing `react-hooks/exhaustive-deps` warnings)
- [x] `npm run check:tenant-models` — passes; `Setting` now counted among the registered models
- [x] `npm run check:release-fragments`, `npm run check:openapi`, `npm run check:auth-reads`, `npm run check:query-scalars` — all pass
- [x] `npx playwright test --list e2e/setting-org-scope.spec.ts` — 2 tests collected
- [ ] E2E suite not run locally (no database or browser build in this environment) — CI runs the smoke set on this PR

## Deliberately out of scope

- No `programId` column, no `src/lib/settingsResolver.ts`, no `resolveSetting()` and no typed `SETTING_SCHEMA` — those belong to #1619, which stays purely additive on top of this shape, and #1621 then moves the readers.
- The ~20 existing `getSetting()` call sites are unchanged by design; they keep working through the ambient-org resolution.
- The new spec is **not** tagged `@smoke` (it needs two orgs and DB round-trips); it runs in the scheduled full suite.
- No new user-facing copy, so no `src/i18n/dictionaries.ts` change.

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip): my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it passes to the rights holder (Mehmet Erşahin) who may also license it commercially, it is my own work, and I make no claim over the application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ra7wrp478VPjzHJHh4QMvZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ra7wrp478VPjzHJHh4QMvZ)_