### PR TITLE
fix: mentor profile message shortcut, and stage labels that stopped translating

### DIFF
--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -5975,3 +5975,40 @@ yaptığı atıfları düzeltmek gerekiyor. Marker kalmaması, metnin doğru olm
 kendiliğinden birleşti; yine de `grep -n "key: '"` ile iki girdinin de yerinde olduğuna
 baktım. Otomatik birleşme "çatışma yok" demektir, "iki taraf da korundu" demek değildir —
 kayıt defteri gibi dosyalarda sessizce bir girdi düşerse hiçbir tip hatası vermez.
+
+## 2026-09-07 — Bir kilit değerin kaynağı veriyse, kodu düzeltmek veriyi de iyileştirebilir (#2268)
+
+İki küçük kusuru tek PR'da kapattım (#2269). İkincisinin — Türkçe arayüzde İngilizce
+pipeline aşama etiketleri — bulgusu "isDataNotCode: true" idi ve doğruydu: semptomu üreten
+şey `PipelineStage.label` satırlarıydı. Refleks çözüm bir backfill betiği yazıp
+`infra/deploy-prod.sh`'e eklemek olurdu; bu, canlı satırları her ortamda yeniden yazmak
+demekti ve onay gerektirirdi. Bunun yerine **okuma yolunu** "bu etiket hâlâ bizim yerleşik
+etiketimizse, okuyanın diliyle çevir" diye değiştirdim. Aynı sonuç, sıfır veri mutasyonu,
+sıfır operatör adımı. Ders: veriden gelen bir semptomda önce "bu değeri kim okuyor ve
+okurken düzeltebilir miyim?" diye sor — backfill en son çare.
+
+**"Herhangi bir dilde eşleşiyor mu" kontrolü, kapatılması en zor deliği kapatıyor.**
+`isDefaultLabel` sadece okuyanın dilindeki yerleşik etiketle karşılaştırsaydı, editörde
+yalnızca **rengi** değiştirip kaydeden bir yönetici hâlâ bir dili dondururdu (prefill
+İngilizceydi, karşılaştırma Türkçeydi, eşleşme olmazdı). Üç dilin hepsine bakmak bu deliği
+kapatıyor; bedeli — bir kiracı Almanca yerleşik dizeyi Türkçe okuyuculara sabitleyemiyor —
+kod yorumuna yazılmalı, yoksa bir sonraki okuyan bunu hata sanar.
+
+**Konu numarasını issue'yu AÇTIKTAN sonra yaz.** Yorumlara ve release fragment'ına `#2270`
+yazdım (sıradaki numarayı tahmin ederek); `gh issue create` `#2268` verdi ve tahminim iki
+şey birden kaydırmıştı. Dokuz dosyada `sed` ile düzeltip kontrolleri baştan koşturmak
+gerekti. Ya issue'yu ilk iş aç, ya da numarayı yer tutucu bırakıp commit'ten önce doldur.
+
+**`npm install`, PR'ına versiyon değişikliği sızdırır.** Yerel `node_modules` eksikti
+(`@axe-core/playwright`, `web-push` yüzünden `tsc` 13 sahte hata veriyordu), `npm install`
+sorunu çözdü ama `package-lock.json`'ın `version` alanını 0.135.0 → 0.156.21 diye
+güncelledi. CLAUDE.md PR'ların versiyon dosyalarına dokunmamasını söylüyor: commit'ten önce
+`git checkout -- package-lock.json`. `git status`'u diff'e bakmadan `git add -A` ile
+geçmeyin.
+
+**`node --experimental-strip-types` `@/` takma adını çözmez.** `scripts/test/*.test.mjs`
+birim koşucusu `.ts` dosyalarını doğrudan import ediyor, ama `src/lib/pipeline.ts`
+`@/i18n/config`'ten import ettiği için o koşucudan erişilemiyor (coverage raporu da
+"Playwright altında, #1598 bekliyor" diyor). Saf yardımcıları yine de doğrulamak için
+`/tmp`'ye kopyalayıp import satırını `sed`'le göreceli hale getirdim: 30 saniye, ve üç
+dilin çıktısını gözle gördüm. Veritabanı olmadan da saf mantık kanıtlanabilir.

--- a/e2e/mentor-detail.spec.ts
+++ b/e2e/mentor-detail.spec.ts
@@ -39,3 +39,39 @@ test('mentor detail page shows expertise, capacity and active mentees', async ({
     await cleanupByEmail(menteeEmail);
   }
 });
