### PR TITLE
fix: stage clock takes the hired key from the allowlisted constant (#1724)

### DIFF
--- a/releases/unreleased/stage-clock-hired-key-via-constant.json
+++ b/releases/unreleased/stage-clock-hired-key-via-constant.json
@@ -1,0 +1,4 @@
+{
+  "bump": "patch",
+  "changelog": "- **`main` is green on `check:stage-keys` again** (#1724 follow-up). The stage-clock carve-out that stops the clock on the default hired stage was typed as a `'HIRED_660'` literal in `src/lib/stageClock.ts`, which `npm run check:stage-keys` (#1886) forbids outside the two modules that own the canonical defaults — so every PR opened after #2253 merged inherited a red `Lint · Typecheck · Build`. It now imports `DEFAULT_HIRED_STAGE_KEY` from `src/lib/offers.ts` (an allowlisted module with no imports of its own, so nothing changes for the client components that use the clock), and the doc comment says why the key is not re-typed. The baseline ratchet was also retightened: #1634's work removed the last hits in `src/lib/dormantFirstContact.ts` and `src/lib/menteeOnboarding.ts`, and a generous baseline would have let a regression back into both."
+}

--- a/scripts/stage-keys-baseline.json
+++ b/scripts/stage-keys-baseline.json
@@ -40,14 +40,6 @@
     "hits": 2,
     "issue": "#1884"
   },
-  "src/lib/dormantFirstContact.ts": {
-    "hits": 1,
-    "issue": "#1880"
-  },
-  "src/lib/menteeOnboarding.ts": {
-    "hits": 1,
-    "issue": "#1634"
-  },
   "src/lib/outcomeComms.ts": {
     "hits": 2,
     "issue": "#1880"

--- a/src/lib/stageClock.ts
+++ b/src/lib/stageClock.ts
@@ -12,6 +12,7 @@
 // the clock in the browser, so nothing here may import Prisma.
 
 import { defaultPipelineStages, type ResolvedStage } from './pipeline';
+import { DEFAULT_HIRED_STAGE_KEY } from './offers';
 
 export const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -66,7 +67,12 @@ const CANONICAL_STOPPED = new Set<string>(
 /**
  * Stages whose clock has stopped whatever the tenant's own flags say.
  *
- * HIRED_660 is not flagged terminal in the canonical set (EMPLOYED_700 is) and
+ * The key comes from `DEFAULT_HIRED_STAGE_KEY` (src/lib/offers.ts) rather than
+ * being typed here: `npm run check:stage-keys` forbids naming a canonical stage
+ * key outside the two modules that own the defaults, and re-typing it would put
+ * the same string in a third place that nothing keeps in step.
+ *
+ * The default hired stage is not flagged terminal in the canonical set (EMPLOYED_700 is) and
  * a tenant's `PipelineStage` row for it will not be either, because the flag
  * means "the journey ended here" and a hire is followed by employment. The
  * clock still has to stop: an accepted offer is not a queue anybody is running
@@ -81,7 +87,7 @@ const CANONICAL_STOPPED = new Set<string>(
  * always won and a hired candidate with a stale `stageDeadline` still rendered
  * the red "past the stage deadline" chip.
  */
-const ALWAYS_STOPPED = new Set<string>(['HIRED_660']);
+const ALWAYS_STOPPED = new Set<string>([DEFAULT_HIRED_STAGE_KEY]);
 
 /**
  * Has this stage's clock stopped? Prefers the viewer's resolved stages so a


### PR DESCRIPTION
## Summary

**`main` is red and has been since #2253 merged.** `npm run check:stage-keys` fails on it:

```
stage keys FAILED — a canonical pipeline stage key is hardcoded:
  • src/lib/stageClock.ts:84  HIRED_660
```

Every PR branched or rebased after that merge inherits a red `Lint · Typecheck · Build` — that is how it surfaced, on #2257, whose diff has nothing to do with pipeline stages.

My mistake: I resolved #2253's merge conflict, pushed, and then merged it without re-confirming CI on the new head. The conflict resolution was fine; the branch was already failing this check before it.

## The fix

The carve-out itself is **correct and stays exactly where it is** — outside the resolved-stage lookup, for the reason its own comment gives (in the fallback set it was dead code, because every UI caller passes `useResolvedStages()`, which never yields an empty list, so a hired candidate with a stale `stageDeadline` still rendered the red "past the deadline" chip).

Only the way it *names* the key changes. `scripts/check-stage-keys.mjs` (#1886) allows a canonical stage key to be named in two modules: `src/lib/pipeline.ts` and `src/lib/offers.ts`. The latter already exports exactly this value:

```ts
// src/lib/offers.ts
export const DEFAULT_HIRED_STAGE_KEY = 'HIRED_660';
```

`stageClock.ts` now imports it. `src/lib/offers.ts` has **no imports of its own**, so pulling it into `stageClock` is safe for the client components that use the clock (`StageClockChip`, `JourneyTracker`, both board pages). The doc comment now records why the literal must not come back — otherwise the next reader re-types it and we are here again.

## Also: the baseline ratchet was retightened

The guard reported the baseline had become **generous**, which is its own quiet failure mode — a stale entry lets a regression back into a file without failing CI. #1634's work removed the last hardcoded keys from two files:

```
  • src/lib/dormantFirstContact.ts  1 → 0
  • src/lib/menteeOnboarding.ts     1 → 0
```

Both entries are gone. 38 known hits across 12 files remain to clean up, and the list can still only shrink.

## Verification

- [x] `npm run check:stage-keys` — `OK — no new hardcoded key; 38 known hit(s) in 12 baselined file(s)`
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm run check:i18n` — 4460 keys × 3 locales
- [x] `npm run check:release-fragments` OK
- [x] **`npm run build` completes** — a full production build, not just a typecheck

No schema change, so no `prisma validate`.

Preview: https://pr2266.interncrm.com

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qTSgQDDVBYo6gXf8xpsnR

---
_Generated by [Claude Code](https://claude.ai/code/session_017qTSgQDDVBYo6gXf8xpsnR)_