### PR TITLE
feat(vertical): host'a göre landing — tek deployment, iki ürün (#2355)

### DIFF
--- a/e2e/host-vertical-landing.spec.ts
+++ b/e2e/host-vertical-landing.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+
+// Host → vertical landing (#2355, epic #2348). Two urls serve two products'
+// landing copy from one deployment: interncrm.com (default) shows the internship
+// hero, marketing.ersah.in the marketing one. The signal on a public, sessionless
+// page is the request host (x-forwarded-host, set by the reverse proxy). The
+// default MARKETING_HOSTS is 'marketing.ersah.in', so forging that header routes
+// the marketing overlay without any env change.
+
+test('the default host shows the internship hero — a no-op for the current product', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByText('Companies that want experience', { exact: false })).toBeVisible();
+  // The marketing pitch is absent.
+  await expect(page.getByText('Every lead, every conversation', { exact: false })).toHaveCount(0);
+});
+
+test('the marketing host shows the marketing hero', async ({ page }) => {
+  await page.setExtraHTTPHeaders({ 'x-forwarded-host': 'marketing.ersah.in' });
+  await page.goto('/');
+  await expect(page.getByText('Every lead, every conversation', { exact: false })).toBeVisible();
+  await expect(page.getByText('Marketing CRM · Track leads', { exact: false })).toBeVisible();
+  // The internship hero is gone.
+  await expect(page.getByText('Companies that want experience', { exact: false })).toHaveCount(0);
+});
+
+test('an unknown host falls back to the internship hero, never a blank one', async ({ page }) => {
+  await page.setExtraHTTPHeaders({ 'x-forwarded-host': 'random.example.com' });
+  await page.goto('/');
+  await expect(page.getByText('Companies that want experience', { exact: false })).toBeVisible();
+});

--- a/releases/unreleased/host-vertical-landing.json
+++ b/releases/unreleased/host-vertical-landing.json
@@ -1,0 +1,9 @@
+{
+  "bump": "minor",
+  "changelog": "- **Two urls serve two products' landing from one deployment** (#2355, epic #2348). A public, sessionless page (the landing, `/apply`, `/for-companies`) has no organization to read a vertical from, so its vertical now comes from the request host: `src/lib/hostVertical.ts` maps the `X-Forwarded-Host` (or `Host`) header to a vertical — `marketing.ersah.in` (configurable via `MARKETING_HOSTS`, comma-separated) resolves to MARKETING, everything else to INTERNSHIP — and `resolveRequestVertical()` falls back to it when there is no session, so the terminology overlay (#2354) dresses the whole public surface per host. The landing overlay gives the marketing host its own hero, badge and value proposition in EN/TR/DE (`Every lead, every conversation, every deal — in one pipeline`), while the default host is byte-identical to today. An unknown host resolves to INTERNSHIP, never a blank product. This is the code half of serving marketing.ersah.in from the new deployment; the DNS/proxy cutover of that live domain is a separate, deliberate infra step.",
+  "notes": {
+    "en": ["Visiting the marketing address now shows a marketing landing page — its own headline and pitch — while the internship address is unchanged."],
+    "tr": ["Pazarlama adresini ziyaret etmek artık pazarlama landing sayfasını gösteriyor — kendi başlığı ve sunumuyla — staj adresi ise değişmedi."],
+    "de": ["Der Besuch der Marketing-Adresse zeigt jetzt eine Marketing-Landingpage — mit eigener Überschrift und eigenem Pitch — während die Praktikums-Adresse unverändert bleibt."]
+  }
+}

--- a/src/i18n/server.ts
+++ b/src/i18n/server.ts
@@ -50,14 +50,20 @@ export async function resolveRequestVertical(): Promise<VerticalKey> {
   if (!(await hasSessionCookie())) return hostVertical();
   try {
     const session = await getServerSession(authOptions);
-    if (!session?.user?.id) return DEFAULT_VERTICAL;
+    // No VALID identity (a stale/expired/revoked cookie decodes to no user) is
+    // still "signed out" for this purpose, so the vertical is a host signal —
+    // otherwise a marketing-host visitor with a leftover cookie sees the
+    // internship landing (#2355 review).
+    if (!session?.user?.id) return hostVertical();
     const user = await prisma.user.findUnique({
       where: { id: session.user.id },
       select: { org: { select: { vertical: true } } },
     });
     return toVerticalKey(user?.org?.vertical);
   } catch {
-    return DEFAULT_VERTICAL;
+    // A transient session/DB error is not a reason to override the host's
+    // product with the default one; fall back to the host signal.
+    return hostVertical();
   }
 }
 

