### PR TITLE
fix: 5 e2e-full test-side failures — isolation project, axe selector, 3 stale/brittle assertions

### DIFF
--- a/e2e/contrast-1299.spec.ts
+++ b/e2e/contrast-1299.spec.ts
@@ -147,15 +147,21 @@ test('issue #1299 the unread notification badge meets AA contrast in both themes
       const theme = dark ? 'dark' : 'light';
       await page.goto('/portal');
       await forceTheme(page, dark);
-      // `:visible` is load-bearing — see the locator note at the top of the
-      // file. The count is fetched client-side, so wait for the badge itself
-      // rather than for the bell; the bell is there either way.
-      const visibleBadge = '[data-testid="notifications-unread-badge"]:visible';
+      // `:visible` is load-bearing for the Playwright locator — see the note
+      // at the top of the file — but it is a Playwright-only pseudo-class:
+      // AxeBuilder#include() resolves selectors with the browser's own
+      // `document.querySelectorAll`, which throws on it ("':visible' is not
+      // a valid selector"). axe's color-contrast rule already skips
+      // non-visible nodes on its own, so the plain testid selector (matching
+      // both the hidden mobile-bar badge and the visible desktop one) is
+      // enough to scope the scan to the one node that actually renders.
+      const badgeSelector = '[data-testid="notifications-unread-badge"]';
+      const visibleBadge = `${badgeSelector}:visible`;
       await expect(
         page.locator(visibleBadge).first(),
         `the unread badge should render in ${theme}`
       ).toBeVisible({ timeout: 20_000 });
-      await expectNoContrastViolation(page, visibleBadge, theme);
+      await expectNoContrastViolation(page, badgeSelector, theme);
     }
   } finally {
     await cleanupByEmail(email);

--- a/e2e/dropoff-reasons.spec.ts
+++ b/e2e/dropoff-reasons.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, type Page } from '@playwright/test';
 import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { submitSignInForm } from './helpers/auth';
 
 // Drop-off reason codes + analytics (#810): every pipeline-stage write path
 // (status-changes, mentorship/[id] — also what the board drag/drop and the
@@ -10,11 +11,14 @@ test.afterAll(async () => {
   await prisma.$disconnect();
 });
 
+// Delegates to the shared, form-scoped submitSignInForm() (e2e/helpers/auth.ts)
+// rather than filling/clicking raw page-level selectors: a hand-rolled
+// page.click('button[type="submit"]') right after page.goto('/auth/signin')
+// can race the sign-in page's own hydration, which sometimes swaps the form
+// node out from under the click ("element was detached from the DOM") — the
+// same failure mode documented on signInAsFreshUser/submitSignInForm.
 async function signInAdmin(page: Page, email: string, password: string) {
-  await page.goto('/auth/signin');
-  await page.fill('input[type="email"], input[name="email"]', email);
-  await page.fill('input[type="password"]', password);
-  await page.click('button[type="submit"]');
+  await submitSignInForm(page, email, password);
   await page.waitForURL((u) => u.pathname.startsWith('/admin'), { timeout: 20_000 });
 }
 

