### PR TITLE
fix(e2e): settle two more navigation races left by same-day-style redirects

### DIFF
--- a/e2e/interview-request-form.spec.ts
+++ b/e2e/interview-request-form.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect, type Page, type Locator } from '@playwright/test';
 import bcrypt from 'bcryptjs';
 import { prisma, uniqueEmail } from './helpers/db';
+import { gotoSettled } from './helpers/auth';
 import { companyInterestScopeKey } from '@/lib/companyInterests';
 import { interviewActiveKey } from '@/lib/interviewRequests';
 
@@ -145,7 +146,11 @@ test.describe.serial('Interview request form (note + proposed slots)', () => {
     const approved = await page.request.patch(`/api/interview-requests/${pending.id}`, { data: { action: 'approve' } });
     expect(approved.status()).toBe(200);
 
-    await page.goto('/mentor/interview-requests');
+    // login() above only waits for the URL to leave /auth/signin, not for a
+    // full settle (see gotoSettled's doc comment) — the mentor's own
+    // post-login redirect can still be in flight and race this goto
+    // ("interrupted by another navigation").
+    await gotoSettled(page, '/mentor/interview-requests');
     const queue = page.getByTestId('mentor-interview-requests');
     await expect(queue.getByText('Please interview this candidate soon.')).toBeVisible();
     // The one proposed slot from the first test renders under its own heading —

--- a/e2e/sso-roundtrip.spec.ts
+++ b/e2e/sso-roundtrip.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect, type APIRequestContext } from '@playwright/test';
 import crypto from 'crypto';
 import { prisma, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { gotoSettled } from './helpers/auth';
 import { E2E_IDP_MOCK_PORT } from '../playwright.config';
 import { SSO_IMPLEMENTED_PROVIDERS, SSO_OIDC_UNSUPPORTED, validateSsoConfig } from '../src/lib/sso';
 
@@ -299,7 +300,11 @@ test('SAML: a consumed SsoLoginGrant cannot be replayed into a second session', 
     // Second use, from a browser with no session: a leaked or logged grant URL
     // must be inert. Only the session cookie is dropped — a blanket
     // clearCookies() would also drop the seeded cookie-consent state.
-    await page.goto('about:blank');
+    // `/auth/sso/complete` redirects client-side once the session poll above
+    // observes it, so a plain goto here can race that still-in-flight
+    // navigation ("interrupted by another navigation to /portal") — the same
+    // shape gotoSettled exists to absorb elsewhere (see its doc comment).
+    await gotoSettled(page, 'about:blank');
     await page.context().clearCookies({ name: /next-auth\.session-token/ });
     await page.goto(`/auth/sso/complete?token=${token}`);
     await page.waitForURL(/\/(auth\/signin|auth\/error|api\/auth\/error)/, { timeout: 30_000 });


### PR DESCRIPTION
## Root cause

Scheduled `e2e-full.yml` run [34231171198](https://github.com/21072026/Internship/actions/runs/34231171198) (main @ `e110fcd`) failed 14 tests across its 4 shards. Two of them are the same class of test-side bug PR #2317 already fixed twice in this same spec family: a plain `page.goto()` racing a still-in-flight client-side redirect from the action just before it, throwing `Navigation ... interrupted by another navigation`. `gotoSettled()` (`e2e/helpers/auth.ts`) exists for exactly this and just wasn't used at these two call sites:

- **`e2e/sso-roundtrip.spec.ts:302`** — the session-establishing `expect.poll` only waits for `/api/auth/session` to report the new user, not for `/auth/sso/complete`'s own client-side redirect to `/portal` to finish, so the immediate `page.goto('about:blank')` right after it could race that redirect.
- **`e2e/interview-request-form.spec.ts:148`** — this file's local `login()` helper only waits for the URL to leave `/auth/signin` (the same gap `signInAsFreshUser` documents), so the mentor's own post-login redirect could still be in flight when the very next line navigated to `/mentor/interview-requests`.

Both switched to `gotoSettled(page, url)`.

## Verified locally

Fresh MariaDB 10.11 + `npx prisma db push` + `next dev` (this container's usual recipe):

- `e2e/interview-request-form.spec.ts` (all 3 tests in the file, serial): **green on 4 consecutive full-file runs.**
- `e2e/sso-roundtrip.spec.ts --grep "replayed into a second session"`: green every time the test reaches the patched code path.
  - This container also hits an unrelated, **pre-existing** flake earlier in the same test (the *first* session-establishing poll at line 298, before any code this PR touches, occasionally times out — likely this box's single-core resource pressure racing the stub IdP). I confirmed it's not a regression from this change by stashing the diff and re-running unpatched `main`: same intermittent timeout, same line, same symptom. It is also a different symptom than the CI failure this PR targets ("interrupted by another navigation"), which never reproduced locally after the fix.

`npx tsc --noEmit` is clean.

## Not in this PR

The other 12 `e2e-full` failures from this run are already covered by existing open issues — not duplicated here:
- #1465 (`/mentor` German 360px overflow)
- #1497 / #1486 (`/release-notes` + `/projects` footer overflow — same shared-`PublicFooter` root cause)
- #2310 (`/admin/newsletters`, `/admin/api-explorer`, `/projects` German overflow — the other mobile-layout-coverage German failures)
- #2311 (org-less admin API key rejected by `/api/v1` since #1546 — `integrations.spec.ts`, and I've left a comment there since `api-explorer.spec.ts:174` hits the identical 403 for the identical reason)
- #2312 (`portal-insights.spec.ts` / `project-dm.spec.ts` duplicate-DOM strict-mode violations)
- #2241 / #2316 (the wider `loading.tsx`-boundary duplicate-render pattern — I've added a note there that `account-access-history.spec.ts`'s residual flakiness looks like a fifth occurrence, since `/account` also has its own `loading.tsx`)
- #1484 (analytics trend chart data-side regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vnrjk63Wfnj3ua6LN4Q5Yt

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vnrjk63Wfnj3ua6LN4Q5Yt)_