### PR TITLE
fix(e2e): give the v1-API test admins an org, matching real accounts

### DIFF
--- a/e2e/api-explorer.spec.ts
+++ b/e2e/api-explorer.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, type Page } from '@playwright/test';
 import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { defaultOrgId } from '@/lib/defaultOrg';
 
 test.afterAll(async () => {
   await prisma.$disconnect();
@@ -94,6 +95,12 @@ test('Swagger UI renders the operations and the token button pre-authorizes it',
   const email = uniqueEmail('apiexp-ui');
   const pw = 'ApiExpPass123!';
   const admin = await seedUser(email, pw, 'ADMIN', 'API Explorer UI Admin');
+  // A key minted for an org-less admin is refused by withApiKey() ("not bound
+  // to an organization", #1546) — real accounts always get an org at
+  // registration (defaultOrgId(), see src/lib/defaultOrg.ts), but seedUser()
+  // does not, so this test has to assign one itself for the v1 request below
+  // to reach the same path a real admin's key would.
+  await prisma.user.update({ where: { id: admin.id }, data: { orgId: await defaultOrgId() } });
   // Every key this test causes to exist, by id, read off the mint response.
   // The cleanup used to be `name: { startsWith: 'Swagger UI' }` — which is the
   // exact name the page mints, so pointed at a real DATABASE_URL (CLAUDE.md

--- a/e2e/integrations.spec.ts
+++ b/e2e/integrations.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { prisma, seedUser, cleanupByEmail, uniqueEmail } from './helpers/db';
+import { defaultOrgId } from '@/lib/defaultOrg';
 
 test.afterAll(async () => {
   await prisma.$disconnect();
@@ -7,7 +8,12 @@ test.afterAll(async () => {
 
 test('admin generates an API key that authorizes the read-only v1 API', async ({ page }) => {
   const adminEmail = uniqueEmail('int-admin');
-  await seedUser(adminEmail, 'AdminPass123', 'ADMIN', 'Int Admin');
+  const admin = await seedUser(adminEmail, 'AdminPass123', 'ADMIN', 'Int Admin');
+  // A key minted for an org-less admin is refused by withApiKey() ("not bound
+  // to an organization", #1546) — real accounts always get an org at
+  // registration (defaultOrgId(), see src/lib/defaultOrg.ts), but seedUser()
+  // does not, so this test has to assign one itself to exercise the real path.
+  await prisma.user.update({ where: { id: admin.id }, data: { orgId: await defaultOrgId() } });
   let keyId = '';
   try {
     await page.goto('/auth/signin');


### PR DESCRIPTION
## Summary

CI-watchdog fix for the e2e-full red on run [34603036357](https://github.com/21072026/Internship/actions/runs/34603036357) — `integrations.spec.ts:8` ("admin generates an API key that authorizes the read-only v1 API") and `api-explorer.spec.ts:93` ("Swagger UI renders the operations and the token button pre-authorizes it") both fail calling `GET /api/v1/candidates` with a freshly-minted key (`ok.ok()` false / expected 200, got 403).

Root cause, confirmed locally: both tests seed their ADMIN via `seedUser()` (`e2e/helpers/db.ts`), a raw `prisma.user.create()` with no `orgId`. `withApiKey()` (`src/lib/apiKey.ts`, #1546 — untouched by the recent vertical-epic commits I checked this against) unconditionally 403s a key whose owner has no organization. Every real account gets one at registration through `defaultOrgId()` (`src/lib/defaultOrg.ts`); `seedUser()` bypasses that, so these are the only two specs that ever exercise a v1-API key and notice the gap.

I do **not** believe this is caused by the "vertical" epic (`ca90295`..`79a773e`) or the SSO-enforcement commit (`be597bb`) — none of `src/lib/apiKey.ts`, `src/lib/orgContext.ts`'s `TENANT_MODELS`, or `e2e/helpers/db.ts` were touched by any commit in that range or since (last touch: `395815f`, unrelated). It looks like a latent, always-broken pairing between this test fixture and an existing app invariant, not a regression.

This PR is a **test-fixture fix only**. The actual tenant-scoping gap around `ApiKey` (no `orgId` column, not in `TENANT_MODELS`, `/api/v1/candidates` unscoped once `MT_ENFORCE_ISOLATION=true`) is already tracked as **#1466** with its own larger, schema-touching plan — deliberately out of scope for an unattended CI-watchdog run. This PR does not close #1466; it only restores the CI signal for these two tests by making the fixture look like a real account.

Refs #1466 (left open)

## Changes

- `e2e/integrations.spec.ts`: after `seedUser()`, assign the admin `orgId: await defaultOrgId()`.
- `e2e/api-explorer.spec.ts`: same, for the Swagger-UI admin.

## Verification

- [x] `npx tsc --noEmit` clean
- [x] Reproduced both failures locally against `origin/main` HEAD (`206d787`, fresh MariaDB + `npm run build && npm run start`): confirmed via the DB that the minted key's `orgId` was `null`, and both specs failed with the exact CI symptom (403 / `ok.ok() === false`) before the fix.
- [x] All 8 tests across both files pass after the fix.
- [ ] Full `npm run test:e2e` — not run locally (time budget).

No `releases/unreleased/` fragment: pure test-file fix, no app-code or user-visible change.

## Contributor terms

- [x] I accept the [contributor terms](https://github.com/21072026/internship/blob/main/CONTRIBUTING.md#contributor-terms-ip): my contribution is licensed under AGPL-3.0-or-later, the exclusive right to use it passes to the rights holder (Mehmet Erşahin) who may also license it commercially, it is my own work, and I make no claim over the application.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Y7wuKNUfsYGw8fDou8UMM

---
_Generated by [Claude Code](https://claude.ai/code/session_014Y7wuKNUfsYGw8fDou8UMM)_