### PR TITLE
feat(billing): Subscription + OrgEntitlement and the plan→feature matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,15 @@ jobs:
       # (#1892).
       - name: the ROI model is deterministic and refuses to guess (#1892)
         run: npm run test:roi
+      # src/lib/plans.ts is the single source of what each plan sells and what
+      # it costs, and every way of getting it wrong typechecks: an unknown plan
+      # key resolving to "everything" gives the paid product away, a cancelled
+      # subscription that keeps its limits is a customer who stopped paying and
+      # noticed nothing, and the legacy FREE/PRO/ENTERPRISE translation exists
+      # twice (TypeScript + the deploy backfill, which runs as plain node) so
+      # the two can silently disagree (#1731).
+      - name: the plan → feature matrix and its fallbacks (#1731)
+        run: npm run test:plans
       - name: auth path reads only the columns it needs (#1150)
         run: npm run check:auth-reads
       # An API-key request has no session, so nothing resolves a tenant for it

--- a/infra/deploy-prod.sh
+++ b/infra/deploy-prod.sh
@@ -580,6 +580,14 @@ run_tool node prisma/backfill-mentor-application-admin-note.mjs || true
 # deliberate choice. Converges to a no-op after the first deploy.
 run_tool node prisma/backfill-relation-start-stage.mjs --apply || true
 
+# Give every Organization a Subscription row matching the plan it already had
+# (#1731). The commercial state moved from the `Organization.plan` enum to its
+# own table on this deploy; an org without a row would be read as the free tier.
+# Creates only what is missing and never edits an existing subscription, so it
+# converges to a no-op — and the app's own getOrCreateSubscription() covers any
+# org created after this ran.
+run_tool node prisma/backfill-org-subscription.mjs || true
+
 # ── 5. Swap the container ────────────────────────────────────────────────────
 # Blue/green, because the old way was an outage waiting to happen (#961): it
 # stopped and removed the running container BEFORE proving the new image works,

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "test:impersonation-history": "node --test --experimental-strip-types scripts/test/impersonation-history.test.mjs",
     "test:rate-limit-store": "node --test --experimental-strip-types scripts/test/rate-limit-store.test.mjs",
     "test:roi": "node --test --experimental-strip-types scripts/test/roi.test.mjs",
+    "test:plans": "node --test --experimental-strip-types scripts/test/plans.test.mjs",
     "check:auth-reads": "node scripts/check-auth-reads.mjs",
     "check:api-key-routes": "node scripts/check-api-key-routes.mjs",
     "check:query-scalars": "node scripts/check-query-scalars.mjs",

--- a/prisma/backfill-org-subscription.mjs
+++ b/prisma/backfill-org-subscription.mjs
@@ -1,0 +1,105 @@
+// Give every existing Organization a Subscription row (#1731, epic #1727).
+//
+// WHY THIS EXISTS. Before this task a tenant's whole commercial state was the
+// `Organization.plan` enum. The new `Subscription` table is where it lives from
+// now on, and every later billing screen is written assuming the row is there.
+// An org that predates the table has none, so this translates what it already
+// had — FREE → community, PRO → program, ENTERPRISE → enterprise — into a row.
+// Nobody loses access on the deploy that adds the table.
+//
+// Idempotent and safe to re-run: it only ever creates a row for an org that has
+// none, and NEVER edits an existing one. That matters more than it looks —
+// re-running must not undo a plan change made in the app, and once Stripe is
+// wired up (a later task) the provider is the authority for these fields, not
+// this script. On a database that has already been backfilled it prints zeros.
+//
+// The legacy translation is duplicated from LEGACY_PLAN_MAP in src/lib/plans.ts
+// rather than imported: this runs as plain node inside the built image, which
+// has no TypeScript toolchain (same reason backfill-sso-plan.mjs re-states the
+// SSO predicate). scripts/test/plans.test.mjs asserts the two copies agree, so
+// packaging that changes in one place and not the other is a red build rather
+// than a silently mis-planned tenant.
+//
+// Run: node prisma/backfill-org-subscription.mjs   [--dry-run]
+
+import { PrismaClient } from '@prisma/client';
+
+// MUST equal LEGACY_PLAN_MAP in src/lib/plans.ts (asserted by the unit test).
+export const LEGACY_PLAN_MAP = {
+  FREE: 'community',
+  PRO: 'program',
+  ENTERPRISE: 'enterprise',
+};
+
+// An unexpected/unreadable legacy plan resolves to the free tier, never to a
+// paid one: guessing upwards hands out the paid product for free, guessing
+// downwards is visible and fixable in one click.
+function planKeyFor(plan) {
+  return LEGACY_PLAN_MAP[plan] ?? LEGACY_PLAN_MAP.FREE;
+}
+
+// The Prisma client is constructed inside run(), not at module scope, so that
+// importing this file costs nothing and needs no DATABASE_URL — that is what
+// lets scripts/test/plans.test.mjs import LEGACY_PLAN_MAP above and compare it
+// with the TypeScript matrix.
+async function run(prisma, { dryRun }) {
+  const orgs = await prisma.organization.findMany({
+    select: { id: true, slug: true, plan: true, subscription: { select: { id: true } } },
+  });
+
+  let created = 0;
+  let skipped = 0;
+
+  for (const org of orgs) {
+    if (org.subscription) {
+      skipped++;
+      continue;
+    }
+
+    const planKey = planKeyFor(org.plan);
+
+    if (dryRun) {
+      created++;
+      console.log(`backfill-org-subscription: WOULD create ${org.slug} ${org.plan} -> ${planKey}`);
+      continue;
+    }
+
+    try {
+      await prisma.subscription.create({
+        data: { orgId: org.id, planKey, status: 'ACTIVE', interval: 'MONTHLY' },
+      });
+      created++;
+      console.log(`backfill-org-subscription: ${org.slug} ${org.plan} -> ${planKey}`);
+    } catch (error) {
+      // A concurrent create is not a failure: the app's own lazy
+      // getOrCreateSubscription() runs against the same database while this
+      // deploys, and `orgId` is unique, so the row the caller wanted exists
+      // either way.
+      const row = await prisma.subscription.findUnique({ where: { orgId: org.id }, select: { id: true } });
+      if (!row) throw error;
+      skipped++;
+    }
+  }
+
+  console.log(
+    `backfill-org-subscription: created=${created} already-had-one=${skipped} orgs=${orgs.length}` +
+      `${dryRun ? ' (dry run)' : ''}`,
+  );
+}
+
+async function main() {
+  const prisma = new PrismaClient();
+  try {
+    await run(prisma, { dryRun: process.argv.includes('--dry-run') });
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+// Only run when invoked as a script; an import (the unit test) just gets the map.
+if (process.argv[1]?.endsWith('backfill-org-subscription.mjs')) {
+  main().catch((error) => {
+    console.error('backfill-org-subscription failed:', error);
+    process.exitCode = 1;
+  });
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -66,36 +66,47 @@ enum PipelineStatus {
 // enforces isolation yet, so behaviour is unchanged. Enforcement (query
 // filtering, per-org uniqueness) lands in a later, guarded slice.
 model Organization {
-  id             String   @id @default(cuid())
-  name           String
-  slug           String   @unique
+  id               String   @id @default(cuid())
+  name             String
+  slug             String   @unique
   // Per-tenant plan tier (#547). Limits per plan live in src/lib/orgPlans.ts
   // (client-safe catalogue), not the DB. New tenants start on FREE; the
   // backfilled legacy "default" org is grandfathered to ENTERPRISE (unlimited)
   // so single-tenant production is never constrained. Limits are advisory in
   // this phase (surfaced as usage-vs-limit), not hard-enforced.
-  plan           OrgPlan  @default(FREE)
+  plan             OrgPlan  @default(FREE)
   // White-label branding (#546). All optional — when null the app falls back to
   // its own defaults (see src/lib/branding.ts). These are stored per tenant and
   // resolved once per-tenant chrome application lands (needs tenant resolution,
   // the #543 enforcement slice); until then they are managed but not applied to
   // the live single-tenant UI.
-  brandName      String?
-  brandLogoUrl   String?  @db.Text
-  brandColor     String?
-  supportEmail   String?
+  brandName        String?
+  brandLogoUrl     String?  @db.Text
+  brandColor       String?
+  supportEmail     String?
   // Enterprise SSO config (#545). All optional; nothing is active until
   // ssoEnabled is true AND a valid config is present (see src/lib/sso.ts).
   // Actual assertion handling requires the tenant's IdP metadata and a SAML
   // library — see docs/sso-saml.md; this stores/validates the config and gates
   // the (documented, not-yet-wired) auth code path.
-  ssoEnabled     Boolean  @default(false)
-  ssoProvider    String? // 'saml' | 'oidc'
-  ssoIssuer      String? // IdP entity ID / issuer
-  ssoEntryPoint  String?  @db.Text // IdP SSO sign-in URL
-  ssoCertificate String?  @db.Text // IdP x509 signing certificate (PEM)
-  createdAt      DateTime @default(now())
-  updatedAt      DateTime @updatedAt
+  ssoEnabled       Boolean  @default(false)
+  ssoProvider      String? // 'saml' | 'oidc'
+  ssoIssuer        String? // IdP entity ID / issuer
+  ssoEntryPoint    String?  @db.Text // IdP SSO sign-in URL
+  ssoCertificate   String?  @db.Text // IdP x509 signing certificate (PEM)
+  // Billing identity (#1731, epic #1727). All optional and additive: the
+  // Organization is the ONE billing subject (a Company is a role inside it),
+  // and this is where the invoice is addressed. Nothing here talks to Stripe
+  // yet — `stripeCustomerId` is the column the later checkout task fills, kept
+  // unique so one customer can never be attached to two tenants.
+  stripeCustomerId String?  @unique
+  billingEmail     String?
+  vatId            String?
+  // ISO-3166 alpha-2 ("DE", "TR"). Decides VAT treatment, so it is stored,
+  // never inferred from an IP or a locale.
+  billingCountry   String?
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
 
   users                User[]
   sources              Source[]
@@ -120,6 +131,8 @@ model Organization {
   settings             Setting[]
   programCosts         ProgramCost[]
   placements           Placement[]
+  subscription         Subscription?
+  orgEntitlements      OrgEntitlement[]
 }
 
 // Per-tenant customizable pipeline stages (#747, part of white-label #546).
@@ -3221,4 +3234,115 @@ model Placement {
   @@index([orgId, placedAt])
   @@index([companyId])
   @@index([menteeId])
+}
+
+// ── Commercial spine (#1731, epic #1727) ─────────────────────────────────────
+//
+// What a tenant is paying for. Until now the whole commercial state of an
+// Organization was one enum column (`plan OrgPlan`), which cannot express a
+// customer id, a billing period, a trial, an interval or a single feature
+// granted outside the plan — so every non-standard deal had to be modelled as
+// "put them on ENTERPRISE and hope".
+//
+// `Organization.plan` and `src/lib/orgPlans.ts` are deliberately LEFT IN PLACE
+// and still authoritative for the four planGate call sites. This slice lands
+// the storage and the plan→feature matrix (`src/lib/plans.ts`) without changing
+// any behaviour; migrating the gates onto it is a later task in the epic.
+//
+// `planKey`, `status` and `interval` are Strings, not enums, for the same
+// reason `MentorshipRelation.pipelineStatus` is (#747): this repo deploys with
+// `prisma db push --accept-data-loss`, which resolves a MySQL ENUM change as
+// DROP + CREATE. Packaging changes more often than the schema should, and a
+// per-PR topic environment pushes against its own fresh database — so the
+// destructive diff would look perfectly healthy on the PR and only bite
+// production. The legal values live in src/lib/plans.ts.
+model Subscription {
+  id String @id @default(cuid())
+
+  // One live subscription per tenant, hence @unique. A superseded subscription
+  // is not kept here as a second row: history belongs in the billing provider
+  // (and later in an event log), not in the row the app reads on every request.
+  orgId String @unique
+
+  // A key from PLANS in src/lib/plans.ts ('community' | 'program' | …), stored
+  // as text so repackaging needs no migration. An unknown value resolves to the
+  // free tier rather than to unlimited access (see resolveEntitlements()).
+  planKey String @default("community")
+
+  // TRIALING | ACTIVE | PAST_DUE | CANCELED | INCOMPLETE — see
+  // SUBSCRIPTION_STATUSES in src/lib/plans.ts, which also decides which of them
+  // still carry the plan's features.
+  status String @default("ACTIVE")
+
+  // MONTHLY | YEARLY. Decides which published price applies; it is not a
+  // discount of its own (the annual saving is baked into the yearly price).
+  interval String @default("MONTHLY")
+
+  // The period the tenant has paid for. Nullable because a free/community
+  // subscription has no period at all, and because the authority for these
+  // dates is the billing provider, which is not wired up yet.
+  currentPeriodStart DateTime?
+  currentPeriodEnd   DateTime?
+  trialEndsAt        DateTime?
+
+  // Set when the customer has cancelled but keeps access to the end of the
+  // period. Access is decided by `status`, never by this flag alone.
+  cancelAtPeriodEnd Boolean @default(false)
+
+  // The published 50% education/non-profit discount. It lives on the
+  // subscription because it is a property of the DEAL: re-deriving it per
+  // screen from a domain, a country or an org name would make two screens
+  // disagree about what the customer pays.
+  educationDiscount Boolean @default(false)
+
+  // Filled by the later Stripe task; unique so one provider subscription can
+  // never be linked to two tenants.
+  stripeSubscriptionId String? @unique
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  org Organization @relation(fields: [orgId], references: [id], onDelete: Cascade)
+
+  @@index([status])
+}
+
+// A feature granted to a tenant OUTSIDE its plan: a pilot, a goodwill unlock,
+// a paid add-on (the AI pack), a contractual exception. Row presence = feature
+// on, mirroring the CompanyEntitlement convention (#517) so nothing new has to
+// be learned — but keyed on the ORG, because white-label, SSO and the AI pack
+// belong to the customer running the programme, not to a company in its talent
+// pool.
+//
+// A grant only ever ADDS to what the plan already includes; there is no
+// negative grant. Revoking is deleting the row, and taking away something the
+// plan sells is a plan change.
+model OrgEntitlement {
+  id    String @id @default(cuid())
+  orgId String
+
+  // A key from PREMIUM_FEATURES (src/lib/entitlementsCatalog.ts), stored as
+  // text so adding a feature needs no migration.
+  feature String
+
+  // Who granted it. Deliberately NOT a foreign key (same as Tag.createdById):
+  // the audit trail of a commercial exception must outlive the admin account
+  // that created it.
+  grantedById String?
+
+  // Why it was granted — the sentence a future admin needs in order to decide
+  // whether the exception is still justified.
+  note String? @db.Text
+
+  // Optional end date for a time-boxed grant. Enforced by the resolver in
+  // src/lib/subscription.ts, which drops expired rows before handing the set
+  // to the pure matrix; nothing deletes them, so the history stays readable.
+  expiresAt DateTime?
+
+  createdAt DateTime @default(now())
+
+  org Organization @relation(fields: [orgId], references: [id], onDelete: Cascade)
+
+  @@unique([orgId, feature])
+  @@index([orgId])
 }

--- a/releases/unreleased/org-subscription-plan-matrix.json
+++ b/releases/unreleased/org-subscription-plan-matrix.json
@@ -1,0 +1,4 @@
+{
+  "bump": "minor",
+  "changelog": "- **Commercial spine: `Subscription` + `OrgEntitlement` and the plan→feature matrix** (#1731). New additive models give an Organization a real subscription (plan key, status, interval, period, trial, education discount, Stripe ids) and a place to grant a single feature outside its plan; both carry `orgId` and are registered in `TENANT_MODELS`. `src/lib/plans.ts` is the one source of the packaging (Community / Program / Program Plus / Enterprise + Employer tiers, published EUR prices, limits, features) and is pure/data-only, so it is unit-tested (`npm run test:plans`) and importable from client components. `resolveEntitlements()` is the single entitlement resolver; `src/lib/subscription.ts` adds `getOrCreateSubscription()` plus the DB-backed `orgEntitled()`. An idempotent deploy backfill maps every existing org's legacy plan onto a subscription row. No feature is gated behind a plan by this change."
+}

--- a/scripts/check-unit-coverage.mjs
+++ b/scripts/check-unit-coverage.mjs
@@ -86,6 +86,10 @@ const FLOORS = new Map([
     'src/lib/lastContactRule.ts',
     { floor: 95, measured: 100.0, why: 'what counts as contact: 1:1 yes, group only if the mentee wrote it (#2275)' },
   ],
+  [
+    'src/lib/plans.ts',
+    { floor: 95, measured: 99.56, why: 'the plan -> feature matrix and its free-tier fallbacks (#1731)' },
+  ],
 ]);
 
 // ── Awaiting tests (a ratchet, not an allowlist) ─────────────────────────────

--- a/scripts/test/plans.test.mjs
+++ b/scripts/test/plans.test.mjs
@@ -1,0 +1,300 @@
+// Unit tests for the plan → feature matrix (#1731, epic #1727).
+//
+// Run: npm run test:plans  (node --test --experimental-strip-types)
+//
+// src/lib/plans.ts decides who may use what and what they pay for it, and every
+// way of getting it wrong typechecks perfectly:
+//   • an unknown plan key resolving to "everything" instead of the free tier
+//     gives the paid product away on a typo;
+//   • a cancelled subscription that keeps its plan's limits is a customer who
+//     stopped paying and noticed nothing;
+//   • a hand-granted pilot feature that the resolver drops is a customer who
+//     paid and lost access;
+//   • the 50 % education discount applied to a price that is not sold on that
+//     interval invents a number nobody published;
+//   • and the legacy FREE/PRO/ENTERPRISE translation exists TWICE — here in
+//     TypeScript and again in prisma/backfill-org-subscription.mjs, which runs
+//     as plain node inside the deployed image. Those two disagreeing puts a
+//     tenant on the wrong plan on the deploy that creates its row.
+// None of that is reachable from a browser test, so it is pinned here.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  BILLING_INTERVALS,
+  EDUCATION_DISCOUNT_RATE,
+  ENTITLING_STATUSES,
+  FREE_PLAN_KEY,
+  GRANT_ONLY_FEATURES,
+  KNOWN_GRANTABLE_FEATURES,
+  LEGACY_PLAN_MAP,
+  PLANS,
+  PLAN_KEYS,
+  SUBSCRIPTION_STATUSES,
+  effectivePrice,
+  getPlan,
+  isEntitled,
+  isPlanKey,
+  planFeatures,
+  planIncludingFeature,
+  planLimits,
+  planPrice,
+  plansForAudience,
+  resolveEntitlements,
+  statusCarriesPlan,
+} from '../../src/lib/plans.ts';
+import { PREMIUM_FEATURES } from '../../src/lib/entitlementsCatalog.ts';
+import { LEGACY_PLAN_MAP as BACKFILL_LEGACY_PLAN_MAP } from '../../prisma/backfill-org-subscription.mjs';
+
+const LIMIT_KEYS = [
+  'activePairs',
+  'adminSeats',
+  'companies',
+  'programs',
+  'monthlyBroadcastRecipients',
+  'aiCallsPerMonth',
+];
+
+// ── The matrix itself ────────────────────────────────────────────────────────
+
+test('every declared plan key has exactly one plan, and vice versa', () => {
+  assert.deepEqual(
+    PLANS.map((p) => p.key),
+    [...PLAN_KEYS],
+  );
+  assert.equal(new Set(PLANS.map((p) => p.key)).size, PLANS.length);
+});
+
+test('every plan declares every limit, and only sane values', () => {
+  for (const plan of PLANS) {
+    for (const key of LIMIT_KEYS) {
+      const value = plan.limits[key];
+      assert.ok(
+        value === null || (Number.isInteger(value) && value >= 0),
+        `${plan.key}.${key} must be null (unlimited) or a non-negative integer, got ${String(value)}`,
+      );
+    }
+    for (const interval of BILLING_INTERVALS) {
+      const price = plan.prices[interval];
+      assert.ok(
+        price === null || (Number.isInteger(price) && price >= 0),
+        `${plan.key} price for ${interval} must be null or a non-negative integer, got ${String(price)}`,
+      );
+    }
+  }
+});
+
+test('every feature a plan sells is a real catalogue key', () => {
+  const catalogue = new Set(PREMIUM_FEATURES.map((f) => f.key));
+  for (const plan of PLANS) {
+    for (const feature of plan.features) {
+      assert.ok(catalogue.has(feature), `${plan.key} sells unknown feature ${feature}`);
+    }
+  }
+});
+
+// The grantable set is enumerated from the matrix instead of imported from the
+// catalogue, so plans.ts can stay free of runtime imports (it is imported by
+// client components). This is the assertion that keeps that trick honest: a
+// feature added to PREMIUM_FEATURES and to no plan would otherwise be silently
+// unGRANTable — an admin could create the OrgEntitlement row and the resolver
+// would drop it as a typo.
+test('every catalogue feature can be granted', () => {
+  for (const { key } of PREMIUM_FEATURES) {
+    assert.ok(KNOWN_GRANTABLE_FEATURES.has(key), `${key} is in the catalogue but no plan or add-on can grant it`);
+  }
+});
+
+test('a grant-only feature is sold by no plan', () => {
+  for (const feature of GRANT_ONLY_FEATURES) {
+    assert.equal(
+      planIncludingFeature(feature),
+      null,
+      `${feature} is an add-on — including it in a plan gives it away`,
+    );
+    assert.equal(planIncludingFeature(feature, 'EMPLOYER'), null);
+  }
+});
+
+test('the free tier of each audience sells nothing premium', () => {
+  for (const [audience, key] of Object.entries(FREE_PLAN_KEY)) {
+    const plan = getPlan(key);
+    assert.ok(plan, `${audience} free plan ${key} does not exist`);
+    assert.equal(plan.audience, audience);
+    assert.deepEqual([...plan.features], []);
+  }
+});
+
+test('a paid plan never sells less than the cheaper plan of the same audience', () => {
+  for (const audience of ['PROGRAM', 'EMPLOYER']) {
+    const ladder = plansForAudience(audience);
+    for (let i = 1; i < ladder.length; i++) {
+      for (const feature of ladder[i - 1].features) {
+        assert.ok(
+          ladder[i].features.includes(feature),
+          `${ladder[i].key} drops ${feature}, which the cheaper ${ladder[i - 1].key} includes`,
+        );
+      }
+    }
+  }
+});
+
+test('the cheapest plan including a feature is named, per audience', () => {
+  assert.equal(planIncludingFeature('ADVANCED_ANALYTICS'), 'program');
+  assert.equal(planIncludingFeature('WHITE_LABEL'), 'program_plus');
+  assert.equal(planIncludingFeature('SSO_SAML'), 'program_plus');
+  // A programme-side answer must never point a university at an employer plan.
+  assert.equal(planIncludingFeature('TALENT_POOL_SEARCH'), null);
+  assert.equal(planIncludingFeature('TALENT_POOL_SEARCH', 'EMPLOYER'), 'employer');
+});
+
+// ── Fallbacks: unknown input must land on the free tier, never on everything ─
+
+test('an unknown plan key resolves to the free tier, not to unlimited', () => {
+  for (const bad of ['', 'ENTERPRISE', 'program-plus', 'pro', null, undefined, 42, {}]) {
+    assert.equal(isPlanKey(bad), false, `${String(bad)} must not be a plan key`);
+    assert.equal(getPlan(bad), null);
+    assert.deepEqual([...planFeatures(bad)], []);
+    assert.deepEqual(planLimits(bad), planLimits(FREE_PLAN_KEY.PROGRAM));
+    assert.equal(planPrice(bad, 'YEARLY'), null);
+  }
+});
+
+test('a plan not sold on an interval has no price on it', () => {
+  assert.equal(planPrice('enterprise', 'MONTHLY'), null);
+  assert.equal(planPrice('enterprise', 'YEARLY'), 8_988);
+  assert.equal(effectivePrice('enterprise', 'MONTHLY', { educationDiscount: true }), null);
+});
+
+// ── The education discount ───────────────────────────────────────────────────
+
+test('the education discount halves the published price and nothing else', () => {
+  assert.equal(EDUCATION_DISCOUNT_RATE, 0.5);
+  assert.equal(effectivePrice('program', 'YEARLY'), 1_788);
+  assert.equal(effectivePrice('program', 'YEARLY', { educationDiscount: false }), 1_788);
+  assert.equal(effectivePrice('program', 'YEARLY', { educationDiscount: true }), 894);
+  // Rounded to whole euros: 189 / 2 = 94.5 → 95, never 94.5 on an invoice.
+  assert.equal(effectivePrice('program', 'MONTHLY', { educationDiscount: true }), 95);
+  assert.equal(effectivePrice('enterprise', 'YEARLY', { educationDiscount: true }), 4_494);
+  // Free stays free, and the discount cannot make a price negative.
+  assert.equal(effectivePrice('community', 'MONTHLY', { educationDiscount: true }), 0);
+  for (const plan of PLANS) {
+    for (const interval of BILLING_INTERVALS) {
+      const price = effectivePrice(plan.key, interval, { educationDiscount: true });
+      assert.ok(price === null || price >= 0, `${plan.key}/${interval} discounted to ${String(price)}`);
+    }
+  }
+});
+
+// ── Status → does the plan still apply? ──────────────────────────────────────
+
+test('trialing, active and past-due carry the plan; cancelled and incomplete do not', () => {
+  assert.deepEqual([...ENTITLING_STATUSES], ['TRIALING', 'ACTIVE', 'PAST_DUE']);
+  for (const status of ['TRIALING', 'ACTIVE', 'PAST_DUE']) {
+    assert.equal(statusCarriesPlan(status), true, `${status} must carry the plan`);
+  }
+  for (const status of ['CANCELED', 'INCOMPLETE']) {
+    assert.equal(statusCarriesPlan(status), false, `${status} must not carry the plan`);
+  }
+  // Every declared status is decided one way or the other, and nothing else is.
+  for (const status of SUBSCRIPTION_STATUSES) {
+    assert.equal(typeof statusCarriesPlan(status), 'boolean');
+  }
+  for (const junk of ['active', 'ACTIVE ', '', null, undefined, 1]) {
+    assert.equal(statusCarriesPlan(junk), false, `${String(junk)} must not carry the plan`);
+  }
+});
+
+// ── resolveEntitlements: the one function every caller goes through ──────────
+
+test('an active plan grants exactly its own features', () => {
+  const r = resolveEntitlements({ planKey: 'program_plus', status: 'ACTIVE' });
+  assert.equal(r.planKey, 'program_plus');
+  assert.equal(r.planActive, true);
+  assert.deepEqual([...r.features], ['ADVANCED_ANALYTICS', 'REPORT_EXPORT', 'WHITE_LABEL', 'SSO_SAML']);
+  assert.deepEqual([...r.fromGrant], []);
+  assert.deepEqual(r.limits, planLimits('program_plus'));
+  assert.equal(isEntitled({ planKey: 'program_plus', status: 'ACTIVE' }, 'WHITE_LABEL'), true);
+  assert.equal(isEntitled({ planKey: 'program', status: 'ACTIVE' }, 'WHITE_LABEL'), false);
+});
+
+test('a trialing tenant gets the full plan — a trial that entitles nothing is a screenshot', () => {
+  const trial = resolveEntitlements({ planKey: 'program', status: 'TRIALING' });
+  assert.equal(trial.planActive, true);
+  assert.deepEqual([...trial.features], [...planFeatures('program')]);
+  assert.deepEqual(trial.limits, planLimits('program'));
+});
+
+test('past due keeps access; cancelled falls back to the free tier of its own audience', () => {
+  const pastDue = resolveEntitlements({ planKey: 'program_plus', status: 'PAST_DUE' });
+  assert.equal(pastDue.planActive, true);
+  assert.deepEqual([...pastDue.features], [...planFeatures('program_plus')]);
+
+  for (const status of ['CANCELED', 'INCOMPLETE']) {
+    const dead = resolveEntitlements({ planKey: 'program_plus', status });
+    assert.equal(dead.planActive, false);
+    assert.deepEqual([...dead.features], []);
+    // Not unlimited: an expired Program Plus tenant is a Community tenant.
+    assert.deepEqual(dead.limits, planLimits('community'));
+    assert.equal(dead.limits.activePairs, 25);
+  }
+
+  const deadEmployer = resolveEntitlements({ planKey: 'employer_plus', status: 'CANCELED' });
+  assert.deepEqual(deadEmployer.limits, planLimits('employer_free'));
+});
+
+test('an empty input is the free tier, not an error and not everything', () => {
+  const r = resolveEntitlements({});
+  assert.equal(r.planKey, FREE_PLAN_KEY.PROGRAM);
+  assert.equal(r.planActive, false);
+  assert.deepEqual([...r.features], []);
+  assert.deepEqual(r.limits, planLimits('community'));
+});
+
+test('a grant adds a feature the plan does not sell, even on the free tier', () => {
+  const r = resolveEntitlements({ planKey: 'community', status: 'ACTIVE', grants: ['WHITE_LABEL'] });
+  assert.deepEqual([...r.features], ['WHITE_LABEL']);
+  assert.deepEqual([...r.fromPlan], []);
+  assert.deepEqual([...r.fromGrant], ['WHITE_LABEL']);
+  // A grant never buys the plan's LIMITS — only the feature.
+  assert.deepEqual(r.limits, planLimits('community'));
+});
+
+test('a grant survives a cancelled subscription — it was granted, not sold', () => {
+  const r = resolveEntitlements({ planKey: 'program_plus', status: 'CANCELED', grants: ['AI_PACKAGE'] });
+  assert.equal(r.planActive, false);
+  assert.deepEqual([...r.features], ['AI_PACKAGE']);
+  assert.equal(isEntitled({ planKey: 'program_plus', status: 'CANCELED', grants: ['AI_PACKAGE'] }, 'WHITE_LABEL'), false);
+});
+
+test('a grant is never counted twice and a typo is never an entitlement', () => {
+  const r = resolveEntitlements({
+    planKey: 'program',
+    status: 'ACTIVE',
+    grants: ['ADVANCED_ANALYTICS', 'WHITE_LABEL', 'WHITE_LABEL', 'white_label', 'NOT_A_FEATURE', ''],
+  });
+  assert.deepEqual([...r.features], ['ADVANCED_ANALYTICS', 'REPORT_EXPORT', 'WHITE_LABEL']);
+  assert.deepEqual([...r.fromGrant], ['WHITE_LABEL']);
+});
+
+test('resolveEntitlements never mutates the matrix it read from', () => {
+  const before = JSON.stringify(PLANS);
+  resolveEntitlements({ planKey: 'program', status: 'ACTIVE', grants: ['WHITE_LABEL', 'AI_PACKAGE'] });
+  assert.equal(JSON.stringify(PLANS), before);
+});
+
+// ── The legacy translation exists twice; the copies must agree ───────────────
+
+test('LEGACY_PLAN_MAP maps the three legacy tiers onto real plans', () => {
+  assert.deepEqual(LEGACY_PLAN_MAP, { FREE: 'community', PRO: 'program', ENTERPRISE: 'enterprise' });
+  for (const key of Object.values(LEGACY_PLAN_MAP)) {
+    assert.ok(isPlanKey(key), `${key} is not a plan key`);
+  }
+  // FREE must land on the free tier: it is also the fallback both the backfill
+  // and getOrCreateSubscription() use for an unreadable legacy plan.
+  assert.equal(LEGACY_PLAN_MAP.FREE, FREE_PLAN_KEY.PROGRAM);
+});
+
+test('the deploy backfill translates legacy plans exactly like the matrix does', () => {
+  assert.deepEqual(BACKFILL_LEGACY_PLAN_MAP, LEGACY_PLAN_MAP);
+});

--- a/src/lib/orgContext.ts
+++ b/src/lib/orgContext.ts
@@ -83,6 +83,14 @@ const TENANT_MODELS: ReadonlySet<Prisma.ModelName> = new Set([
   // there is no null-org fallback row to reason about.
   'ProgramCost',
   'Placement',
+  // The commercial spine (#1731). What a tenant pays for, and every feature
+  // granted to it outside its plan. Both carry a REQUIRED orgId. Reading
+  // another tenant's subscription would leak its plan, its trial and its
+  // discount; writing one would change what somebody else is billed — so
+  // these are registered from the moment the tables exist, before anything
+  // reads them.
+  'Subscription',
+  'OrgEntitlement',
 ]);
 
 // Actions whose `where` selects rows to read or mutate — inject orgId there.

--- a/src/lib/plans.ts
+++ b/src/lib/plans.ts
@@ -1,0 +1,462 @@
+// The plan → feature matrix: what each plan sells (#1731, epic #1727).
+//
+// THIS FILE IS THE SINGLE SOURCE OF THE PACKAGING. Prices, limits and the set
+// of premium features per plan are all here and nowhere else, so "which plan
+// includes white-label" has exactly one answer — for the pricing page, the
+// upgrade prompt behind a 403, the admin billing screen and the server-side
+// entitlement check alike.
+//
+// PURE AND DATA-ONLY, on purpose:
+//   • no `@prisma/client`, no `@/lib/prisma`, no server-only import — the
+//     pricing page and the admin billing screen are client components;
+//   • no `Date`, no `Date.now()` — nothing here depends on a clock, so every
+//     rule in it is unit-testable (scripts/test/plans.test.mjs) and gives the
+//     same answer on the server and in the browser. Time-boxed grants are
+//     filtered by the DB layer (src/lib/subscription.ts) BEFORE they reach
+//     resolveEntitlements() for exactly that reason.
+// Only `import type` is allowed, because a type import is erased and cannot
+// drag a runtime dependency in.
+//
+// Nothing in this file gates anything yet. `Organization.plan` and
+// src/lib/orgPlans.ts still drive the four existing planGate call sites;
+// migrating those onto this matrix is a later task in the epic. Landing the
+// matrix without changing behaviour is deliberate. Until then both files
+// export a `planLimits()` — this one takes a plan KEY ('program'), the old one
+// the legacy OrgPlan enum ('PRO') — so a caller that needs both must alias one
+// on import rather than assume they are interchangeable.
+//
+// The numbers are the PUBLISHED ones (docs/research/competitive-analysis-2026-08.md
+// § 9.3, docs/marketing/go-to-market.md): Community €0 → Program €149/mo billed
+// annually → Program Plus €399/mo annually → Enterprise €749/mo, annual only.
+// If packaging changes it changes there first and here second.
+
+import type { PremiumFeature } from '@/lib/entitlementsCatalog';
+
+// ── Vocabulary ───────────────────────────────────────────────────────────────
+// These are the legal values of the String columns on `Subscription`. They are
+// strings and not Prisma enums because this repo deploys with
+// `prisma db push --accept-data-loss`, which resolves a MySQL ENUM change as
+// DROP + CREATE (see the model's header comment).
+
+export const PLAN_KEYS = [
+  'community',
+  'program',
+  'program_plus',
+  'enterprise',
+  'employer_free',
+  'employer',
+  'employer_plus',
+] as const;
+export type PlanKey = (typeof PLAN_KEYS)[number];
+
+export const BILLING_INTERVALS = ['MONTHLY', 'YEARLY'] as const;
+export type BillingInterval = (typeof BILLING_INTERVALS)[number];
+
+export const SUBSCRIPTION_STATUSES = ['TRIALING', 'ACTIVE', 'PAST_DUE', 'CANCELED', 'INCOMPLETE'] as const;
+export type SubscriptionStatus = (typeof SUBSCRIPTION_STATUSES)[number];
+
+// Two wallets, sold to two different buyers and never mixed (the programme
+// owner pays for the programme; a hiring company pays for its own hiring
+// surface). A plan belongs to exactly one of them, which is what keeps a
+// "cheapest plan including feature X" answer from offering a university an
+// employer plan.
+export const PLAN_AUDIENCES = ['PROGRAM', 'EMPLOYER'] as const;
+export type PlanAudience = (typeof PLAN_AUDIENCES)[number];
+
+// ── Limits ───────────────────────────────────────────────────────────────────
+// `null` = unlimited. `0` = the meter does not apply to this plan at all (an
+// employer plan owns no mentoring pairs); it is 0 rather than null so that a
+// careless read can never report "unlimited" for a meter nobody sells.
+export interface PlanLimits {
+  // Monthly ACTIVE MATCHED PAIRS — the one metering unit of the programme side
+  // (#1750 computes it). Mentors and mentees are never a billable unit.
+  activePairs: number | null;
+  // Seats that can administer the tenant. Mentor and mentee accounts are free
+  // and uncounted, forever.
+  adminSeats: number | null;
+  // Hiring companies in the talent pool.
+  companies: number | null;
+  // Concurrent programmes / cohorts. We never charge per programme above the
+  // free tier and say so out loud, hence the early jump to unlimited.
+  programs: number | null;
+  // Announcement + newsletter recipients per calendar month. A cap on the
+  // sending domain's reputation as much as on the plan.
+  monthlyBroadcastRecipients: number | null;
+  // Admin-side AI calls per month, applicable only once the AI pack is granted
+  // (it is a paid add-on, not part of any plan — see PLAN_FEATURES). All
+  // participant-facing AI is free at every tier and is not metered here.
+  aiCallsPerMonth: number | null;
+}
+
+// ── Features per plan ────────────────────────────────────────────────────────
+// Keys come from PREMIUM_FEATURES (src/lib/entitlementsCatalog.ts). A feature
+// that no plan lists is sold as an add-on or a pilot and is granted per tenant
+// through an `OrgEntitlement` row — AI_PACKAGE is exactly that (published as a
+// €49/mo per-org pack, so folding it into a tier here would give it away).
+const PLAN_FEATURES: Record<PlanKey, readonly PremiumFeature[]> = {
+  // The trial that never ends: pipeline board and basic analytics, nothing
+  // premium. Also the fallback for an unknown or non-entitling subscription,
+  // which is why it must stay empty.
+  community: [],
+  // "Full analytics + XLSX/CSV export + scheduled report email".
+  program: ['ADVANCED_ANALYTICS', 'REPORT_EXPORT'],
+  // Adds the two org-scope features the premium model puts above Program:
+  // white-label incl. custom domain, and SSO.
+  program_plus: ['ADVANCED_ANALYTICS', 'REPORT_EXPORT', 'WHITE_LABEL', 'SSO_SAML'],
+  // Enterprise buys assurances, not extra feature flags: EU-only hosting, DPA,
+  // SLA, audit export, named onboarding. Feature-wise it is Program Plus.
+  enterprise: ['ADVANCED_ANALYTICS', 'REPORT_EXPORT', 'WHITE_LABEL', 'SSO_SAML'],
+  // Employer side. Free: a brand page and answering a mentor-gated shortlist.
+  employer_free: [],
+  employer: ['TALENT_POOL_SEARCH', 'VERIFIED_CANDIDATE_CARD', 'COMPANY_NEED_MATCH_ALERTS'],
+  employer_plus: [
+    'TALENT_POOL_SEARCH',
+    'VERIFIED_CANDIDATE_CARD',
+    'COMPANY_NEED_MATCH_ALERTS',
+    'ADVANCED_ANALYTICS',
+    'REPORT_EXPORT',
+    'EARLY_ACCESS',
+  ],
+};
+
+export interface Plan {
+  key: PlanKey;
+  audience: PlanAudience;
+  // Product name as published. NOT a translated label: the plan names are the
+  // same in EN/TR/DE on the pricing page, so there is nothing to translate and
+  // no dictionary key to drift.
+  name: string;
+  features: readonly PremiumFeature[];
+  limits: PlanLimits;
+  // Amount charged per interval in whole EUR, net of VAT: MONTHLY is per
+  // month, YEARLY is per year (the annual saving is baked into the yearly
+  // number, it is not a discount applied on top). `null` = the plan is not
+  // sold on that interval — Enterprise is annual-only, by design.
+  prices: Record<BillingInterval, number | null>;
+}
+
+export const PLANS: readonly Plan[] = [
+  {
+    key: 'community',
+    audience: 'PROGRAM',
+    name: 'Community',
+    features: PLAN_FEATURES.community,
+    limits: {
+      activePairs: 25,
+      adminSeats: 2,
+      companies: 3,
+      programs: 1,
+      monthlyBroadcastRecipients: 250,
+      aiCallsPerMonth: 0,
+    },
+    prices: { MONTHLY: 0, YEARLY: 0 },
+  },
+  {
+    key: 'program',
+    audience: 'PROGRAM',
+    name: 'Program',
+    features: PLAN_FEATURES.program,
+    limits: {
+      activePairs: 100,
+      adminSeats: 5,
+      companies: null,
+      programs: null,
+      monthlyBroadcastRecipients: 2_000,
+      aiCallsPerMonth: 500,
+    },
+    // €149/mo billed annually (€1 788/yr) or €189/mo monthly.
+    prices: { MONTHLY: 189, YEARLY: 1_788 },
+  },
+  {
+    key: 'program_plus',
+    audience: 'PROGRAM',
+    name: 'Program Plus',
+    features: PLAN_FEATURES.program_plus,
+    limits: {
+      activePairs: 400,
+      adminSeats: 15,
+      companies: null,
+      programs: null,
+      monthlyBroadcastRecipients: 10_000,
+      aiCallsPerMonth: 2_000,
+    },
+    // €399/mo annually (€4 788/yr) or €479 monthly.
+    prices: { MONTHLY: 479, YEARLY: 4_788 },
+  },
+  {
+    key: 'enterprise',
+    audience: 'PROGRAM',
+    name: 'Enterprise',
+    features: PLAN_FEATURES.enterprise,
+    limits: {
+      activePairs: null,
+      adminSeats: null,
+      companies: null,
+      programs: null,
+      monthlyBroadcastRecipients: null,
+      aiCallsPerMonth: null,
+    },
+    // €749/mo, annual only — €8 988/yr, printed on the website. The published
+    // sub-€9 000 top tier IS the campaign; do not raise it here.
+    prices: { MONTHLY: null, YEARLY: 8_988 },
+  },
+  {
+    key: 'employer_free',
+    audience: 'EMPLOYER',
+    name: 'Employer Free',
+    features: PLAN_FEATURES.employer_free,
+    limits: {
+      activePairs: 0,
+      adminSeats: 1,
+      companies: 1,
+      programs: 0,
+      monthlyBroadcastRecipients: 0,
+      aiCallsPerMonth: 0,
+    },
+    prices: { MONTHLY: 0, YEARLY: 0 },
+  },
+  {
+    key: 'employer',
+    audience: 'EMPLOYER',
+    name: 'Employer',
+    features: PLAN_FEATURES.employer,
+    limits: {
+      activePairs: 0,
+      adminSeats: 5,
+      companies: 1,
+      programs: 0,
+      // 50 candidate messages per month.
+      monthlyBroadcastRecipients: 50,
+      aiCallsPerMonth: 0,
+    },
+    // €99/mo annually (€1 188/yr); no published monthly price.
+    prices: { MONTHLY: null, YEARLY: 1_188 },
+  },
+  {
+    key: 'employer_plus',
+    audience: 'EMPLOYER',
+    name: 'Employer Plus',
+    features: PLAN_FEATURES.employer_plus,
+    limits: {
+      activePairs: 0,
+      adminSeats: 20,
+      companies: 1,
+      programs: 0,
+      monthlyBroadcastRecipients: 500,
+      aiCallsPerMonth: 0,
+    },
+    // €299/mo annually (€3 588/yr); no published monthly price.
+    prices: { MONTHLY: null, YEARLY: 3_588 },
+  },
+];
+
+// The free plan of each wallet. Every fallback in this module lands here: an
+// unknown plan key, a cancelled subscription, an org with no subscription row
+// at all. Failing to the free tier is the only safe direction — failing to
+// "unlimited" would hand out the paid product on a typo.
+export const FREE_PLAN_KEY: Record<PlanAudience, PlanKey> = {
+  PROGRAM: 'community',
+  EMPLOYER: 'employer_free',
+};
+
+// Legacy `Organization.plan` (the three-value OrgPlan enum) → a plan key here.
+// Used by BOTH the deploy backfill (prisma/backfill-org-subscription.mjs, which
+// keeps its own copy because it runs as plain node with no TS toolchain — the
+// unit test asserts the two agree) and getOrCreateSubscription(), so a tenant
+// resolves the same plan whichever path creates its row.
+export const LEGACY_PLAN_MAP: Record<'FREE' | 'PRO' | 'ENTERPRISE', PlanKey> = {
+  FREE: 'community',
+  PRO: 'program',
+  ENTERPRISE: 'enterprise',
+};
+
+// The published, non-negotiated education / non-profit discount: 50 %.
+export const EDUCATION_DISCOUNT_RATE = 0.5;
+
+const BY_KEY = new Map<PlanKey, Plan>(PLANS.map((p) => [p.key, p]));
+
+// ── Type guards ──────────────────────────────────────────────────────────────
+
+export function isPlanKey(value: unknown): value is PlanKey {
+  return typeof value === 'string' && BY_KEY.has(value as PlanKey);
+}
+
+export function isBillingInterval(value: unknown): value is BillingInterval {
+  return typeof value === 'string' && (BILLING_INTERVALS as readonly string[]).includes(value);
+}
+
+export function isSubscriptionStatus(value: unknown): value is SubscriptionStatus {
+  return typeof value === 'string' && (SUBSCRIPTION_STATUSES as readonly string[]).includes(value);
+}
+
+// ── Lookups ──────────────────────────────────────────────────────────────────
+
+// The plan for a key, or null when the key is not one we sell. Callers that
+// need a plan no matter what should use planFeatures()/planLimits(), which fall
+// back to the free tier instead of returning null.
+export function getPlan(key: unknown): Plan | null {
+  return isPlanKey(key) ? (BY_KEY.get(key) as Plan) : null;
+}
+
+export function plansForAudience(audience: PlanAudience): readonly Plan[] {
+  return PLANS.filter((p) => p.audience === audience);
+}
+
+// Features included in a plan. An unknown key resolves to the programme-side
+// free tier (= no premium features), never to an error and never to everything.
+export function planFeatures(key: unknown): readonly PremiumFeature[] {
+  return (getPlan(key) ?? (BY_KEY.get(FREE_PLAN_KEY.PROGRAM) as Plan)).features;
+}
+
+// Limits of a plan, with the same fallback as planFeatures().
+export function planLimits(key: unknown): PlanLimits {
+  return (getPlan(key) ?? (BY_KEY.get(FREE_PLAN_KEY.PROGRAM) as Plan)).limits;
+}
+
+// Amount charged for one interval, in whole EUR; null when the plan is not sold
+// on that interval or the key is unknown.
+export function planPrice(key: unknown, interval: BillingInterval): number | null {
+  const plan = getPlan(key);
+  return plan ? plan.prices[interval] : null;
+}
+
+// What a customer actually pays for one interval, in whole EUR: the published
+// price with the education/non-profit discount applied when the subscription
+// carries it. Rounded to the nearest euro, because that is the granularity
+// every published price in this file uses — half-euro line items on an invoice
+// are a support ticket, not a feature.
+export function effectivePrice(
+  key: unknown,
+  interval: BillingInterval,
+  options: { educationDiscount?: boolean } = {},
+): number | null {
+  const price = planPrice(key, interval);
+  if (price == null) return null;
+  if (!options.educationDiscount) return price;
+  return Math.round(price * (1 - EDUCATION_DISCOUNT_RATE));
+}
+
+// The cheapest plan that includes a feature, in PLANS order (cheapest first
+// within each wallet). This is what a refusal names so the caller can render
+// "upgrade to X" without hardcoding the packaging a second time. Null when no
+// plan sells the feature at all — which for AI_PACKAGE is the correct answer:
+// it is an add-on, granted per tenant.
+export function planIncludingFeature(feature: PremiumFeature, audience: PlanAudience = 'PROGRAM'): PlanKey | null {
+  return PLANS.find((p) => p.audience === audience && p.features.includes(feature))?.key ?? null;
+}
+
+// ── Entitlement resolution — the one function ────────────────────────────────
+//
+// Every entitlement answer in the product comes from here. A feature check
+// written inline at a call site ("if plan === 'enterprise'") is how a paywall
+// leaks: one of the checks is always forgotten, or disagrees with the pricing
+// page, or forgets that a pilot tenant was granted the feature by hand.
+//
+// The rule has exactly three inputs and no clock:
+//   1. the plan's own features — but only while the subscription's STATUS
+//      still carries them;
+//   2. the per-tenant grants (OrgEntitlement rows), which only ever ADD;
+//   3. the free tier, which is where everything unknown lands.
+
+// Which statuses still carry the plan's features:
+//   TRIALING  — the trial IS the product; a trial that entitles nothing is a
+//               screenshot.
+//   ACTIVE    — obviously.
+//   PAST_DUE  — a failed card is a dunning problem, not a reason to take a
+//               running programme offline mid-cohort. Access continues while
+//               we chase the payment; CANCELED is how access actually ends.
+// and which do not:
+//   CANCELED   — the subscription is over (cancelAtPeriodEnd is a *pending*
+//                cancellation and stays ACTIVE until it lands, so this really
+//                does mean over).
+//   INCOMPLETE — checkout never completed, so nothing was ever paid for.
+export const ENTITLING_STATUSES: readonly SubscriptionStatus[] = ['TRIALING', 'ACTIVE', 'PAST_DUE'];
+
+export function statusCarriesPlan(status: unknown): boolean {
+  return isSubscriptionStatus(status) && ENTITLING_STATUSES.includes(status);
+}
+
+export interface EntitlementInput {
+  // `Subscription.planKey`; anything unknown or absent → the free tier.
+  planKey?: string | null;
+  // `Subscription.status`; anything unknown or absent → not entitling.
+  status?: string | null;
+  // Features granted outside the plan (`OrgEntitlement.feature`). The caller
+  // MUST have dropped expired rows already — this module has no clock.
+  grants?: readonly string[] | null;
+}
+
+export interface EntitlementResolution {
+  // The plan the answer was computed from, normalized (never an unknown key).
+  planKey: PlanKey;
+  // Whether the subscription's status carries the plan's features at all.
+  planActive: boolean;
+  // Everything the tenant may use: plan features (when active) + grants.
+  features: readonly PremiumFeature[];
+  // Where each half came from, so a billing screen can say "included in your
+  // plan" vs. "granted to you" instead of guessing.
+  fromPlan: readonly PremiumFeature[];
+  fromGrant: readonly PremiumFeature[];
+  // Limits that apply. A non-entitling status falls back to the free tier of
+  // the plan's own wallet — an expired Program Plus tenant is a Community
+  // tenant, not an unlimited one.
+  limits: PlanLimits;
+}
+
+export function resolveEntitlements(input: EntitlementInput): EntitlementResolution {
+  const plan = getPlan(input.planKey);
+  const audience: PlanAudience = plan?.audience ?? 'PROGRAM';
+  const planActive = !!plan && statusCarriesPlan(input.status);
+
+  const fromPlan = planActive ? (plan as Plan).features : [];
+  // A grant for a feature the plan already includes is not counted twice, and
+  // an unrecognised grant key is ignored rather than trusted: the column is
+  // free text, and a typo must never become an entitlement.
+  const planned = new Set<string>(fromPlan);
+  const fromGrant = dedupeFeatures(input.grants).filter((f) => !planned.has(f));
+
+  const effectiveKey: PlanKey = planActive ? (plan as Plan).key : FREE_PLAN_KEY[audience];
+
+  return {
+    planKey: plan?.key ?? FREE_PLAN_KEY[audience],
+    planActive,
+    features: [...fromPlan, ...fromGrant],
+    fromPlan,
+    fromGrant,
+    limits: planLimits(effectiveKey),
+  };
+}
+
+// Is one feature available? The single question every gate should ask.
+export function isEntitled(input: EntitlementInput, feature: PremiumFeature): boolean {
+  return resolveEntitlements(input).features.includes(feature);
+}
+
+// Grants are free text in the DB. Keep only keys some plan in this matrix could
+// legitimately name, deduplicated, in the order the caller supplied them.
+function dedupeFeatures(values: readonly string[] | null | undefined): PremiumFeature[] {
+  if (!values) return [];
+  const seen = new Set<string>();
+  const out: PremiumFeature[] = [];
+  for (const value of values) {
+    if (typeof value !== 'string' || seen.has(value)) continue;
+    seen.add(value);
+    if (KNOWN_GRANTABLE_FEATURES.has(value)) out.push(value as PremiumFeature);
+  }
+  return out;
+}
+
+// Features sold only as a grant — no plan includes them, so a tenant gets them
+// through an OrgEntitlement row: the AI pack is a paid add-on (€49/mo per org)
+// and early access is handed out per pilot.
+export const GRANT_ONLY_FEATURES: readonly PremiumFeature[] = ['AI_PACKAGE'];
+
+// Every feature key a grant may legitimately name: whatever some plan sells,
+// plus the grant-only add-ons. Enumerated from the matrix itself rather than
+// imported from PREMIUM_FEATURES, so this file keeps its no-runtime-imports
+// promise; the unit test asserts the two sets agree, which is what catches a
+// feature added to the catalogue and forgotten here.
+export const KNOWN_GRANTABLE_FEATURES: ReadonlySet<string> = new Set<string>([
+  ...PLANS.flatMap((p) => [...p.features]),
+  ...GRANT_ONLY_FEATURES,
+]);

--- a/src/lib/subscription.ts
+++ b/src/lib/subscription.ts
@@ -1,0 +1,130 @@
+// The tenant's subscription and its entitlements, read from the database
+// (#1731, epic #1727). Server-only: it imports prisma. The pure plan→feature
+// matrix lives in src/lib/plans.ts and stays client-safe.
+//
+// This is the ONE door between "what the database says a tenant bought" and
+// "may this tenant use feature X". A feature check written inline at a call
+// site is how a paywall leaks: the checks drift apart, one of them forgets the
+// hand-granted pilot, and nobody notices until a customer either loses access
+// they paid for or gets access they did not.
+//
+// NOTHING IS GATED YET. No existing call site reads this module — the four
+// planGate call sites still read `Organization.plan` through
+// src/lib/orgPlans.ts. Landing the storage, the matrix and this resolver
+// without changing behaviour is deliberate (#1731); moving the gates over is a
+// later task in the epic.
+
+import type { Subscription } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+import type { PremiumFeature } from '@/lib/entitlementsCatalog';
+import { LEGACY_PLAN_MAP, resolveEntitlements, type EntitlementResolution, type PlanKey } from '@/lib/plans';
+
+export { LEGACY_PLAN_MAP } from '@/lib/plans';
+
+// The plan a tenant gets when it has no Subscription row yet: whatever its
+// legacy `Organization.plan` enum said, translated through the ONE map both
+// this accessor and the deploy backfill use. An org whose plan is unreadable
+// falls back to the free tier — never to a paid one.
+function planKeyForLegacyPlan(plan: string | null | undefined): PlanKey {
+  if (plan && plan in LEGACY_PLAN_MAP) return LEGACY_PLAN_MAP[plan as keyof typeof LEGACY_PLAN_MAP];
+  return LEGACY_PLAN_MAP.FREE;
+}
+
+// The tenant's subscription, created on first read if it does not exist.
+//
+// Belt and braces next to prisma/backfill-org-subscription.mjs: the backfill
+// gives every org that existed at deploy time a row, and this covers every org
+// created AFTER it ran — a new tenant, a freshly seeded topic environment, a
+// restored database — so every later billing screen may assume the row exists
+// without anyone re-running a script.
+//
+// Safe to call concurrently: `orgId` is unique, so two racing creates end with
+// one row and one caught P2002, after which the loser reads the winner's row.
+export async function getOrCreateSubscription(orgId: string): Promise<Subscription> {
+  const existing = await prisma.subscription.findUnique({ where: { orgId } });
+  if (existing) return existing;
+
+  const org = await prisma.organization.findUnique({ where: { id: orgId }, select: { plan: true } });
+  if (!org) throw new Error(`getOrCreateSubscription: no organization ${orgId}`);
+
+  try {
+    return await prisma.subscription.create({
+      data: {
+        orgId,
+        planKey: planKeyForLegacyPlan(org.plan),
+        status: 'ACTIVE',
+        interval: 'MONTHLY',
+      },
+    });
+  } catch {
+    // Lost the race (or the row appeared some other way). Re-read rather than
+    // reporting a failure: the only thing the caller asked for is a row, and
+    // there is exactly one.
+    const row = await prisma.subscription.findUnique({ where: { orgId } });
+    if (row) return row;
+    throw new Error(`getOrCreateSubscription: could not create or read a subscription for ${orgId}`);
+  }
+}
+
+// Everything a tenant may use right now: its plan's features (while the
+// subscription's status carries them) plus the grants that have not expired,
+// with the limits that apply. One indexed lookup plus one small collection
+// read; safe on a request path.
+//
+// The expiry filter lives HERE, not in plans.ts, because the matrix has no
+// clock on purpose. `now` is injectable so a caller (and a test) can ask the
+// question as of a specific moment instead of implicitly trusting the wall.
+export async function resolveOrgEntitlements(
+  orgId: string | null | undefined,
+  now: Date = new Date(),
+): Promise<EntitlementResolution> {
+  // No tenant resolves → the free tier. Not "everything": a request that
+  // cannot name its org must never be the one that unlocks the paid product.
+  if (!orgId) return resolveEntitlements({});
+
+  const [subscription, grants] = await Promise.all([
+    prisma.subscription.findUnique({
+      where: { orgId },
+      select: { planKey: true, status: true },
+    }),
+    prisma.orgEntitlement.findMany({
+      where: {
+        orgId,
+        // Row present = feature on, until it expires. A NULL expiresAt is a
+        // permanent grant.
+        OR: [{ expiresAt: null }, { expiresAt: { gt: now } }],
+      },
+      select: { feature: true },
+    }),
+  ]);
+
+  // No row yet? Answer from the legacy plan enum rather than refusing — the
+  // lazy create belongs to getOrCreateSubscription(), and a read should not
+  // write. The org is looked up only in that (rare) case.
+  if (!subscription) {
+    const org = await prisma.organization.findUnique({ where: { id: orgId }, select: { plan: true } });
+    return resolveEntitlements({
+      planKey: planKeyForLegacyPlan(org?.plan),
+      status: 'ACTIVE',
+      grants: grants.map((g) => g.feature),
+    });
+  }
+
+  return resolveEntitlements({
+    planKey: subscription.planKey,
+    status: subscription.status,
+    grants: grants.map((g) => g.feature),
+  });
+}
+
+// May this tenant use this feature? The single question a gate should ask —
+// one call, one answer, whether the feature came with the plan or was granted
+// by hand.
+export async function orgEntitled(
+  orgId: string | null | undefined,
+  feature: PremiumFeature,
+  now: Date = new Date(),
+): Promise<boolean> {
+  const resolution = await resolveOrgEntitlements(orgId, now);
+  return resolution.features.includes(feature);
+}


### PR DESCRIPTION
## Summary

Gives the Organization somewhere to record **what it is paying for**. Until now a tenant's whole commercial state was one enum column (`Organization.plan`): no customer id, no period, no trial, no interval, and no way to grant a single feature outside the plan — so every non-standard deal had to be modelled as "put them on `ENTERPRISE` and hope".

This is the foundation of the commercial spine (epic #1727). **Everything is additive and nothing changes behaviour**: no existing feature is gated behind a plan, `src/lib/orgPlans.ts` stays in place for the four `planGate` call sites, and Stripe is deliberately not wired here (later task in the epic).

Closes #1731

## Changes

**Schema (additive: new nullable columns + two new tables)**
- `Organization` gains `stripeCustomerId String? @unique`, `billingEmail`, `vatId`, `billingCountry` (ISO-3166 alpha-2).
- New **`Subscription`** — one per tenant (`orgId @unique`): `planKey`, `status`, `interval`, `currentPeriodStart/End`, `trialEndsAt`, `cancelAtPeriodEnd`, `educationDiscount`, `stripeSubscriptionId @unique`, timestamps, `@@index([status])`. The three vocabulary columns are **Strings, not enums** — `db push --accept-data-loss` resolves a MySQL ENUM change as DROP + CREATE, and a topic env pushes against its own fresh database, so that diff would look perfectly healthy on the PR and only bite production. `OrgPlan` is untouched; `CompanyEntitlement` is not re-keyed.
- New **`OrgEntitlement`** — `@@unique([orgId, feature])`, `grantedById`, `note`, `expiresAt`. Row presence = feature on, mirroring the `CompanyEntitlement` convention. A grant only ever *adds*; there is no negative grant.
- Both models carry `orgId` and are registered in `TENANT_MODELS` (`src/lib/orgContext.ts`) — registered from the moment the tables exist, before anything reads them.

**The matrix**
- **`src/lib/plans.ts`** is the single source of the packaging: Community / Program / Program Plus / Enterprise plus the Employer / Employer Plus tiers, with the **published** EUR prices, the limits (`activePairs`, `adminSeats`, `companies`, `programs`, `monthlyBroadcastRecipients`, `aiCallsPerMonth`; `null` = unlimited) and the features each plan sells. Numbers come from `docs/research/competitive-analysis-2026-08.md` § 9.3 / `docs/marketing/go-to-market.md`.
- Pure and data-only on purpose: **no `@prisma/client`, no `@/lib/prisma`, no clock** — `import type` only, so a client component can import it and every rule in it is unit-testable. `LEGACY_PLAN_MAP` (`FREE→community`, `PRO→program`, `ENTERPRISE→enterprise`) lives here.
- **One resolver, `resolveEntitlements()`**: plan features while the subscription's status carries them (`TRIALING`/`ACTIVE`/`PAST_DUE` do; `CANCELED`/`INCOMPLETE` do not), plus grants, with the **free tier as the only fallback** — an unknown plan key or a dead subscription never resolves to "unlimited".

**The DB half**
- **`src/lib/subscription.ts`** (server-only): `getOrCreateSubscription(orgId)` — lazy, race-safe (`orgId` is unique, a lost create re-reads), seeded through `LEGACY_PLAN_MAP`; `resolveOrgEntitlements(orgId, now)`, which filters **expired** grants before handing them to the clock-free matrix; and `orgEntitled(orgId, feature)` as the single question a future gate asks.
- **`prisma/backfill-org-subscription.mjs`** — idempotent (creates only what is missing, never edits an existing subscription), wired into `infra/deploy-prod.sh` after the existing backfills. It keeps its own copy of the legacy map because it runs as plain node inside the image with no TS toolchain (same reason `backfill-sso-plan.mjs` re-states its predicate) — **and the unit test asserts the two copies agree**.

**Tests / guards**
- `scripts/test/plans.test.mjs` (22 assertions, `npm run test:plans`, wired into `ci.yml`): the free-tier fallbacks, the status rule, the feature ladder monotonicity, the 50 % education discount arithmetic and rounding, that a grant-only add-on (AI pack) is in no plan, that every catalogue feature is grantable, and that the backfill's legacy map still equals the TypeScript one.
- `src/lib/plans.ts` added to the unit-coverage ratchet (`floor: 95`, measured 99.56).

## Verification

- [x] `npx prisma format` / `npx prisma validate` / `npx prisma generate` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (only the two pre-existing `react-hooks/exhaustive-deps` warnings)
- [x] `npm run build` green
- [x] `npm run test:plans` — 22/22; `npm run test:unit` — 110/110; `npm run test:unit:coverage` — no floor breached
- [x] `npm run check:tenant-models` — no new drift (still the 8 known `#1559` pending models, 21 registered → 23 with these two)
- [x] `npm run check:release-fragments`, `check:auth-reads`, `check:query-scalars`, `check:openapi` clean
- [ ] e2e not run here (no database or browser build in this environment) — `e2e/plan-limit-gate.spec.ts` and `e2e/admin-organizations.spec.ts` are untouched and read `Organization.plan` through `orgPlans.ts`, which this PR does not change; CI is the check

**Deliberately left out**: Stripe (webhooks, checkout, price ids), any plan gate on an existing feature, deleting `src/lib/orgPlans.ts`, widening `OrgPlan`, re-keying `CompanyEntitlement`, and any admin UI for granting an `OrgEntitlement`. The backfill is wired into `infra/deploy-prod.sh` (prod + preview) only; topic environments rely on the lazy `getOrCreateSubscription()`, which is what it is for.

**Note for #1750** (activeMatchedPairs metering, in parallel): the models are defined here — `Subscription.planKey` + `PlanLimits.activePairs` is the pair budget to meter against, and `resolveOrgEntitlements()` is the one door for reading it.

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ra7wrp478VPjzHJHh4QMvZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ra7wrp478VPjzHJHh4QMvZ)_