--- a/src/i18n/server.ts
+++ b/src/i18n/server.ts
@@ -6,7 +6,7 @@ import { hasSessionCookie } from '@/lib/sessionCookie';
 import { defaultLocale, isLocale, LOCALE_COOKIE, type Locale } from './config';
 import { getDictionary } from './dictionaries';
 import { applyVerticalOverlay } from './verticalOverlays';
-import { toVerticalKey, DEFAULT_VERTICAL, type VerticalKey } from '@/lib/verticals';
+import { toVerticalKey, type VerticalKey } from '@/lib/verticals';
 import { hostVertical } from '@/lib/hostVertical';
 
 // Read the active locale. An explicit cookie (set via the language switcher)

--- a/src/i18n/server.ts
+++ b/src/i18n/server.ts
@@ -7,6 +7,7 @@ import { defaultLocale, isLocale, LOCALE_COOKIE, type Locale } from './config';
 import { getDictionary } from './dictionaries';
 import { applyVerticalOverlay } from './verticalOverlays';
 import { toVerticalKey, DEFAULT_VERTICAL, type VerticalKey } from '@/lib/verticals';
+import { hostVertical } from '@/lib/hostVertical';
 
 // Read the active locale. An explicit cookie (set via the language switcher)
 // always wins; otherwise fall back to the signed-in user's saved preference,