--- a/e2e/job-queue-dlq-alert.unit.spec.ts
+++ b/e2e/job-queue-dlq-alert.unit.spec.ts
@@ -126,7 +126,11 @@ test('the queue counters are read only for a verified caller who asks for them',
   const calls = src.match(/jobQueueHealth\(\)/g) ?? [];
   expect(calls).toHaveLength(1);
   expect(src).toContain("params.get('jobs') === '1'");
-  expect(src).toContain('...(wantsJobs && access.verified ? { jobs: await jobQueueHealth() } : {})');
+  // The guard wraps across several lines in source (`?`/`{` on their own
+  // lines), so assert the pieces rather than one exact-formatted string —
+  // a reflow of the ternary shouldn't fail a test about WHO can read it.
+  expect(src).toContain('...(wantsJobs && access.verified');
+  expect(src).toContain('jobs: await jobQueueHealth(),');
 
   // `detail` is fail-open when HEALTH_TOKEN is unset — that is the bargain the
   // deploy drift gate needs. `verified` is not, and the counters ride on

--- a/e2e/retention-prune.spec.ts
+++ b/e2e/retention-prune.spec.ts
@@ -154,7 +154,7 @@ test('old telemetry rows are pruned and recent ones survive', async () => {
     // No entry may fail: a failure here is a broken query, not a clean table.
     expect(result.failed).toEqual([]);
     expect(result.results.map((r) => r.key).sort()).toEqual(
-      ['activityLog', 'emailLog', 'job', 'notification', 'pageView', 'pushSubscription'].sort()
+      ['activityLog', 'emailLog', 'job', 'notification', 'orphanApplicant', 'pageView', 'pushSubscription'].sort()
     );
 
     const gone = async (

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -42,6 +42,17 @@ function projectRequested(name: string): boolean {
   );
 }
 const runsIsolation = process.env.E2E_ISOLATION === '1' || projectRequested('isolation');
+// Worker processes re-`require` this file too, but they are forked with their
+// OWN argv (pointing at Playwright's internal workerProcessEntry.js), not the
+// `--project=isolation` the top-level `playwright test` command was called
+// with — so `projectRequested('isolation')` silently comes back false in the
+// worker, the `isolation` project drops out of ITS project list, and the run
+// dies with "Project isolation not found in the worker process" before a
+// single spec executes. Stamping the decision into process.env here, in the
+// main process and before any worker is forked, means every worker inherits
+// the SAME answer via env (which forked children DO get a copy of) instead of
+// re-deriving a different one from argv (which they don't).
+if (runsIsolation) process.env.E2E_ISOLATION = '1';
 // An isolation run is an isolation run: the default project (and therefore the
 // default server) is dropped from the config unless the command line asks for
 // chromium by name. E2E_ISOLATION=1 used to leave the default project in place,


### PR DESCRIPTION
## Summary

CI watchdog run. `e2e-full.yml` has been red on `main` for the last 3 scheduled runs (191/`316077b`, 190/`316ebda9`, 189/`94950ef3`) — deploys (`deploy-prod.yml`, `deploy-preview.yml`) are green and current (`/api/health` sha matches `origin/main`), so this is purely a test-suite problem. Triaged every failing test in run 191 (see the full breakdown at the bottom); this PR fixes the five that are confirmed test-side, each with a traced root cause and no guessing.

## 1. Isolation project — every spec fails instantly with `Error: Project "isolation" not found in the worker process.`

Started the moment #1566 (adds the `isolation` project) merged (~02:23 UTC today); failed identically on both scheduled runs since.

**Root cause:** `playwright.config.ts` detects `--project=isolation` via `process.argv`. Playwright's worker processes are **forked with their own argv** (pointing at Playwright's internal `workerProcessEntry.js`), not the original CLI invocation — so when a worker re-`require`s the config, `projectRequested('isolation')` comes back `false` and the `isolation` project silently drops out of the worker's own project list, while the dispatcher (main process) still thinks it exists.

Reproduced in an isolated throwaway Playwright config (not committed) mirroring the same detection logic, logging each process's own `process.argv`:
```
CONFIG EVAL: pid=2340 argv=[...,"test","--project=isolation"]  runsIsolation=true   ← main process
CONFIG EVAL: pid=2352 argv=[...,"workerProcessEntry.js"]        runsIsolation=false  ← worker, no --project at all
  ✘ Error: Project "isolation" not found in the worker process.
```
**Fix:** stamp `process.env.E2E_ISOLATION = '1'` in the main process, before any worker is forked, whenever `runsIsolation` resolves true — env vars *are* inherited by forked children, argv is not. Verified in the same repro that the worker then agrees:
```
CONFIG EVAL: pid=2432 argv=[...,"workerProcessEntry.js"]        runsIsolation=true   ← now agrees
  ✓ 1 passed
```

## 2. `e2e/contrast-1299.spec.ts:127` — `frame.evaluate: SyntaxError: ':visible' is not a valid selector`

Added by today's a11y PR (#2297). The test needs `:visible` to pick the *desktop* copy of the notification badge (`ResponsiveShell` renders `NotificationBell` twice), which works fine for `page.locator()` — but the same selector string was also handed to `AxeBuilder#include()`, which resolves selectors via the browser's native `document.querySelectorAll`, where `:visible` isn't valid CSS. axe's `color-contrast` rule already excludes non-visible nodes on its own, so the plain testid selector (matching both copies) is enough to scope the scan correctly — axe naturally evaluates only the one that renders.

## 3. `e2e/dropoff-reasons.spec.ts` — flaky, "element was detached from the DOM" during sign-in

Passed on Playwright's own retry (so didn't fail the run outright), but hit the documented recurring class (CLAUDE.md / `e2e/helpers/auth.ts`): a hand-rolled `page.click('button[type="submit"]')` right after `page.goto('/auth/signin')` can race the sign-in page's own hydration. Replaced the local `signInAdmin()` with the shared, hardened `submitSignInForm()` instead of duplicating the sign-in flow.

## 4. `e2e/job-queue-dlq-alert.unit.spec.ts:122` — brittle exact-string source assertion

Asserted one exact single-line string for a ternary in `src/app/api/health/route.ts` that actually wraps across several lines (`?`/`{` each on their own line) — a formatting difference, not a behavior change. Manually verified every assertion in this test against the current route source; only the one exact-formatted string was missing. Now asserts the meaningful fragments separately.

## 5. `e2e/retention-prune.spec.ts:156` — stale hardcoded entry-key list

#2260 (closed today, fixing #1780) added a seventh `retentionEntries.ts` entry (`key: 'orphanApplicant'`) but didn't update this pre-existing test's hardcoded list of the six original keys. Added `'orphanApplicant'` to the expected list; confirmed the key name against `src/lib/retentionEntries.ts:467`.

## Changes

- `playwright.config.ts` — stamp `E2E_ISOLATION=1` into `process.env` once `runsIsolation` is determined, before any worker forks.
- `e2e/contrast-1299.spec.ts` — pass the plain (non-`:visible`) testid selector to `AxeBuilder#include()`, keeping `:visible` only for the Playwright locator/`toBeVisible()` check.
- `e2e/dropoff-reasons.spec.ts` — `signInAdmin()` now delegates to the shared `submitSignInForm()`.
- `e2e/job-queue-dlq-alert.unit.spec.ts` — split the brittle one-line assertion into two substring checks matching the real (wrapped) source.
- `e2e/retention-prune.spec.ts` — add `'orphanApplicant'` to the expected entry-key list.

## Verification

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (two pre-existing unrelated warnings only)
- [x] `npx playwright test --list` (default project, 1213 tests), `--project=isolation --list` (7 tests), and per-file `--list` for all four edited specs all resolve correctly and unchanged in count
- [x] Reproduced the exact failing→passing transition for the argv/env fix against an isolated minimal Playwright config (see above)
- [x] job-queue-dlq-alert: manually ran every assertion in the test against the live `src/app/api/health/route.ts` source (all pass)
- [x] retention-prune: confirmed `'orphanApplicant'` is the real key in `src/lib/retentionEntries.ts:467`, added by #2260 today
- [ ] Did **not** additionally re-run `npm run test:e2e:isolation` or the four edited specs end-to-end against a live local MySQL + dev server in this container — the first `next dev` compile for the isolation server was still running after ~9 minutes in this session's container and I cut it rather than block further. CI (a much faster GitHub-hosted runner) will be the first real end-to-end confirmation for the isolation fix specifically; the other four fixes are static/source-level verifications as described above. Flagging this explicitly per the "a fix you haven't seen pass locally is a guess" rule.

No release fragment: pure test/CI-config fixes, no user-visible or app-code change (`releases/README.md`).

## Other failures in the same run (not fixed here — filed separately)

Full triage of run [34134715956](https://github.com/21072026/Internship/actions/runs/34134715956) (all 4 shards + isolation + tenant-isolation job):

**Already tracked by open issues:** analytics-trends → #1501, api-explorer → #2163, mobile-layout-audit (mentor German, /release-notes) → #2165 / #1497, person-hover-card → #2181 (flaky — passed on retry), support-chat → #2158/#2159 (rate limit).

**New issue filed:** #2310 — three new `mobile-layout-coverage.spec.ts` German-viewport overflow failures (`/admin/newsletters`, `/admin/api-explorer`, `/projects`), added by #1615 (closed today) which explicitly expected new overflow findings to be filed separately.

**Flaky, passed on Playwright's own retry (no action):** `command-palette.spec.ts:18`, `settings-ai-quota-and-stage-editor-i18n.spec.ts:14`, `sso-roundtrip.spec.ts:276`, `timezone-settings.spec.ts:24`, `portal-projects.spec.ts:16` (the `@smoke` one — flaky here, not confirmed-red, consistent with it not failing the PR gate).

**Filing as real-bug candidates (too uncertain to fix blind):** `integrations.spec.ts:8` (a freshly-created admin's API key gets rejected by `/api/v1/candidates` — traced to `resolveOrgId()` returning `null` for an org-less admin, which #1546 (merged today) now treats as a hard 403; unclear whether org-less admins are expected to exist in production), `portal-insights.spec.ts:14` and `project-dm.spec.ts:23` (both show a testid resolving to 2 DOM elements where the source only renders it once — not the known/documented ResponsiveShell mobile+desktop dual-render pattern, so likely a real duplicate-mount bug, not traced further).

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip): my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it passes to the rights holder (Mehmet Erşahin) who may also license it commercially, it is my own work, and I make no claim over the application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GaYTTsBGfdCSxQuuTRgKsV