+
+// #2268: the admin mentor profile is where every "open profile" for a MENTOR
+// lands, and it was the one person page with no way to contact them — the
+// affordance existed on the candidate profile and in the hover cards only. Also
+// the first end-to-end proof of the ADMIN → MENTOR branch of `canMessage`.
+test('mentor detail page offers the message and view-as shortcuts', async ({ page }) => {
+  const mentorEmail = uniqueEmail('mdqa-mentor');
+  const mentor = await seedUser(mentorEmail, 'Pass1234!', 'MENTOR', 'MDQA Mentor');
+  let conversationId: string | null = null;
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', ADMIN_EMAIL);
+    await page.fill('input[type="password"]', ADMIN_PASSWORD);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => !u.pathname.includes('/auth/signin'), { timeout: 20_000 });
+
+    await page.goto(`/admin/mentors/${mentor.id}`);
+    await expect(page.getByTestId('user-quick-actions')).toBeVisible();
+    // Present, but NOT clicked — e2e/impersonation.spec.ts owns that flow, and
+    // starting one here would notify the mentor and write an audit row.
+    await expect(page.getByTestId('quick-login-as')).toBeVisible();
+
+    // One click only: /api/conversations is rate-limited to 20 per 15 minutes
+    // per IP and every spec in the job shares one.
+    await page.getByTestId('quick-message').click();
+    await page.waitForURL(/\/messages\/c\/[^/]+$/, { timeout: 20_000 });
+    conversationId = new URL(page.url()).pathname.split('/').pop() ?? null;
+    expect(conversationId).toBeTruthy();
+  } finally {
+    // The participant rows cascade with the user; the conversation itself does
+    // not, so drop it explicitly.
+    if (conversationId) await prisma.conversation.deleteMany({ where: { id: conversationId } });
+    await cleanupByEmail(mentorEmail);
+  }
+});

