### PR TITLE
fix(e2e): back the free-room group conversation with a project

### DIFF
--- a/e2e/instant-meeting-team.spec.ts
+++ b/e2e/instant-meeting-team.spec.ts
@@ -146,10 +146,29 @@ test('a group call on the free room says so before anyone joins', async ({ page 
   const starter = await seedUser(starterEmail, 'MentorPass123', 'MENTOR', 'Warn Starter');
   const one = await seedUser(uniqueEmail('warn-one'), 'x', 'MENTEE', 'Warn One');
   const two = await seedUser(uniqueEmail('warn-two'), 'x', 'MENTEE', 'Warn Two');
-  // Three people, so the room is a group room and not a pair.
+  // Three people, so the room is a group room and not a pair. A GROUP
+  // conversation is only ever a project's room in this app — getConversationIfAllowed()
+  // (src/lib/conversations.ts) refuses one with no `projectId` outright, for
+  // anyone — so a bare ad-hoc group here 403s the thread fetch before the page
+  // renders anything, including the start-meeting button this test clicks.
+  const project = await prisma.project.create({
+    data: {
+      name: 'Instant Team Free Room Project',
+      ownerType: 'MENTOR',
+      ownerUserId: starter.id,
+      members: {
+        create: [
+          { userId: starter.id, role: 'OWNER' },
+          { userId: one.id, role: 'MENTEE' },
+          { userId: two.id, role: 'MENTEE' },
+        ],
+      },
+    },
+  });
   const conversation = await prisma.conversation.create({
     data: {
       type: 'GROUP',
+      projectId: project.id,
       participants: { create: [{ userId: starter.id }, { userId: one.id }, { userId: two.id }] },
     },
   });
@@ -182,6 +201,8 @@ test('a group call on the free room says so before anyone joins', async ({ page 
     await prisma.notification.deleteMany({ where: { userId: { in: [starter.id, one.id, two.id] } } });
     await prisma.conversationParticipant.deleteMany({ where: { conversationId: conversation.id } });
     await prisma.conversation.deleteMany({ where: { id: conversation.id } });
+    await prisma.projectMember.deleteMany({ where: { projectId: project.id } });
+    await prisma.project.deleteMany({ where: { id: project.id } });
     await cleanupByEmail(two.email);
     await cleanupByEmail(one.email);
     await cleanupByEmail(starterEmail);


### PR DESCRIPTION
## Summary

CI-watchdog fix for the e2e-full red on run [34603036357](https://github.com/21072026/Internship/actions/runs/34603036357), already filed as #2345 — `instant-meeting-team.spec.ts:144` ("a group call on the free room says so before anyone joins") times out clicking `start-meeting-conversation`.

#2345's own investigation correctly ruled out its first hypothesis (the two viewport variants use different testids, so `:visible` isn't the issue) but hadn't reproduced it locally yet. I did: the button never renders at all because the whole thread page renders **"Not found"**. `MessageThreadView` shows that string whenever `GET /api/messages?conversationId=...` comes back 403, and `getConversationIfAllowed()` (`src/lib/conversations.ts` — untouched by #2334, the PR that added this test) unconditionally refuses a `GROUP` conversation that has no `projectId`, for every caller. A `GROUP` room is always a project's room in this app; the test created its 3-person group directly via Prisma with no `projectId`, which is not a state the product itself can produce.

## Changes

- `e2e/instant-meeting-team.spec.ts`: the free-room test now creates a backing `Project` (owner + the two other participants as members) and sets `projectId` on the `GROUP` conversation, matching the pattern the sibling test in the same file already uses ("a meeting started from a group chat drops its link into that chat"). Cleanup extended to drop the project/members too.

## Verification

- [x] `npx tsc --noEmit` clean
- [x] Reproduced locally against `origin/main` HEAD (`206d787`, fresh MariaDB + `npm run build && npm run start`, Playwright via the pinned Chromium symlinked from `/opt/pw-browsers`): before the fix, the screenshot on failure showed the thread page rendering "Not found" and the button never appearing — same 15s timeout as CI.
- [x] All 5 tests in `e2e/instant-meeting-team.spec.ts` pass after the fix.
- [ ] Full `npm run test:e2e` — not run locally (time budget); this spec is not `@smoke`.

No `releases/unreleased/` fragment: pure test-file fix, no app-code or user-visible change.

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip): my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it passes to the rights holder (Mehmet Erşahin) who may also license it commercially, it is my own work, and I make no claim over the application.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Y7wuKNUfsYGw8fDou8UMM

---
_Generated by [Claude Code](https://claude.ai/code/session_014Y7wuKNUfsYGw8fDou8UMM)_