### PR TITLE
fix: make zod upper bounds match the column they guard (#1433)

### DIFF
--- a/e2e/text-limits-columns.unit.spec.ts
+++ b/e2e/text-limits-columns.unit.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+import { z } from 'zod';
+import { TEXT_LIMITS } from '@/lib/textLimits';
+
+// The invariant `src/lib/textLimits.ts` states in its own header, checked
+// against the schema instead of trusted (#1433).
+//
+//   server cap > column width → Prisma P2000 ("Data too long"), which no route
+//   handles, so it surfaces as a 500.
+//
+// Two fields had drifted past it. `Company.name` had no `max()` at all on
+// either side, so a 250-character paste reached MySQL and came back to the
+// admin as "Internal server error"; `ProjectTask.title` was capped at 300
+// against a VARCHAR(191) column, and the to-dos endpoint had no try/catch, so
+// the same paste produced a 500 with an EMPTY BODY and the UI said nothing.
+//
+// The three assertions below are deliberately separate, because each one alone
+// is satisfiable by a wrong fix:
+//
+//   1. the constant equals what the column can actually hold (parsed from
+//      prisma/schema.prisma — the source of truth, not a number retyped here);
+//   2. the guarded fields reference the constant rather than an inline number,
+//      which is the rule the limits file exists to enforce;
+//   3. a schema built from the constant accepts the column's capacity exactly
+//      and rejects one character more.
+//
+// Raising `TEXT_LIMITS.todoTitle` back to 300 fails (1) and (3); re-inlining a
+// literal in a route fails (2).
+
+const root = process.cwd();
+const schemaSource = fs.readFileSync(path.join(root, 'prisma/schema.prisma'), 'utf8');
+
+/**
+ * The width of one `String` column, read from the schema. A `String` with no
+ * `@db.` attribute is VARCHAR(191) in MySQL — that default is exactly what made
+ * both bugs invisible in review, so it is spelled out here.
+ */
+function columnWidth(model: string, field: string): number {
+  const block = new RegExp(`^model ${model} \\{$([\\s\\S]*?)^\\}$`, 'm').exec(schemaSource);
+  expect(block, `model ${model} not found in prisma/schema.prisma`).not.toBeNull();
+  const line = new RegExp(`^\\s+${field}\\s+String\\??\\s*(.*)$`, 'm').exec(block![1]);
+  expect(line, `${model}.${field} not found (or not a String)`).not.toBeNull();
+  const attrs = line![1];
+  const explicit = /@db\.VarChar\((\d+)\)/.exec(attrs);
+  expect(attrs, `${model}.${field} is a TEXT column — this spec is about VARCHAR bounds`).not.toMatch(
+    /@db\.(Text|MediumText|LongText)/,
+  );
+  return explicit ? Number(explicit[1]) : 191;
+}
+
+const FIELDS = [
+  { limit: 'companyName', model: 'Company', column: 'name' },
+  { limit: 'companyAddress', model: 'Company', column: 'address' },
+  { limit: 'todoTitle', model: 'ProjectTask', column: 'title' },
+] as const;
+
+for (const { limit, model, column } of FIELDS) {
+  test(`TEXT_LIMITS.${limit} fits ${model}.${column}`, async () => {
+    expect(TEXT_LIMITS[limit]).toBeLessThanOrEqual(columnWidth(model, column));
+  });
+
+  test(`${model}.${column} accepts the column's capacity and rejects one more`, async () => {
+    const width = columnWidth(model, column);
+    const schema = z.string().min(1).max(TEXT_LIMITS[limit]);
+
+    // At the limit: fine. One over: rejected here, not by the database driver.
+    expect(schema.safeParse('x'.repeat(width)).success).toBe(true);
+    expect(schema.safeParse('x'.repeat(width + 1)).success).toBe(false);
+
+    // And the 250-character paste from the bug report, which used to 500.
+    expect(schema.safeParse('x'.repeat(250)).success).toBe(false);
+  });
+}
+
+// Every place that guards one of these fields, and the constant it must use.
+// A route that goes back to an inline number silently reopens the drift the
+// limits file was written to close.
+const GUARDS: { file: string; limit: keyof typeof TEXT_LIMITS }[] = [
+  { file: 'src/app/api/companies/route.ts', limit: 'companyName' },
+  { file: 'src/app/api/companies/route.ts', limit: 'companyAddress' },
+  { file: 'src/app/api/companies/[id]/route.ts', limit: 'companyName' },
+  { file: 'src/app/api/companies/[id]/route.ts', limit: 'companyAddress' },
+  { file: 'src/components/forms/CompanyForm.tsx', limit: 'companyName' },
+  { file: 'src/components/forms/CompanyForm.tsx', limit: 'companyAddress' },
+  { file: 'src/app/api/todos/route.ts', limit: 'todoTitle' },
+  { file: 'src/app/api/projects/[id]/tasks/route.ts', limit: 'todoTitle' },
+  { file: 'src/app/api/project-tasks/[taskId]/route.ts', limit: 'todoTitle' },
+  { file: 'src/components/todos/MyTodos.tsx', limit: 'todoTitle' },
+  { file: 'src/components/todos/PersonTodos.tsx', limit: 'todoTitle' },
+  { file: 'src/components/todos/TodoRow.tsx', limit: 'todoTitle' },
+];
+
+for (const { file, limit } of GUARDS) {
+  test(`${file} caps with TEXT_LIMITS.${limit}, not a literal`, async () => {
+    const source = fs.readFileSync(path.join(root, file), 'utf8');
+    expect(source).toContain(`TEXT_LIMITS.${limit}`);
+  });
+}
+
+test('POST /api/todos can no longer answer with an empty-bodied 500', async () => {
+  const source = fs.readFileSync(path.join(root, 'src/app/api/todos/route.ts'), 'utf8');
+  const post = source.slice(source.indexOf('export async function POST'));
+  // A catch that returns JSON is what turns "the box just sits there" into a
+  // message the client can read out.
+  expect(post).toMatch(/catch \(error\)[\s\S]*NextResponse\.json\([\s\S]*status: 500/);
+});

--- a/e2e/text-limits-columns.unit.spec.ts
+++ b/e2e/text-limits-columns.unit.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 import fs from 'fs';
 import path from 'path';
 import { z } from 'zod';
-import { TEXT_LIMITS } from '@/lib/textLimits';
+import { TEXT_LIMITS, type TextLimitKey } from '@/lib/textLimits';
 
 // The invariant `src/lib/textLimits.ts` states in its own header, checked
 // against the schema instead of trusted (#1433).
@@ -10,93 +10,203 @@ import { TEXT_LIMITS } from '@/lib/textLimits';
 //   server cap > column width → Prisma P2000 ("Data too long"), which no route
 //   handles, so it surfaces as a 500.
 //
-// Two fields had drifted past it. `Company.name` had no `max()` at all on
-// either side, so a 250-character paste reached MySQL and came back to the
-// admin as "Internal server error"; `ProjectTask.title` was capped at 300
-// against a VARCHAR(191) column, and the to-dos endpoint had no try/catch, so
-// the same paste produced a 500 with an EMPTY BODY and the UI said nothing.
+// `Company.name` had no `max()` at all on either side, so a 250-character paste
+// reached MySQL and came back to the admin as "Internal server error";
+// `ProjectTask.title` (and `ProjectTaskTemplate.title`, whose wording is copied
+// into it verbatim) was capped at 300 against a VARCHAR(191) column, and the
+// to-dos endpoint had no try/catch, so the same paste produced a 500 with an
+// EMPTY BODY and the UI said nothing.
 //
-// The three assertions below are deliberately separate, because each one alone
-// is satisfiable by a wrong fix:
+// THE POINT OF THIS FILE is that the list below is not hand-picked. Every
+// `String` column of the guarded models is read out of prisma/schema.prisma and
+// must appear in `COLUMN_GUARDS` — either with the constant that bounds it, or
+// with a written reason why it needs none. Adding a sixth text field to the
+// company modal without capping it fails here, which is exactly how the first
+// version of this fix missed `industry` and `logoUrl` sitting one input to the
+// right of the field it corrected.
 //
-//   1. the constant equals what the column can actually hold (parsed from
+// The assertions are deliberately separate, because each one alone is
+// satisfiable by a wrong fix:
+//
+//   1. every String column is accounted for (capped, or exempt with a reason);
+//   2. the constant fits what the column can actually hold (parsed from
 //      prisma/schema.prisma — the source of truth, not a number retyped here);
-//   2. the guarded fields reference the constant rather than an inline number,
+//   3. the guarding files reference the constant rather than an inline number,
 //      which is the rule the limits file exists to enforce;
-//   3. a schema built from the constant accepts the column's capacity exactly
+//   4. a schema built from the constant accepts the column's capacity exactly
 //      and rejects one character more.
 //
-// Raising `TEXT_LIMITS.todoTitle` back to 300 fails (1) and (3); re-inlining a
-// literal in a route fails (2).
+// Raising `TEXT_LIMITS.todoTitle` back to 300 fails (2) and (4); re-inlining a
+// literal in a route fails (3); a new uncapped column fails (1).
 
 const root = process.cwd();
 const schemaSource = fs.readFileSync(path.join(root, 'prisma/schema.prisma'), 'utf8');
 
+type Column = { name: string; kind: 'varchar'; width: number } | { name: string; kind: 'text' };
+
 /**
- * The width of one `String` column, read from the schema. A `String` with no
- * `@db.` attribute is VARCHAR(191) in MySQL — that default is exactly what made
- * both bugs invisible in review, so it is spelled out here.
+ * Every `String` column of one model, with its width. A `String` with no `@db.`
+ * attribute is VARCHAR(191) in MySQL — that default is exactly what made both
+ * bugs invisible in review, so it is spelled out here.
  */
-function columnWidth(model: string, field: string): number {
+function stringColumns(model: string): Column[] {
   const block = new RegExp(`^model ${model} \\{$([\\s\\S]*?)^\\}$`, 'm').exec(schemaSource);
   expect(block, `model ${model} not found in prisma/schema.prisma`).not.toBeNull();
-  const line = new RegExp(`^\\s+${field}\\s+String\\??\\s*(.*)$`, 'm').exec(block![1]);
-  expect(line, `${model}.${field} not found (or not a String)`).not.toBeNull();
-  const attrs = line![1];
-  const explicit = /@db\.VarChar\((\d+)\)/.exec(attrs);
-  expect(attrs, `${model}.${field} is a TEXT column — this spec is about VARCHAR bounds`).not.toMatch(
-    /@db\.(Text|MediumText|LongText)/,
-  );
-  return explicit ? Number(explicit[1]) : 191;
+  const columns: Column[] = [];
+  for (const line of block![1].split('\n')) {
+    // `name String?  @db.VarChar(500)` — a relation field (`company Company`) or
+    // a non-String scalar never matches.
+    const match = /^\s+(\w+)\s+String\??\s*(.*)$/.exec(line);
+    if (!match) continue;
+    const [, name, attrs] = match;
+    if (/@db\.(Text|MediumText|LongText)/.test(attrs)) {
+      columns.push({ name, kind: 'text' });
+      continue;
+    }
+    const explicit = /@db\.VarChar\((\d+)\)/.exec(attrs);
+    columns.push({ name, kind: 'varchar', width: explicit ? Number(explicit[1]) : 191 });
+  }
+  expect(columns.length, `no String columns found in model ${model}`).toBeGreaterThan(0);
+  return columns;
 }
 
-const FIELDS = [
-  { limit: 'companyName', model: 'Company', column: 'name' },
-  { limit: 'companyAddress', model: 'Company', column: 'address' },
-  { limit: 'todoTitle', model: 'ProjectTask', column: 'title' },
-] as const;
+type Guard =
+  /** The constant that bounds this column, and every file that must use it. */
+  | { limit: TextLimitKey; files: string[] }
+  /** Not free text a user types — say why, so the next reader can disagree. */
+  | { exempt: string };
 
-for (const { limit, model, column } of FIELDS) {
-  test(`TEXT_LIMITS.${limit} fits ${model}.${column}`, async () => {
-    expect(TEXT_LIMITS[limit]).toBeLessThanOrEqual(columnWidth(model, column));
-  });
+/** A cuid the server generates, or a foreign key that has to match a real row. */
+const ID = { exempt: 'an id — server-generated, or matched against an existing row' } as const;
 
-  test(`${model}.${column} accepts the column's capacity and rejects one more`, async () => {
-    const width = columnWidth(model, column);
-    const schema = z.string().min(1).max(TEXT_LIMITS[limit]);
-
-    // At the limit: fine. One over: rejected here, not by the database driver.
-    expect(schema.safeParse('x'.repeat(width)).success).toBe(true);
-    expect(schema.safeParse('x'.repeat(width + 1)).success).toBe(false);
-
-    // And the 250-character paste from the bug report, which used to 500.
-    expect(schema.safeParse('x'.repeat(250)).success).toBe(false);
-  });
-}
-
-// Every place that guards one of these fields, and the constant it must use.
-// A route that goes back to an inline number silently reopens the drift the
-// limits file was written to close.
-const GUARDS: { file: string; limit: keyof typeof TEXT_LIMITS }[] = [
-  { file: 'src/app/api/companies/route.ts', limit: 'companyName' },
-  { file: 'src/app/api/companies/route.ts', limit: 'companyAddress' },
-  { file: 'src/app/api/companies/[id]/route.ts', limit: 'companyName' },
-  { file: 'src/app/api/companies/[id]/route.ts', limit: 'companyAddress' },
-  { file: 'src/components/forms/CompanyForm.tsx', limit: 'companyName' },
-  { file: 'src/components/forms/CompanyForm.tsx', limit: 'companyAddress' },
-  { file: 'src/app/api/todos/route.ts', limit: 'todoTitle' },
-  { file: 'src/app/api/projects/[id]/tasks/route.ts', limit: 'todoTitle' },
-  { file: 'src/app/api/project-tasks/[taskId]/route.ts', limit: 'todoTitle' },
-  { file: 'src/components/todos/MyTodos.tsx', limit: 'todoTitle' },
-  { file: 'src/components/todos/PersonTodos.tsx', limit: 'todoTitle' },
-  { file: 'src/components/todos/TodoRow.tsx', limit: 'todoTitle' },
+const COMPANY_WRITERS = [
+  'src/app/api/companies/route.ts',
+  'src/app/api/companies/[id]/route.ts',
+  'src/components/forms/CompanyForm.tsx',
+];
+const TASK_WRITERS = [
+  'src/app/api/todos/route.ts',
+  'src/app/api/projects/[id]/tasks/route.ts',
+  'src/app/api/project-tasks/[taskId]/route.ts',
+  'src/components/todos/MyTodos.tsx',
+  'src/components/todos/PersonTodos.tsx',
+  'src/components/todos/TodoRow.tsx',
+];
+const TEMPLATE_WRITERS = [
+  'src/lib/goalTemplates.ts',
+  'src/app/api/admin/goal-templates/route.ts',
+  'src/app/api/projects/[id]/task-templates/route.ts',
 ];
 
-for (const { file, limit } of GUARDS) {
-  test(`${file} caps with TEXT_LIMITS.${limit}, not a literal`, async () => {
-    const source = fs.readFileSync(path.join(root, file), 'utf8');
-    expect(source).toContain(`TEXT_LIMITS.${limit}`);
+// The models the "Add company" modal and the to-do surface write into. Every
+// String column of each one is accounted for below — the test fails on a column
+// that is missing from this map, not merely on one that is wrong.
+const COLUMN_GUARDS: Record<string, Record<string, Guard>> = {
+  Company: {
+    id: ID,
+    orgId: ID,
+    name: { limit: 'companyName', files: COMPANY_WRITERS },
+    description: { limit: 'companyDescription', files: COMPANY_WRITERS },
+    contactEmail: { limit: 'companyContactEmail', files: COMPANY_WRITERS },
+    industry: { limit: 'companyIndustry', files: COMPANY_WRITERS },
+    logoUrl: { limit: 'companyLogoUrl', files: COMPANY_WRITERS },
+    size: { limit: 'companySize', files: COMPANY_WRITERS },
+    address: { limit: 'companyAddress', files: COMPANY_WRITERS },
+  },
+  CompanyNeed: {
+    id: ID,
+    companyId: ID,
+    position: { limit: 'companyNeedPosition', files: COMPANY_WRITERS },
+    period: { limit: 'companyNeedPeriod', files: COMPANY_WRITERS },
+  },
+  ProjectTask: {
+    id: ID,
+    projectId: ID,
+    assigneeId: ID,
+    createdById: ID,
+    templateId: ID,
+    title: { limit: 'todoTitle', files: TASK_WRITERS },
+  },
+  ProjectTaskTemplate: {
+    id: ID,
+    projectId: ID,
+    createdById: ID,
+    // The same constant as ProjectTask.title, and not by coincidence: a
+    // template's wording is written into a task's title unchanged.
+    title: { limit: 'todoTitle', files: TEMPLATE_WRITERS },
+  },
+};
+
+for (const [model, guards] of Object.entries(COLUMN_GUARDS)) {
+  const columns = stringColumns(model);
+
+  test(`every String column of ${model} is capped or exempt`, async () => {
+    const unaccounted = columns.map((c) => c.name).filter((name) => !(name in guards));
+    expect(
+      unaccounted,
+      `add ${model}.${unaccounted.join('/')} to COLUMN_GUARDS: either the TEXT_LIMITS key that ` +
+        'bounds it in every schema that writes it, or an exemption with a reason',
+    ).toEqual([]);
+
+    // And nothing stale: a guard for a column the schema no longer has would
+    // quietly stop testing anything.
+    const gone = Object.keys(guards).filter((name) => !columns.some((c) => c.name === name));
+    expect(gone, `${model} no longer has these columns — drop them from COLUMN_GUARDS`).toEqual([]);
   });
+
+  for (const column of columns) {
+    const guard = guards[column.name];
+    if (!guard || 'exempt' in guard) continue;
+    const { limit } = guard;
+
+    test(`TEXT_LIMITS.${limit} fits ${model}.${column.name}`, async () => {
+      if (column.kind === 'text') {
+        // @db.Text is 65 535 BYTES; utf8mb4 Turkish/German runs 2-3 bytes per
+        // non-ASCII character, so the limits file caps TEXT-backed fields at
+        // 20 000 characters.
+        expect(TEXT_LIMITS[limit]).toBeLessThanOrEqual(20000);
+        return;
+      }
+      expect(TEXT_LIMITS[limit]).toBeLessThanOrEqual(column.width);
+    });
+
+    if (column.kind === 'varchar') {
+      test(`${model}.${column.name} rejects one character past the column`, async () => {
+        const schema = z.string().min(1).max(TEXT_LIMITS[limit]);
+
+        // At the constant: fine. Past the column: rejected here, not by the
+        // database driver.
+        expect(schema.safeParse('x'.repeat(TEXT_LIMITS[limit])).success).toBe(true);
+        expect(schema.safeParse('x'.repeat(column.width + 1)).success).toBe(false);
+
+        // And the 250-character paste from the bug report, which used to 500.
+        expect(schema.safeParse('x'.repeat(250)).success).toBe(false);
+      });
+    }
+  }
+}
+
+// Every place that guards one of these columns, and the constant it must use.
+// A route that goes back to an inline number silently reopens the drift the
+// limits file was written to close.
+const GUARDED_FILES = new Map<string, Set<TextLimitKey>>();
+for (const guards of Object.values(COLUMN_GUARDS)) {
+  for (const guard of Object.values(guards)) {
+    if ('exempt' in guard) continue;
+    for (const file of guard.files) {
+      if (!GUARDED_FILES.has(file)) GUARDED_FILES.set(file, new Set());
+      GUARDED_FILES.get(file)!.add(guard.limit);
+    }
+  }
+}
+
+for (const [file, limits] of GUARDED_FILES) {
+  for (const limit of limits) {
+    test(`${file} caps with TEXT_LIMITS.${limit}, not a literal`, async () => {
+      const source = fs.readFileSync(path.join(root, file), 'utf8');
+      expect(source).toContain(`TEXT_LIMITS.${limit}`);
+    });
+  }
 }
 
 test('POST /api/todos can no longer answer with an empty-bodied 500', async () => {
@@ -105,4 +215,23 @@ test('POST /api/todos can no longer answer with an empty-bodied 500', async () =
   // A catch that returns JSON is what turns "the box just sits there" into a
   // message the client can read out.
   expect(post).toMatch(/catch \(error\)[\s\S]*NextResponse\.json\([\s\S]*status: 500/);
+  // …and it has to cover the session read, not just the work after it. The jwt
+  // callback queries the DB on every request (the `sessionsValidFrom` revocation
+  // check), so a pool timeout rejects there — outside a `try` that starts later,
+  // which is a catch that guards nothing that can realistically throw.
+  // Comments are stripped first: the handler's own comment explains this, and
+  // matching that prose instead of the call would make the test always pass.
+  const code = post.replace(/^\s*\/\/.*$/gm, '');
+  const body = code.slice(code.indexOf('{'));
+  expect(body.indexOf('try {'), 'move `try {` above the getServerSession call').toBeLessThan(
+    body.indexOf('getServerSession('),
+  );
+});
+
+test('a template title cannot outgrow the task title it becomes', async () => {
+  // `canonicalTitle`/`normalizeTranslations` slice to their own constant before
+  // the value is written; if that constant drifts past the column again, the
+  // route's zod cap is bypassed by the slice rather than enforced by it.
+  const source = fs.readFileSync(path.join(root, 'src/lib/goalTemplates.ts'), 'utf8');
+  expect(source).toMatch(/const MAX_TITLE = TEXT_LIMITS\.todoTitle;/);
 });

--- a/releases/unreleased/zod-bounds-match-columns.json
+++ b/releases/unreleased/zod-bounds-match-columns.json
@@ -1,0 +1,15 @@
+{
+  "bump": "patch",
+  "changelog": "- **Two zod upper bounds were wider than their column** (#1433). `Company.name` had no `max()` at all and `ProjectTask.title` was capped at 300 against `VARCHAR(191)`, so a long paste passed validation and died as a Prisma P2000 — a 500 in the company modal, and an empty-bodied 500 with no UI feedback at all when adding a to-do. `TEXT_LIMITS` gains `companyName`, `companyAddress` and `todoTitle`, used in the server schema, the client schema and the `maxLength` prop; `POST /api/todos` is wrapped so it can never answer without a JSON body, and a failed add now raises a toast. `e2e/text-limits-columns.unit.spec.ts` checks each constant against the column width parsed from `prisma/schema.prisma` and asserts rejection at exactly one character over.",
+  "notes": {
+    "en": [
+      "Long company names and long to-do titles now stop at the field's limit with a clear message, instead of failing with \"Internal server error\" — or, when adding a to-do, failing with no message at all."
+    ],
+    "tr": [
+      "Uzun şirket adları ve uzun yapılacak başlıkları artık \"Internal server error\" ile düşmek yerine alanın sınırında anlaşılır bir uyarıyla duruyor — yapılacak eklerken hiçbir şey söylemeden başarısız olma durumu da bitti."
+    ],
+    "de": [
+      "Lange Firmennamen und lange Aufgabentitel stoppen jetzt mit einem verständlichen Hinweis an der Feldgrenze, statt mit „Internal server error“ zu scheitern — und beim Hinzufügen einer Aufgabe scheitert nichts mehr kommentarlos."
+    ]
+  }
+}

--- a/releases/unreleased/zod-bounds-match-columns.json
+++ b/releases/unreleased/zod-bounds-match-columns.json
@@ -1,15 +1,15 @@
 {
   "bump": "patch",
-  "changelog": "- **Two zod upper bounds were wider than their column** (#1433). `Company.name` had no `max()` at all and `ProjectTask.title` was capped at 300 against `VARCHAR(191)`, so a long paste passed validation and died as a Prisma P2000 — a 500 in the company modal, and an empty-bodied 500 with no UI feedback at all when adding a to-do. `TEXT_LIMITS` gains `companyName`, `companyAddress` and `todoTitle`, used in the server schema, the client schema and the `maxLength` prop; `POST /api/todos` is wrapped so it can never answer without a JSON body, and a failed add now raises a toast. `e2e/text-limits-columns.unit.spec.ts` checks each constant against the column width parsed from `prisma/schema.prisma` and asserts rejection at exactly one character over.",
+  "changelog": "- **zod upper bounds now match the column they guard** (#1433). Every text field of the \"Add company\" modal and of the to-do/goal-template surface was capped wider than its `VARCHAR(191)` column, or not capped at all, so a long paste passed validation and died as a Prisma P2000 — a 500 in the company modal, and an empty-bodied 500 with no UI feedback at all when adding a to-do. `TEXT_LIMITS` gains `companyName`, `companyAddress`, `companyIndustry`, `companyLogoUrl`, `companyContactEmail`, `companySize`, `companyNeedPosition`, `companyNeedPeriod` and `todoTitle`, used in the server schema and the client schema; `goalTemplates`' own `MAX_TITLE` (300, sliced before the write) becomes `TEXT_LIMITS.todoTitle` so a shared goal cannot outgrow the task title it is copied into. `POST /api/todos` is wrapped **including its `getServerSession` call** — the jwt callback queries the DB on every request, so that was the likeliest throw — and a failed to-do now raises a toast, translated from the status via `apiErrorMessage` rather than echoing the route's English literal. The company inputs deliberately carry no `maxLength`: the browser applies it silently on paste, which replaced the validation error with a quietly truncated name. `e2e/text-limits-columns.unit.spec.ts` reads **every** `String` column of `Company`, `CompanyNeed`, `ProjectTask` and `ProjectTaskTemplate` out of `prisma/schema.prisma` and fails on any that is neither bound to a `TEXT_LIMITS` key nor exempted with a reason, so the next uncapped sibling breaks the test instead of shipping.",
   "notes": {
     "en": [
-      "Long company names and long to-do titles now stop at the field's limit with a clear message, instead of failing with \"Internal server error\" — or, when adding a to-do, failing with no message at all."
+      "Long company names, addresses, industries, logo URLs and to-do titles now stop at the field's limit with a clear message, instead of failing with \"Internal server error\" — or, when adding a to-do, failing with no message at all."
     ],
     "tr": [
-      "Uzun şirket adları ve uzun yapılacak başlıkları artık \"Internal server error\" ile düşmek yerine alanın sınırında anlaşılır bir uyarıyla duruyor — yapılacak eklerken hiçbir şey söylemeden başarısız olma durumu da bitti."
+      "Uzun şirket adları, adresler, sektörler, logo adresleri ve yapılacak başlıkları artık \"Internal server error\" ile düşmek yerine alanın sınırında anlaşılır bir uyarıyla duruyor — yapılacak eklerken hiçbir şey söylemeden başarısız olma durumu da bitti."
     ],
     "de": [
-      "Lange Firmennamen und lange Aufgabentitel stoppen jetzt mit einem verständlichen Hinweis an der Feldgrenze, statt mit „Internal server error“ zu scheitern — und beim Hinzufügen einer Aufgabe scheitert nichts mehr kommentarlos."
+      "Lange Firmennamen, Adressen, Branchen, Logo-Adressen und Aufgabentitel stoppen jetzt mit einem verständlichen Hinweis an der Feldgrenze, statt mit „Internal server error“ zu scheitern — und beim Hinzufügen einer Aufgabe scheitert nichts mehr kommentarlos."
     ]
   }
 }

--- a/src/app/api/admin/goal-templates/route.ts
+++ b/src/app/api/admin/goal-templates/route.ts
@@ -5,6 +5,7 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { withTenantScope } from '@/lib/orgContext';
 import { canonicalTitle, normalizeTranslations, readTranslations } from '@/lib/goalTemplates';
+import { TEXT_LIMITS } from '@/lib/textLimits';
 
 // The shared goal-template pool (#51 follow-up).
 //
@@ -17,7 +18,10 @@ import { canonicalTitle, normalizeTranslations, readTranslations } from '@/lib/g
 // by whoever leads that project, through
 // /api/projects/[id]/task-templates — not here.
 
-const localeText = z.string().trim().max(300).optional();
+// ProjectTaskTemplate.title is VARCHAR(191): a wider cap here was a P2000 in
+// the driver, and neither handler catches, so it reached the admin as a 500
+// with an empty body (#1433).
+const localeText = z.string().trim().max(TEXT_LIMITS.todoTitle).optional();
 const translationsSchema = z.object({ en: localeText, tr: localeText, de: localeText });
 
 const createSchema = z.object({ translations: translationsSchema });

--- a/src/app/api/companies/[id]/route.ts
+++ b/src/app/api/companies/[id]/route.ts
@@ -7,13 +7,13 @@ import { z } from 'zod';
 import { TEXT_LIMITS } from '@/lib/textLimits';
 
 const updateCompanySchema = z.object({
-  name: z.string().min(1).optional(),
+  name: z.string().min(1).max(TEXT_LIMITS.companyName).optional(),
   description: z.string().max(TEXT_LIMITS.companyDescription).optional(),
   contactEmail: z.string().email().optional().or(z.literal('')),
   industry: z.string().optional(),
   logoUrl: z.string().url().or(z.literal('')).optional(),
   size: z.string().max(40).optional(),
-  address: z.string().max(300).optional(),
+  address: z.string().max(TEXT_LIMITS.companyAddress).optional(),
   quota: z.number().int().min(0).max(10000).nullable().optional(),
   needs: z
     .array(

--- a/src/app/api/companies/[id]/route.ts
+++ b/src/app/api/companies/[id]/route.ts
@@ -9,19 +9,19 @@ import { TEXT_LIMITS } from '@/lib/textLimits';
 const updateCompanySchema = z.object({
   name: z.string().min(1).max(TEXT_LIMITS.companyName).optional(),
   description: z.string().max(TEXT_LIMITS.companyDescription).optional(),
-  contactEmail: z.string().email().optional().or(z.literal('')),
-  industry: z.string().optional(),
-  logoUrl: z.string().url().or(z.literal('')).optional(),
-  size: z.string().max(40).optional(),
+  contactEmail: z.string().email().max(TEXT_LIMITS.companyContactEmail).optional().or(z.literal('')),
+  industry: z.string().max(TEXT_LIMITS.companyIndustry).optional(),
+  logoUrl: z.string().url().max(TEXT_LIMITS.companyLogoUrl).or(z.literal('')).optional(),
+  size: z.string().max(TEXT_LIMITS.companySize).optional(),
   address: z.string().max(TEXT_LIMITS.companyAddress).optional(),
   quota: z.number().int().min(0).max(10000).nullable().optional(),
   needs: z
     .array(
       z.object({
         id: z.string().optional(),
-        position: z.string().min(1),
+        position: z.string().min(1).max(TEXT_LIMITS.companyNeedPosition),
         count: z.number().int().min(1),
-        period: z.string().min(1),
+        period: z.string().min(1).max(TEXT_LIMITS.companyNeedPeriod),
       })
     )
     .optional(),

--- a/src/app/api/companies/route.ts
+++ b/src/app/api/companies/route.ts
@@ -7,13 +7,13 @@ import { withTenantScope } from '@/lib/orgContext';
 import { TEXT_LIMITS } from '@/lib/textLimits';
 
 const companySchema = z.object({
-  name: z.string().min(1, 'Company name is required'),
+  name: z.string().min(1, 'Company name is required').max(TEXT_LIMITS.companyName),
   description: z.string().max(TEXT_LIMITS.companyDescription).optional(),
   contactEmail: z.string().email('Invalid contact email').optional().or(z.literal('')),
   industry: z.string().optional(),
   logoUrl: z.string().url().or(z.literal('')).optional(),
   size: z.string().max(40).optional(),
-  address: z.string().max(300).optional(),
+  address: z.string().max(TEXT_LIMITS.companyAddress).optional(),
   quota: z.number().int().min(0).max(10000).nullable().optional(),
   needs: z
     .array(

--- a/src/app/api/companies/route.ts
+++ b/src/app/api/companies/route.ts
@@ -9,18 +9,23 @@ import { TEXT_LIMITS } from '@/lib/textLimits';
 const companySchema = z.object({
   name: z.string().min(1, 'Company name is required').max(TEXT_LIMITS.companyName),
   description: z.string().max(TEXT_LIMITS.companyDescription).optional(),
-  contactEmail: z.string().email('Invalid contact email').optional().or(z.literal('')),
-  industry: z.string().optional(),
-  logoUrl: z.string().url().or(z.literal('')).optional(),
-  size: z.string().max(40).optional(),
+  contactEmail: z
+    .string()
+    .email('Invalid contact email')
+    .max(TEXT_LIMITS.companyContactEmail)
+    .optional()
+    .or(z.literal('')),
+  industry: z.string().max(TEXT_LIMITS.companyIndustry).optional(),
+  logoUrl: z.string().url().max(TEXT_LIMITS.companyLogoUrl).or(z.literal('')).optional(),
+  size: z.string().max(TEXT_LIMITS.companySize).optional(),
   address: z.string().max(TEXT_LIMITS.companyAddress).optional(),
   quota: z.number().int().min(0).max(10000).nullable().optional(),
   needs: z
     .array(
       z.object({
-        position: z.string().min(1),
+        position: z.string().min(1).max(TEXT_LIMITS.companyNeedPosition),
         count: z.number().int().min(1),
-        period: z.string().min(1),
+        period: z.string().min(1).max(TEXT_LIMITS.companyNeedPeriod),
       })
     )
     .optional(),

--- a/src/app/api/project-tasks/[taskId]/route.ts
+++ b/src/app/api/project-tasks/[taskId]/route.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import { canManageProject, isProjectMember, isProjectOwner } from '@/lib/projectAccess';
 import { notify } from '@/lib/notify';
 import { goalLinkFor } from '@/lib/projectGoalLink';
+import { TEXT_LIMITS } from '@/lib/textLimits';
 
 // One to-do: tick it off, put it away, reword it, hand it over.
 //
@@ -37,7 +38,7 @@ const schema = z.object({
   done: z.boolean().optional(),
   // Finished and put away — leaves the active list without losing the record.
   archived: z.boolean().optional(),
-  title: z.string().min(1).max(300).optional(),
+  title: z.string().min(1).max(TEXT_LIMITS.todoTitle).optional(),
   // null clears the assignment (back to an unassigned project goal).
   assigneeId: z.string().min(1).nullable().optional(),
 });

--- a/src/app/api/projects/[id]/task-templates/route.ts
+++ b/src/app/api/projects/[id]/task-templates/route.ts
@@ -6,6 +6,7 @@ import { prisma } from '@/lib/prisma';
 import { withTenantScope } from '@/lib/orgContext';
 import { canManageProject, isProjectMember } from '@/lib/projectAccess';
 import { canonicalTitle, normalizeTranslations, readTranslations } from '@/lib/goalTemplates';
+import { TEXT_LIMITS } from '@/lib/textLimits';
 
 // The goal/task template pool (#51, reworked in #1113).
 //
@@ -22,12 +23,15 @@ import { canonicalTitle, normalizeTranslations, readTranslations } from '@/lib/g
 // would blank the wording for everyone who has it. Archived means "stop offering
 // this"; adding the same wording back revives the row.
 
-const localeText = z.string().trim().max(300).optional();
+// ProjectTaskTemplate.title is VARCHAR(191): a wider cap here was a P2000 in
+// the driver, and neither handler catches, so it reached the admin as a 500
+// with an empty body (#1433).
+const localeText = z.string().trim().max(TEXT_LIMITS.todoTitle).optional();
 const translationsSchema = z.object({ en: localeText, tr: localeText, de: localeText });
 // `title` alone is still accepted: that is how the automatic capture and the
 // older clients add a template.
 const createSchema = z.object({
-  title: z.string().min(1).max(300).optional(),
+  title: z.string().min(1).max(TEXT_LIMITS.todoTitle).optional(),
   translations: translationsSchema.optional(),
 });
 const updateSchema = z.object({ id: z.string().min(1), translations: translationsSchema });

--- a/src/app/api/projects/[id]/tasks/route.ts
+++ b/src/app/api/projects/[id]/tasks/route.ts
@@ -9,6 +9,7 @@ import { withTenantScope } from '@/lib/orgContext';
 import { goalLinkFor } from '@/lib/projectGoalLink';
 import { resolveTemplateTitle } from '@/lib/goalTemplates';
 import { defaultLocale } from '@/i18n/config';
+import { TEXT_LIMITS } from '@/lib/textLimits';
 
 // A task may be created from free text (`title`) or from the template pool
 // (`templateIds`) — the latter is the "send the standard goals to the person who
@@ -23,7 +24,7 @@ import { defaultLocale } from '@/i18n/config';
 // round after round. The pool is now only what someone put there on purpose.
 const schema = z
   .object({
-    title: z.string().min(1).max(300).optional(),
+    title: z.string().min(1).max(TEXT_LIMITS.todoTitle).optional(),
     templateIds: z.array(z.string().min(1)).max(50).optional(),
     assigneeId: z.string().min(1).nullable().optional(),
   })

--- a/src/app/api/todos/route.ts
+++ b/src/app/api/todos/route.ts
@@ -7,6 +7,7 @@ import { withTenantScope } from '@/lib/orgContext';
 import { notify } from '@/lib/notify';
 import { resolveTemplateTitle, serializeTaskTemplate, taskTemplateSelect } from '@/lib/goalTemplates';
 import { defaultLocale } from '@/i18n/config';
+import { TEXT_LIMITS } from '@/lib/textLimits';
 
 // One person's to-do list, whole (#1113).
 //
@@ -162,7 +163,7 @@ export async function GET(request: Request) {
 
 const createSchema = z
   .object({
-    title: z.string().trim().min(1).max(300).optional(),
+    title: z.string().trim().min(1).max(TEXT_LIMITS.todoTitle).optional(),
     // Shared-pool templates to hand over, straight from a person's list — no
     // project needed. The to-do keeps a reference, so the wording stays live.
     templateIds: z.array(z.string().min(1)).max(50).optional(),
@@ -179,70 +180,79 @@ export async function POST(request: Request) {
   const session = await getServerSession(authOptions);
   if (!session?.user?.id) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
-  return await withTenantScope(session, async () => {
-    const parsed = createSchema.safeParse(await request.json().catch(() => null));
-    if (!parsed.success) return NextResponse.json({ error: 'Validation failed' }, { status: 400 });
+  // Everything below is wrapped (#1433): an unhandled throw here left Next to
+  // answer with a 500 that had NO BODY, so the client's `res.json()` failed too
+  // and the add silently did nothing. A 500 now always carries JSON, which is
+  // what every other create endpoint already did.
+  try {
+    return await withTenantScope(session, async () => {
+      const parsed = createSchema.safeParse(await request.json().catch(() => null));
+      if (!parsed.success) return NextResponse.json({ error: 'Validation failed' }, { status: 400 });
 
-    const viewerId = session.user.id;
-    const assigneeId = parsed.data.assigneeId ?? viewerId;
-    if (!(await mayReach(session.user, assigneeId))) {
-      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-    }
-
-    const rows: { title: string; templateId: string | null }[] = [];
-    if (parsed.data.templateIds?.length) {
-      // Only the shared pool is reachable here — a project's own templates are
-      // handed out from that project, where the assignee is a member.
-      const templates = await prisma.projectTaskTemplate.findMany({
-        where: { id: { in: parsed.data.templateIds }, projectId: null, archivedAt: null },
-        select: { id: true, title: true, translations: true },
-      });
-      for (const tpl of templates) {
-        rows.push({ title: resolveTemplateTitle(tpl, defaultLocale), templateId: tpl.id });
+      const viewerId = session.user.id;
+      const assigneeId = parsed.data.assigneeId ?? viewerId;
+      if (!(await mayReach(session.user, assigneeId))) {
+        return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
       }
-      if (templates.length > 0) {
-        await prisma.projectTaskTemplate.updateMany({
-          where: { id: { in: templates.map((t) => t.id) } },
-          data: { useCount: { increment: 1 } },
+
+      const rows: { title: string; templateId: string | null }[] = [];
+      if (parsed.data.templateIds?.length) {
+        // Only the shared pool is reachable here — a project's own templates are
+        // handed out from that project, where the assignee is a member.
+        const templates = await prisma.projectTaskTemplate.findMany({
+          where: { id: { in: parsed.data.templateIds }, projectId: null, archivedAt: null },
+          select: { id: true, title: true, translations: true },
         });
+        for (const tpl of templates) {
+          rows.push({ title: resolveTemplateTitle(tpl, defaultLocale), templateId: tpl.id });
+        }
+        if (templates.length > 0) {
+          await prisma.projectTaskTemplate.updateMany({
+            where: { id: { in: templates.map((t) => t.id) } },
+            data: { useCount: { increment: 1 } },
+          });
+        }
       }
-    }
-    if (parsed.data.title) rows.push({ title: parsed.data.title, templateId: null });
-    if (rows.length === 0) return NextResponse.json({ error: 'Nothing to create' }, { status: 400 });
+      if (parsed.data.title) rows.push({ title: parsed.data.title, templateId: null });
+      if (rows.length === 0) return NextResponse.json({ error: 'Nothing to create' }, { status: 400 });
 
-    const created = [];
-    for (const row of rows) {
-      created.push(
-        await prisma.projectTask.create({
-          data: {
-            title: row.title,
-            templateId: row.templateId,
-            assigneeId,
-            createdById: viewerId,
-            projectId: null,
-          },
-          select: listSelect,
-        })
+      const created = [];
+      for (const row of rows) {
+        created.push(
+          await prisma.projectTask.create({
+            data: {
+              title: row.title,
+              templateId: row.templateId,
+              assigneeId,
+              createdById: viewerId,
+              projectId: null,
+            },
+            select: listSelect,
+          })
+        );
+      }
+
+      if (assigneeId !== viewerId) {
+        const language = (
+          await prisma.user.findUnique({ where: { id: assigneeId }, select: { preferredLanguage: true } })
+        )?.preferredLanguage;
+        const first = created[0] as Row;
+        const firstTitle = first.template ? resolveTemplateTitle(first.template, language) : first.title;
+        await notify(
+          assigneeId,
+          created.length === 1 ? 'project.newTodo' : 'project.newTodos',
+          created.length === 1 ? { title: firstTitle } : { count: created.length },
+          '/todos'
+        );
+      }
+
+      return NextResponse.json(
+        { todos: (created as Row[]).map((r) => serialize(r, session.user, assigneeId)) },
+        { status: 201 }
       );
-    }
-
-    if (assigneeId !== viewerId) {
-      const language = (
-        await prisma.user.findUnique({ where: { id: assigneeId }, select: { preferredLanguage: true } })
-      )?.preferredLanguage;
-      const first = created[0] as Row;
-      const firstTitle = first.template ? resolveTemplateTitle(first.template, language) : first.title;
-      await notify(
-        assigneeId,
-        created.length === 1 ? 'project.newTodo' : 'project.newTodos',
-        created.length === 1 ? { title: firstTitle } : { count: created.length },
-        '/todos'
-      );
-    }
-
-    return NextResponse.json(
-      { todos: (created as Row[]).map((r) => serialize(r, session.user, assigneeId)) },
-      { status: 201 }
-    );
-  });
+    });
+  } catch (error) {
+    console.error('Create to-do error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
 }

--- a/src/app/api/todos/route.ts
+++ b/src/app/api/todos/route.ts
@@ -177,14 +177,20 @@ const createSchema = z
 // POST — put a to-do on a list: mine (a line for myself) or my mentee's (what I
 // want them to do, hand-written or from the shared pool).
 export async function POST(request: Request) {
-  const session = await getServerSession(authOptions);
-  if (!session?.user?.id) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-
-  // Everything below is wrapped (#1433): an unhandled throw here left Next to
+  // Everything is inside the try (#1433): an unhandled throw here left Next to
   // answer with a 500 that had NO BODY, so the client's `res.json()` failed too
   // and the add silently did nothing. A 500 now always carries JSON, which is
   // what every other create endpoint already did.
+  //
+  // `getServerSession` is INSIDE it on purpose, matching
+  // /api/companies POST: the JWT callback hits `prisma.user.findUnique` on every
+  // request for the `sessionsValidFrom` revocation check, so a pool timeout
+  // (P2024) or a MySQL restart rejects *here*, before any of the work below —
+  // the exact empty-bodied 500 this wrapper exists to rule out.
   try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
     return await withTenantScope(session, async () => {
       const parsed = createSchema.safeParse(await request.json().catch(() => null));
       if (!parsed.success) return NextResponse.json({ error: 'Validation failed' }, { status: 400 });

--- a/src/components/forms/CompanyForm.tsx
+++ b/src/components/forms/CompanyForm.tsx
@@ -21,30 +21,53 @@ const optionalText = z.string().nullish().transform((v) => v ?? '');
 
 // The schema is built per render because the length messages are translated —
 // a cap the user can hit has to explain itself in their own language (#1433).
-// `name` and `address` are VARCHAR(191) columns: an uncapped name meant a
+// Every text field here writes a VARCHAR column, and an uncapped one meant a
 // 250-character paste passed the form, passed the API and died as a Prisma
 // P2000, which reached the admin as "Internal server error".
+//
+// NO `maxLength` ON THESE INPUTS, deliberately. The browser enforces
+// `maxLength` silently on paste: a 250-character legal entity name would be
+// clipped to 191, sail through `.max()` and be saved 59 characters short with
+// nothing shown. The cap has to be reported, not applied behind the user's
+// back, so the bound lives only in zod and surfaces on the field. (The
+// description box is a `<Textarea showCounter>`, where the hard stop *is*
+// visible.)
 function buildCompanySchema(t: ClientDictionary) {
   const tooLong = (max: number) => t.companyForm.tooLong.replace('{max}', String(max));
+  /** An optional free-text column: normalize null → '' first, then bound it. */
+  const boundedOptional = (max: number) => optionalText.pipe(z.string().max(max, tooLong(max)));
+  /**
+   * Same, for the two fields that are also format-checked. The length check is
+   * a SEPARATE `.pipe()` stage ahead of the `x.or(z.literal(''))` union on
+   * purpose: inside the union, an over-long value fails every branch and zod
+   * reports the union's own "Invalid input" instead of the message that says
+   * what is actually wrong.
+   */
+  const boundedFormat = (max: number, format: z.ZodType<string, z.ZodTypeDef, string>) =>
+    optionalText.pipe(z.string().max(max, tooLong(max))).pipe(format.or(z.literal('')));
   return z.object({
     name: z
       .string()
       .min(1, 'Company name is required')
       .max(TEXT_LIMITS.companyName, tooLong(TEXT_LIMITS.companyName)),
     description: optionalText,
-    contactEmail: z.string().email('Invalid email').or(z.literal('')).nullish().transform((v) => v ?? ''),
-    industry: optionalText,
-    logoUrl: z.string().url('Enter a valid URL').or(z.literal('')).nullish().transform((v) => v ?? ''),
-    size: optionalText,
-    address: optionalText.pipe(
-      z.string().max(TEXT_LIMITS.companyAddress, tooLong(TEXT_LIMITS.companyAddress)),
-    ),
+    contactEmail: boundedFormat(TEXT_LIMITS.companyContactEmail, z.string().email('Invalid email')),
+    industry: boundedOptional(TEXT_LIMITS.companyIndustry),
+    logoUrl: boundedFormat(TEXT_LIMITS.companyLogoUrl, z.string().url('Enter a valid URL')),
+    size: boundedOptional(TEXT_LIMITS.companySize),
+    address: boundedOptional(TEXT_LIMITS.companyAddress),
     quota: z.coerce.number().int().min(0).nullish(),
     needs: z.array(
       z.object({
-        position: z.string().min(1, 'Position is required'),
+        position: z
+          .string()
+          .min(1, 'Position is required')
+          .max(TEXT_LIMITS.companyNeedPosition, tooLong(TEXT_LIMITS.companyNeedPosition)),
         count: z.coerce.number().int().min(1, 'Count must be at least 1'),
-        period: z.string().min(1, 'Period is required'),
+        period: z
+          .string()
+          .min(1, 'Period is required')
+          .max(TEXT_LIMITS.companyNeedPeriod, tooLong(TEXT_LIMITS.companyNeedPeriod)),
       })
     ).optional(),
   });
@@ -102,7 +125,6 @@ export function CompanyForm({ defaultValues, onSubmit, onCancel, isEditing }: Co
         <Input
           label={t.companyForm.name}
           required
-          maxLength={TEXT_LIMITS.companyName}
           {...register('name')}
           error={errors.name?.message}
         />
@@ -147,7 +169,6 @@ export function CompanyForm({ defaultValues, onSubmit, onCancel, isEditing }: Co
       <Input
         label={t.companyForm.address}
         placeholder={t.companyForm.addressPlaceholder}
-        maxLength={TEXT_LIMITS.companyAddress}
         {...register('address')}
         error={errors.address?.message}
       />

--- a/src/components/forms/CompanyForm.tsx
+++ b/src/components/forms/CompanyForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useForm, useFieldArray } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -10,6 +10,7 @@ import { TEXT_LIMITS } from '@/lib/textLimits';
 import { Button } from '@/components/ui/Button';
 import { Plus, Trash2 } from 'lucide-react';
 import { useT } from '@/i18n/client';
+import type { ClientDictionary } from '@/i18n/dictionaries';
 
 // Optional free-text field. Prisma returns `null` for empty nullable columns,
 // so when editing an existing company those nulls reach the form. Plain
@@ -18,25 +19,39 @@ import { useT } from '@/i18n/client';
 // normalize to '' so validation passes AND the API always receives a string.
 const optionalText = z.string().nullish().transform((v) => v ?? '');
 
-const companySchema = z.object({
-  name: z.string().min(1, 'Company name is required'),
-  description: optionalText,
-  contactEmail: z.string().email('Invalid email').or(z.literal('')).nullish().transform((v) => v ?? ''),
-  industry: optionalText,
-  logoUrl: z.string().url('Enter a valid URL').or(z.literal('')).nullish().transform((v) => v ?? ''),
-  size: optionalText,
-  address: optionalText,
-  quota: z.coerce.number().int().min(0).nullish(),
-  needs: z.array(
-    z.object({
-      position: z.string().min(1, 'Position is required'),
-      count: z.coerce.number().int().min(1, 'Count must be at least 1'),
-      period: z.string().min(1, 'Period is required'),
-    })
-  ).optional(),
-});
+// The schema is built per render because the length messages are translated —
+// a cap the user can hit has to explain itself in their own language (#1433).
+// `name` and `address` are VARCHAR(191) columns: an uncapped name meant a
+// 250-character paste passed the form, passed the API and died as a Prisma
+// P2000, which reached the admin as "Internal server error".
+function buildCompanySchema(t: ClientDictionary) {
+  const tooLong = (max: number) => t.companyForm.tooLong.replace('{max}', String(max));
+  return z.object({
+    name: z
+      .string()
+      .min(1, 'Company name is required')
+      .max(TEXT_LIMITS.companyName, tooLong(TEXT_LIMITS.companyName)),
+    description: optionalText,
+    contactEmail: z.string().email('Invalid email').or(z.literal('')).nullish().transform((v) => v ?? ''),
+    industry: optionalText,
+    logoUrl: z.string().url('Enter a valid URL').or(z.literal('')).nullish().transform((v) => v ?? ''),
+    size: optionalText,
+    address: optionalText.pipe(
+      z.string().max(TEXT_LIMITS.companyAddress, tooLong(TEXT_LIMITS.companyAddress)),
+    ),
+    quota: z.coerce.number().int().min(0).nullish(),
+    needs: z.array(
+      z.object({
+        position: z.string().min(1, 'Position is required'),
+        count: z.coerce.number().int().min(1, 'Count must be at least 1'),
+        period: z.string().min(1, 'Period is required'),
+      })
+    ).optional(),
+  });
+}
 
-type CompanyFormData = z.infer<typeof companySchema>;
+type CompanySchema = ReturnType<typeof buildCompanySchema>;
+type CompanyFormData = z.infer<CompanySchema>;
 
 interface CompanyFormProps {
   defaultValues?: Partial<CompanyFormData>;
@@ -49,6 +64,7 @@ export function CompanyForm({ defaultValues, onSubmit, onCancel, isEditing }: Co
   const t = useT();
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+  const companySchema = useMemo(() => buildCompanySchema(t), [t]);
 
   const {
     register,
@@ -86,6 +102,7 @@ export function CompanyForm({ defaultValues, onSubmit, onCancel, isEditing }: Co
         <Input
           label={t.companyForm.name}
           required
+          maxLength={TEXT_LIMITS.companyName}
           {...register('name')}
           error={errors.name?.message}
         />
@@ -130,6 +147,7 @@ export function CompanyForm({ defaultValues, onSubmit, onCancel, isEditing }: Co
       <Input
         label={t.companyForm.address}
         placeholder={t.companyForm.addressPlaceholder}
+        maxLength={TEXT_LIMITS.companyAddress}
         {...register('address')}
         error={errors.address?.message}
       />

--- a/src/components/todos/MyTodos.tsx
+++ b/src/components/todos/MyTodos.tsx
@@ -8,6 +8,9 @@ import { SkeletonRows } from '@/components/ui/Skeleton';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { useT, useLocale } from '@/i18n/client';
+import { useToast } from '@/components/ui/Toast';
+import { useCharacterCounter } from '@/hooks/useCharacterCounter';
+import { TEXT_LIMITS } from '@/lib/textLimits';
 import { TodoRow, todoText, type Todo } from '@/components/todos/TodoRow';
 
 // One person's whole to-do list (#1113).
@@ -22,6 +25,7 @@ import { TodoRow, todoText, type Todo } from '@/components/todos/TodoRow';
 export function MyTodos({ myId }: { myId: string }) {
   const t = useT();
   const locale = useLocale();
+  const toast = useToast();
   const [todos, setTodos] = useState<Todo[]>([]);
   const [open, setOpen] = useState<Todo[]>([]);
   const [archive, setArchive] = useState<Todo[]>([]);
@@ -57,7 +61,12 @@ export function MyTodos({ myId }: { myId: string }) {
       await load();
       return true;
     } catch (e) {
-      setError(e instanceof Error ? e.message : t.common.error);
+      // Say it out loud (#1433). The inline line below the list is easy to miss
+      // — it sits under the archive toggle — and adding a to-do that failed on
+      // the server used to look exactly like adding one that worked.
+      const message = e instanceof Error ? e.message : t.common.error;
+      setError(message);
+      toast(message, 'error');
       return false;
     } finally {
       setBusy('');
@@ -84,6 +93,10 @@ export function MyTodos({ myId }: { myId: string }) {
   const claim = (todo: Todo) => call(`/api/project-tasks/${todo.id}`, 'PATCH', { assigneeId: myId }, todo.id);
 
   const doneCount = useMemo(() => todos.filter((x) => x.done).length, [todos]);
+  // ProjectTask.title is VARCHAR(191). The counter only appears once the draft
+  // is close to that, so the box stays quiet for the one-line to-dos that are
+  // the normal case, and the limit is visible exactly when it starts to matter.
+  const draftCounter = useCharacterCounter(draft, TEXT_LIMITS.todoTitle);
 
   if (loading) {
     return (
@@ -108,14 +121,30 @@ export function MyTodos({ myId }: { myId: string }) {
 
         {!showArchive && (
           <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center">
-            <input
-              value={draft}
-              onChange={(e) => setDraft(e.target.value)}
-              onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); add(); } }}
-              placeholder={t.todos.addPlaceholder}
-              data-testid="todo-input"
-              className="w-full min-w-0 rounded-lg border border-gray-300 px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-900 sm:flex-1"
-            />
+            <div className="relative w-full min-w-0 sm:flex-1">
+              <input
+                value={draft}
+                onChange={(e) => setDraft(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); add(); } }}
+                placeholder={t.todos.addPlaceholder}
+                maxLength={TEXT_LIMITS.todoTitle}
+                data-testid="todo-input"
+                className="w-full min-w-0 rounded-lg border border-gray-300 px-3 py-2 pr-16 text-sm dark:border-gray-700 dark:bg-gray-900"
+              />
+              {draftCounter.state !== 'normal' && (
+                <span
+                  data-testid="todo-input-counter"
+                  data-counter-state={draftCounter.state}
+                  className={`pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 select-none text-xs font-medium ${
+                    draftCounter.state === 'error'
+                      ? 'text-red-600 dark:text-red-400'
+                      : 'text-amber-600 dark:text-amber-400'
+                  }`}
+                >
+                  {draftCounter.display}
+                </span>
+              )}
+            </div>
             <Button type="button" size="sm" variant="outline" className="w-full sm:w-auto" loading={busy === 'add'} onClick={add} data-testid="todo-add">
               <Plus className="mr-1 h-3.5 w-3.5" /> {t.todos.add}
             </Button>

--- a/src/components/todos/MyTodos.tsx
+++ b/src/components/todos/MyTodos.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Hand, ListChecks, Plus } from 'lucide-react';
 import { Card, CardHeader, CardTitle, CardDescription } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
@@ -9,7 +9,9 @@ import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { useT, useLocale } from '@/i18n/client';
 import { useToast } from '@/components/ui/Toast';
+import { useAnnounce } from '@/components/ui/LiveRegion';
 import { useCharacterCounter } from '@/hooks/useCharacterCounter';
+import { apiErrorMessage } from '@/lib/apiErrorMessage';
 import { TEXT_LIMITS } from '@/lib/textLimits';
 import { TodoRow, todoText, type Todo } from '@/components/todos/TodoRow';
 
@@ -26,6 +28,7 @@ export function MyTodos({ myId }: { myId: string }) {
   const t = useT();
   const locale = useLocale();
   const toast = useToast();
+  const announce = useAnnounce();
   const [todos, setTodos] = useState<Todo[]>([]);
   const [open, setOpen] = useState<Todo[]>([]);
   const [archive, setArchive] = useState<Todo[]>([]);
@@ -57,7 +60,12 @@ export function MyTodos({ myId }: { myId: string }) {
         method,
         ...(body ? { headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) } : {}),
       });
-      if (!res.ok) throw new Error((await res.json().catch(() => ({}))).error || t.common.error);
+      // Never `body.error`: every 4xx on these routes carries a hardcoded English
+      // literal ('Forbidden', 'Validation failed', 'Nothing to create'), and this
+      // now goes into a toast rather than a small line — so a Turkish admin would
+      // get an English one, centre stage. Same stance as every other call site
+      // in the app: the status is what gets translated (@/lib/apiErrorMessage).
+      if (!res.ok) throw new Error(apiErrorMessage(res, t.common, t.common.error));
       await load();
       return true;
     } catch (e) {
@@ -97,6 +105,23 @@ export function MyTodos({ myId }: { myId: string }) {
   // is close to that, so the box stays quiet for the one-line to-dos that are
   // the normal case, and the limit is visible exactly when it starts to matter.
   const draftCounter = useCharacterCounter(draft, TEXT_LIMITS.todoTitle);
+
+  // WCAG 4.1.3, the rule `Textarea` states and implements for the same widget:
+  // the counter is a visual-only cue, so a screen-reader user pasting an
+  // over-long line hears nothing while the field silently clips it. Announce the
+  // two THRESHOLD CROSSINGS only — `state` changes at most twice per draft, so
+  // this never speaks per keystroke, which would make the box unusable.
+  const previousCounterState = useRef(draftCounter.state);
+  useEffect(() => {
+    const previous = previousCounterState.current;
+    previousCounterState.current = draftCounter.state;
+    if (previous === draftCounter.state) return;
+    if (draftCounter.state === 'error') {
+      announce(t.a11y.characterLimitReached, 'assertive');
+    } else if (draftCounter.state === 'warning') {
+      announce(t.a11y.charactersRemaining.replace('{count}', String(Math.max(0, draftCounter.remaining))));
+    }
+  }, [draftCounter.state, draftCounter.remaining, announce, t]);
 
   if (loading) {
     return (

--- a/src/components/todos/PersonTodos.tsx
+++ b/src/components/todos/PersonTodos.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/Button';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { useT, useLocale } from '@/i18n/client';
 import { resolveTemplateTitle } from '@/lib/goalTemplates';
+import { TEXT_LIMITS } from '@/lib/textLimits';
 import type { Locale } from '@/i18n/config';
 import { TodoRow, type Todo } from '@/components/todos/TodoRow';
 
@@ -134,6 +135,7 @@ export function PersonTodos({
             onChange={(e) => setDraft(e.target.value)}
             onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); assign(); } }}
             placeholder={t.todos.assignPlaceholder.replace('{name}', name)}
+            maxLength={TEXT_LIMITS.todoTitle}
             data-testid="assign-todo-input"
             className="w-full min-w-0 rounded-lg border border-gray-300 px-2.5 py-1.5 text-sm dark:border-gray-700 dark:bg-gray-900 sm:flex-1"
           />

--- a/src/components/todos/TodoRow.tsx
+++ b/src/components/todos/TodoRow.tsx
@@ -6,6 +6,7 @@ import { Archive, ArchiveRestore, Check, CheckCircle2, Circle, Pencil, Trash2, X
 import { useT, useLocale } from '@/i18n/client';
 import { formatDate } from '@/lib/relativeTime';
 import { resolveTemplateTitle } from '@/lib/goalTemplates';
+import { TEXT_LIMITS } from '@/lib/textLimits';
 import type { Locale } from '@/i18n/config';
 
 // One line of a to-do list (#1113).
@@ -76,6 +77,7 @@ export function TodoRow({
             if (e.key === 'Enter') { e.preventDefault(); save(); }
             if (e.key === 'Escape') setEditing(false);
           }}
+          maxLength={TEXT_LIMITS.todoTitle}
           data-testid={`todo-edit-input-${todo.id}`}
           className="w-full min-w-0 rounded-lg border border-gray-300 px-2.5 py-1.5 text-sm dark:border-gray-700 dark:bg-gray-900 sm:flex-1"
         />

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -643,6 +643,8 @@ const en = {
   },
   companyForm: {
     name: 'Company Name',
+    // Shown when a field runs past what the column can hold (#1433).
+    tooLong: 'At most {max} characters',
     industry: 'Industry',
     industryPlaceholder: 'e.g. Technology, Finance',
     contactEmail: 'Contact Email',
@@ -5281,6 +5283,7 @@ const tr: Dict = {
   },
   companyForm: {
     name: 'Şirket Adı',
+    tooLong: 'En fazla {max} karakter',
     industry: 'Sektör',
     industryPlaceholder: 'ör. Teknoloji, Finans',
     contactEmail: 'İletişim E-postası',
@@ -9849,6 +9852,7 @@ const de: Dict = {
   },
   companyForm: {
     name: 'Firmenname',
+    tooLong: 'Höchstens {max} Zeichen',
     industry: 'Branche',
     industryPlaceholder: 'z. B. Technologie, Finanzen',
     contactEmail: 'Kontakt-E-Mail',

--- a/src/lib/goalTemplates.ts
+++ b/src/lib/goalTemplates.ts
@@ -1,4 +1,5 @@
 import { locales, defaultLocale, isLocale, type Locale } from '@/i18n/config';
+import { TEXT_LIMITS } from '@/lib/textLimits';
 
 // Multilingual goal templates (#51 follow-up).
 //
@@ -11,7 +12,13 @@ import { locales, defaultLocale, isLocale, type Locale } from '@/i18n/config';
 
 export type TemplateTranslations = Partial<Record<Locale, string>>;
 
-const MAX_TITLE = 300;
+// ProjectTaskTemplate.title is VARCHAR(191), and a template's wording is copied
+// into ProjectTask.title verbatim — so this is the same bound, not a second one
+// (#1433). It was 300 here, so a 250-character goal passed the slice untouched,
+// passed the route's matching `max(300)` and was thrown out by the driver as a
+// P2000 — and neither goal-template route catches, so that reached the admin as
+// a 500 with an empty body.
+const MAX_TITLE = TEXT_LIMITS.todoTitle;
 
 /** Keep only known locales with non-empty text, trimmed and length-bounded. */
 export function normalizeTranslations(input: unknown): TemplateTranslations {

--- a/src/lib/textLimits.ts
+++ b/src/lib/textLimits.ts
@@ -33,6 +33,21 @@ export const TEXT_LIMITS = {
   companyDescription: 2000,
   /** Company.address — VARCHAR(191) */
   companyAddress: 191,
+  /** Company.industry — VARCHAR(191) */
+  companyIndustry: 191,
+  /** Company.logoUrl — VARCHAR(191) */
+  companyLogoUrl: 191,
+  /**
+   * Company.contactEmail — VARCHAR(191). RFC 5321 allows an address up to 254
+   * characters; the column does not, so the shorter of the two is the bound.
+   */
+  companyContactEmail: 191,
+  /** Company.size — VARCHAR(191); the field holds a bracket label ("11-50") */
+  companySize: 40,
+  /** CompanyNeed.position — VARCHAR(191) */
+  companyNeedPosition: 191,
+  /** CompanyNeed.period — VARCHAR(191) */
+  companyNeedPeriod: 191,
   /** MentorshipRequest.message — @db.Text */
   mentorshipRequestMessage: 1000,
   /** Public contact form message — Message.body, @db.Text */
@@ -86,10 +101,15 @@ export const TEXT_LIMITS = {
   /** Call-to-action target — same width as Announcement.link */
   newsletterCtaUrl: 500,
   /**
-   * ProjectTask.title — VARCHAR(191). One column, three writers: a to-do you
-   * write yourself (`/api/todos`), a project task, and a rename
-   * (`/api/project-tasks/[taskId]`). All three capped at 300 before #1433, so
-   * a 250-character paste passed validation and died as a P2000 in the driver.
+   * ProjectTask.title AND ProjectTaskTemplate.title — both VARCHAR(191).
+   *
+   * Two columns, five writers: a to-do you write yourself (`/api/todos`), a
+   * project task, a rename (`/api/project-tasks/[taskId]`), the shared goal pool
+   * (`/api/admin/goal-templates`) and a project's own pool
+   * (`/api/projects/[id]/task-templates`). All five capped at 300 before #1433,
+   * so a 250-character paste passed validation and died as a P2000 in the
+   * driver. A template's wording becomes a task's title verbatim, so the two
+   * columns cannot be bounded independently.
    */
   todoTitle: 191,
   /** InvitationToken.label — the inviter's private note, VARCHAR(191) */

--- a/src/lib/textLimits.ts
+++ b/src/lib/textLimits.ts
@@ -27,8 +27,12 @@ export const TEXT_LIMITS = {
   interactionNotes: 5000,
   /** InteractionLog.subject — VARCHAR(191) */
   interactionSubject: 191,
+  /** Company.name — VARCHAR(191) */
+  companyName: 191,
   /** Company.description — @db.Text */
   companyDescription: 2000,
+  /** Company.address — VARCHAR(191) */
+  companyAddress: 191,
   /** MentorshipRequest.message — @db.Text */
   mentorshipRequestMessage: 1000,
   /** Public contact form message — Message.body, @db.Text */
@@ -81,6 +85,13 @@ export const TEXT_LIMITS = {
   newsletterCtaLabel: 60,
   /** Call-to-action target — same width as Announcement.link */
   newsletterCtaUrl: 500,
+  /**
+   * ProjectTask.title — VARCHAR(191). One column, three writers: a to-do you
+   * write yourself (`/api/todos`), a project task, and a rename
+   * (`/api/project-tasks/[taskId]`). All three capped at 300 before #1433, so
+   * a 250-character paste passed validation and died as a P2000 in the driver.
+   */
+  todoTitle: 191,
   /** InvitationToken.label — the inviter's private note, VARCHAR(191) */
   invitationLabel: 120,
   /** InvitationToken.email — VARCHAR(191) */


### PR DESCRIPTION
## Summary

`src/lib/textLimits.ts` was written to keep client cap = server cap ≤ column width, and its
header names the failure mode exactly: *server cap > column width → Prisma P2000 ("Data too
long"), which no route handles, so it surfaces as a 500.* Two fields the issue names had
drifted past it, and both were reachable by nothing more than pasting text into an admin screen.

- **`Company.name`** — column `VARCHAR(191)`, **no `max()` at all** on either side. A
  250-character name passed the form, passed the API, and died in the driver:
  `500 POST /api/companies`, "Internal server error" in the modal.
- **`ProjectTask.title`** — same 191-wide column, capped at **300**. Worse, `POST /api/todos`
  had no `try/catch`, so Next answered with a **500 carrying no body**; the client's
  `res.json()` then failed too and the add did *nothing at all*, silently — the text just sat
  in the box.

The fix is the **bound**, not the column. 191 characters is far more than a company name or a
one-line to-do needs, and #1433 is about honesty rather than capacity.

Closes #1433

## Scope: the whole modal, not the two named fields

Self-review of the first pass found the identical defect **one input to the right** of each
field it corrected, so this PR now closes the *surface* rather than the two examples:

| Field | Column | Was | Now |
|---|---|---|---|
| `Company.name` | VARCHAR(191) | no cap | `companyName: 191` |
| `Company.address` | VARCHAR(191) | `max(300)` | `companyAddress: 191` |
| `Company.industry` | VARCHAR(191) | **no cap** | `companyIndustry: 191` |
| `Company.logoUrl` | VARCHAR(191) | **no cap** | `companyLogoUrl: 191` |
| `Company.contactEmail` | VARCHAR(191) | **no cap** (RFC allows 254) | `companyContactEmail: 191` |
| `Company.size` | VARCHAR(191) | inline `max(40)` | `companySize: 40` |
| `CompanyNeed.position` / `.period` | VARCHAR(191) | **no cap** | `companyNeedPosition/Period: 191` |
| `ProjectTask.title` | VARCHAR(191) | `max(300)` | `todoTitle: 191` |
| `ProjectTaskTemplate.title` | VARCHAR(191) | `max(300)` + `MAX_TITLE = 300` slice | `todoTitle: 191` |

`ProjectTaskTemplate.title` was pulled forward from #2262 rather than left there: a template's
wording is written into `ProjectTask.title` **verbatim**, so the two columns cannot be bounded
independently — and neither goal-template route has a `try/catch`, so a 250-character shared
goal produced the *empty-bodied* 500 this PR claims to have removed, in the adjacent feature it
edits. One constant now covers both, in `lib/goalTemplates.ts`, `api/admin/goal-templates` and
`api/projects/[id]/task-templates`.

## Changes

- **`TEXT_LIMITS` gains the nine keys above**, each documented with the column it belongs to,
  used in the server schema and the client schema — no inline numbers.
- **`ProjectTask.title` is one column with three writers**, so all three are capped:
  `POST /api/todos`, `POST /api/projects/[id]/tasks` and the rename in
  `PATCH /api/project-tasks/[taskId]`. Fixing only the to-dos endpoint would have left the
  identical 500 one rename away.
- **`POST /api/todos` is wrapped, `getServerSession` included.** The jwt callback runs
  `prisma.user.findUnique` on *every* request for the `sessionsValidFrom` revocation check, so a
  pool timeout (P2024) or a MySQL restart rejects in the session read — outside a `try` that
  starts after it, which is a catch that guards nothing that realistically throws. The session
  read is inside, matching `POST /api/companies`.
- **No `maxLength` on the company inputs — deliberately.** The browser applies `maxLength`
  *silently* on paste, so a 250-character legal entity name was clipped to 191, sailed through
  `.max()`, and was saved 59 characters short with no error, no counter, and no hint. AC #1 asks
  for a validation error, so the bound lives only in zod, where it can speak. The two
  format-checked fields (`contactEmail`, `logoUrl`) put the length stage **ahead** of their
  `.or(z.literal(''))` union — inside it, an over-long value fails every branch and zod reports
  its own "Invalid input" instead of the message that says what is wrong.
- **The to-do box's counter is announced.** `Textarea` documents the rule for this exact widget
  ("WCAG 4.1.3: the counter is a visual-only cue … a screen-reader user is told nothing") and
  implements it; the new counter now does the same, via `useAnnounce()` and the existing
  `a11y.characterLimitReached` / `a11y.charactersRemaining` keys, fired only on the two
  threshold crossings so it never speaks per keystroke.
- **The to-do toast is translated.** It went through `body.error`, which on these routes is a
  hardcoded English literal — a Turkish admin got "Forbidden" centre stage where the same string
  used to sit in a small inline line. It now goes through the app's existing
  `@/lib/apiErrorMessage`, which translates the *status* and falls back to `t.common.error`,
  same as every other call site.
- **New i18n key** `companyForm.tooLong` in EN/TR/DE (“At most {max} characters” /
  “En fazla {max} karakter” / „Höchstens {max} Zeichen“). The company schema is built per render
  from the dictionary so the message arrives in the admin's own language. No other new keys —
  the a11y and error strings already existed.
- Release fragment `releases/unreleased/zod-bounds-match-columns.json` (`bump: patch`, EN/TR/DE
  notes — the change is visible to anyone who has hit either 500).

## The test does not hand-pick the fields

`e2e/text-limits-columns.unit.spec.ts` reads **every `String` column** of `Company`,
`CompanyNeed`, `ProjectTask` and `ProjectTaskTemplate` out of `prisma/schema.prisma` and fails
on any that is neither bound to a `TEXT_LIMITS` key nor exempted with a written reason. That is
the point: the first version listed three fields by hand and therefore reported the invariant as
*enforced* while `industry` and `logoUrl` sat unchecked in the very schema it inspected.

Four assertions, deliberately separate, because each alone is satisfiable by a wrong fix:

1. every `String` column is accounted for — capped, or exempt with a reason (a new column fails);
2. the constant fits the width parsed from the schema, not a number retyped in the test;
3. every guarding file references the constant instead of a literal;
4. a schema built from the constant accepts the column's capacity exactly and rejects one more.

Plus: `POST /api/todos` has a JSON-bodied catch **and** its `try` opens above the
`getServerSession` call (comments stripped first, so the handler's own prose about it cannot
satisfy the test), and `goalTemplates`' `MAX_TITLE` is the shared constant rather than a literal.

Verified negatively: adding a `slogan String?` column to `Company` and widening
`companyIndustry` to 300 each make it red. 63 tests pass.

## Still out of scope

#2262 keeps the rest of the sweep — `Project.name`/`repoUrl`/`demoUrl`/`boardUrl`, `Goal.title`,
`MeetingRequest.topic` (verified: `String` = VARCHAR(191), capped at 300), `Document.title`,
`Organization.*`, `MentorApplication.linkedinUrl`, `CompanyInquiry.email`, and the six uncapped
fields in `api/profile/route.ts`. `ProjectTaskTemplate.title` has been struck from that list.
The new spec is written so each of those becomes one `COLUMN_GUARDS` entry.

Also out of scope on purpose (the issue says so): wiring the `TEXT_LIMITS` invariant into a CI
check script. Noted as a bonus on #2262 — `scripts/check-tenant-models.mjs` is the shape it
would take.

Preview: https://pr2263.interncrm.com

## Verification

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (only the two pre-existing `react-hooks/exhaustive-deps` warnings in
      unrelated files)
- [x] `npm run check:i18n` — 4414 keys × 3 locales
- [x] `npm run check:release-fragments` — fragment valid (the "compaction looks stuck" line is
      pre-existing and the script itself says it is not a problem with this PR)
- [x] `e2e/text-limits-columns.unit.spec.ts` — **63/63 pass**, run locally with `BASE_URL` set so
      Playwright skips the `webServer` (the spec is pure Node: it reads files, it never opens a
      page), and negatively verified as described above
- [ ] The rest of the Playwright suite was not run: this container has no database — CI is the check

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qTSgQDDVBYo6gXf8xpsnR