### PR TITLE
ci: release-compact opens an issue when it cannot open its PR (#2323)

### DIFF
--- a/.github/workflows/release-compact.yml
+++ b/.github/workflows/release-compact.yml
@@ -38,6 +38,19 @@ name: Compact release fragments
 # + alert email) naming the branch — a maintainer opens the PR in one click, or
 # any agent session runs `node scripts/release-compact.mjs` and opens it
 # normally.
+#
+# FAILURE TRAIL (#2323). "Fails LOUDLY" above was not loud enough: four
+# scheduled runs in a row pushed a correct branch, failed at the PR step and
+# went unnoticed for three days, because an annotation lives in a run log
+# nobody opens for a workflow that has always been green, and the alert e-mail
+# is separately broken (#2322). So the failure path now also OPENS — or, on the
+# next failed run, UPDATES — a labelled issue naming the branch, the fragment
+# count, the version and the one-click manual step
+# (scripts/release-compact-alert.mjs), and CLOSES it again as soon as a
+# compaction PR exists. Updating rather than duplicating is deliberate: this
+# fires daily, and 30 identical issues would be its own kind of silence.
+# Nothing about the success path changed — the push, the force-push, the
+# arithmetic and the stamping are untouched.
 
 on:
   schedule:
@@ -53,6 +66,11 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
+  # A workflow that is forbidden from opening a pull request can still open an
+  # ISSUE, which is the whole failure trail of #2323 — see the FAILURE TRAIL
+  # note above. This is the default GITHUB_TOKEN's own issues scope; it grants
+  # nothing to any other workflow and needs no secret.
+  issues: write
 
 env:
   # One branch for every compaction, ever. See the header note.
@@ -132,7 +150,14 @@ jobs:
                 --head "$BRANCH" \
                 --title "chore(release): compact fragments into ${VERSION}" \
                 --body "$BODY"; then
-              echo "::error title=Could not open the compaction PR::The branch ${BRANCH} is pushed and correct (${COUNT} fragment(s) -> ${VERSION}), but creating the PR failed. Usual cause: the RELEASE_BOT_TOKEN secret is missing, and this org forbids GITHUB_TOKEN from creating pull requests. Open the PR from ${BRANCH} manually, or add the secret."
+              # The branch is pushed and correct; only the PR is missing. Leave
+              # a trail a person actually encounters — an issue plus the
+              # ::error:: annotation, both naming the branch, the count, the
+              # version and the manual step (#2323). Best effort: if even the
+              # issue cannot be filed, the annotation still goes out and this
+              # step still fails.
+              node scripts/release-compact-alert.mjs stuck \
+                || echo "::error title=Could not open the compaction PR::The branch ${BRANCH} is pushed and correct (${COUNT} fragment(s) -> ${VERSION}), but creating the PR failed and the failure could not be recorded as an issue either. Open the PR from ${BRANCH} manually; see #2323."
               exit 1
             fi
             PR="$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty' || true)"
@@ -142,6 +167,11 @@ jobs:
           # auto-merge enabled must not turn a successful compaction into a
           # failed run.
           if [ -n "$PR" ]; then
+            # A PR exists, so any open "compaction is stuck" alert from an
+            # earlier failed run is answered — close it (#2323). Housekeeping
+            # only: never turn a good compaction into a failed run.
+            PR_NUMBER="$PR" node scripts/release-compact-alert.mjs resolved || true
+
             gh pr merge "$PR" --squash --auto --delete-branch \
               || echo "::warning title=Auto-merge not armed::PR #${PR} is open but auto-merge could not be enabled; merge it manually."
           fi

--- a/releases/README.md
+++ b/releases/README.md
@@ -242,6 +242,30 @@ Two causes, chained — and both are now designed against:
   emails through `scripts/send-alert-email.mjs`, like `e2e-full`, `k6-load`,
   `stress` and `backup-verify`.
 
+It happened again anyway, 2026-09-05..09: four runs pushed a correct branch and
+were refused at `gh pr create` ("GitHub Actions is not permitted to create or
+approve pull requests"), 65 fragments piled up, and nobody noticed for three
+days — the annotation was right but lived in a run log nobody opens, and the
+alert e-mail was itself broken (`ETIMEDOUT` to SMTP from a GitHub runner,
+#2322). So the failure path no longer relies on anyone reading a log (#2323):
+
+- **It opens an issue.** `scripts/release-compact-alert.mjs stuck` opens — or,
+  on the next failed run, **updates in place** — one issue labelled
+  `release-compact-stuck`, naming the branch, the fragment count, the version
+  and a one-click compare link to open the PR from. It updates rather than
+  duplicates because the workflow fires daily, and it comments again only when
+  the count or version actually moved. As soon as a compaction PR exists, the
+  same script (`resolved`) closes the issue. All of it is best effort: if even
+  the issue cannot be filed, the `::error::` annotation still goes out and the
+  run still fails.
+- **It needs no new secret and no new repo permission** beyond `issues: write`
+  on the workflow's own `GITHUB_TOKEN`. Whether Actions may open a *pull
+  request* — the setting, or a `RELEASE_BOT_TOKEN` — stays a maintainer
+  decision, asked in #2323.
+- **`npm run check:release-fragments` names who acts.** Its backlog warning
+  used to end "Not a problem with this PR", which was true and got it skipped
+  by every reviewer; it now points at the maintainer and #2323.
+
 To compact by hand at any time — no secret needed, and the right move if the
 scheduled run is red:
 

--- a/scripts/check-release-fragments.mjs
+++ b/scripts/check-release-fragments.mjs
@@ -17,7 +17,10 @@
 // (disabled, schedule removed, or GitHub suspending cron after 60 days of repo
 // inactivity) — then there is no failed run to alert on, and the only visible
 // trace is the pile itself. Warn, never fail: an infrastructure problem must
-// not block an unrelated PR.
+// not block an unrelated PR. The workflow's own failure path now opens a
+// labelled issue (#2323, scripts/release-compact-alert.mjs), so this warning
+// is the second net, not the only one — and it names who acts, because as
+// "not a problem with this PR" it was correctly read and correctly ignored.
 import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);
 const { resolveRelease } = require('./release-derive.cjs');
@@ -59,12 +62,21 @@ function warnOnStaleBacklog(timeline) {
   if (ageDays > MAX_AGE_DAYS) reasons.push(`the oldest is from ${oldest}, ${ageDays} days ago (> ${MAX_AGE_DAYS})`);
   if (reasons.length === 0) return;
 
+  // "Not a problem with this PR" was the whole message once, and it worked
+  // exactly as written: every reviewer read it, agreed, and moved on for three
+  // days while nothing recorded what shipped (#2323). A warning nobody is
+  // accountable for is a warning nobody acts on — so it now says who acts and
+  // where, and keeps saying it is not this PR's fault to fix in this PR.
   const message =
     `${reasons.join(' and ')}. Compaction runs daily, so this backlog means ` +
     'release-compact.yml is not folding fragments — CHANGELOG.md and ' +
-    'src/lib/releaseNotes.ts have stopped recording what shipped. Check that ' +
-    "workflow's recent runs; releases/README.md -> \"When compaction is stuck\" " +
-    'has the manual recovery. Not a problem with this PR.';
+    'src/lib/releaseNotes.ts have stopped recording what shipped. ' +
+    'WHO ACTS: not this PR and not its reviewer — the maintainer (@mersahin), ' +
+    'in #2323, by opening the pending PR from the bot/release-compact branch ' +
+    'and choosing how Actions is allowed to open it in future. If #2323 is ' +
+    'closed and this still fires, reopen it with a link to this run: something ' +
+    'new is wrong. releases/README.md -> "When compaction is stuck" has the ' +
+    'manual recovery, which any session can run.';
 
   // GitHub Actions annotation when running in CI, plain text otherwise.
   console.log(

--- a/scripts/release-compact-alert.mjs
+++ b/scripts/release-compact-alert.mjs
@@ -1,0 +1,289 @@
+#!/usr/bin/env node
+// The failure trail for release-compact.yml (#2323).
+//
+// WHY THIS EXISTS
+//   Compaction does its job and then cannot deliver it: the branch is pushed
+//   and correct, and `gh pr create` is refused with "GitHub Actions is not
+//   permitted to create or approve pull requests". Four scheduled runs in a
+//   row ended that way and nobody noticed for three days — the workflow did
+//   print a good message, but only inside a log nobody opens, and the alert
+//   e-mail that should have flagged it is separately broken (#2322).
+//
+//   So the trail has to be somewhere a person actually walks past. A workflow
+//   that cannot open a pull request CAN open an issue, with no new secret and
+//   no new permission beyond `issues: write`. That is what this script does:
+//   it opens — or, on the next failed run, UPDATES — one issue carrying the
+//   branch, the fragment count, the version the compaction would ship and the
+//   exact manual step, and it closes that issue again as soon as a compaction
+//   PR exists.
+//
+//   Updating instead of duplicating is the load-bearing part: this workflow
+//   fires daily, so "open an issue on failure" without the lookup would be 30
+//   identical issues in a month — its own kind of silence.
+//
+// WHAT IT DELIBERATELY DOES NOT DO
+//   It does not try to get the PR created. Which credential Actions may use to
+//   open a pull request is a repository permission decision for the
+//   maintainer, asked in #2323; this script only makes the failure impossible
+//   to miss.
+//
+// USAGE (from the workflow; every input is an env var Actions already sets)
+//   node scripts/release-compact-alert.mjs stuck
+//   node scripts/release-compact-alert.mjs resolved
+//
+//   COMPACT_BRANCH  branch that holds the compaction commit
+//   COUNT           fragments folded into it
+//   VERSION         version those fragments ship as
+//   PR_NUMBER       the compaction PR (resolved mode only)
+//   GH_TOKEN        needs `issues: write`. The workflow grants that to its own
+//                   GITHUB_TOKEN; if RELEASE_BOT_TOKEN is set instead and that
+//                   PAT lacks the scope, every gh call here fails and the
+//                   script degrades to the annotation alone — which is also
+//                   the case where PR creation worked and none of this ran.
+//   plus GITHUB_REPOSITORY / GITHUB_SERVER_URL / GITHUB_RUN_ID
+//
+// Pure message/state helpers are exported and unit-tested in
+// scripts/test/release-compact-alert.test.mjs — the text a human reads is the
+// whole point of the script, so it is not left untested inside a YAML file.
+
+import { execFileSync } from 'node:child_process';
+
+/** One issue per outage: found by this label, never by title matching. */
+export const ALERT_LABEL = 'release-compact-stuck';
+
+/** The maintainer decides the repo setting that fixes this for good (#2323).
+ *  Named in the body on purpose: a warning nobody is accountable for is a
+ *  warning nobody acts on. */
+export const MAINTAINER = '@mersahin';
+
+/** Machine-readable tail of the issue body, so a later run can tell whether
+ *  anything actually changed and stay quiet when it did not. */
+const STATE_RE = /<!--\s*release-compact-alert:\s*version=(\S+)\s+count=(\d+)\s*-->/;
+
+/** Read the state a previous run stamped into the issue body. */
+export function parseState(body) {
+  const match = STATE_RE.exec(body || '');
+  if (!match) return null;
+  return { version: match[1], count: Number(match[2]) };
+}
+
+/** Comment only when the situation moved. The body is refreshed every run, but
+ *  a comment is a notification, and a daily "still stuck, same numbers" ping
+ *  is how an alert gets muted. */
+export function shouldComment(previous, current) {
+  if (!previous) return false;
+  return previous.version !== current.version || previous.count !== Number(current.count);
+}
+
+/** URL that opens the pull request the workflow could not open — the whole
+ *  manual step is clicking it and pressing the green button. */
+export function compareUrl({ serverUrl, repo, branch }) {
+  return `${serverUrl}/${repo}/compare/main...${encodeURIComponent(branch)}?expand=1`;
+}
+
+export function buildStuckIssue(ctx) {
+  const { branch, count, version, repo, serverUrl, runUrl } = ctx;
+  const title = `📓 Release compaction is stuck — ${count} fragment(s) waiting on a PR (${version})`;
+  const body = [
+    '`release-compact.yml` folded the pending release fragments and force-pushed them, then could',
+    '**not open the pull request**: GitHub Actions is not permitted to create pull requests in this',
+    'repository.',
+    '',
+    '**Nothing is lost and nothing needs rebuilding** — the branch is correct and current. The only',
+    'missing step is the PR.',
+    '',
+    '| | |',
+    '|---|---|',
+    `| Branch | \`${branch}\` |`,
+    `| Fragments compacted | ${count} |`,
+    `| Version they ship as | \`${version}\` |`,
+    `| Last failed run | ${runUrl} |`,
+    '',
+    '### Open it by hand (this is the whole fix for today)',
+    '',
+    compareUrl({ serverUrl, repo, branch }),
+    '',
+    'Then merge it like any other PR. Every later failed run force-pushes the same branch with an',
+    'up-to-date compaction, so opening it late is never wrong — compaction always folds *everything*',
+    'pending.',
+    '',
+    '### Make it stop happening',
+    '',
+    `That takes a repository setting, and an agent must not change one — ${MAINTAINER} picks between the`,
+    'two options in #2323 (allow Actions to create pull requests, or add a `RELEASE_BOT_TOKEN` secret).',
+    '',
+    '### Why an issue and not just a log line',
+    '',
+    'This failure was invisible for three days: the run log said exactly the right thing, and nobody',
+    'opens a run log for a workflow that has always been green. The alert e-mail that should have',
+    'caught it is separately broken (#2322). This issue is **updated in place** by every failed run',
+    'and **closed automatically** as soon as a compaction PR is open again, so it says one true thing',
+    'at a time.',
+    '',
+    "While it is open, `CHANGELOG.md`, `src/lib/releaseNotes.ts` and `package.json`'s version stop",
+    'recording what shipped. The version the app *displays* stays correct — the build derives it from',
+    'base+fragments (`releases/README.md`).',
+    '',
+    `<!-- release-compact-alert: version=${version} count=${count} -->`,
+  ].join('\n');
+  return { title, body };
+}
+
+/** Single-line `::error::` carrying the same content, so the run summary shows
+ *  it without anyone opening the log. `%0A` is how an annotation gets a line
+ *  break. */
+export function buildAnnotation(ctx) {
+  const { branch, count, version, repo, serverUrl, issueUrl } = ctx;
+  const lines = [
+    `The branch ${branch} is pushed and correct (${count} fragment(s) -> ${version}), but creating the PR failed:`,
+    'GitHub Actions is not permitted to create pull requests in this repository.',
+    `Open it in one click: ${compareUrl({ serverUrl, repo, branch })}`,
+    issueUrl
+      ? `Tracked in ${issueUrl} — that issue closes itself when a compaction PR exists.`
+      : 'Could not record it as an issue either (the token needs issues: write) — see #2323.',
+    `The permanent fix is a repository setting for ${MAINTAINER}, asked in #2323: allow Actions to create PRs, or add RELEASE_BOT_TOKEN.`,
+  ];
+  return `::error title=Release compaction could not open its PR::${lines.join('%0A')}`;
+}
+
+// ── the gh plumbing ─────────────────────────────────────────────────────────
+
+function gh(args) {
+  return execFileSync('gh', args, { encoding: 'utf8' }).trim();
+}
+
+function findOpenAlert(repo) {
+  const raw = gh([
+    'issue',
+    'list',
+    '--repo',
+    repo,
+    '--label',
+    ALERT_LABEL,
+    '--state',
+    'open',
+    '--limit',
+    '1',
+    '--json',
+    'number,body',
+  ]);
+  const [first] = JSON.parse(raw || '[]');
+  return first || null;
+}
+
+function ensureLabel(repo) {
+  try {
+    gh([
+      'label',
+      'create',
+      ALERT_LABEL,
+      '--repo',
+      repo,
+      '--color',
+      'D93F0B',
+      '--description',
+      'release-compact.yml pushed a branch but could not open its PR (#2323)',
+    ]);
+  } catch {
+    // Already exists, or labels are not writable — neither is worth failing on.
+  }
+}
+
+function context() {
+  const repo = process.env.GITHUB_REPOSITORY || '';
+  const serverUrl = process.env.GITHUB_SERVER_URL || 'https://github.com';
+  const runId = process.env.GITHUB_RUN_ID || '';
+  return {
+    repo,
+    serverUrl,
+    runUrl: runId ? `${serverUrl}/${repo}/actions/runs/${runId}` : '(no run id)',
+    branch: process.env.COMPACT_BRANCH || 'bot/release-compact',
+    count: process.env.COUNT || '?',
+    version: process.env.VERSION || '(version not resolved)',
+  };
+}
+
+function reportStuck() {
+  const ctx = context();
+  let issueUrl = null;
+
+  // The annotation must survive a failure in here, so every gh call is
+  // best-effort and the annotation is printed last, with whatever we got.
+  try {
+    ensureLabel(ctx.repo);
+    const { title, body } = buildStuckIssue(ctx);
+    const existing = findOpenAlert(ctx.repo);
+    if (existing) {
+      gh([
+        'issue',
+        'edit',
+        String(existing.number),
+        '--repo',
+        ctx.repo,
+        '--title',
+        title,
+        '--body',
+        body,
+      ]);
+      issueUrl = `${ctx.serverUrl}/${ctx.repo}/issues/${existing.number}`;
+      if (shouldComment(parseState(existing.body), ctx)) {
+        gh([
+          'issue',
+          'comment',
+          String(existing.number),
+          '--repo',
+          ctx.repo,
+          '--body',
+          `Still stuck, and the backlog moved: now ${ctx.count} fragment(s) -> \`${ctx.version}\`. Run: ${ctx.runUrl}`,
+        ]);
+      }
+      console.log(`updated ${issueUrl}`);
+    } else {
+      issueUrl = gh([
+        'issue',
+        'create',
+        '--repo',
+        ctx.repo,
+        '--label',
+        ALERT_LABEL,
+        '--title',
+        title,
+        '--body',
+        body,
+      ]);
+      console.log(`opened ${issueUrl}`);
+    }
+  } catch (error) {
+    console.log(
+      `::warning title=Could not record the compaction failure as an issue::${error.message} — the error annotation below is the only trail this run leaves.`
+    );
+  }
+
+  console.log(buildAnnotation({ ...ctx, issueUrl }));
+}
+
+function reportResolved() {
+  const ctx = context();
+  const pr = process.env.PR_NUMBER || '';
+  try {
+    const existing = findOpenAlert(ctx.repo);
+    if (!existing) return;
+    const note = pr
+      ? `A compaction PR is open again (#${pr}), so this is no longer stuck.`
+      : 'A compaction PR is open again, so this is no longer stuck.';
+    gh(['issue', 'close', String(existing.number), '--repo', ctx.repo, '--comment', note]);
+    console.log(`closed #${existing.number} (${ALERT_LABEL})`);
+  } catch (error) {
+    // A stale open alert is untidy, not broken; never fail a good compaction
+    // over housekeeping.
+    console.log(`::warning title=Could not close the stale compaction alert::${error.message}`);
+  }
+}
+
+const [mode] = process.argv.slice(2);
+if (mode === 'stuck') reportStuck();
+else if (mode === 'resolved') reportResolved();
+else if (mode) {
+  console.error(`unknown mode "${mode}" — expected "stuck" or "resolved"`);
+  process.exit(2);
+}

--- a/scripts/test/release-compact-alert.test.mjs
+++ b/scripts/test/release-compact-alert.test.mjs
@@ -1,0 +1,114 @@
+// Regression tests for the compaction failure trail (#2323).
+//
+// WHY THIS EXISTS
+//   The only thing this code produces is text a person has to be able to act
+//   on, and the run that produces it happens once a day at 04:45 UTC with
+//   nobody watching. Four failed runs in a row went unnoticed for three days
+//   because the message existed but nowhere anyone looked; the replacement is
+//   an issue that must carry the branch, the count, the version and the manual
+//   step — and must NOT re-notify daily while nothing changes, or it becomes
+//   the same kind of noise from the other direction.
+//
+//   Both of those are asserted here, because the alternative is finding out at
+//   the next outage.
+//
+// USAGE
+//   node --test scripts/test/release-compact-alert.test.mjs
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  ALERT_LABEL,
+  MAINTAINER,
+  buildAnnotation,
+  buildStuckIssue,
+  compareUrl,
+  parseState,
+  shouldComment,
+} from '../release-compact-alert.mjs';
+
+const ctx = {
+  branch: 'bot/release-compact',
+  count: '65',
+  version: '0.181.0-beta',
+  repo: '21072026/Internship',
+  serverUrl: 'https://github.com',
+  runUrl: 'https://github.com/21072026/Internship/actions/runs/34333371629',
+};
+
+test('the issue names the branch, the count and the version', () => {
+  const { title, body } = buildStuckIssue(ctx);
+  assert.match(title, /65 fragment/);
+  assert.match(title, /0\.181\.0-beta/);
+  assert.match(body, /bot\/release-compact/);
+  assert.match(body, /\| Fragments compacted \| 65 \|/);
+  assert.match(body, /0\.181\.0-beta/);
+  assert.match(body, /actions\/runs\/34333371629/);
+});
+
+test('the issue carries the one-click manual step and says who owns the real fix', () => {
+  const { body } = buildStuckIssue(ctx);
+  assert.match(body, /compare\/main\.\.\.bot%2Frelease-compact\?expand=1/);
+  assert.ok(body.includes(MAINTAINER), 'the body must name who decides the repo setting');
+  assert.match(body, /#2323/);
+  assert.match(body, /RELEASE_BOT_TOKEN/);
+});
+
+test('the branch name is URL-escaped in the compare link', () => {
+  // A raw slash in the compare target 404s; every branch here has one.
+  assert.equal(
+    compareUrl(ctx),
+    'https://github.com/21072026/Internship/compare/main...bot%2Frelease-compact?expand=1'
+  );
+});
+
+test('the body stamps a state a later run can read back', () => {
+  const { body } = buildStuckIssue(ctx);
+  assert.deepEqual(parseState(body), { version: '0.181.0-beta', count: 65 });
+});
+
+test('parseState survives a body a human edited or wrote by hand', () => {
+  assert.equal(parseState('someone rewrote this issue entirely'), null);
+  assert.equal(parseState(''), null);
+  assert.equal(parseState(undefined), null);
+});
+
+test('an unchanged backlog does not comment again', () => {
+  // The daily re-run is the common case: refresh the body, stay silent.
+  const previous = parseState(buildStuckIssue(ctx).body);
+  assert.equal(shouldComment(previous, ctx), false);
+});
+
+test('a moved backlog comments once', () => {
+  const previous = parseState(buildStuckIssue(ctx).body);
+  assert.equal(shouldComment(previous, { ...ctx, count: '66' }), true);
+  assert.equal(shouldComment(previous, { ...ctx, version: '0.182.0-beta' }), true);
+});
+
+test('a first failure does not comment — the issue body already says it', () => {
+  assert.equal(shouldComment(null, ctx), false);
+});
+
+test('the annotation repeats the whole story on one line', () => {
+  const line = buildAnnotation({ ...ctx, issueUrl: 'https://github.com/21072026/Internship/issues/2400' });
+  assert.ok(line.startsWith('::error title='), 'must be an error annotation, not a notice');
+  assert.equal(line.includes('\n'), false, 'a multi-line annotation is truncated by Actions');
+  assert.match(line, /bot\/release-compact/);
+  assert.match(line, /65 fragment/);
+  assert.match(line, /0\.181\.0-beta/);
+  assert.match(line, /issues\/2400/);
+  assert.match(line, /#2323/);
+});
+
+test('the annotation still stands on its own when the issue could not be filed', () => {
+  const line = buildAnnotation({ ...ctx, issueUrl: null });
+  assert.match(line, /issues: write/);
+  assert.match(line, /compare\/main/);
+  assert.match(line, /#2323/);
+});
+
+test('the alert label is a fixed string', () => {
+  // The workflow finds its own issue by this label; renaming it silently
+  // orphans the open alert and starts duplicating.
+  assert.equal(ALERT_LABEL, 'release-compact-stuck');
+});


### PR DESCRIPTION
## Summary

Four scheduled `release-compact.yml` runs in a row did the work and could not deliver it: each force-pushed a correct `bot/release-compact`, was refused at `gh pr create` ("GitHub Actions is not permitted to create or approve pull requests"), and stopped there. Nobody noticed for three days — 65 fragments piled up while `CHANGELOG.md`, `src/lib/releaseNotes.ts` and `package.json`'s version stopped recording what shipped. The workflow *did* print the right message; it printed it into a run log nobody opens for a workflow that has always been green, and the alert e-mail that should have flagged it is separately broken (#2322).

This closes that loop without touching the repository's permission surface. **A workflow that cannot open a pull request can still open an issue** — no new secret, and no permission beyond `issues: write` on the workflow's own `GITHUB_TOKEN`.

Refs #2323 — deliberately **not** `Closes`. The issue's actual ask is a repository setting (allow Actions to create PRs, or add a `RELEASE_BOT_TOKEN` secret), which is the maintainer's decision and explicitly out of scope for an agent. That ask must stay open after this merges. What this PR delivers is the "What code CAN do, and should" section of the issue; tick those three boxes and the remaining one is yours.

## Changes

- **`scripts/release-compact-alert.mjs` (new)** — the failure trail.
  - `stuck` mode: opens, or **updates in place**, one issue labelled `release-compact-stuck` naming the branch, the fragment count, the version those fragments ship as, the failed run, and a one-click `compare/main...bot/release-compact?expand=1` link — the entire manual step is clicking it and pressing the green button.
  - Updating rather than duplicating is the load-bearing part: this fires **daily**, so "open an issue on failure" without the lookup is 30 identical issues in a month, which is its own kind of silence. It also **comments only when the situation moved** (count or version changed) — a daily "still stuck, same numbers" notification is how an alert gets muted.
  - `resolved` mode: **closes** that issue as soon as a compaction PR exists, so it never sits open lying about the current state.
  - Every `gh` call is best effort. If the issue cannot be filed at all (a PAT without `issues: write`, `gh` missing), the `::error::` annotation still goes out and the step still fails.
- **`::error::` annotation** — same content on one line (`%0A` breaks), so the run summary carries the branch, the count, the version, the compare link, the tracking issue and who fixes it permanently, without opening the log.
- **`.github/workflows/release-compact.yml`** — `issues: write`, the two script calls, and a `FAILURE TRAIL` header note. The **success path is untouched**: the push, the force-push, the fragment arithmetic and the stamping are byte-for-byte what they were.
- **`scripts/test/release-compact-alert.test.mjs` (new, 11 assertions)** — the only thing this code produces is text somebody has to act on, generated once a day at 04:45 UTC with nobody watching, so it is not left untested inside a YAML file: the issue names branch/count/version, carries the manual step and the accountable person, the compare link URL-escapes the branch's slash, an unchanged backlog does not comment, a moved one does, and the annotation is single-line and stands alone when the issue could not be filed. Picked up by `npm run test:unit` / `test:unit:coverage` via the existing `scripts/test/*.test.mjs` glob — no new CI step.
- **`scripts/check-release-fragments.mjs`** — the backlog warning ended *"Not a problem with this PR"*, which was accurate and got it correctly skipped by every reviewer across a whole session. It now says **who acts** (the maintainer, in #2323), **what the action is** (open the pending PR from `bot/release-compact`, then choose how Actions may open it in future), and what to do if #2323 is already closed and it still fires. Still warn-never-fail.
- **`releases/README.md`** — "When compaction is stuck" documents the new trail and the 2026-09-05..09 recurrence.

### Does the warning change belong here?

Yes, here — asked in the brief, so stating the reasoning: it is the same failure loop and about ten lines of text, and splitting it would put the "who is accountable" half of one fix behind a second review. It changes no behaviour and no exit code; the warning still cannot fail a PR.

## Verification

Static only — no database and no Docker in this container, so the app and Playwright cannot run. This change has no runtime surface (a workflow, two scripts, one doc).

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (pre-existing `react-hooks/exhaustive-deps` warnings only, untouched files)
- [x] `npm run build` passes
- [x] `npm run check:i18n` — 4777 keys × 3 locales (no new strings: nothing here is user-facing)
- [x] `npm run check:stage-keys` — no new hardcoded key
- [x] `npm run check:release-fragments` — well-formed, and the reworded backlog warning verified in its output
- [x] `npm run test:unit:coverage` — all suites pass, no floor breached
- [x] `node --test scripts/test/release-compact-alert.test.mjs` — 11/11
- [x] YAML re-parsed with `js-yaml` and the changed step's shell body checked with `bash -n`
- [x] Both script modes exercised end-to-end against a stubbed `gh`: first failure (creates), repeat failure with identical numbers (edits, **no** comment), repeat failure with a moved backlog (edits **and** comments once), resolved with an alert open (closes), resolved with none (silent), `gh` absent (warning + annotation, exit 0 so the workflow's own `exit 1` is what fails the run)

**No release fragment**: CI plumbing with no user-visible surface — nothing to put in `/release-notes` or the changelog. No i18n keys and no schema change for the same reason.

Preview: https://pr2329.interncrm.com

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qTSgQDDVBYo6gXf8xpsnR
