### PR TITLE
Count in-app messages as contact, except other people's group posts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,6 +266,16 @@ workaround, #636, and it compiled on every PR push).
   İki sınır tartışmaya kapalıdır: **üçüncü mail yok** (gönderen alan adının itibarı) ve
   **otomatik aşama değişikliği / kapatma yok**. Herhangi bir yaşam belirtisi (mentee mesajı,
   yanıtsız soru, bekleyen toplantı, aşama ilerlemesi) damgayı ve sayaçları sıfırlar.
+- **"Son temas" tek bir kuraldır** (`docs/last-contact.md`, #2275): mentor panosundaki
+  *Yakın zamanda temas yok* rozeti, günlük durgunluk hatırlatması, haftalık özet, mentee
+  kartları ve `/admin/candidates/[id]` "Sıradaki aksiyon" — hepsi
+  `src/lib/lastContact.ts`'ten okur (kuralın kendisi bağımlılıksız `lastContactRule.ts`'te,
+  birim testli). Temas = **en yenisi**: `InteractionLog` kaydı, mentorluk başlığındaki
+  **birebir (DIRECT)** mesaj (her iki yönde) ve **mentee'nin kendi yazdığı grup mesajı**.
+  Başkasının grup mesajı bilinçli olarak temas **değildir** — grup sohbeti bir yayındır,
+  mentorun tek satırı dokuz mentee ile temas sayılsa listeyi hepsi için birden susturur.
+  Etkileşim **sayaçları** ("Toplam Etkileşim", `/mentor/interactions`) hâlâ yalnızca
+  `InteractionLog` satırlarını sayar: orası bir kayıt defteri, değişen şey tazelik.
 - **Feature catalogue**: when a user-visible feature ships, add/update its entry in
   `src/lib/features.ts` (+ `featureCatalog` i18n block) — the landing cards and the `/features`
   page are both fed from that single source. Same discipline as CHANGELOG/releaseNotes.

--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -6055,3 +6055,59 @@ yazmak demek. `DATABASE_URL="mysql://e2e:e2epass@127.0.0.1:3306/internship_e2e"`
 export edilir (Next `.env`'i process env'in üzerine yazmaz), `prisma db push
 --accept-data-loss` + `npm run build`, sonra `CI=1 npx playwright test` — prod build'e karşı
 136/136 smoke yeşil, yeni spec dahil.
