### PR TITLE
fix(e2e): stop tripping on the /messages Suspense-streamed duplicate

### DIFF
--- a/e2e/project-dm.spec.ts
+++ b/e2e/project-dm.spec.ts
@@ -45,7 +45,15 @@ test('project co-members can start a DM, and lose the composer when the project 
     await page.goto('/messages');
 
     // The co-member is offered as a "new chat" candidate.
-    await page.getByTestId('new-chat-toggle').click();
+    // Next's streaming SSR (loading.tsx wraps this route in a Suspense
+    // boundary) can briefly — and, per the live-refresh listener above,
+    // repeatedly — land a second copy of this button at the end of <body>
+    // before relocating it into #main-content, so a bare getByTestId() can hit
+    // a strict-mode violation more than once in a row. `.first()` sidesteps it:
+    // in document order the real, in-place copy always comes before the
+    // transient one appended to <body>, and the page never actually shows two.
+    const toggle = page.getByTestId('new-chat-toggle').first();
+    await toggle.click();
     const candidate = page.getByTestId('new-chat-candidate').filter({ hasText: 'Peer Bravo' });
     await expect(candidate).toBeVisible({ timeout: 10_000 });
     await candidate.click();
@@ -70,9 +78,11 @@ test('project co-members can start a DM, and lose the composer when the project 
     expect(stored).not.toBeNull();
     expect(stored!.relationId).toBeNull();
 
-    // Back in the inbox the DM now appears as a thread.
+    // Back in the inbox the DM now appears as a thread. Same streaming
+    // duplicate as the toggle above, and `.first()` for the same reason —
+    // `toBeVisible()` alone can hit the ambiguity again on almost every retry.
     await page.goto('/messages');
-    await expect(page.locator('a[href^="/messages/c/"]').filter({ hasText: 'Peer Bravo' })).toBeVisible({
+    await expect(page.locator('a[href^="/messages/c/"]').filter({ hasText: 'Peer Bravo' }).first()).toBeVisible({
       timeout: 10_000,
     });
 

--- a/e2e/support-chat.spec.ts
+++ b/e2e/support-chat.spec.ts
@@ -27,8 +27,15 @@ test('support chat: first message opens a ticket, next one appends, admin is not
 
     // The pinned Support entry is always present in the inbox.
     await page.goto('/messages');
-    await expect(page.getByTestId('support-entry')).toBeVisible({ timeout: 10_000 });
-    await page.getByTestId('support-entry').click();
+    // /messages is wrapped in a loading.tsx Suspense boundary, whose streamed
+    // content can briefly (and, per MessagesLiveRefresh, repeatedly) land a
+    // second copy of the inbox at the end of <body> before React relocates it
+    // into #main-content — the page never actually shows two. `.first()` picks
+    // the real, in-place copy (it's first in document order) instead of
+    // tripping strict mode on the transient one (#2241).
+    const supportEntry = page.getByTestId('support-entry').first();
+    await expect(supportEntry).toBeVisible({ timeout: 10_000 });
+    await supportEntry.click();
     await page.waitForURL((u) => u.pathname === '/messages/support', { timeout: 10_000 });
     await expect(page.getByTestId('support-chat')).toBeVisible({ timeout: 10_000 });
 


### PR DESCRIPTION
## Summary

CI-watchdog fix for the e2e-full red on run [34603036357](https://github.com/21072026/Internship/actions/runs/34603036357) — `project-dm.spec.ts:23` and `support-chat.spec.ts:12` both hit a strict-mode `getByTestId(...)` violation ("resolved to 2 elements") right after navigating to `/messages`.

Root cause, confirmed by local reproduction (not guessed): `/messages` is wrapped in a `loading.tsx` Suspense boundary. React's streaming SSR briefly lands its server-streamed content at the end of `<body>` (inside a `div#S:0`-style placeholder) before relocating it into `#main-content` a beat later — during that window the same button/link exists twice in the live DOM. `MessagesLiveRefresh`'s `router.refresh()` can retrigger this more than once for the same page load, so even `expect(locator).toBeVisible()`'s auto-retry can keep landing inside an open window and time out. The page itself never shows two — this is a client-side relocation artifact, not a rendering bug.

This matches (and confirms) the working hypothesis already written up in #2241.

Closes #2241

## Changes

- `e2e/project-dm.spec.ts`: `.first()` on the `new-chat-toggle` click and the "thread appears in the inbox" assertion.
- `e2e/support-chat.spec.ts`: `.first()` on the `support-entry` click.

`.first()` is safe here (not papering over a real future duplication bug): in document order the real, in-place copy is always emitted before the transient one appended to `<body>`, confirmed by walking the DOM tree at multiple points during the race in a local repro script.

## Verification

- [x] `npx tsc --noEmit` clean
- [x] Reproduced both failures locally against `origin/main` HEAD (`206d787`) with a from-scratch local stack (MariaDB via apt, `npx prisma db push` + seed, `npm run build && npm run start`, Playwright with the pinned Chromium build symlinked from `/opt/pw-browsers`) — both specs failed 100% of the time (3-5 runs each) without this change, in exactly the shape CI reported.
- [x] Both specs pass 5/5 local runs with the fix applied, on the same stack.
- [ ] `npm run test:e2e` full suite — not run locally (time/resource budget); relying on CI (this spec is not `@smoke`, so it only runs in the scheduled full suite / on this PR's own workflow if configured).
- Not a `next lint` regression: `e2e/` is outside `next lint`'s scope (`src/` only), unaffected either way.

No `releases/unreleased/` fragment: pure test-file fix, no user-visible or app-code change (see `releases/README.md`).

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip): my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it passes to the rights holder (Mehmet Erşahin) who may also license it commercially, it is my own work, and I make no claim over the application.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Y7wuKNUfsYGw8fDou8UMM

---
_Generated by [Claude Code](https://claude.ai/code/session_014Y7wuKNUfsYGw8fDou8UMM)_