### PR TITLE
fix: order requisition backfill in topic deploy

### DIFF
--- a/infra/server/topic-deploy.sh
+++ b/infra/server/topic-deploy.sh
@@ -295,7 +295,6 @@ fi
 _in_image "$IMAGE" npx prisma db push --accept-data-loss
 _in_image "$IMAGE" node prisma/seed-templates.mjs || true
 _in_image "$IMAGE" node prisma/seed-contributor-terms.mjs || true
-_in_image "$IMAGE" node scripts/backfill-requisitions.mjs || true
 
 if [ "${EXISTING_TABLES:-0}" -eq 0 ]; then
   # First deploy of this PR: fill it with the synthetic demo set. Nothing here
@@ -315,6 +314,8 @@ fi
 # to be rehearsed, so it has to run here too, not only in deploy-prod.sh.
 _in_image "$IMAGE" node prisma/backfill-organization.mjs \
   || echo "WARN: org backfill FAILED (exit non-zero) — see the output above"
+# Legacy needs require company orgId; include rows created by the demo seed.
+_in_image "$IMAGE" node scripts/backfill-requisitions.mjs || true
 
 docker stop "$CONTAINER" 2>/dev/null || true
 docker rm   "$CONTAINER" 2>/dev/null || true

--- a/releases/unreleased/requisitions-backfill-deploy.json
+++ b/releases/unreleased/requisitions-backfill-deploy.json
@@ -1,0 +1,4 @@
+{
+  "bump": "patch",
+  "changelog": "- **Infra: requisition backfill ordering** (#1385). Run the topic deploy's existing requisition backfill after demo seeding and the organization backfill so newly seeded legacy needs and repaired company orgIds are included. Preserve non-blocking execution and stdout/stderr logs; production and shared preview already run the backfill after organization repair."
+}


### PR DESCRIPTION
 Summary

Fixes #1385 by ensuring the existing requisition backfill runs at the correct point in the topic deployment flow.

The backfill already existed in production/shared preview deploys, so no duplicate invocation was added there. In infra/server/topic-deploy.sh, the existing requisition backfill was moved to run after demo seeding and the organization backfill.

This ensures that:

newly seeded legacy CompanyNeed rows are included;
repaired company orgId values are available before conversion;
the existing non-blocking || true behavior is preserved;
backfill logs remain visible in deployment output.

A patch release fragment was also added.

Validation

Local backfill idempotency check:

First run:  migrated=3 skipped=0 errors=0
Second run: migrated=0 skipped=3 errors=0

Additional checks completed successfully:

npm run check:i18n
npx tsc --noEmit --incremental false
npm run lint
npm run build
bash -n infra/deploy-prod.sh
bash -n infra/server/topic-deploy.sh
python3 -m json.tool releases/unreleased/requisitions-backfill-deploy.json
bash infra/test/schema-guard.test.sh

Schema guard result:

Total: 32 passed, 0 failed

Changed files:

infra/server/topic-deploy.sh
releases/unreleased/requisitions-backfill-deploy.json