+
+## 2026-09-07 — Bir rozetin yanlış olması, kuralın yanlış yerden okunması demekti (#2275)
+
+**Bulgu, tek bir sorunun cevabıydı: "temas" nereden okunuyor?** Mentor panosunda 11 satırlık
+"Dikkat gerektiriyor" listesi vardı ve satırların çoğu, mentorun o hafta yazıştığı
+mentee'lerdi. Kodun tek kusuru `r.interactions[0]?.date` idi: temas, mentorun ayrıca
+doldurmayı hatırladığı formdan okunuyordu. Ürünün etkileşim yüzeyi taşındığında (uygulama
+içi mesajlaşma), tazelik hesabı taşınmayı unutmuş. Aynı yanlış girdi beş yüzeyi besliyordu
+(kuyruk, günlük hatırlatma, haftalık özet, mentee kartları, aday sayfasındaki "Sıradaki
+aksiyon"), dolayısıyla doğru düzeltme beş yerde `||` eklemek değil, **kuralı tek modüle
+çıkarmak**tı.
+
+**Kuralın kendisini bağımlılıksız modüle koy, sorguları ayrı tut.** Repo deseni bu
+(`stageAging.ts`): `lastContactRule.ts` hiç `@/` importu içermiyor, bu yüzden
+`node --experimental-strip-types` ile birim testi yazılabiliyor; `lastContact.ts` üç grouped
+aggregate'i çalıştırıp aynı fonksiyonu çağırıyor ve her şeyi re-export ediyor, böylece çağrı
+yerleri tek yerden import ediyor. İlk denemede ikisini tek dosyada yazdım ve test
+`ERR_MODULE_NOT_FOUND` ile patladı — `@/lib/prisma` alias'ını strip-types çözemiyor. Yeni
+modülün gerçek bir suite'i olunca `scripts/check-unit-coverage.mjs`'teki `FLOORS`'a kaydını
+**aynı PR'da** eklemek gerekiyor, yoksa yarın kuralı silen bir refactor hiçbir yeri
+kırmızıya çevirmez.
+
+**Prisma `groupBy`, `where` içinde ilişki filtresi kabul ediyor.** Grup mesajının
+`relationId`'si yok (yazma yolu yalnızca DIRECT sohbette damgalıyor), dolayısıyla yazara göre
+aramak gerekiyor: `groupBy({ by: ['senderId'], where: { senderId: { in: ids },
+conversation: { type: 'GROUP' } }, _max: { createdAt: true } })`. Aynı imkân, "birebir mesaj"
+tarafını da yazma yoluna güvenmek yerine **inşa gereği** doğru tutmayı sağlıyor
+(`OR: [{ conversationId: null }, { conversation: { type: 'DIRECT' } }]`).
+
+**Simetrik kural burada yanlış olurdu.** "Mesaj = temas" derken grup mesajlarını da katmak
+en kısa diff'ti ve tam ters hatayı üretirdi: dokuz mentee'nin bulunduğu kanala mentorun
+attığı tek satır, kuyruğu dokuz kişi için birden susturur. Sınır şu: **birebir** mesaj her iki
+yönde sayılır, **grup** mesajı yalnızca mentee kendi yazdıysa sayılır. Bir asimetriyi
+"tutarsızlık" diye düzleştirmeden önce, iki tarafın aynı şeyi mi ölçtüğüne bakmak gerekiyor.
+
+**Sayaçlara dokunmamak da bir karar ve yazıya geçmesi gerekiyor.** "Toplam Etkileşim" ve
+`/mentor/interactions` hâlâ `InteractionLog` satırlarını sayıyor: orası bir kayıt defteri,
+bozuk olan şey tazelikti. PR'da ve `docs/last-contact.md`'de açıkça yazmasam, bir sonraki
+oturum bunu eksik iş sanıp defteri de bozardı.
+
+**Bu container'da lokal e2e reçetesi (güncel adımlar):**
+- `apt-get install mariadb-server` **önce `apt-get update` istiyor** — bayat paket indeksi
+  iproute2/libmysqlclient21 için 404 veriyor ve mesaj "maybe run apt-get update" diye
+  gerçek sebebi söylüyor. `mariadbd --user=mysql` elle başlatılıyor (`service` yok,
+  `policy-rc.d` restart'ı reddediyor), `/run/mysqld` dizinini önce açmak gerekiyor.
+- **Playwright'ın pinlenmiş build'i (`chromium_headless_shell-1234`) yok, kurulu olan
+  1194** — ve iki sürümün **dizin düzeni farklı**: yenisi
+  `chrome-headless-shell-linux64/chrome-headless-shell`, eskisi `chrome-linux/headless_shell`.
+  Yani dizin sembolik bağı yetmiyor; beklenen yolu açıp **binary'ye** bağ vermek gerekiyor
+  (`mkdir -p .../chromium_headless_shell-1234/chrome-headless-shell-linux64` + `ln -s`
+  `.../chromium_headless_shell-1194/chrome-linux/headless_shell`), ayrıca
+  `INSTALLATION_COMPLETE` dosyasına dokunmak.
+- **Seed edilmemiş DB'ye karşı koşulan smoke, `AccountLockout` bırakıyor.** `admin@example.com`
+  yokken 5 spec düşüyor; `prisma db seed` sonrası **aynı 5 spec yine düşüyor**, bu kez
+  "Too many attempts" ile — ve bu, gerçek bir auth regresyonu gibi okunuyor. `delete from
+  AccountLockout` sonrası 9/9 yeşil. Önce seed et, sonra koş; sıra ters gittiyse kilidi sil.

--- a/docs/dormant-first-contacts.md
+++ b/docs/dormant-first-contacts.md
@@ -22,6 +22,12 @@ Bir ilişki şu koşulların **hepsi** sağlandığında "pasif ilk temas" sayı
 | **Bir temas var**: `InteractionLog` **veya** mentee dışında birinin (mentor/admin) attığı bir mesaj — hangisi daha yeniyse | Mentor üzerine düşeni yapmış. Mesaj atmak ile "etkileşim kaydı" formunu doldurmak aynı şey değil; kural yalnızca `InteractionLog`'a bakarsa, dört kez yazılmış bir mentee listede kalır (#1512) |
 | **Sessizliğin başlangıcından** (mentee'nin yanıtlamadığı **ilk** temas) en az **`DORMANT_GRACE_DAYS` (14) gün** geçmiş | Dünkü sessizlik bir cevap değildir. Sayaç **son** temastan ölçülürse mentorun ısrarına ait olur: üç haftadır yanıt vermeyen birine atılan bir "Hi?" onu iki hafta daha listeye döndürür ve her kovalama bir iki hafta daha satın alır (#1516) |
 | Mentee'nin **son mesajından sonra en az bir cevapsız temas var**, **yanıtsız soru yok**, **bekleyen toplantı talebi yok** | Soru "top kimde?" — mentee'nin son mesajından beri mentor hiç yazmamışsa cevap borcu **mentordadır**, kişi listede kalır |
+
+Mentee tarafındaki "yaşam belirtisi", birebir başlıktaki mesajlarıyla sınırlı değil:
+**kendi yazdığı bir grup mesajı** da sayılır (#2275). Bir proje kanalına yazan kişi,
+kayıt olup kaybolmuş biri değildir — ki bu kuralın tespit etmeye çalıştığı tek şey odur.
+Mentorun grup mesajı ise hiçbir yerde temas sayılmaz; ayrıntısı
+[last-contact.md](last-contact.md).
 | Aşamaya **mentor tarafından konmuş bir termin yok** (`stageDeadline`) | Termin, "bunu takip et" demenin bilinçli hâlidir |
 
 Hiç kimsenin yazmadığı bir ilişki **asla** pasif sayılmaz: orada eksik olan şey zaten

--- a/docs/last-contact.md
+++ b/docs/last-contact.md
@@ -1,0 +1,58 @@
+# "Son temas" ne demek? (#2275)
+
+> Mentor panosundaki *Yakın zamanda temas yok* rozetinin, hatırlatma
+> e-postalarının ve mentee kartlarındaki "Son etkileşimden bu yana N gün"
+> satırının tek kaynağı.
+
+## Problem
+
+Mentor panosu, mentee ile bütün hafta uygulama içinde yazışmış bir mentora hâlâ
+*Yakın zamanda temas yok* diyordu. Sebep tek satırdı: "temas" yalnızca
+`InteractionLog` tablosundan okunuyordu — yani mentorun ayrıca doldurmayı
+hatırladığı formdan. Etkileşim artık büyük ölçüde uygulamanın kendi
+mesajlaşmasında geçtiği için "Dikkat gerektiriyor" listesi on bir satıra çıkıp
+hiçbir şey ifade etmez hâle geldi; bir mentorun listeyi ciddiye almayı bırakması
+da tam olarak bu şekilde oluyor.
+
+## Kural
+
+Tek kaynak `src/lib/lastContactRule.ts` (kural, bağımlılıksız ve birim testli),
+sorguları `src/lib/lastContact.ts`. Bir ilişkinin **son teması**, aşağıdakilerin
+**en yenisidir**:
+
+| Sinyal | Sayılır mı? | Neden |
+|---|---|---|
+| `InteractionLog` kaydı | ✅ | Zaten kuralın eski hâli; elle girilen ve otomatik (toplantı) kayıtlar dâhil |
+| Mentorluk başlığındaki **birebir (DIRECT) mesaj** — her iki yönde | ✅ | Mentor yazmış ya da mentee cevaplamış; ikisi de tam olarak bu iki kişi arasında geçen temastır |
+| **Grup mesajı** — mentee'nin **kendi** yazdığı | ✅ | Bir proje kanalına yazan kişi, kayıt olup kaybolmuş biri değildir. Yaşam belirtisi kişiye aittir, eşleşmeye değil: mentee'nin bir grup mesajı, içinde bulunduğu **bütün** mentorluklara işlenir |
+| **Grup mesajı** — başkasının yazdığı | ❌ | Grup sohbeti bir yayındır. Dokuz mentee'nin bulunduğu kanala mentorun düştüğü tek satır, dokuz mentee ile temas değildir; öyle sayılsa listeyi hepsi için birden susturur — bu dokümanın düzeltmeye çalıştığı hatanın tersi |
+| Mesaj okuma, emoji tepkisi, giriş yapma | ❌ | Bunlar "kişi buradaydı" der, "konuştular" demez. Mevcudiyet `lib/activityReport.ts`'in işi |
+
+Eşitlik hâlinde damga aynı olduğu için yalnızca raporlanan `source` değişir
+(`interaction` > `direct_message` > `group_message`).
+
+## Kuralı kullanan yerler
+
+Hepsi aynı fonksiyondan okur; biri değişirse hepsi değişir:
+
+- `src/lib/mentorAttention.ts` — *Yakın zamanda temas yok* rozeti ve
+  "Son etkileşimden bu yana N gün" (eşik: `Setting.reminderDays`, varsayılan 14)
+- `checkMentorInteractionReminders()` — günlük durgunluk hatırlatması (zil
+  bildirimi + gruplanmış mentor e-postası)
+- `sendWeeklyMentorDigests()` — haftalık özetteki "durgun mentee" sayısı
+- `/mentor` mentee kartları
+- `/api/users/[id]` → `menteeRelations[].lastContactAt` — `/admin/candidates/[id]`
+  sayfasındaki "Sıradaki aksiyon" önerisi (`lib/matching.ts`)
+- `src/lib/dormantFirstContact.ts` — mentee'nin kendi grup mesajı da bir yaşam
+  belirtisi sayılır, yani damgayı ve "hâlâ ilgileniyor musun?" sayaçlarını
+  sıfırlar (bkz. [dormant-first-contacts.md](dormant-first-contacts.md))
+
+## Bilinçli olarak yapılmayanlar
+
+- **Etkileşim sayaçları değişmedi.** `/mentor` panosundaki "Toplam Etkileşim",
+  mentee listesindeki rozet ve `/mentor/interactions` sayfası hâlâ
+  `InteractionLog` satırlarını sayar. Orada gösterilen şey bir *kayıt defteri*;
+  bir mesajı oraya satır olarak eklemek defterin ne olduğunu değiştirirdi.
+  Değişen şey **tazelik** — yani "temas var mı?" sorusu.
+- **Mentorun grup mesajı hiçbir yerde temas sayılmıyor** — ne bu kuralda, ne de
+  pasiflik kuralındaki "ilk temas" (outreach) tarafında.

--- a/e2e/mentor-attention-queue.spec.ts
+++ b/e2e/mentor-attention-queue.spec.ts
@@ -102,3 +102,117 @@ test('mentor dashboard surfaces a needs-attention queue for stale/overdue/unansw
     await cleanupByEmail(mentorEmail);
   }
 });
+
+// #2275: "contact" is not "a row in InteractionLog". A mentor exchanging
+// messages with a mentee in the app has been in touch, and the queue used to
+// say otherwise — which is what made an eleven-row queue meaningless. The two
+// edges worth an e2e run are the group-chat ones, because they pull in opposite
+// directions: somebody else's group message must NOT clear the flag, the
+// mentee's own group message must.
+test('in-app messages count as contact — 1:1 either way, group only when the mentee wrote it', async ({ page }) => {
+  const mentorEmail = uniqueEmail('contact-mentor');
+  const dmEmail = uniqueEmail('contact-dm-mentee');
+  const groupOtherEmail = uniqueEmail('contact-group-other');
+  const groupSelfEmail = uniqueEmail('contact-group-self');
+  const mentor = await seedUser(mentorEmail, 'MentorPass123', 'MENTOR', 'Contact Mentor');
+  const dmMentee = await seedUser(dmEmail, 'x', 'MENTEE', 'Direct Message Mentee');
+  const groupOtherMentee = await seedUser(groupOtherEmail, 'x', 'MENTEE', 'Group Silent Mentee');
+  const groupSelfMentee = await seedUser(groupSelfEmail, 'x', 'MENTEE', 'Group Poster Mentee');
+
+  const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
+  const relationFor = async (menteeId: string) => {
+    const relation = await prisma.mentorshipRelation.create({
+      data: { mentorId: mentor.id, menteeId, status: 'ACTIVE' },
+    });
+    // An open goal on every one of them, so "no open goal" cannot be the reason
+    // a row shows up and the assertions below are about contact only.
+    await prisma.goal.create({ data: { relationId: relation.id, title: 'Finish portfolio site' } });
+    return relation;
+  };
+
+  const dmRel = await relationFor(dmMentee.id);
+  const groupOtherRel = await relationFor(groupOtherMentee.id);
+  const groupSelfRel = await relationFor(groupSelfMentee.id);
+
+  // The mentorship's 1:1 thread, written by the MENTOR — the direction that was
+  // broken: reaching out is not the same as logging that you reached out.
+  const dmConversation = await prisma.conversation.create({
+    data: {
+      type: 'DIRECT',
+      directKey: [mentor.id, dmMentee.id].sort().join('|'),
+      participants: { create: [{ userId: mentor.id }, { userId: dmMentee.id }] },
+    },
+  });
+  await prisma.message.create({
+    data: {
+      conversationId: dmConversation.id,
+      relationId: dmRel.id,
+      senderId: mentor.id,
+      body: 'Sent you the interview prep list — have a look before Friday.',
+      createdAt: twoDaysAgo,
+    },
+  });
+
+  // One group chat holding both group mentees. The MENTOR posts in it: a
+  // broadcast, so it is contact with neither of them.
+  const groupConversation = await prisma.conversation.create({
+    data: {
+      type: 'GROUP',
+      participants: {
+        create: [{ userId: mentor.id }, { userId: groupOtherMentee.id }, { userId: groupSelfMentee.id }],
+      },
+    },
+  });
+  await prisma.message.create({
+    data: {
+      conversationId: groupConversation.id,
+      senderId: mentor.id,
+      body: 'Reminder for everyone: the cohort demo is next Tuesday.',
+      createdAt: twoDaysAgo,
+    },
+  });
+  // …and one of them answers in the same group. That is a sign of life.
+  await prisma.message.create({
+    data: {
+      conversationId: groupConversation.id,
+      senderId: groupSelfMentee.id,
+      body: 'Noted, I will be there.',
+      createdAt: twoDaysAgo,
+    },
+  });
+
+  try {
+    await page.goto('/auth/signin');
+    await page.fill('input[type="email"], input[name="email"]', mentorEmail);
+    await page.fill('input[type="password"]', 'MentorPass123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL((u) => u.pathname.startsWith('/mentor'), { timeout: 20_000 });
+
+    const queue = page.getByTestId('attention-queue');
+    // The group mentee who never wrote is the only one of the three still
+    // flagged — which also proves the queue rendered at all, so the two
+    // absence assertions below are not vacuously true.
+    const silentRow = queue.getByRole('link', { name: /Group Silent Mentee/ });
+    await expect(silentRow).toBeVisible({ timeout: 10_000 });
+    await expect(silentRow.getByText(/No recent contact/i)).toBeVisible();
+
+    // A 1:1 message from the mentor is contact: nothing left to flag.
+    await expect(queue.getByText('Direct Message Mentee', { exact: true })).toHaveCount(0);
+    // The mentee's own group post is contact too.
+    await expect(queue.getByText('Group Poster Mentee', { exact: true })).toHaveCount(0);
+  } finally {
+    const relationIds = [dmRel.id, groupOtherRel.id, groupSelfRel.id];
+    await prisma.message.deleteMany({
+      where: { conversationId: { in: [dmConversation.id, groupConversation.id] } },
+    });
+    await prisma.goal.deleteMany({ where: { relationId: { in: relationIds } } });
+    await prisma.mentorshipRelation.deleteMany({ where: { id: { in: relationIds } } });
+    await prisma.conversation.deleteMany({
+      where: { id: { in: [dmConversation.id, groupConversation.id] } },
+    });
+    await cleanupByEmail(dmEmail);
+    await cleanupByEmail(groupOtherEmail);
+    await cleanupByEmail(groupSelfEmail);
+    await cleanupByEmail(mentorEmail);
+  }
+});

--- a/releases/unreleased/in-app-messages-count-as-contact.json
+++ b/releases/unreleased/in-app-messages-count-as-contact.json
@@ -1,0 +1,21 @@
+{
+  "bump": "patch",
+  "changelog": "- **In-app messaging now counts as contact, so the attention queue stops flagging mentees the mentor talks to daily** (#2275). \"Last contact\" was read from `InteractionLog` alone — the form a mentor has to remember to fill in separately — so a mentor mid-conversation with a mentee still saw *Yakın zamanda temas yok* next to their name, and an 11-row queue of active mentorships is a queue mentors stop reading (the same failure #1499 was opened for, from the other side). One rule now answers the question for every surface, `src/lib/lastContactRule.ts` (dependency-free and unit-tested) with its queries in `src/lib/lastContact.ts`: the newest of a logged interaction, a **1:1 (DIRECT) message in the mentorship thread in either direction**, and a **group message the mentee wrote themselves**. A group message somebody *else* wrote is deliberately not contact — a group chat is a broadcast, and one mentor line into a channel with nine mentees in it would otherwise silence the queue for all nine at once. A mentee's group post is one timestamp applied to every mentorship they are in: the sign of life belongs to the person, not to one pairing. Read receipts, reactions and logins stay out (presence, not contact — that is `lib/activityReport.ts`). Wired into `getAttentionItems()`, the daily `checkMentorInteractionReminders()` bell item + grouped mentor email, `sendWeeklyMentorDigests()`'s stale count, the `/mentor` mentee cards and `/admin/candidates/[id]`'s \"next action\" (via a new server-computed `lastContactAt` on `/api/users/[id]`); `lib/dormantFirstContact.ts` now treats a mentee's own group post as a sign of life too, so it clears `dormantSince` and the nudge counters. Interaction **counts** are untouched by design — \"Toplam Etkileşim\", the mentee-list badge and `/mentor/interactions` are a logbook of `InteractionLog` rows, and what was wrong was freshness, not the ledger. Rule and rationale: [docs/last-contact.md](docs/last-contact.md).",
+  "notes": {
+    "en": [
+      "Messages you exchange in the app now count as contact: a mentee you have been messaging is no longer flagged \"No recent contact\", and the mentee card's \"last contact\" counts from your last message as well as from a logged interaction.",
+      "The daily reminder email and the weekly digest use the same rule, so they no longer chase you about mentees you are already talking to.",
+      "Group chats are treated as the broadcasts they are: another person's group message is not contact with you — but a mentee posting in a group themselves counts, because it shows they are still there."
+    ],
+    "tr": [
+      "Uygulama içindeki yazışmalar artık temas sayılıyor: mesajlaştığınız bir mentee'ye artık \"Yakın zamanda temas yok\" denmiyor ve mentee kartındaki \"son temas\", etkileşim kaydı kadar son mesajınızdan da sayılıyor.",
+      "Günlük hatırlatma e-postası ve haftalık özet aynı kuralı kullanıyor; hâlihazırda konuştuğunuz mentee'ler için sizi artık sıkıştırmıyorlar.",
+      "Grup sohbetleri olduğu gibi, yani bir yayın olarak değerlendiriliyor: başkasının grup mesajı sizinle temas değildir — ama mentee'nin gruba kendi yazdığı mesaj sayılır, çünkü orada olduğunu gösterir."
+    ],
+    "de": [
+      "Nachrichten in der App zählen jetzt als Kontakt: Ein Mentee, mit dem Sie geschrieben haben, wird nicht mehr mit \"Kein Kontakt in letzter Zeit\" markiert, und der \"letzte Kontakt\" auf der Mentee-Karte zählt auch ab Ihrer letzten Nachricht, nicht nur ab einem erfassten Kontakt.",
+      "Die tägliche Erinnerungs-E-Mail und die Wochenübersicht verwenden dieselbe Regel und mahnen Sie deshalb nicht mehr zu Mentees, mit denen Sie ohnehin im Gespräch sind.",
+      "Gruppenchats werden als das behandelt, was sie sind — eine Rundnachricht: Die Gruppennachricht einer anderen Person ist kein Kontakt mit Ihnen. Schreibt ein Mentee selbst in eine Gruppe, zählt das dagegen, denn es zeigt, dass er noch da ist."
+    ]
+  }
+}

--- a/scripts/check-unit-coverage.mjs
+++ b/scripts/check-unit-coverage.mjs
@@ -82,6 +82,10 @@ const FLOORS = new Map([
     'src/lib/stageAging.ts',
     { floor: 95, measured: 100.0, why: 'stage visits counted separately from candidates (#1427)' },
   ],
+  [
+    'src/lib/lastContactRule.ts',
+    { floor: 95, measured: 100.0, why: 'what counts as contact: 1:1 yes, group only if the mentee wrote it (#2275)' },
+  ],
 ]);
 
 // ── Awaiting tests (a ratchet, not an allowlist) ─────────────────────────────

--- a/scripts/test/last-contact.test.mjs
+++ b/scripts/test/last-contact.test.mjs
@@ -1,0 +1,117 @@
+// Unit tests for the "what counts as contact" rule (#2275).
+//
+// Run: npm run test:unit  (node --test --experimental-strip-types)
+//
+// The bug these pin down: a mentor exchanging in-app messages with a mentee all
+// week still saw "no recent contact" next to their name, because only
+// InteractionLog rows were consulted. The two edges the rule turns on are the
+// interesting part:
+//   - a GROUP message somebody ELSE wrote is not contact with this mentee (one
+//     broadcast into a project channel must not silence the whole queue), but
+//   - a GROUP message the MENTEE wrote themselves is.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveLastContacts, daysSince } from '../../src/lib/lastContactRule.ts';
+
+const DAY = 24 * 60 * 60 * 1000;
+const T0 = new Date('2026-09-01T00:00:00Z').getTime();
+const at = (days) => new Date(T0 + days * DAY);
+
+const RELATIONS = [
+  { id: 'rel-a', menteeId: 'mentee-a' },
+  { id: 'rel-b', menteeId: 'mentee-b' },
+];
+const EMPTY = { interactions: [], directMessages: [], menteeGroupPosts: [] };
+
+test('a 1:1 message is contact, and beats an older logged interaction', () => {
+  const result = resolveLastContacts(RELATIONS, {
+    ...EMPTY,
+    interactions: [{ relationId: 'rel-a', at: at(1) }],
+    directMessages: [{ relationId: 'rel-a', at: at(9) }],
+  });
+
+  assert.deepEqual(result.get('rel-a'), { at: at(9), source: 'direct_message' });
+});
+
+test('a logged interaction still wins when it is the newer of the two', () => {
+  const result = resolveLastContacts(RELATIONS, {
+    ...EMPTY,
+    interactions: [{ relationId: 'rel-a', at: at(9) }],
+    directMessages: [{ relationId: 'rel-a', at: at(1) }],
+  });
+
+  assert.deepEqual(result.get('rel-a'), { at: at(9), source: 'interaction' });
+});
+
+test("a mentee's own group post counts as contact", () => {
+  const result = resolveLastContacts(RELATIONS, {
+    ...EMPTY,
+    menteeGroupPosts: [{ menteeId: 'mentee-a', at: at(5) }],
+  });
+
+  assert.deepEqual(result.get('rel-a'), { at: at(5), source: 'group_message' });
+});
+
+test("somebody else's group post is not contact with this mentee", () => {
+  // mentee-b posted in the group; rel-a's mentee did not. Only rel-b gets a
+  // timestamp — this is the broadcast case that must NOT clear the queue.
+  const result = resolveLastContacts(RELATIONS, {
+    ...EMPTY,
+    menteeGroupPosts: [{ menteeId: 'mentee-b', at: at(5) }],
+  });
+
+  assert.equal(result.get('rel-a'), undefined);
+  assert.deepEqual(result.get('rel-b'), { at: at(5), source: 'group_message' });
+});
+
+test("a mentee's group post applies to every mentorship they are in", () => {
+  const relations = [
+    { id: 'rel-1', menteeId: 'mentee-a' },
+    { id: 'rel-2', menteeId: 'mentee-a' },
+  ];
+  const result = resolveLastContacts(relations, {
+    ...EMPTY,
+    menteeGroupPosts: [{ menteeId: 'mentee-a', at: at(3) }],
+  });
+
+  assert.equal(result.get('rel-1').at.getTime(), at(3).getTime());
+  assert.equal(result.get('rel-2').at.getTime(), at(3).getTime());
+});
+
+test('the newest of several group posts by the same mentee wins', () => {
+  const result = resolveLastContacts(RELATIONS, {
+    ...EMPTY,
+    menteeGroupPosts: [
+      { menteeId: 'mentee-a', at: at(2) },
+      { menteeId: 'mentee-a', at: at(7) },
+      { menteeId: 'mentee-a', at: at(4) },
+    ],
+  });
+
+  assert.equal(result.get('rel-a').at.getTime(), at(7).getTime());
+});
+
+test('signals for relations that were not asked about are ignored', () => {
+  const result = resolveLastContacts([{ id: 'rel-a', menteeId: 'mentee-a' }], {
+    ...EMPTY,
+    interactions: [{ relationId: 'rel-z', at: at(4) }],
+    directMessages: [{ relationId: 'rel-z', at: at(4) }],
+  });
+
+  assert.equal(result.size, 0);
+});
+
+test('no signals at all means no contact — not a contact of zero days ago', () => {
+  const result = resolveLastContacts(RELATIONS, EMPTY);
+
+  assert.equal(result.size, 0);
+  assert.equal(daysSince(result.get('rel-a')?.at), null);
+});
+
+test('daysSince floors to whole days', () => {
+  const now = at(10).getTime();
+  assert.equal(daysSince(at(10), now), 0);
+  assert.equal(daysSince(new Date(at(9).getTime() + 1000), now), 0);
+  assert.equal(daysSince(at(9), now), 1);
+  assert.equal(daysSince(at(-4), now), 14);
+});

--- a/src/app/admin/candidates/[id]/page.tsx
+++ b/src/app/admin/candidates/[id]/page.tsx
@@ -51,6 +51,9 @@ interface Relation {
   project: { id: string; name: string } | null;
   cohort: { id: string; name: string } | null;
   interactions: Interaction[];
+  // Newest contact of any kind — a logged interaction OR an in-app message
+  // (lib/lastContact.ts). Server-computed: the messages are not in this payload.
+  lastContactAt?: string | null;
   statusChanges: StatusChange[];
 }
 interface MenteeDetail {
@@ -459,7 +462,7 @@ export default function AdminMenteeDetailPage() {
               </div>
 
               {(() => {
-                const na = nextAction({ pipelineStatus: rel.pipelineStatus, lastInteractionAt: rel.interactions[0]?.date }, t.nextActions);
+                const na = nextAction({ pipelineStatus: rel.pipelineStatus, lastInteractionAt: rel.lastContactAt ?? rel.interactions[0]?.date }, t.nextActions);
                 const color = na.level === 'urgent' ? 'text-red-700 bg-red-50 border-red-200' : na.level === 'warn' ? 'text-amber-700 bg-amber-50 border-amber-200' : 'text-green-700 bg-green-50 border-green-200';
                 return (
                   <div className={`inline-flex items-center gap-2 text-sm rounded-lg border px-3 py-1.5 ${color}`}>

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -11,6 +11,7 @@ import { notify } from '@/lib/notify';
 import { roleHome } from '@/lib/roleHome';
 import { sendRoleChangeEmail } from '@/services/emailService';
 import { isStageTransition } from '@/lib/stageChange';
+import { getLastContacts } from '@/lib/lastContact';
 
 export async function GET(_request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
@@ -92,11 +93,21 @@ export async function GET(_request: Request, { params }: { params: Promise<{ id:
       // the address and send the activation link (#1123).
       const { password, ...rest } = user;
 
+      // "Next action" on the candidate page counts from the last CONTACT, which
+      // includes the 1:1 message thread and not only the interaction log — the
+      // same rule the mentor's attention queue applies (lib/lastContact.ts).
+      // Sent alongside `interactions` rather than derived from it on the client,
+      // because the messages themselves are not in this payload.
+      const lastContacts = await getLastContacts(
+        rest.menteeRelations.map((relation) => ({ id: relation.id, menteeId: relation.menteeId })),
+      );
+
       return NextResponse.json({
         user: {
           ...rest,
           menteeRelations: rest.menteeRelations.map((relation) => ({
             ...relation,
+            lastContactAt: lastContacts.get(relation.id)?.at ?? null,
             statusChanges: relation.statusChanges.filter((change) =>
               isStageTransition(change.fromStatus, change.toStatus)
             ),

--- a/src/app/mentor/page.tsx
+++ b/src/app/mentor/page.tsx
@@ -10,6 +10,7 @@ import { getServerDictionary } from "@/i18n/server";
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { getAttentionItems } from '@/lib/mentorAttention';
+import { getLastContacts } from '@/lib/lastContact';
 import { Card, CardHeader, CardTitle, CardDescription } from '@/components/ui/Card';
 import { Badge, StatusBadge } from '@/components/ui/Badge';
 import { InteractionTypeBadge } from '@/components/InteractionTypeBadge';
@@ -36,10 +37,9 @@ async function getMentorData(mentorId: string) {
         },
       },
       company: { select: { id: true, name: true, industry: true } },
-      interactions: {
-        orderBy: { date: 'desc' },
-        take: 3,
-      },
+      // Only the count: the cards' "last contact" line comes from
+      // getLastContacts below, and the "Recent interactions" panel has its own
+      // query. Selecting three logs per relation here fed nothing.
       _count: { select: { interactions: true } },
     },
     orderBy: { startDate: 'desc' },
@@ -58,7 +58,14 @@ async function getMentorData(mentorId: string) {
     take: 10,
   });
 
-  return { relations, recentInteractions };
+  // The mentee cards say "last contact N days ago", and contact includes the
+  // 1:1 message thread — not just what somebody remembered to log
+  // (lib/lastContact.ts).
+  const lastContacts = await getLastContacts(
+    relations.map((r) => ({ id: r.id, menteeId: r.menteeId })),
+  );
+
+  return { relations, recentInteractions, lastContacts };
 }
 
 export default async function MentorDashboard() {
@@ -89,7 +96,7 @@ export default async function MentorDashboard() {
   }
 
   const { t, locale } = await getServerDictionary();
-  const { relations, recentInteractions } = await getMentorData(session.user.id);
+  const { relations, recentInteractions, lastContacts } = await getMentorData(session.user.id);
   const attention = await getAttentionItems(session.user.id);
 
   const activeRelations = relations.filter((r) => r.status === 'ACTIVE');
@@ -170,11 +177,9 @@ export default async function MentorDashboard() {
               <p className="text-sm text-gray-600 dark:text-gray-400 text-center py-4">{t.mentor.noActiveMentees}</p>
             )}
             {activeRelations.map((rel) => {
-              const lastInteraction = rel.interactions[0];
-              const daysSince = lastInteraction
-                ? Math.floor(
-                    (Date.now() - new Date(lastInteraction.date).getTime()) / (1000 * 60 * 60 * 24)
-                  )
+              const lastContact = lastContacts.get(rel.id);
+              const daysSince = lastContact
+                ? Math.floor((Date.now() - lastContact.at.getTime()) / (1000 * 60 * 60 * 24))
                 : null;
 
               return (

--- a/src/lib/dormantFirstContact.ts
+++ b/src/lib/dormantFirstContact.ts
@@ -15,7 +15,9 @@
 // visible everywhere they were before (mentee list, pipeline board, search).
 //
 // Anything that looks like a live thread keeps the relation on the list:
-//   - the mentee wrote a message,
+//   - the mentee wrote a message (in the 1:1 thread, or in a group chat — a
+//     post they wrote themselves is a sign of life wherever they wrote it, the
+//     same rule lib/lastContact.ts applies to "last contact"),
 //   - the mentee has an unanswered question,
 //   - a meeting request is pending,
 //   - the mentor put a deadline on the stage (a deliberate "chase this one").
@@ -74,13 +76,24 @@ export async function findDormantFirstContacts(relations: DormantCandidate[]): P
   if (candidates.length === 0) return dormant;
 
   const ids = candidates.map((r) => r.id);
-  const [messages, interactions, openQuestions, pendingMeetings] = await Promise.all([
+  const candidateMenteeIds = [...new Set(candidates.map((r) => r.menteeId))];
+  const [messages, groupPosts, interactions, openQuestions, pendingMeetings] = await Promise.all([
     // The timestamps only, and only for relations parked at first contact —
     // threads that by definition never got going. Whole rows are not needed and
     // a message body is the one expensive column here.
     prisma.message.findMany({
       where: { relationId: { in: ids } },
       select: { relationId: true, senderId: true, createdAt: true },
+    }),
+    // The mentee's own posts in group chats. Not outreach and not thread
+    // traffic — but somebody writing in a project channel is plainly not a
+    // person who registered and vanished, which is the only thing this rule is
+    // trying to identify. A GROUP message carries no relationId, so it has to
+    // be looked up by author (see lib/lastContact.ts for the same rule).
+    prisma.message.groupBy({
+      by: ['senderId'],
+      where: { senderId: { in: candidateMenteeIds }, conversation: { type: 'GROUP' } },
+      _max: { createdAt: true },
     }),
     // Reaching out is not the same as logging that you reached out, so a logged
     // interaction and a message from the mentor are the same kind of event to
@@ -111,6 +124,17 @@ export async function findDormantFirstContacts(relations: DormantCandidate[]): P
     }
   }
   for (const i of interactions) noteOutreach(i.relationId, i.date);
+
+  const groupPostByMentee = new Map<string, Date>();
+  for (const row of groupPosts) {
+    if (row._max.createdAt) groupPostByMentee.set(row.senderId, row._max.createdAt);
+  }
+  for (const r of candidates) {
+    const at = groupPostByMentee.get(r.menteeId);
+    if (!at) continue;
+    const seen = lastMenteeActivity.get(r.id);
+    if (!seen || at > seen) lastMenteeActivity.set(r.id, at);
+  }
 
   const withOpenQuestion = new Set(openQuestions.map((q) => q.relationId));
   const withPendingMeeting = new Set(pendingMeetings.map((m) => m.relationId));

--- a/src/lib/lastContact.ts
+++ b/src/lib/lastContact.ts
@@ -1,0 +1,64 @@
+// The database half of the "when was this mentorship last in contact?" rule.
+// The rule itself — and the reasoning behind it — is in lib/lastContactRule.ts,
+// which is dependency-free so it can be unit-tested; everything it exports is
+// re-exported here so call sites need only one import.
+
+import { prisma } from '@/lib/prisma';
+import { resolveLastContacts, type LastContact, type LastContactRelation } from '@/lib/lastContactRule';
+
+export * from '@/lib/lastContactRule';
+
+/**
+ * Read the signals for the given relations and fold them into one
+ * relationId → last contact map. Three grouped aggregates regardless of how
+ * many relations are passed, so the daily cron (every active relation) and a
+ * single mentor's dashboard cost the same number of round trips.
+ */
+export async function getLastContacts(
+  relations: LastContactRelation[],
+): Promise<Map<string, LastContact>> {
+  if (relations.length === 0) return new Map();
+
+  const relationIds = relations.map((r) => r.id);
+  const menteeIds = [...new Set(relations.map((r) => r.menteeId))];
+
+  const [interactions, directMessages, menteeGroupPosts] = await Promise.all([
+    prisma.interactionLog.groupBy({
+      by: ['relationId'],
+      where: { relationId: { in: relationIds } },
+      _max: { date: true },
+    }),
+    prisma.message.groupBy({
+      by: ['relationId'],
+      where: {
+        relationId: { in: relationIds },
+        // A relation-stamped message is written into the pair's DIRECT
+        // conversation (or, for rows predating the conversation layer, into no
+        // conversation at all) — see lib/conversations.ts. The filter is
+        // belt-and-braces: it keeps the "groups don't count" half of the rule
+        // true by construction rather than by trusting the write path.
+        OR: [{ conversationId: null }, { conversation: { type: 'DIRECT' } }],
+      },
+      _max: { createdAt: true },
+    }),
+    prisma.message.groupBy({
+      by: ['senderId'],
+      where: { senderId: { in: menteeIds }, conversation: { type: 'GROUP' } },
+      _max: { createdAt: true },
+    }),
+  ]);
+
+  return resolveLastContacts(relations, {
+    interactions: interactions.flatMap((row) =>
+      row.relationId && row._max.date ? [{ relationId: row.relationId, at: row._max.date }] : [],
+    ),
+    directMessages: directMessages.flatMap((row) =>
+      row.relationId && row._max.createdAt
+        ? [{ relationId: row.relationId, at: row._max.createdAt }]
+        : [],
+    ),
+    menteeGroupPosts: menteeGroupPosts.flatMap((row) =>
+      row._max.createdAt ? [{ menteeId: row.senderId, at: row._max.createdAt }] : [],
+    ),
+  });
+}

--- a/src/lib/lastContactRule.ts
+++ b/src/lib/lastContactRule.ts
@@ -1,0 +1,110 @@
+// "When was this mentorship last in contact?" — one rule, one implementation.
+//
+// The attention queue, the daily staleness reminder, the weekly mentor digest
+// and the mentee cards all used to answer this from `InteractionLog` alone, and
+// that is not where the contact happens any more: mentors talk to their mentees
+// in the app's own messaging. A mentor who had exchanged forty messages with
+// somebody last week still saw "Yakın zamanda temas yok" next to their name,
+// which is how a queue of eleven rows ends up meaning nothing (#2275).
+//
+// So an in-app message counts as contact, with one deliberate exception:
+//
+//   * a 1:1 (DIRECT) message in the mentorship thread counts, in EITHER
+//     direction — the mentor wrote, or the mentee answered; both are contact
+//     between exactly these two people;
+//   * a GROUP message counts only when the MENTEE wrote it themselves.
+//
+// The group rule is the whole point of the exception. A group chat is a
+// broadcast: one mentor line dropped into a project channel with nine mentees
+// in it is not contact with nine mentees, and treating it as such would silence
+// the queue for all of them at once — the exact failure this module exists to
+// fix, only inverted. A mentee posting in that same channel *is* a sign of
+// life, and one the mentor should not be nagged past.
+//
+// Deliberately NOT included: reading a message, a reaction, a login. Those say
+// somebody was present, not that the two of them spoke; the activity report
+// (lib/activityReport.ts) is where presence belongs.
+//
+// This module is the RULE and is deliberately dependency-free (no `@/` imports,
+// no Prisma types) so a plain `node --experimental-strip-types` test can import
+// it — scripts/test/last-contact.test.mjs. The queries that feed it live in
+// lib/lastContact.ts, which re-exports everything here.
+
+export type ContactSource = 'interaction' | 'direct_message' | 'group_message';
+
+export interface LastContactRelation {
+  id: string;
+  menteeId: string;
+}
+
+export interface LastContact {
+  at: Date;
+  source: ContactSource;
+}
+
+/**
+ * The raw newest-timestamp-per-key rows the rule is folded from. Split out from
+ * the queries so the rule itself is a pure function and can be unit-tested
+ * without a database (scripts/test/last-contact.test.mjs).
+ */
+export interface LastContactSignals {
+  /** Newest InteractionLog.date per relation id. */
+  interactions: { relationId: string; at: Date }[];
+  /** Newest mentorship-thread (1:1) message per relation id, either direction. */
+  directMessages: { relationId: string; at: Date }[];
+  /** Newest GROUP message per author, for mentees only. */
+  menteeGroupPosts: { menteeId: string; at: Date }[];
+}
+
+// Latest wins. On an exact tie the more specific source is kept, which only
+// affects what `source` reports — the timestamp is the same either way.
+const SOURCE_RANK: Record<ContactSource, number> = {
+  interaction: 3,
+  direct_message: 2,
+  group_message: 1,
+};
+
+export function resolveLastContacts(
+  relations: LastContactRelation[],
+  signals: LastContactSignals,
+): Map<string, LastContact> {
+  const result = new Map<string, LastContact>();
+  const consider = (relationId: string, at: Date, source: ContactSource) => {
+    const current = result.get(relationId);
+    if (
+      !current ||
+      at > current.at ||
+      (at.getTime() === current.at.getTime() && SOURCE_RANK[source] > SOURCE_RANK[current.source])
+    ) {
+      result.set(relationId, { at, source });
+    }
+  };
+
+  const known = new Set(relations.map((r) => r.id));
+  for (const row of signals.interactions) {
+    if (known.has(row.relationId)) consider(row.relationId, row.at, 'interaction');
+  }
+  for (const row of signals.directMessages) {
+    if (known.has(row.relationId)) consider(row.relationId, row.at, 'direct_message');
+  }
+
+  // A mentee's group post is one timestamp that applies to every mentorship
+  // they are in — the sign of life is about the person, not about one pairing.
+  const groupPostByMentee = new Map<string, Date>();
+  for (const row of signals.menteeGroupPosts) {
+    const seen = groupPostByMentee.get(row.menteeId);
+    if (!seen || row.at > seen) groupPostByMentee.set(row.menteeId, row.at);
+  }
+  for (const relation of relations) {
+    const at = groupPostByMentee.get(relation.menteeId);
+    if (at) consider(relation.id, at, 'group_message');
+  }
+
+  return result;
+}
+
+/** Whole days between `at` and now — null when there is no timestamp at all. */
+export function daysSince(at: Date | null | undefined, now = Date.now()): number | null {
+  if (!at) return null;
+  return Math.floor((now - at.getTime()) / (24 * 60 * 60 * 1000));
+}

--- a/src/lib/mentorAttention.ts
+++ b/src/lib/mentorAttention.ts
@@ -1,5 +1,6 @@
 import { prisma } from '@/lib/prisma';
 import { findDormantFirstContacts } from '@/lib/dormantFirstContact';
+import { getLastContacts } from '@/lib/lastContact';
 import { getSetting } from '@/lib/settings';
 import { addUtcWeeks, firstFullUtcWeek, utcWeekStart } from '@/lib/week';
 import { SUBMITTED_WEEKLY_REPORT_STATUSES } from '@/lib/weeklyReports';
@@ -27,7 +28,9 @@ export interface AttentionQueue {
 // A ranked "needs attention" list for a mentor's active mentees (EPIC: mentor
 // attention queue). Reuses the same inactivity threshold as the weekly email
 // digest (Setting.reminderDays, default 14) so the in-app view and the email
-// agree on what "stale" means.
+// agree on what "stale" means, and the same definition of *contact* as both
+// (lib/lastContact.ts): in-app messaging counts, so a mentor mid-conversation
+// with a mentee is never told they have not been in touch.
 export async function getAttentionItems(mentorId: string): Promise<AttentionQueue> {
   const reminderDays = parseInt(await getSetting('reminderDays'), 10) || 14;
   const now = Date.now();
@@ -42,7 +45,6 @@ export async function getAttentionItems(mentorId: string): Promise<AttentionQueu
       startDate: true,
       stageDeadline: true,
       mentee: { select: { id: true, fullName: true } },
-      interactions: { orderBy: { date: 'desc' }, take: 1, select: { date: true } },
       questions: { where: { answer: null }, select: { id: true } },
       meetingRequests: { where: { status: 'PENDING' }, select: { id: true } },
       goals: { where: { status: 'OPEN' }, select: { id: true } },
@@ -87,6 +89,10 @@ export async function getAttentionItems(mentorId: string): Promise<AttentionQueu
     })),
   );
 
+  const lastContacts = await getLastContacts(
+    relations.map((r) => ({ id: r.id, menteeId: r.mentee.id })),
+  );
+
   const items: AttentionItem[] = [];
   let dormantCount = 0;
   for (const r of relations) {
@@ -95,7 +101,7 @@ export async function getAttentionItems(mentorId: string): Promise<AttentionQueu
       continue;
     }
     const reasons: AttentionReason[] = [];
-    const last = r.interactions[0]?.date ?? null;
+    const last = lastContacts.get(r.id)?.at ?? null;
     const daysSince = last ? Math.floor((now - last.getTime()) / (24 * 60 * 60 * 1000)) : null;
 
     if (!last || last < staleCutoff) reasons.push('inactive');

--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -20,6 +20,7 @@ import { getRetentionMonths, RETENTION_GRACE_DAYS } from '@/lib/retention';
 import { pruneInBatches } from '@/lib/retentionPrune';
 import { getMentorMenteeActivity, getSystemMenteeActivity, type MenteeActivity } from '@/lib/activityReport';
 import { findDormantFirstContacts, sweepDormantFirstContacts } from '@/lib/dormantFirstContact';
+import { getLastContacts } from '@/lib/lastContact';
 import { getOrgBranding } from '@/lib/orgBranding';
 import { formatInTimeZone, readingsByZone, resolveTimeZone, sameWallClock, zoneLabel, type ZonedPerson } from '@/lib/timezone';
 import { seriesOccurrences } from '@/lib/meetingSeriesOccurrences';
@@ -1916,12 +1917,16 @@ export async function checkMentorInteractionReminders() {
     include: {
       mentor: true,
       mentee: true,
-      interactions: {
-        orderBy: { date: 'desc' },
-        take: 1,
-      },
     },
   });
+
+  // "Contact" is not "a row in InteractionLog": a mentor who is mid-thread with
+  // a mentee in the app's messaging has been in touch, and nagging them to log
+  // it is how this reminder taught mentors to ignore it. Same rule and same
+  // implementation as the in-app attention queue (lib/lastContact.ts).
+  const lastContacts = await getLastContacts(
+    activeRelations.map((relation) => ({ id: relation.id, menteeId: relation.menteeId })),
+  );
 
   const remindersToSend: typeof activeRelations = [];
 
@@ -1936,14 +1941,13 @@ export async function checkMentorInteractionReminders() {
       menteeId: relation.menteeId,
       pipelineStatus: relation.pipelineStatus,
       stageDeadline: relation.stageDeadline,
-      lastInteractionAt: relation.interactions[0]?.date ?? null,
     })),
   );
 
   for (const relation of activeRelations) {
     if (dormant.has(relation.id)) continue;
-    const lastInteraction = relation.interactions[0];
-    const stale = !lastInteraction || lastInteraction.date < fourteenDaysAgo;
+    const lastContact = lastContacts.get(relation.id);
+    const stale = !lastContact || lastContact.at < fourteenDaysAgo;
     if (stale) {
       remindersToSend.push(relation);
       // In-app notification once per staleness episode (#573): only when we
@@ -1992,13 +1996,13 @@ export async function checkMentorInteractionReminders() {
 
     const rows = relations
       .map((relation) => {
-        const lastDate = relation.interactions[0]?.date;
+        const lastDate = lastContacts.get(relation.id)?.at;
         const daysSince = lastDate
           ? Math.floor((Date.now() - lastDate.getTime()) / (1000 * 60 * 60 * 24))
           : null;
         const since = daysSince !== null
-          ? `${daysSince} day${daysSince === 1 ? '' : 's'} since the last interaction`
-          : 'no interactions logged yet';
+          ? `${daysSince} day${daysSince === 1 ? '' : 's'} since the last contact`
+          : 'no contact yet';
         return `<li style="margin-bottom:6px;"><strong>${relation.mentee.fullName}</strong> — ${since}</li>`;
       })
       .join('');
@@ -2668,21 +2672,30 @@ export async function sendWeeklyMentorDigests() {
       preferredLanguage: true,
       mentorRelations: {
         select: {
+          id: true,
+          menteeId: true,
           startDate: true,
-          interactions: { orderBy: { date: 'desc' }, take: 1, select: { date: true } },
           meetings: { where: { scheduledAt: { gt: now, lte: in7d } }, select: { id: true } },
         },
       },
     },
   });
 
+  // One grouped read for every mentor's relations rather than one per mentor —
+  // and the same definition of contact the attention queue uses, so the digest
+  // and the dashboard cannot disagree about who is stale (lib/lastContact.ts).
+  const lastContacts = await getLastContacts(
+    mentors.flatMap((m) => m.mentorRelations.map((r) => ({ id: r.id, menteeId: r.menteeId }))),
+  );
+
   let sent = 0;
   for (const m of mentors) {
     if (m.mentorRelations.length === 0) continue;
     if (!emailAllowed(m, 'digest') || !emailGroupAllowedForCategory(m, 'mentor-digest')) continue;
-    const stale = m.mentorRelations.filter(
-      (r) => !r.interactions[0] || r.interactions[0].date < fourteenDaysAgo
-    ).length;
+    const stale = m.mentorRelations.filter((r) => {
+      const contact = lastContacts.get(r.id);
+      return !contact || contact.at < fourteenDaysAgo;
+    }).length;
     const upcoming = m.mentorRelations.reduce((n, r) => n + r.meetings.length, 0);
     const newApplications = m.mentorRelations.filter((r) => r.startDate >= weekAgo).length;
 


### PR DESCRIPTION
## Summary

The mentor dashboard's *Dikkat gerektiriyor* queue read "last contact" from `InteractionLog` alone — the form a mentor has to remember to fill in separately — so a mentor who had been messaging a mentee all week still saw **Yakın zamanda temas yok** next to their name. An eleven-row queue of active mentorships is a queue mentors stop reading, which is the same failure #1499 was opened for, from the other side.

One rule now answers the question for every surface — `src/lib/lastContactRule.ts` (dependency-free, unit-tested) with its queries in `src/lib/lastContact.ts`. Contact is the **newest of**:

| Signal | Counts? | Why |
|---|---|---|
| `InteractionLog` row | ✅ | today's behaviour, unchanged |
| **1:1 (DIRECT)** message in the mentorship thread, either direction | ✅ | contact between exactly these two people |
| **GROUP** message the **mentee wrote themselves** | ✅ | somebody posting in a project channel is not a person who registered and vanished |
| **GROUP** message somebody else wrote | ❌ | a group chat is a broadcast — one mentor line into a channel with nine mentees is not contact with nine mentees, and counting it would silence the queue for all nine at once, i.e. this bug inverted |
| Read receipts, reactions, logins | ❌ | presence, not contact — that stays `lib/activityReport.ts`'s job |

A mentee's group post is one timestamp applied to **every** mentorship they are in: the sign of life belongs to the person, not to one pairing.

**Interaction counts are untouched by design.** "Toplam Etkileşim", the mentee-list badge and `/mentor/interactions` still count `InteractionLog` rows — that surface is a logbook, and what was wrong here was *freshness*, not the ledger.

Rule and rationale written up in [`docs/last-contact.md`](docs/last-contact.md).

Closes #2275

## Changes

- **New** `src/lib/lastContactRule.ts` — the rule as a pure function (`resolveLastContacts`, `daysSince`), no `@/` imports so `node --experimental-strip-types` can test it; `src/lib/lastContact.ts` holds the three grouped aggregates that feed it and re-exports everything, so call sites need one import. Three queries regardless of how many relations are passed — the daily cron over every active relation costs the same round trips as one mentor's dashboard.
- `src/lib/mentorAttention.ts` — the `inactive` badge and "Son etkileşimden bu yana N gün" read the new map instead of `interactions[0]`.
- `src/services/emailService.ts` — `checkMentorInteractionReminders()` (bell item + grouped mentor mail, whose rows now say "since the last contact" / "no contact yet") and `sendWeeklyMentorDigests()`'s stale count, the latter with one grouped read across all mentors rather than one per mentor.
- `src/app/mentor/page.tsx` — mentee cards; also drops a `take: 3` interactions select that fed nothing.
- `src/app/api/users/[id]/route.ts` + `src/app/admin/candidates/[id]/page.tsx` — a server-computed `lastContactAt` per mentee relation, so the "Sıradaki aksiyon" hint (`lib/matching.ts`) counts from contact too. Computed server-side because the messages are not in that payload.
- `src/lib/dormantFirstContact.ts` — a mentee's own group post is a sign of life, so it clears `dormantSince` and the "hâlâ ilgileniyor musun?" counters. A mentor's group post is still not outreach.
- **Tests**: `scripts/test/last-contact.test.mjs` (9 cases — the two group-chat edges, tie-breaking, multi-relation fan-out, and "no signals ≠ contact today"), plus a `lastContactRule.ts` floor of 95% in `scripts/check-unit-coverage.mjs` (measures 100%). `e2e/mentor-attention-queue.spec.ts` gains an end-to-end case: a mentor's 1:1 message clears the flag, the mentee's own group post clears it, and a mentor's group post to the same channel does **not**.
- **Docs**: `docs/last-contact.md`, a cross-reference from `docs/dormant-first-contacts.md`, a conventions bullet in `CLAUDE.md`, and a session retrospective in `docs/agent-experience.md`.
- Release fragment `releases/unreleased/in-app-messages-count-as-contact.json` (`patch`, EN/TR/DE notes).

## Verification

Run against a local MariaDB + production build in the agent container (never the shared preview DB):

- [x] `npm run lint` + `npx tsc --noEmit` + `npm run build` clean (lint's two `exhaustive-deps` warnings are pre-existing, in untouched files)
- [x] `npm run test:unit` — **68/68**, 9 of them new; `npm run test:unit:coverage` no floor breached (`lastContactRule.ts` at 100%)
- [x] `npm run test:e2e:smoke` — **140/140** green. (First pass reported 5 failures in `smoke`/`auth`/`invite`: the local DB had no seeded admin, and the failed logins then left an `AccountLockout` row that reads as "Too many attempts". After `prisma db seed` + clearing that row, all 9 pass.)
- [x] `e2e/mentor-attention-queue.spec.ts` — 2/2 including the new case; `e2e/dormant-first-contact.spec.ts`, `e2e/dormant-check-in.spec.ts`, `e2e/weekly-reports.spec.ts` — 8/8, since this PR touches the dormancy rule
- [x] `check:i18n`, `check:events`, `check:query-scalars`, `check:auth-reads`, `check:tenant-models`, `check:stage-keys`, `check:release-fragments` all pass

⚠️ Unrelated but worth a look: `check:release-fragments` reports **41 pending fragments** and warns that `release-compact.yml` is not folding them, so `CHANGELOG.md` and `src/lib/releaseNotes.ts` have stopped recording what shipped. Pre-existing, not caused by this PR.

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lt4F2JBGBNusNSfgYsRHRh