--- a/e2e/mobile-layout-audit.spec.ts
+++ b/e2e/mobile-layout-audit.spec.ts
@@ -181,7 +181,10 @@ test('phone width: the admin rows keep the person identifiable', { tag: '@smoke'
     await setLocale(page, 'tr');
     await signInAndSettle(page, adminEmail, pw, '/admin');
 
-    for (const path of ['/admin', '/admin/mentors', '/admin/activity']) {
+    // The mentor DETAIL page is in the loop because its header carries four
+    // controls with long Turkish labels since #2268 (capacity badge, message,
+    // view-as, convert) — the audit only ever measured the list (#1305).
+    for (const path of ['/admin', '/admin/mentors', `/admin/mentors/${mentor.id}`, '/admin/activity']) {
       await gotoSettled(page, path);
       await settle(page);
       expect(await auditLayout(page), `${path} at ${PHONE.width}px (tr)`).toEqual([]);

--- a/e2e/pipeline-stages.spec.ts
+++ b/e2e/pipeline-stages.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { prisma, uniqueEmail } from './helpers/db';
-import { defaultPipelineStages, resolvePipelineStages, onPathKeys, startStageKey } from '../src/lib/pipelineStages';
+import { defaultPipelineStages, resolvePipelineStages, onPathKeys, startStageKey, isDefaultLabel } from '../src/lib/pipelineStages';
 
 // Per-tenant pipeline stages (#747, Phase A). Behavior-preserving: no rows → the
 // canonical enum defaults; rows → the tenant's override. Exercised against a real
@@ -71,4 +71,50 @@ test('startStageKey never returns a key outside a non-empty stage set', () => {
   expect(startStageKey([stage('LOST', 1, true), stage('WITHDRAWN', 0, true)])).toBe('WITHDRAWN');
   // Genuinely empty (an org on the defaults, resolved elsewhere): canonical floor.
   expect(startStageKey([])).toBe('APPLICATION_100');
+});
+
+// #2268: a stage the tenant never renamed must read back in the VIEWER'S
+// language. The editor's GET used to prefill the English built-in labels and its
+// Save posted them straight back, so a single click on an untouched editor froze
+// English into the DB for every reader in every language.
+test('isDefaultLabel recognizes a built-in label in any locale, and only for a built-in key', () => {
+  // The label the editor prefilled, in each of the three languages.
+  expect(isDefaultLabel('APPLICATION_100', '100 · First contact')).toBe(true);
+  expect(isDefaultLabel('APPLICATION_100', '100 · İlk temas')).toBe(true);
+  expect(isDefaultLabel('APPLICATION_100', '100 · Erstkontakt')).toBe(true);
+  // Blank is the sentinel a save writes for an untouched stage.
+  expect(isDefaultLabel('APPLICATION_100', '')).toBe(true);
+  expect(isDefaultLabel('APPLICATION_100', '   ')).toBe(true);
+  // Something an admin actually typed is theirs, and a custom KEY never counts
+  // as a default however plausible its label reads.
+  expect(isDefaultLabel('APPLICATION_100', 'Ön görüşme')).toBe(false);
+  expect(isDefaultLabel('APPLICATION_100', '100 · First contacts')).toBe(false);
+  expect(isDefaultLabel('LEAD', 'Lead')).toBe(false);
+});
+
+test('un-renamed stage rows localize, renamed ones render verbatim', async () => {
+  const stamp = uniqueEmail('ps').replace(/[^a-z0-9]/gi, '').toLowerCase();
+  const org = await prisma.organization.create({ data: { name: `PS ${stamp}`, slug: `psl-${stamp}` } });
+  try {
+    await prisma.pipelineStage.createMany({
+      data: [
+        // The sentinel a save writes now …
+        { orgId: org.id, key: 'APPLICATION_100', label: '', order: 0 },
+        // … and what the old editor actually persisted: the English default.
+        { orgId: org.id, key: 'APPROVAL_PENDING_220', label: '220 · Awaiting approval', order: 1 },
+        // A label the admin really typed.
+        { orgId: org.id, key: 'INTERVIEW_PENDING_250', label: 'Ön görüşme', order: 2 },
+      ],
+    });
+
+    const tr = await resolvePipelineStages(org.id, 'tr');
+    expect(tr.map((s) => s.label)).toEqual(['100 · İlk temas', '220 · Onay bekliyor', 'Ön görüşme']);
+    const de = await resolvePipelineStages(org.id, 'de');
+    expect(de.map((s) => s.label)).toEqual(['100 · Erstkontakt', '220 · Warte auf Freigabe', 'Ön görüşme']);
+    const en = await resolvePipelineStages(org.id, 'en');
+    expect(en.map((s) => s.label)).toEqual(['100 · First contact', '220 · Awaiting approval', 'Ön görüşme']);
+  } finally {
+    await prisma.pipelineStage.deleteMany({ where: { orgId: org.id } });
+    await prisma.organization.deleteMany({ where: { id: org.id } });
+  }
 });

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -205,6 +205,9 @@ model PipelineStage {
   orgId      String
   org        Organization @relation(fields: [orgId], references: [id], onDelete: Cascade)
   key        String
+  /// A label the tenant actually typed, shown verbatim in every language — or
+  /// "" meaning "use the built-in localized label for this key" (#2268). Always
+  /// read it through resolvePipelineStages()/useResolvedStages(), never raw.
   label      String
   order      Int
   isTerminal Boolean      @default(false)

--- a/releases/unreleased/mentor-profile-actions-and-stage-label-locale.json
+++ b/releases/unreleased/mentor-profile-actions-and-stage-label-locale.json
@@ -1,0 +1,18 @@
+{
+  "bump": "patch",
+  "changelog": "- **Fixed** the admin mentor profile had no message / view-as shortcut — `/admin/mentors/[id]` now renders `UserQuickActions` like the candidate profile does, with the candidate page's `flex-wrap` / `min-w-0` header so four controls survive a 360px phone (#2268).\n- **Fixed** pipeline stage labels rendered in English inside a Turkish UI (#2268). The stage editor's GET resolved the built-in labels with no locale and its Save posted the prefill back verbatim, freezing English into `PipelineStage.label` for the whole tenant. A save now stores `\"\"` for a stage nobody renamed, `resolvePipelineStages()` / `useResolvedStages()` localize any label that is still one of ours, and the editor plus `/api/admin/stage-sla` resolve in the viewer's locale.",
+  "notes": {
+    "en": [
+      "Pipeline stage names are shown in your own language again, even for organizations whose stages were saved through the stage editor.",
+      "A mentor's profile now has the same \"send a message\" and \"view as this user\" shortcuts as a candidate's."
+    ],
+    "tr": [
+      "Pipeline aşama adları yeniden kendi dilinizde görünüyor — aşama düzenleyicisinden kaydedilmiş kurumlarda da.",
+      "Mentor profilinden doğrudan mesaj gönderebilir ve o kullanıcı gibi girebilirsiniz."
+    ],
+    "de": [
+      "Pipeline-Phasennamen erscheinen wieder in deiner eigenen Sprache — auch bei Organisationen, deren Phasen über den Phasen-Editor gespeichert wurden.",
+      "Das Mentor-Profil bietet nun die gleichen Verknüpfungen \"Nachricht senden\" und \"Als dieser Nutzer ansehen\" wie ein Kandidatenprofil."
+    ]
+  }
+}

--- a/src/app/admin/mentors/[id]/page.tsx
+++ b/src/app/admin/mentors/[id]/page.tsx
@@ -8,6 +8,7 @@ import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Badge } from '@/components/ui/Badge';
 import { useStageLabel } from '@/lib/pipelineStagesClient';
 import { RoleConvertButton } from '@/components/RoleConvertButton';
+import { UserQuickActions } from '@/components/UserQuickActions';
 import { useT } from '@/i18n/client';
 
 interface MentorRelation {
@@ -66,16 +67,21 @@ export default function AdminMentorDetailPage() {
           <ArrowLeft className="h-4 w-4" />
           {t.mentorDetail.back}
         </Link>
-        <div className="flex items-center justify-between gap-3">
-          <div>
-            <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{user.fullName}</h1>
-            <p className="text-gray-500">{user.email}{user.department ? ` · ${user.department}` : ''}</p>
+        {/* Same header shape as the candidate profile: the identity column is
+            the one allowed to give (min-w-0 + break-words), because the action
+            column now holds four controls with long labels (#1305). */}
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="min-w-0">
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 break-words">{user.fullName}</h1>
+            <p className="text-gray-500 break-words">{user.email}{user.department ? ` · ${user.department}` : ''}</p>
           </div>
-          <div className="flex flex-wrap items-center justify-end gap-2 flex-shrink-0">
+          <div className="flex flex-wrap items-center gap-2 sm:gap-3">
             <Badge variant={atCapacity ? 'warning' : 'info'} className="flex items-center gap-1">
               <Users className="h-3 w-3" />
               {active.length}{cap != null ? `/${cap}` : ''} {t.mentors.mentee}
             </Badge>
+            {/* Message / view-as shortcuts, right where the profile is read (#51). */}
+            <UserQuickActions userId={user.id} role={user.role} />
             {/* Convert right where the person is looked at (#1252). */}
             <RoleConvertButton userId={user.id} fullName={user.fullName} role={user.role} onDone={load} />
           </div>

--- a/src/app/api/admin/organizations/[id]/pipeline-stages/route.ts
+++ b/src/app/api/admin/organizations/[id]/pipeline-stages/route.ts
@@ -4,9 +4,10 @@ import { z } from 'zod';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { isHexColor } from '@/lib/branding';
-import { resolvePipelineStages, defaultPipelineStages } from '@/lib/pipelineStages';
+import { resolvePipelineStages, defaultPipelineStages, isDefaultLabel } from '@/lib/pipelineStages';
 import { isSuperAdmin, logCrossTenantDenial } from '@/lib/superAdmin';
 import { resolveOrgId } from '@/lib/orgScope';
+import { getLocale } from '@/i18n/server';
 
 // Per-tenant pipeline-stage management (#747). Admin-only; premium-gated (custom
 // stages require a paid plan). Phase A: label / order / color / on-path grouping
@@ -37,7 +38,10 @@ export async function GET(_req: Request, { params }: { params: Promise<{ id: str
   if ('error' in gate) return NextResponse.json({ error: gate.error }, { status: gate.status });
 
   const count = await prisma.pipelineStage.count({ where: { orgId: id } });
-  const stages = await resolvePipelineStages(id);
+  // The editor prefills its inputs from this response, so it has to speak the
+  // admin's language — a locale-less resolve handed them English labels to save
+  // back verbatim, freezing English for the whole tenant (#2268).
+  const stages = await resolvePipelineStages(id, await getLocale());
   return NextResponse.json({ stages, custom: count > 0, plan: gate.org.plan });
 }
 
@@ -83,7 +87,11 @@ export async function PUT(req: Request, { params }: { params: Promise<{ id: stri
       data: stages.map((s) => ({
         orgId: id,
         key: s.key,
-        label: s.label.trim(),
+        // A label that is still one of ours is stored blank, which means "use
+        // the built-in localized label" — so saving a colour or a reorder does
+        // not pin a language (#2268). Only a label the admin actually typed is
+        // persisted, and it renders verbatim to everyone.
+        label: isDefaultLabel(s.key, s.label) ? '' : s.label.trim(),
         order: s.order,
         isTerminal: s.isTerminal ?? false,
         isOffPath: s.isOffPath ?? false,
@@ -92,7 +100,7 @@ export async function PUT(req: Request, { params }: { params: Promise<{ id: stri
     }),
   ]);
 
-  const resolved = await resolvePipelineStages(id);
+  const resolved = await resolvePipelineStages(id, await getLocale());
   return NextResponse.json({ stages: resolved, custom: true });
 }
 
@@ -103,5 +111,5 @@ export async function DELETE(_req: Request, { params }: { params: Promise<{ id: 
   if ('error' in gate) return NextResponse.json({ error: gate.error }, { status: gate.status });
 
   await prisma.pipelineStage.deleteMany({ where: { orgId: id } });
-  return NextResponse.json({ stages: defaultPipelineStages(), custom: false });
+  return NextResponse.json({ stages: defaultPipelineStages(await getLocale()), custom: false });
 }

--- a/src/app/api/admin/stage-sla/route.ts
+++ b/src/app/api/admin/stage-sla/route.ts
@@ -5,6 +5,7 @@ import { prisma } from '@/lib/prisma';
 import { withTenantScope } from '@/lib/orgContext';
 import { resolveOrgId } from '@/lib/orgScope';
 import { resolvePipelineStages } from '@/lib/pipelineStages';
+import { getLocale } from '@/i18n/server';
 import { resolveStageSlas } from '@/lib/stageSla';
 import { logActivity } from '@/lib/activity';
 import { z } from 'zod';
@@ -37,7 +38,9 @@ export async function GET() {
   }
   return await withTenantScope(session, async () => {
     const orgId = resolveOrgId(session);
-    const stages = await resolvePipelineStages(orgId);
+    // The labels are printed straight into the settings card, so they need the
+    // viewer's locale — without it the whole list read English (#2268).
+    const stages = await resolvePipelineStages(orgId, await getLocale());
     const slas = await resolveStageSlas(orgId);
     // Every stage is listed, configured or not, so the form shows the whole
     // pipeline rather than only the rules that already exist.

--- a/src/lib/pipeline.ts
+++ b/src/lib/pipeline.ts
@@ -1,7 +1,7 @@
 // Single source of truth for the mentee pipeline stages (mirrors the Prisma
 // PipelineStatus enum). Enum identifiers are English; display labels are
 // localized (EN/TR).
-import type { Locale } from '@/i18n/config';
+import { locales, type Locale } from '@/i18n/config';
 
 export const PIPELINE_STATUSES = [
   'APPLICATION_100',
@@ -266,7 +266,36 @@ export function startStageKey(stages: ResolvedStage[]): string {
 }
 
 // Label lookup over a resolved set, falling back to the canonical label and then
-// the raw key — so a custom key always renders something sensible.
+// the raw key — so a custom key always renders something sensible. A blank
+// stored label falls through too; see `isDefaultLabel`.
 export function stageLabel(stages: ResolvedStage[], key: string, locale: Locale = 'en'): string {
-  return stages.find((s) => s.key === key)?.label ?? pipelineLabel(key, locale);
+  return stages.find((s) => s.key === key)?.label || pipelineLabel(key, locale);
+}
+
+// Is this stored label one the tenant never actually chose? Two shapes count:
+// blank (what a save now writes for an untouched built-in stage), and a
+// byte-for-byte copy of one of OUR OWN built-in labels — which is what the stage
+// editor used to persist. Its GET prefilled the 13 built-in labels resolved in
+// the wrong language and Save posted them straight back, so one click on an
+// untouched editor froze English into the DB for every reader in every language
+// (#2268).
+//
+// Matching ANY locale, not just the viewer's, is deliberate: it means an admin
+// who only recoloured or reordered the built-in stages keeps translated labels.
+// The cost is that a tenant cannot pin our German string as a fixed label for
+// Turkish readers — the right trade for a stage nobody renamed. Typing anything
+// that differs by a character is still honoured verbatim.
+export function isDefaultLabel(key: string, label: string): boolean {
+  const trimmed = label.trim();
+  if (!trimmed) return true;
+  if (!(PIPELINE_STATUSES as readonly string[]).includes(key)) return false;
+  return locales.some((l) => pipelineLabel(key, l) === trimmed);
+}
+
+// Fill in the built-in localized label for every stage the tenant did not
+// rename, leaving genuinely custom labels exactly as they were set.
+export function localizeStageLabels(stages: ResolvedStage[], locale: Locale): ResolvedStage[] {
+  return stages.map((s) =>
+    isDefaultLabel(s.key, s.label) ? { ...s, label: pipelineLabel(s.key, locale) } : s
+  );
 }

--- a/src/lib/pipelineStages.ts
+++ b/src/lib/pipelineStages.ts
@@ -7,10 +7,18 @@
 // canonical stages, so single-tenant production is unchanged.
 
 import { prisma } from './prisma';
-import { defaultPipelineStages, onPathKeys, stageLabel, startStageKey, type ResolvedStage } from './pipeline';
+import {
+  defaultPipelineStages,
+  isDefaultLabel,
+  localizeStageLabels,
+  onPathKeys,
+  stageLabel,
+  startStageKey,
+  type ResolvedStage,
+} from './pipeline';
 import type { Locale } from '@/i18n/config';
 
-export { defaultPipelineStages, onPathKeys, stageLabel, startStageKey, type ResolvedStage };
+export { defaultPipelineStages, isDefaultLabel, onPathKeys, stageLabel, startStageKey, type ResolvedStage };
 
 // Resolve the stages for a tenant: its custom rows if any, else the canonical
 // defaults. Cheap single indexed query; falls back safely for a null org.
@@ -24,14 +32,19 @@ export async function resolvePipelineStages(
       orderBy: { order: 'asc' },
     });
     if (rows.length > 0) {
-      return rows.map((r) => ({
-        key: r.key,
-        label: r.label,
-        order: r.order,
-        isTerminal: r.isTerminal,
-        isOffPath: r.isOffPath,
-        color: r.color,
-      }));
+      // A row the tenant never renamed reads back in the CALLER'S locale, not
+      // in whatever language the editor happened to persist (#2268).
+      return localizeStageLabels(
+        rows.map((r) => ({
+          key: r.key,
+          label: r.label,
+          order: r.order,
+          isTerminal: r.isTerminal,
+          isOffPath: r.isOffPath,
+          color: r.color,
+        })),
+        locale,
+      );
     }
   }
   return defaultPipelineStages(locale);
@@ -40,6 +53,8 @@ export async function resolvePipelineStages(
 // Resolve a tenant's CUSTOM stages, or null when it uses the built-in defaults.
 // Fed to the client PipelineStagesProvider so default-stage labels can stay
 // localized on the client while custom labels render as the tenant set them.
+// Deliberately locale-free: the labels go out raw (a not-renamed one possibly
+// blank) and the client hook localizes them in the viewer's own locale.
 export async function resolveCustomStages(
   orgId: string | null | undefined,
 ): Promise<ResolvedStage[] | null> {

--- a/src/lib/pipelineStagesClient.tsx
+++ b/src/lib/pipelineStagesClient.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { createContext, useContext } from 'react';
-import { defaultPipelineStages, stageLabel, onPathKeys, type ResolvedStage } from '@/lib/pipeline';
+import { createContext, useContext, useMemo } from 'react';
+import { defaultPipelineStages, localizeStageLabels, stageLabel, onPathKeys, type ResolvedStage } from '@/lib/pipeline';
 import { useLocale } from '@/i18n/client';
 
 // Client access to the viewer's tenant pipeline stages (#747, Slice B). The
@@ -9,7 +9,9 @@ import { useLocale } from '@/i18n/client';
 // built-in defaults) and provides them here; client components read them via the
 // hooks below. When null, we compute the canonical defaults in the *client*
 // locale, so default-stage labels stay localized while custom labels (a single
-// tenant-set string) render as-is.
+// tenant-set string) render as-is. A tenant that customized only SOME stages
+// gets the same treatment per row: the ones it never renamed are localized
+// here, the ones it did are rendered verbatim (#2268).
 
 const Ctx = createContext<ResolvedStage[] | null>(null);
 
@@ -27,7 +29,10 @@ export function PipelineStagesProvider({
 export function useResolvedStages(): ResolvedStage[] {
   const locale = useLocale();
   const ctx = useContext(Ctx);
-  return ctx && ctx.length > 0 ? ctx : defaultPipelineStages(locale);
+  return useMemo(
+    () => (ctx && ctx.length > 0 ? localizeStageLabels(ctx, locale) : defaultPipelineStages(locale)),
+    [ctx, locale],
+  );
 }
 
 // A label(key) resolver bound to the viewer's stages + locale.


### PR DESCRIPTION
Closes #2268.

Two small defects on adjacent admin surfaces, one PR.

## Defect 1 — the admin mentor profile had no "send message" button

**Root cause: a pure UI omission.** `src/app/admin/mentors/[id]/page.tsx` never imported `UserQuickActions`. The component went onto the candidate profile for #51 and into the hover cards for #1166; the mentor detail page (EPIC B / #415, later given `RoleConvertButton` for #1252) was skipped — even though `src/lib/personHref.ts` makes `/admin/mentors/<id>` the canonical admin-side mentor profile, so it is where every `PersonHoverCard` "open profile" for a `MENTOR` lands.

Nothing anywhere else blocked it. `canMessage()` short-circuits to `true` when either side is an `ADMIN`, `POST /api/conversations` creates the DIRECT conversation, `/api/admin/impersonate` refuses only `ADMIN` targets, `/admin/users` already offers `loginAs` on mentor rows, and every string the component needs already exists in EN/TR/DE. **No i18n, API or authorization change was needed.**

**What changed:** the full `<UserQuickActions userId={user.id} role={user.role} />`, in the candidate page's position (badge → quick actions → convert).

The whole component rather than a message-only variant, deliberately:

- its public API is `{ userId, role?, className? }` — "message only" would mean widening a shared component's props for one caller;
- the impersonate button is already self-gating (`session?.user?.role === 'ADMIN'`, plus `if (isSelf) return null`), so on an admin-only route it renders exactly what the candidate page renders;
- the server already sanctions impersonating a mentor, and `roleHome('MENTOR')` maps to `/mentor`, which is precisely why the component takes a `role` prop — so "view the app as this mentor" lands on the mentor dashboard, not `/portal`.

Worth knowing, since it is a product call: **the new view-as button can generate mentor-facing notifications.** `/api/admin/impersonate` writes an `IMPERSONATE_START` audit row, a warning-level activity entry, and notifies the target that their account was accessed. That is by design (transparency) and already reachable from `/admin/users` — but say the word and I will drop the view-as half and keep only "send a message".

The header also needed fixing before gaining two more buttons. It was a `flex-shrink-0` action column opposite an identity block with **no `min-w-0`** — exactly the #1305 shape, where the name/email column is the only thing that can give, and TR "Bu kullanıcı gibi gir" / DE "Nachricht senden" are the long labels. It now uses the candidate page's proven classes: `flex-wrap items-start`, `min-w-0` + `break-words` on the identity column, no `flex-shrink-0` on the actions.

## Defect 2 — pipeline stage labels rendered in English in a Turkish UI

**Root cause: `resolvePipelineStages(orgId, locale: Locale = 'en')` has a silently-English default, and the one caller whose output is written back to the database omitted it.**

1. `GET /api/admin/organizations/[id]/pipeline-stages` resolved the stages with no locale, so it answered with the 13 built-in labels in **English**, whatever the admin's language.
2. The stage editor treats that response as editable state and prefills 13 text inputs from it.
3. Save PUTs the whole prefilled set straight back, and the PUT persisted every label unconditionally (`label: s.label.trim()`).

So **one Save on an untouched editor** — or a recolour, or a reorder — converted "13 localized built-in stages" into "13 hardcoded English rows". After that `useResolvedStages()` renders them correctly as-is in all three languages, because `PipelineStage.label` is a single string with no per-locale variant. `DELETE` ("Reset to defaults") had the same omission, so the reset repopulated the editor in English too.

**What changed** (~40 lines, no schema change, no data migration):

- `isDefaultLabel(key, label)` in `src/lib/pipeline.ts` — true when a stored label is blank or is a byte-for-byte copy of one of *our own* built-in labels, in **any** of the three locales. Matching any locale is what closes the recolour/reorder hole; the cost, stated in the code comment, is that a tenant cannot pin our German string as a fixed label for Turkish readers.
- `PUT` now stores `""` for a stage nobody renamed. The public contract is unchanged (zod still requires `label.min(1)`) — the server normalizes, so no client needs to know about the sentinel. Only labels an admin actually typed are persisted, and those still render verbatim to everyone.
- Both read paths resolve it: `resolvePipelineStages()` on the server, and `useResolvedStages()` on the client for the labels `resolveCustomStages()` sends down raw. This makes the invariant the client file's comment already claimed true for a *partially* customized tenant, which it silently was not.
- `stageLabel()` falls through on a blank label (`??` → `||`).
- The editor's `GET`, `PUT` response and `DELETE` now resolve in the viewer's locale via `getLocale()`, so an admin sees Turkish while editing.
- `GET /api/admin/stage-sla` likewise — it ships `label` to `StageSlaEditor`, which prints it verbatim, so the whole stage-SLA settings list read English for a default-stage org.

A comment on `PipelineStage.label` in `prisma/schema.prisma` records the `""` contract. **It is a comment only — no column, type or index changed, so `db push` is a no-op.**

### Operator note: the org whose labels are already frozen

Rows that the editor already froze **heal by themselves on deploy** — `isDefaultLabel` recognizes them at read time, so a row storing `220 · Awaiting approval` renders `220 · Onay bekliyor` for a Turkish reader with no data change. I did not connect to any database and shipped no backfill.

The one case the code cannot fix is a tenant whose stage labels are **hand-written English that differs from our built-in strings** (e.g. someone typed `First contact` rather than `100 · First contact`). Those are indistinguishable from a deliberate rename, so they are honoured verbatim — by design. Clearing them is an operator action: open `/admin/organizations/<orgId>/pipeline` as that tenant's admin and press **Reset to defaults**, which drops the custom rows and returns the org to the localized built-ins. Worth checking first which case you are in — the editor's own sentence says whether the tenant uses custom stages, and `GET /api/admin/organizations/<orgId>/pipeline-stages` (two reads, writes nothing) returns the 13 labels to compare.

## Tests

- `e2e/mentor-detail.spec.ts` — new test on the affordance: `user-quick-actions` and `quick-login-as` visible, then one click on `quick-message` and assert the URL lands on `/messages/c/<id>`. **These three testids had zero coverage anywhere before this**, on either page, so this is also the first end-to-end proof of the ADMIN → MENTOR branch of `canMessage`. `quick-login-as` is asserted but never clicked (`e2e/impersonation.spec.ts` owns that flow, and starting one here would notify the mentor). One click only — `/api/conversations` is rate-limited to 20 per 15 minutes per shared runner IP. The conversation is deleted in `finally`; participant rows cascade with the user, the conversation row does not.
- `e2e/pipeline-stages.spec.ts` — `isDefaultLabel` across all three locales, blank, whitespace, a near-miss label and a custom key; plus a DB-backed test that a row stored `""`, a row stored with the frozen English default and a row with a genuinely typed label (`Ön görüşme`) resolve correctly in `tr`, `de` and `en`.
- `e2e/mobile-layout-audit.spec.ts` — `/admin/mentors/<id>` joins the 360px Turkish admin loop. The audit only ever measured the mentor **list**, which is where #1305 was filed; the detail page header is now the one with four controls.
- Not tagged `@smoke` (the mentor-detail test): CLAUDE.md caps that set at ~15–20 and this is not a critical path. The mobile-audit test it joins is already `@smoke`, so the count does not grow.

## Checks run locally — all green

| Check | Result |
|---|---|
| `npx prisma generate` | ok |
| `npx prisma validate` | schema valid |
| `npx tsc --noEmit` | 0 errors |
| `npm run lint` | 0 errors (2 pre-existing warnings, unrelated files) |
| `npm run check:i18n` | OK — 4460 keys × 3 locales |
| `npm run check:release-fragments` | OK — ships as `0.168.3-beta` |
| `npm run check:stage-keys` | OK — no new hardcoded key |
| `npm run check:locale-dates` | OK |
| `npm run test:unit` / `test:unit:coverage` | 59/59 pass, no floor breached |
| `npm run test:release`, `check:auth-reads`, `check:api-key-routes`, `check:query-scalars`, `check:tenant-models`, `check:demo-blocklist`, `check:events`, `check:openapi` | all OK |
| `npm run build` | succeeds |

**The e2e specs were not executed locally** — this box has no MySQL and I deliberately connected to no database. They run in CI.

`check:release-fragments` also prints a pre-existing warning that 39 fragments are pending and `release-compact.yml` looks stuck; the script itself flags it as "Not a problem with this PR", but it is worth a look.

## Deliberately out of scope

Filed as remaining leaks in #2268: the ICS feed (`api/calendar/feed/[token]`, locale-less **and** bypasses custom stages — calendar clients cache hard and it deserves its own verification pass), the weekly analytics report e-mail (interpolates the raw enum key; needs the row construction moved inside the per-admin loop), localizing the pipeline editor page itself (100% hardcoded English — a whole new dictionary namespace × 3 locales would bury this fix), and per-locale custom labels (`PipelineStage.labels Json`, the way `EvaluationCriterion.labels` already works). Also noted there: `/admin/mentors` renders the mentor name as a plain `<Link>` rather than a `PersonHoverCard`, so it is the one admin surface where a mentor's name offers neither a message nor a card.