@@ -43,7 +44,10 @@ export async function getLocale(): Promise<Locale> {
 // present — a public view resolves to the default with no query, so the overlay
 // layer costs the live single-tenant product nothing (#1197).
 export async function resolveRequestVertical(): Promise<VerticalKey> {
-  if (!(await hasSessionCookie())) return DEFAULT_VERTICAL;
+  // Signed OUT (a public page — the landing, /apply, /for-companies): the only
+  // signal is the request host, so two urls serve two products' copy from one
+  // deployment (#2355). No query.
+  if (!(await hasSessionCookie())) return hostVertical();
   try {
     const session = await getServerSession(authOptions);
     if (!session?.user?.id) return DEFAULT_VERTICAL;

--- a/src/i18n/verticalOverlays.ts
+++ b/src/i18n/verticalOverlays.ts
@@ -45,14 +45,38 @@ const OVERLAYS: Record<VerticalKey, Record<Locale, LocaleOverlay>> = {
     en: {
       nav: { candidates: 'Leads' },
       candidates: { title: 'Leads', subtitle: 'Browse and search leads' },
+      landing: {
+        badge: 'Marketing CRM · Track leads · Close deals',
+        heroTitle: 'Every lead, every conversation, every deal —',
+        heroAccent: 'in one pipeline.',
+        heroSubtitle: 'Track your customers from first contact to close. See where every deal stands, who touched it last and what to do next — instead of piecing it together from a spreadsheet.',
+        featuresTitle: 'Everything your team needs to close',
+        featuresSubtitle: 'Purpose-built for tracking customers and moving deals forward.',
+      },
     },
     tr: {
       nav: { candidates: 'Fırsatlar' },
       candidates: { title: 'Fırsatlar', subtitle: 'Fırsatları görüntüle ve ara' },
+      landing: {
+        badge: 'Pazarlama CRM · Adayları takip et · Anlaşmaları kapat',
+        heroTitle: 'Her aday, her görüşme, her anlaşma —',
+        heroAccent: 'tek bir hatta.',
+        heroSubtitle: 'Müşterilerini ilk temastan kapanışa kadar takip et. Her anlaşmanın nerede olduğunu, en son kimin dokunduğunu ve sıradaki adımı — tabloda parça parça aramak yerine — tek bakışta gör.',
+        featuresTitle: 'Kapatmak için ekibinin ihtiyacı olan her şey',
+        featuresSubtitle: 'Müşterileri takip etmek ve anlaşmaları ilerletmek için tasarlandı.',
+      },
     },
     de: {
       nav: { candidates: 'Leads' },
       candidates: { title: 'Leads', subtitle: 'Leads durchsuchen' },
+      landing: {
+        badge: 'Marketing-CRM · Leads verfolgen · Abschlüsse erzielen',
+        heroTitle: 'Jeder Lead, jedes Gespräch, jeder Abschluss —',
+        heroAccent: 'in einer Pipeline.',
+        heroSubtitle: 'Verfolgen Sie Ihre Kunden vom ersten Kontakt bis zum Abschluss. Sehen Sie auf einen Blick, wo jeder Deal steht, wer ihn zuletzt bearbeitet hat und was als Nächstes zu tun ist — statt es aus einer Tabelle zusammenzusuchen.',
+        featuresTitle: 'Alles, was Ihr Team zum Abschluss braucht',
+        featuresSubtitle: 'Entwickelt, um Kunden zu verfolgen und Deals voranzutreiben.',
+      },
     },
   },
 };

--- a/src/lib/hostVertical.ts
+++ b/src/lib/hostVertical.ts
@@ -1,0 +1,59 @@
+// Host → vertical resolution for PUBLIC pages (#2355, epic #2348).
+//
+// A signed-in user's vertical comes from their organization (verticalContext).
+// But the landing page and every other public page has no session, and the whole
+// point of #2355 is that TWO urls serve TWO products from ONE deployment:
+// interncrm.com shows the internship landing, marketing.ersah.in the marketing
+// one. The only per-request signal a public page has is the Host header, so that
+// is what decides the vertical there.
+//
+// Kept as a tiny, env-driven map rather than hard-coded hostnames: the marketing
+// host is deployment configuration (it differs between prod, preview and a
+// developer's machine), so it reads from MARKETING_HOSTS — a comma-separated
+// list — and everything else, including a missing header, falls back to the
+// default product. A host we do not recognise is INTERNSHIP, never a blank
+// product, mirroring toVerticalKey's total-function contract.
+
+import { headers } from 'next/headers';
+import { DEFAULT_VERTICAL, type VerticalKey } from '@/lib/verticals';
+
+// The hosts that serve the MARKETING landing. Comma-separated, matched on the
+// hostname only (port and case ignored). Defaults to the known marketing domain
+// so a deployment that sets nothing still routes it correctly.
+function marketingHosts(): Set<string> {
+  const raw = process.env.MARKETING_HOSTS ?? 'marketing.ersah.in';
+  return new Set(
+    raw
+      .split(',')
+      .map((h) => h.trim().toLowerCase())
+      .filter(Boolean),
+  );
+}
+
+// Normalise a Host / X-Forwarded-Host value to a bare lowercase hostname.
+export function hostnameOf(hostHeader: string | null | undefined): string | null {
+  if (!hostHeader) return null;
+  // X-Forwarded-Host can carry a list (proxy chain); the first is the client's.
+  const first = hostHeader.split(',')[0].trim().toLowerCase();
+  // Strip a port if present. IPv6 in brackets has none we care about here.
+  return first.replace(/:\d+$/, '') || null;
+}
+
+// The vertical a given host serves. Pure, so it is unit-testable without the
+// request headers.
+export function verticalForHost(hostHeader: string | null | undefined): VerticalKey {
+  const host = hostnameOf(hostHeader);
+  if (host && marketingHosts().has(host)) return 'MARKETING';
+  return DEFAULT_VERTICAL;
+}
+
+// The vertical for the current request's host. Reads X-Forwarded-Host (set by
+// the reverse proxy) first, then Host. Any failure resolves to the default.
+export async function hostVertical(): Promise<VerticalKey> {
+  try {
+    const h = await headers();
+    return verticalForHost(h.get('x-forwarded-host') ?? h.get('host'));
+  } catch {
+    return DEFAULT_VERTICAL;
+  }
+}

--- a/src/lib/hostVertical.ts
+++ b/src/lib/hostVertical.ts
@@ -47,8 +47,19 @@ export function verticalForHost(hostHeader: string | null | undefined): Vertical
   return DEFAULT_VERTICAL;
 }
 
-// The vertical for the current request's host. Reads X-Forwarded-Host (set by
-// the reverse proxy) first, then Host. Any failure resolves to the default.
+// The vertical for the current request's host. Reads X-Forwarded-Host first,
+// then Host; any failure resolves to the default.
+//
+// TRUST NOTE: on the Caddy front (prod) reverse_proxy overwrites X-Forwarded-Host
+// with the real host, so it is authoritative there. On the nginx/Plesk topic
+// path it is NOT stripped, so a client could forge it. That is acceptable ONLY
+// because the resolved vertical is COSMETIC here — it drives the terminology
+// overlay (landing copy, the "Candidates"→"Leads" label) and nothing else: a
+// forged header just shows the forger marketing copy on their own request, with
+// no authz, data-scope or cache consequence (capability/tenant decisions read
+// the SESSION's org, never this host). If a vertical ever gains authz weight,
+// host resolution MUST move to a signal the proxy is trusted to set (or a
+// server-side host allow-list keyed off the TLS SNI), not this header.
 export async function hostVertical(): Promise<VerticalKey> {
   try {
     const h = await headers();


### PR DESCRIPTION
Closes #2355 · Epic #2348

## Ne

**İki URL, iki ürün, tek deployment.** Public/oturumsuz bir sayfanın dikeyini okuyacağı org yok — artık **istek host'undan** geliyor.

- `src/lib/hostVertical.ts` — `X-Forwarded-Host`/`Host`'u dikeye eşler: `marketing.ersah.in` → MARKETING (env `MARKETING_HOSTS` ile yapılandırılır), gerisi → INTERNSHIP. Bilinmeyen host → INTERNSHIP (asla boş ürün).
- `resolveRequestVertical()` oturum yokken host'a düşer → terminoloji overlay'i (#2354) **tüm public yüzeyi** host'a göre giydiriyor.
- Landing overlay marketing host'una kendi hero/badge/değer önermesini **EN/TR/DE** veriyor.

## Neden no-op (bugün)

Varsayılan host → landing bit-bit aynı. Bir e2e tam bunu doğruluyor.

## Doğrulama

| kontrol | sonuç |
|---|---|
| e2e `host-vertical-landing` (yeni, 3 test) | ✅ varsayılan host → internship hero · `marketing.ersah.in` → marketing hero · bilinmeyen host → güvenli fallback |
| `check:i18n` | ✅ landing overlay anahtarları base'de doğrulandı |
| `check:schema-push` / `check:tenant-models` · `lint` · `tsc` | ✅ |
| `check:release-fragments` (`0.197.0-beta`) | ✅ |

## ⚠️ Bu KOD yarısı — altyapı kesmesi senin onayınla

`marketing.ersah.in` şu an **eski kutuyu** (212.132.111.125) gösteriyor ve orada canlı SaleVali app'i var. Bu PR yeni deployment'ın host'u doğru işlemesini sağlıyor ama **DNS henüz yeni kutuya bakmıyor**. Canlı domaini kesmek (DNS A kaydı + Caddy site + wildcard-dışı sertifika/`*.ersah.in`) dışa-dönük, geri dönüşü zor bir adım — **onayın olmadan yapmayacağım**. Onay verirsen sıra: (1) yeni kutuda Caddy `marketing.ersah.in` site + DNS-01 sertifika (acme.sh'ta CF token var), (2) Cloudflare A kaydını yeni kutuya çevir, (3) eski kutuda SaleVali'yi emekliye ayır.

## Kapsam dışı (overlay büyür)

Landing'in feature kartları hâlâ internship kataloğundan (`getFeatures()`); marketing feature seti + `/apply`,`/for-companies` public sayfalarının marketing kopyası overlay'in sonraki turları. Bu PR mekanizmayı + marketing hero'yu getiriyor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
