### PR TITLE
fix(e2e): repair two scheduled-suite failures left stale by same-day changes

### DIFF
--- a/e2e/account-access-history.spec.ts
+++ b/e2e/account-access-history.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
-import { signInAndSettle, signInAsFreshUser } from './helpers/auth';
+import { signInAndSettle, signInAsFreshUser, gotoSettled } from './helpers/auth';
 
 // #1587 — "Who accessed my account". Impersonation has always written the audit
 // rows; the account holder simply could not read them. This walks the whole
@@ -64,7 +64,10 @@ test('a mentee sees who impersonated their account, when and why', async ({ page
 
     // Now the mentee themselves — the whole point of the feature.
     await signInAsFreshUser(page, menteeEmail, 'MenteePass123!', '/portal');
-    await page.goto('/account');
+    // signInAsFreshUser only waits for the URL, not a full settle — the portal's
+    // own post-login redirect can still be in flight, racing this goto (see
+    // gotoSettled's doc comment in helpers/auth.ts).
+    await gotoSettled(page, '/account');
     const own = page.getByTestId('access-history-card');
     await expect(own).toBeVisible({ timeout: 10_000 });
     await expect(own.getByTestId('no-access-history')).toHaveCount(0);

--- a/e2e/skill-rating.spec.ts
+++ b/e2e/skill-rating.spec.ts
@@ -18,9 +18,11 @@ test('mentee sets a skill level with the star rating and it persists', async ({ 
     await page.waitForURL((u) => u.pathname.startsWith('/portal'), { timeout: 20_000 });
 
     await page.goto('/portal/profile');
-    // Enter a skill so its rating row appears.
-    const skills = page.locator('input[name="skills"]');
-    await skills.fill('React');
+    // Enter a skill so its rating row appears (the SkillsField chip editor, #2314 —
+    // a plain `input[name="skills"]` no longer exists on this page).
+    const skillsInput = page.getByTestId('skills-field-input');
+    await skillsInput.fill('React');
+    await skillsInput.press('Enter');
     // React's rating group; click the 4/5 star.
     const group = page.getByRole('radiogroup', { name: 'React' });
     await expect(group).toBeVisible({ timeout: 10_000 });


### PR DESCRIPTION
## Root cause

The scheduled `e2e-full.yml` run on `main @ 9a4b9e5` (2026-09-07 ~23:15 UTC) failed 10 tests across its 4 shards. Most are already tracked (#2310, #2241 ×2, #2311, #1501, #2181, #2164). This PR fixes the two that were genuine test-side staleness, and files #2316 for the one real, unclear app bug that's left.

### 1. `e2e/skill-rating.spec.ts`
`#2314`/`#2315` (merged as the exact commit this scheduled run tested) replaced `/portal/profile`'s plain `<input name="skills">` with the shared `SkillsField` chip editor (`src/components/ui/SkillsField.tsx`, rendered via `src/components/ProfileForm.tsx`). The test's `page.locator('input[name="skills"]')` no longer matches anything, so `.fill('React')` timed out after 15s.

Fix: use `getByTestId('skills-field-input')` (the chip editor's actual input) and press Enter to commit the chip, matching how the component's `onKeyDown` handler actually works.

### 2. `e2e/account-access-history.spec.ts`
The mentee-side assertion does `signInAsFreshUser(page, ..., '/portal')` immediately followed by `page.goto('/account')`. Per `signInAsFreshUser`'s own doc comment in `e2e/helpers/auth.ts`, it only waits for the URL to match — it does not wait for the client to fully settle. The portal's own post-login redirect was still in flight, so the immediate `goto('/account')` raced it and failed with `Navigation ... interrupted by another navigation to ".../portal"`.

`gotoSettled()` already exists in the same helpers file for exactly this race (its own doc comment describes this precise failure mode) but wasn't used at this call site. Fix: use it.

## Verified locally

Fresh MariaDB 10.11 + `npx prisma db push` + `next dev`, both specs green:

```
✓ e2e/account-access-history.spec.ts:13:5 › a mentee sees who impersonated their account, when and why (58.9s)
✓ e2e/skill-rating.spec.ts:9:5 › mentee sets a skill level with the star rating and it persists (11.2s)
```

`npx tsc --noEmit` and `npm run lint` also clean (lint shows only two pre-existing unrelated warnings).

## Not fixed here

`e2e/goal-templates.spec.ts:23` failed with a strict-mode violation on `getByTestId('new-template-en')` resolving to **two byte-for-byte identical elements** — the entire "new template" form appears to render twice in the live DOM on `/admin/goal-templates`. This looks like the same duplicate-DOM/streaming pattern already tracked in #2241, not a test locator bug, so I filed #2316 rather than guessing at a fix.

The remaining scheduled-run failures were already open issues before this run (#2310, #2241, #2311, #1501, #2181, #2164) — linked in the CI-watchdog report, not duplicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPGFbQ9mY4VhEgqoFGJg87


---
_Generated by [Claude Code](https://claude.ai/code/session_01XPGFbQ9mY4VhEgqoFGJg87)_