### PR TITLE
Fix iOS Safari zoom on message input (16px font)

### DIFF
--- a/src/components/ui/Textarea.tsx
+++ b/src/components/ui/Textarea.tsx
@@ -74,7 +74,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
           // bottom-right, so without extra bottom padding the last line of text
           // runs underneath it — worst exactly when the field is nearly full,
           // which is when the counter matters most.
-          className={`w-full rounded-lg border border-gray-300 px-3 py-2 text-sm placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100 dark:placeholder:text-gray-500 dark:focus:border-blue-400 dark:focus:ring-blue-400 ${
+          className={`w-full rounded-lg border border-gray-300 px-3 py-2 text-base sm:text-sm placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100 dark:placeholder:text-gray-500 dark:focus:border-blue-400 dark:focus:ring-blue-400 ${
             shouldShowCounter ? 'pb-7' : ''
           } ${counter?.isOverLimit ? 'border-red-500 focus:border-red-500 focus:ring-red-500' : ''} ${className}`}
           {...props}


### PR DESCRIPTION
## Summary

<!-- What does this change and why? -->

Mesajlaşma ekranındaki yazı kutusunun font boyutu (text-sm, 14px) iOS Safari'de
klavye açıldığında otomatik zoom tetikliyordu, bu da mobilde ekran düzeninin
bozulmasına (üstteki mesajların aşırı büyümesi, boş alan oluşması) neden oluyordu.

Closes #

## Changes

-- `src/components/ui/Textarea.tsx`: font boyutu `text-sm` → `text-base sm:text-sm`
  (mobilde 16px, masaüstünde eski 14px korunuyor — iOS Safari'nin 16px altı
  input'larda tetiklediği otomatik zoom önleniyor)

## Verification

- [ ] `npm run lint` + `npx tsc --noEmit` clean
- [ ] `npm run test:e2e` passing (or CI green)
- [ ] Tested the change manually / added an e2e test

## Contributor terms

- [ ] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip):
      my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it
      passes to the rights holder (Mehmet Erşahin) who may also license it commercially,
      it is my own work, and I make no claim over the application.
