### PR TITLE
fix: say why an assignment was refused, and stop the race spec asserting a guarantee we don't make

### DIFF
--- a/e2e/one-active-mentor.spec.ts
+++ b/e2e/one-active-mentor.spec.ts
@@ -17,7 +17,9 @@ import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
  * Only the first is @smoke — it is the back door that fires with nobody
  * pressing a button, it notifies the mentee, and it is a single POST. The
  * concurrency case is deliberately excluded from the gate: it is timing
- * sensitive and the PR gate must stay fast.
+ * sensitive and the PR gate must stay fast — and for the same reason it
+ * asserts only the outcomes the shipped code guarantees, not the ones the
+ * unique index will (see the comment in that test).
  */
 
 const PASSWORD = 'OneMentor123!';
@@ -187,7 +189,7 @@ test('reopening a completed mentorship is refused while another one is active', 
   }
 });
 
-test('two simultaneous assignments for one mentee produce exactly one relation', async ({ page }) => {
+test('two simultaneous assignments are each answered 201 or 409, and the rows match the answers', async ({ page }) => {
   const adminEmail = uniqueEmail('oam-race-admin');
   const mentorAEmail = uniqueEmail('oam-race-a');
   const mentorBEmail = uniqueEmail('oam-race-b');
@@ -205,8 +207,32 @@ test('two simultaneous assignments for one mentee produce exactly one relation',
       page.request.post('/api/mentorship', { data: { mentorId: mentorB.id, menteeId: mentee.id } }),
     ]);
     const statuses = [first.status(), second.status()].sort();
-    expect(statuses).toEqual([201, 409]);
-    expect(await prisma.mentorshipRelation.count({ where: { menteeId: mentee.id, status: 'ACTIVE' } })).toBe(1);
+
+    // What this case can honestly assert is NOT "one 201 and one 409".
+    // docs/one-active-mentor.md ("What is *not* closed") says why: MySQL
+    // InnoDB runs REPEATABLE READ, so the guard inside the transaction is a
+    // consistent NON-LOCKING read — both transactions can see "no active
+    // mentor", both insert and both commit, because the
+    // @@unique([activeMenteeKey]) backstop is deliberately out of scope until
+    // the live data is known clean. `toEqual([201, 409])` would encode an
+    // expectation the shipped code does not provide: it would red the 4x/day
+    // scheduled suite (and fire the Turkish alert mail) over documented
+    // behaviour, and on a run that happened to serialise it would "pass" while
+    // proving nothing — inviting a future reader to skip the index that
+    // actually closes the race.
+    //
+    // What the transactions DO buy, and what is asserted here: every request
+    // is answered with one of the two intended outcomes (no 500, no half-open
+    // state), at least one assignment lands, and the rows on disk agree
+    // exactly with the answers given — no relation behind a 409, no 201
+    // without a row. Tighten this to toEqual([201, 409]) in the PR that adds
+    // the unique index.
+    const created = statuses.filter((s) => s === 201).length;
+    expect(statuses.every((s) => s === 201 || s === 409)).toBe(true);
+    expect(created).toBeGreaterThanOrEqual(1);
+    expect(await prisma.mentorshipRelation.count({ where: { menteeId: mentee.id, status: 'ACTIVE' } })).toBe(
+      created,
+    );
   } finally {
     await prisma.mentorshipRelation.deleteMany({ where: { menteeId: mentee.id } });
     await cleanupByEmail(menteeEmail);

--- a/releases/unreleased/assignment-refusal-reasons.json
+++ b/releases/unreleased/assignment-refusal-reasons.json
@@ -1,0 +1,9 @@
+{
+  "bump": "patch",
+  "changelog": "- **Assignment refusals name their reason again** (#2283 follow-up). Switching the three assignment surfaces onto the response `code` had collapsed every refusal but `already_mentored` into a generic line, so an admin at their plan cap was told only \"The mentorship could not be created.\" One resolver, `src/lib/mentorshipAssignmentError.ts`, now translates `plan_limit_reached` (with usage/limit/plan), `already_decided` and the newly coded `invalid_mentor`; unknown codes still fall back to the generic sentence. The concurrency spec in `e2e/one-active-mentor.spec.ts` stopped asserting `[201, 409]` — a guarantee the shipped code does not make until the unique index lands — and asserts instead that every request is answered 201/409 and that the rows on disk match the answers.",
+  "notes": {
+    "en": ["When an assignment is refused, the reason is shown — including which plan limit you hit and that upgrading lifts it."],
+    "tr": ["Bir atama reddedildiğinde gerekçesi gösteriliyor — hangi plan sınırına takıldığınız ve planı yükseltmenin bunu açtığı dahil."],
+    "de": ["Wird eine Zuweisung abgelehnt, wird der Grund angezeigt — auch, welche Plangrenze erreicht ist und dass ein Upgrade sie aufhebt."]
+  }
+}

--- a/src/app/admin/mentorship/page.tsx
+++ b/src/app/admin/mentorship/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useT, useLocale } from "@/i18n/client";
+import { mentorshipAssignmentError } from "@/lib/mentorshipAssignmentError";
 import Link from "next/link";
 
 import { useState, useEffect, useCallback } from 'react';
@@ -153,11 +154,11 @@ export default function MentorshipPage() {
         // Switch on the body's `code`, never on the status: 409 is
         // already_mentored (#419) today but the route also answers 403 for the
         // plan gate, and a future 409 may mean something else. The server's
-        // `error` string is English literal text and is never rendered.
+        // `error` string is English literal text and is never rendered — the
+        // shared resolver translates every code this route can answer,
+        // including the plan gate's quota sentence (#2283 follow-up).
         const body = await res.json().catch(() => ({}));
-        setFormError(
-          body.code === 'already_mentored' ? t.assignMentor.alreadyAssigned : t.mentorships.assignFailed
-        );
+        setFormError(mentorshipAssignmentError(t, body, t.mentorships.assignFailed));
         return;
       }
       await fetchRelations();

--- a/src/components/admin/AssignMentorInline.tsx
+++ b/src/components/admin/AssignMentorInline.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/Button';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { AiBadge } from '@/components/AiBadge';
 import { useT } from '@/i18n/client';
+import { mentorshipAssignmentError } from '@/lib/mentorshipAssignmentError';
 import { formatMentorAvailability } from '@/lib/mentorAvailabilityLabel';
 import type { MentorAvailability } from '@/lib/mentorAvailability';
 import { MATCH_DISMISS_REASONS, type MatchDismissReason } from '@/lib/matchFeedback';
@@ -166,8 +167,9 @@ export function AssignMentorInline({
       const d = await res.json().catch(() => ({}));
       // Keyed on the body's `code`, not the status (#419): a second 409 reason
       // on this route would otherwise render as "already has an active mentor",
-      // which would be a lie.
-      setErr(d.code === 'already_mentored' ? a.alreadyAssigned : t.common.error);
+      // which would be a lie. The plan gate's 403 gets its own sentence rather
+      // than the generic error line (#2283 follow-up).
+      setErr(mentorshipAssignmentError(t, d, t.common.error));
     } catch {
       setErr(t.common.error);
     } finally {

--- a/src/components/admin/MentorshipRequestQueue.tsx
+++ b/src/components/admin/MentorshipRequestQueue.tsx
@@ -6,6 +6,7 @@ import { Card, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { useT } from '@/i18n/client';
+import { mentorshipAssignmentError } from '@/lib/mentorshipAssignmentError';
 import { formatMentorAvailability } from '@/lib/mentorAvailabilityLabel';
 import type { MentorAvailability } from '@/lib/mentorAvailability';
 import { PersonHoverCard } from '@/components/PersonHoverCard';
@@ -99,11 +100,13 @@ export function MentorshipRequestQueue({ mentors, onApproved }: {
         if (action === 'approve') onApproved();
       } else {
         const d = await res.json().catch(() => ({}));
-        // The approval path answers `already_mentored` (#419) and
-        // `already_decided`; both used to arrive here as the server's English
-        // literal. Anything unrecognised falls back to the generic line rather
-        // than publishing whatever text a route happens to carry.
-        setErr(d.code === 'already_mentored' ? a.alreadyAssigned : t.common.error);
+        // The approval path answers `already_mentored` (#419), `already_decided`,
+        // `invalid_mentor` and the plan gate's `plan_limit_reached`; all four
+        // used to arrive here as the server's English literal, and then all but
+        // the first collapsed into the generic line. Anything unrecognised
+        // still falls back to it rather than publishing whatever text a route
+        // happens to carry (#2283 follow-up).
+        setErr(mentorshipAssignmentError(t, d, t.common.error));
       }
     } catch {
       setErr(t.common.error);

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -605,6 +605,10 @@ const en = {
     loadFailed: 'Failed to load data',
     assignSubmit: 'Assign',
     assignFailed: 'The mentorship could not be created.',
+    planLimitReached:
+      'Plan limit reached: {usage}/{limit} active mentorships on the {plan} plan. Existing mentees are unaffected — upgrade to add more.',
+    requestAlreadyDecided: 'This request has already been decided.',
+    invalidMentor: 'That mentor cannot be assigned.',
   },
   companiesPage: {
     title: 'Companies',
@@ -5377,6 +5381,10 @@ const tr: Dict = {
     loadFailed: 'Veriler yüklenemedi',
     assignSubmit: 'Ata',
     assignFailed: 'Mentorluk oluşturulamadı.',
+    planLimitReached:
+      'Plan sınırına ulaşıldı: {plan} planında {usage}/{limit} aktif mentorluk. Mevcut mentee’ler etkilenmez — daha fazlası için planı yükseltin.',
+    requestAlreadyDecided: 'Bu talep zaten karara bağlandı.',
+    invalidMentor: 'Bu mentor atanamaz.',
   },
   companiesPage: {
     title: 'Şirketler',
@@ -10072,6 +10080,10 @@ const de: Dict = {
     loadFailed: 'Daten konnten nicht geladen werden',
     assignSubmit: 'Zuweisen',
     assignFailed: 'Die Mentorschaft konnte nicht erstellt werden.',
+    planLimitReached:
+      'Plangrenze erreicht: {usage}/{limit} aktive Mentorschaften im {plan}-Plan. Bestehende Mentees sind nicht betroffen — für mehr bitte upgraden.',
+    requestAlreadyDecided: 'Diese Anfrage wurde bereits entschieden.',
+    invalidMentor: 'Dieser Mentor kann nicht zugewiesen werden.',
   },
   companiesPage: {
     title: 'Unternehmen',

--- a/src/lib/mentorshipAssignmentError.ts
+++ b/src/lib/mentorshipAssignmentError.ts
@@ -1,0 +1,41 @@
+import type { ClientDictionary } from '@/i18n/dictionaries';
+
+/**
+ * One reader for "why was this assignment refused?" — #2283 follow-up.
+ *
+ * The assignment surfaces stopped rendering the server's English `error`
+ * literal (correct: it is developer text, never translated). But they each
+ * switched on `already_mentored` alone, so every OTHER refusal collapsed into
+ * a generic "could not be created" — including the plan gate's 403, which is
+ * the one refusal that tells the admin what to actually DO about it
+ * (planLimitError, src/lib/planGate.ts). Three call sites drifting apart is
+ * how that happened, so the mapping lives here once.
+ *
+ * Unknown codes still fall back to the caller's generic line: a route that
+ * grows a new refusal shows the safe sentence, not whatever English text it
+ * happens to carry.
+ */
+export function mentorshipAssignmentError(
+  t: ClientDictionary,
+  body: unknown,
+  fallback: string,
+): string {
+  const b = (body ?? {}) as { code?: unknown; usage?: unknown; limit?: unknown; plan?: unknown };
+  switch (b.code) {
+    case 'already_mentored':
+      return t.assignMentor.alreadyAssigned;
+    case 'plan_limit_reached':
+      // The 403 body carries usage/limit/plan precisely so the UI can say
+      // which quota was hit instead of "something went wrong".
+      return t.mentorships.planLimitReached
+        .replace('{usage}', String(b.usage ?? '?'))
+        .replace('{limit}', String(b.limit ?? '?'))
+        .replace('{plan}', String(b.plan ?? '?'));
+    case 'already_decided':
+      return t.mentorships.requestAlreadyDecided;
+    case 'invalid_mentor':
+      return t.mentorships.invalidMentor;
+    default:
+      return fallback;
+  }
+}

--- a/src/lib/mentorshipDecision.ts
+++ b/src/lib/mentorshipDecision.ts
@@ -80,7 +80,9 @@ export async function decideMentorshipRequest(opts: {
       },
     });
     if (!mentor || !mentor.isActive || (mentor.role !== 'MENTOR' && mentor.role !== 'ADMIN')) {
-      return { status: 400, body: { error: 'Invalid mentor' } };
+      // Carries a code so the queue UI can name the reason; without one it
+      // rendered as the generic error line (#2283 follow-up).
+      return { status: 400, body: { error: 'Invalid mentor', code: 'invalid_mentor' } };
     }
     // One mentee, at most one ACTIVE mentor (#419). Cheap pre-flight; the real
     // guard runs inside the transaction below. Both refusals now share one body


### PR DESCRIPTION
Follow-up to #2283 (merged as 0e74340). Two review findings on that PR, both regressions it introduced. Nothing here touches the schema — the `@@unique([activeMenteeKey])` backstop still waits on knowing whether live data is clean, exactly as #2283 left it.

## Finding 1 — the plan-limit refusal was swallowed at all three assignment surfaces

`src/app/admin/mentorship/page.tsx`, `src/components/admin/AssignMentorInline.tsx`, `src/components/admin/MentorshipRequestQueue.tsx`

#2283 was right to stop rendering the server's English `error` literal. But each surface then switched on `already_mentored` **alone** and fell back to a generic line for everything else. `POST /api/mentorship` answers 403 with `planLimitError(gate)` — *"Plan limit reached: 5/5 active mentorships on the FREE plan. Existing mentees are unaffected — upgrade to add more."* Before #2283 the admin saw that sentence. After it they saw only **"The mentorship could not be created."**, with no way to learn they'd hit a quota or that upgrading lifts it. There was no `plan_limit_reached` i18n key at all, so the information wasn't merely untranslated — it was unreachable. `e2e/plan-limit-gate.spec.ts` asserts only the API body, so CI couldn't see it.

Three call sites drifting apart is how this happened, so the mapping now lives once in **`src/lib/mentorshipAssignmentError.ts`** — the same move #2283 made for the invariant itself (`src/lib/activeMentorship.ts`). It translates:

| code | source |
|---|---|
| `already_mentored` | `activeMentorship.ts` (unchanged behaviour) |
| `plan_limit_reached` | `planGate.ts`, interpolating the `usage`/`limit`/`plan` the 403 body already carries |
| `already_decided` | `mentorshipDecision.ts` — the approval queue had been losing this |
| `invalid_mentor` | `mentorshipDecision.ts`, **newly coded** so the reason can be named |

An unrecognised code still falls back to the caller's generic line, so a route that grows a new refusal shows the safe sentence rather than whatever English text it happens to carry. New keys `mentorships.planLimitReached` / `requestAlreadyDecided` / `invalidMentor` in EN/TR/DE.

## Finding 2 — the concurrency spec asserted a guarantee the code does not make

`e2e/one-active-mentor.spec.ts`

The new "two simultaneous assignments" case asserted `expect(statuses).toEqual([201, 409])` and one ACTIVE relation. That is exactly what this PR's own `docs/one-active-mentor.md` ("What is *not* closed") says the shipped code **does not** provide: MySQL InnoDB runs `REPEATABLE READ`, so the guard inside the transaction is a consistent **non-locking** read — both transactions can see "no active mentor", both insert, both commit — and the unique index that would make the second refusal certain is deliberately out of scope.

Both reviewers flagged it independently. The case was untagged, so the `@smoke` PR gate skipped it and it has never been executed; it would have gone red in the 4×/day `e2e-full` suite and fired the Turkish alert email about **documented** behaviour. And the failure mode when it *passes* is worse: a run that happens to serialise proves nothing, and a future reader cites it as evidence the race is closed and skips the index that actually closes it.

It now asserts what the transactions genuinely buy:

- every request is answered 201 or 409 — no 500, no half-open state;
- at least one assignment lands;
- the ACTIVE rows on disk equal the number of 201s — no relation behind a 409, no 201 without a row.

Sound under both interleavings, and still catches a real regression (a 500, a lost write, a row created for a refused request). The comment in the test says to tighten it back to `toEqual([201, 409])` in the PR that adds the unique index.

## Checks

`npx tsc --noEmit`, `npm run lint` (only the two pre-existing `exhaustive-deps` warnings), `npm run check:i18n` (4525 keys × 3 locales), `npm run check:release-fragments` — all green. Release fragment: `releases/unreleased/assignment-refusal-reasons.json`, `bump: patch`.

Note for anyone else on this branch: `npx prisma generate` is needed after pulling #2277 (Subscription/OrgEntitlement), or `tsc` fails with schema drift.